### PR TITLE
feat: add website, verification agents, and release skill

### DIFF
--- a/.claude/agents/a9s-docs-reviewer.md
+++ b/.claude/agents/a9s-docs-reviewer.md
@@ -1,0 +1,62 @@
+---
+name: a9s-docs-reviewer
+description: Reviews a9s documentation for accuracy — verifies README examples match code, services list matches fetchers, key bindings match definitions, and installation instructions are correct. Use after documentation changes or new resource types.
+tools: Read, Glob, Grep, Bash
+model: sonnet
+---
+
+You are a documentation reviewer for the a9s project at /Users/k2m30/projects/a9s.
+
+## Review Checklist
+
+### 1. README.md Accuracy
+
+**Supported Services Table:**
+- Read `internal/resource/types.go` and extract all resource type names and categories
+- Compare against the table in README.md
+- Flag any missing or extra entries
+- Verify the total count (e.g., "62 AWS resource types") matches actual count
+
+**Key Bindings Table:**
+- Read `internal/tui/keys/keys.go` and extract all key bindings
+- Compare against the key bindings tables in README.md
+- Flag any missing, extra, or incorrect bindings
+
+**CLI Flags:**
+- Read `cmd/a9s/main.go` and extract all flag definitions
+- Compare against README Quick Start and usage examples
+- Verify `--version` output format matches what the binary actually prints
+
+**Install Commands:**
+- Verify `go install` path matches go.mod module path
+- Verify Homebrew tap name matches the actual repo (k2m30/homebrew-a9s)
+- Verify Docker image name matches .goreleaser.yaml
+
+### 2. CONTRIBUTING.md Accuracy
+
+- Verify project structure section matches actual directory layout
+- Verify build commands work: `make build`, `make test`, `make lint`
+- Verify Go version requirement matches go.mod
+
+### 3. SECURITY.md Accuracy
+
+- Verify the read-only claim by running `make verify-readonly`
+- Verify dependency scanning tools mentioned are actually configured in CI
+
+### 4. CHANGELOG.md Consistency
+
+- Verify version numbers in headers match git tags
+- Verify comparison links at bottom are correct URLs
+
+### 5. Website Content (if exists)
+
+- Check `website/content/` pages for consistency with README
+- Verify install instructions match README
+
+## Output
+
+List each finding as:
+- MISMATCH: documentation says X, code says Y
+- MISSING: documented but not in code (or vice versa)
+- STALE: likely outdated information
+- OK: verified correct

--- a/.claude/agents/a9s-release-validator.md
+++ b/.claude/agents/a9s-release-validator.md
@@ -1,0 +1,69 @@
+---
+name: a9s-release-validator
+description: Validates a9s release readiness — checks GoReleaser config, verifies builds across architectures, validates changelog, and confirms CI status. Use before tagging a release.
+tools: Read, Glob, Grep, Bash
+model: sonnet
+---
+
+You are a release validator for the a9s project at /Users/k2m30/projects/a9s.
+
+## Validation Checklist
+
+### 1. GoReleaser Config
+
+- Run: `goreleaser check -f .goreleaser.yaml`
+- Verify all target OS/arch combinations are listed
+- Verify Homebrew cask configuration points to k2m30/homebrew-a9s
+- Verify ldflags inject version, commit, and date
+
+### 2. Build Verification
+
+- Run: `make build`
+- Verify: `./a9s --version` outputs version, commit hash, and build date
+- Run: `goreleaser release --snapshot --clean` for a dry-run
+- Verify artifacts are created for all platforms
+
+### 3. Test Suite
+
+- Run: `make test` (must pass with -race)
+- Check test count is reasonable (1000+)
+- Run: `make verify-readonly` (read-only API guarantee)
+
+### 4. CHANGELOG.md
+
+- Verify the [Unreleased] section has content
+- Verify format follows Keep a Changelog
+- Verify comparison links at bottom are correct
+- Check that the latest version section matches the tag being created
+
+### 5. Version Consistency
+
+- Verify no hardcoded version strings remain in cmd/a9s/main.go (should use ldflags vars)
+- Verify go.mod module path is correct: github.com/k2m30/a9s
+- Verify the tag format matches semver: vX.Y.Z
+
+### 6. Git State
+
+- Working tree must be clean: `git status`
+- Must be on main branch
+- Must be up to date with origin: `git fetch origin && git status`
+- No uncommitted changes
+
+### 7. CI Status
+
+- Check latest CI run: `gh run list --limit 5`
+- All checks must be passing on the commit being tagged
+
+### 8. Homebrew Tap
+
+- Verify k2m30/homebrew-a9s repo exists: `gh repo view k2m30/homebrew-a9s`
+- Verify HOMEBREW_TAP_TOKEN secret is referenced in release workflow
+
+### 9. Docker
+
+- Verify Dockerfile exists and uses multi-stage build
+- Verify .goreleaser.yaml has dockers_v2 section
+
+## Output
+
+Report each check as PASS/FAIL with details. End with overall release readiness: READY or BLOCKED (with blockers listed).

--- a/.claude/agents/a9s-security-auditor.md
+++ b/.claude/agents/a9s-security-auditor.md
@@ -1,0 +1,68 @@
+---
+name: a9s-security-auditor
+description: Audits a9s for security issues — verifies read-only AWS API usage, checks for hardcoded secrets, reviews dependency vulnerabilities, and inspects injection vectors. Use after code changes or before releases.
+tools: Read, Glob, Grep, Bash
+model: sonnet
+---
+
+You are a security auditor for the a9s project, a Terminal UI AWS Resource Manager at /Users/k2m30/projects/a9s.
+
+## Audit Checklist
+
+### 1. Read-Only AWS API Verification
+
+Scan all files in `internal/aws/*.go` (excluding client.go, errors.go, interfaces.go, profile.go, regions.go).
+
+Verify that ONLY these API call patterns are used:
+- List*, Describe*, Get*, Search*, Lookup*, BatchGet*, Scan*
+
+Flag any of these as CRITICAL violations:
+- Create*, Delete*, Update*, Put*, Modify*, Terminate*, Start*, Stop*, Reboot*, RunInstances*, Execute*, Send*, Publish*, Remove*, Invoke*, Attach*, Detach*, Associate*, Disassociate*, Enable*, Disable*, Revoke*
+
+Also run: `make verify-readonly`
+
+### 2. Hardcoded Credentials Check
+
+Search the entire codebase for:
+- AWS access keys: pattern `AKIA[0-9A-Z]{16}`
+- AWS secret keys: 40-character base64 strings near "secret"
+- Hardcoded passwords, tokens, or API keys
+- `.env` files checked into git
+
+### 3. Sensitive Data in Logs
+
+Check for `fmt.Print`, `log.Print`, `fmt.Fprintf(os.Stderr` calls that might leak:
+- AWS credentials or session tokens
+- Resource ARNs containing account IDs (acceptable in normal output, not in error messages to external services)
+
+### 4. Dependency Vulnerabilities
+
+Run: `govulncheck ./...` (if available)
+Check go.sum for known vulnerable versions.
+
+### 5. Input Injection
+
+Review `cmd/a9s/main.go` for:
+- Unsanitized profile or region names passed to shell commands
+- Path traversal in config file loading
+- YAML deserialization of untrusted input
+
+Review `internal/config/` for:
+- File path handling (ensure no directory traversal)
+- YAML parsing (ensure no remote code execution via YAML tags)
+
+### 6. Supply Chain
+
+- Verify all direct dependencies are from known, reputable sources
+- Check for typosquatting in module paths
+- Verify go.sum is present and consistent
+
+## Output Format
+
+Report findings as:
+- CRITICAL: must fix before release
+- WARNING: should fix
+- INFO: informational, no action needed
+- PASS: check passed
+
+End with a summary: total checks, pass/warn/critical counts.

--- a/.claude/skills/release.md
+++ b/.claude/skills/release.md
@@ -1,0 +1,48 @@
+---
+name: release
+description: Automate the a9s release process — run checks, update changelog, tag, and push to trigger GoReleaser
+---
+
+## Pre-Release Checks
+
+Run all of these and stop if any fail:
+
+1. `make test` — all tests must pass
+2. `make lint` — no lint errors (skip if golangci-lint not installed locally)
+3. `make security` — no known vulnerabilities (skip if govulncheck not installed)
+4. `make verify-readonly` — confirm no write API calls
+5. `goreleaser check -f .goreleaser.yaml` — validate release config
+
+## Determine Version
+
+Ask the user: "What type of release is this?"
+- **Major** (breaking changes): bump X in vX.Y.Z
+- **Minor** (new features/resources): bump Y in vX.Y.Z
+- **Patch** (bug fixes): bump Z in vX.Y.Z
+
+Get the latest tag: `git describe --tags --abbrev=0`
+Calculate the next version based on user's choice.
+
+## Update CHANGELOG
+
+1. Read CHANGELOG.md
+2. Get commits since last tag: `git log $(git describe --tags --abbrev=0)..HEAD --oneline`
+3. Categorize commits into Added/Changed/Fixed/Removed based on conventional commit prefixes
+4. Replace the [Unreleased] section with the new version and today's date
+5. Add a new empty [Unreleased] section at the top
+6. Update comparison links at the bottom
+
+## Create Release
+
+1. Stage and commit CHANGELOG.md: `git commit -m "chore: release vX.Y.Z"`
+2. Create a feature branch, push, and create a PR
+3. After PR is merged, pull main and create annotated tag: `git tag -a vX.Y.Z -m "vX.Y.Z"`
+4. Push the tag: `git push origin vX.Y.Z`
+5. Monitor the release workflow: `gh run watch` on the Release workflow
+6. Verify release artifacts: `gh release view vX.Y.Z`
+7. Verify Homebrew formula updated: `gh api repos/k2m30/homebrew-a9s/contents/Casks`
+
+## Post-Release
+
+1. Report: version, number of artifacts, platforms, package formats
+2. Suggest: announce in GitHub Discussions

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,39 @@
+name: Deploy Website
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+  workflow_dispatch:
+
+permissions:
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: 'latest'
+      - run: hugo -s website --minify
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ dist/
 # VHS generated assets
 assets/*.gif
 assets/*.mp4
+
+# Hugo build output
+website/public/
+website/.hugo_build.lock
+website/resources/

--- a/website/archetypes/default.md
+++ b/website/archetypes/default.md
@@ -1,0 +1,5 @@
++++
+title = '{{ replace .File.ContentBaseName "-" " " | title }}'
+date = '{{ .Date }}'
+draft = true
++++

--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -1,0 +1,57 @@
+---
+title: "Documentation"
+---
+
+## Getting Started
+
+1. [Install a9s](/a9s/install/)
+2. Ensure you have [AWS credentials configured](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
+3. Run `a9s` (or `a9s -p myprofile`)
+
+## Key Bindings
+
+### Navigation
+
+| Key | Action |
+|-----|--------|
+| `j` / `Down` | Move down |
+| `k` / `Up` | Move up |
+| `g` | Go to top |
+| `G` | Go to bottom |
+| `Enter` | Open / select |
+| `Esc` | Back / close |
+| `h` / `Left` | Scroll left |
+| `l` / `Right` | Scroll right |
+| `PgUp` / `Ctrl+U` | Page up |
+| `PgDn` / `Ctrl+D` | Page down |
+
+### Actions
+
+| Key | Action |
+|-----|--------|
+| `d` | Detail view |
+| `y` | YAML view |
+| `c` | Copy resource ID |
+| `/` | Filter |
+| `:` | Command mode |
+| `?` | Help |
+| `Ctrl+R` | Refresh |
+| `w` | Toggle wrap |
+
+### Sorting
+
+| Key | Action |
+|-----|--------|
+| `N` | Sort by name |
+| `I` | Sort by ID |
+| `A` | Sort by date |
+
+## Configuration
+
+a9s reads your standard AWS configuration from `~/.aws/config` and `~/.aws/credentials`.
+
+Application config is stored in `~/.a9s/config.yaml`.
+
+## AWS Permissions
+
+a9s uses read-only API calls exclusively. The `ReadOnlyAccess` managed policy provides sufficient access. a9s gracefully handles permission errors for services you don't have access to.

--- a/website/content/install.md
+++ b/website/content/install.md
@@ -1,0 +1,49 @@
+---
+title: "Installation"
+---
+
+## Homebrew (macOS and Linux)
+
+```sh
+brew install k2m30/a9s/a9s
+```
+
+## Go install
+
+```sh
+go install github.com/k2m30/a9s/cmd/a9s@latest
+```
+
+## Download Binary
+
+Download the latest release for your platform from [GitHub Releases](https://github.com/k2m30/a9s/releases/latest).
+
+Available platforms:
+- **macOS**: Intel (amd64) and Apple Silicon (arm64)
+- **Linux**: amd64 and arm64, plus .deb, .rpm, and .apk packages
+- **Windows**: amd64 and arm64
+
+## Docker
+
+```sh
+docker run --rm -it -v ~/.aws:/root/.aws:ro ghcr.io/k2m30/a9s:latest
+```
+
+## Build from Source
+
+Requires Go 1.25+.
+
+```sh
+git clone https://github.com/k2m30/a9s.git
+cd a9s
+make build
+./a9s
+```
+
+## Verify Signatures
+
+Release checksums are signed with [cosign](https://github.com/sigstore/cosign):
+
+```sh
+cosign verify-blob --signature checksums.txt.sig checksums.txt
+```

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -1,0 +1,7 @@
+baseURL = 'https://k2m30.github.io/a9s/'
+languageCode = 'en-us'
+title = 'a9s — Terminal UI for AWS'
+theme = 'a9s-theme'
+
+[params]
+  description = 'Terminal UI AWS Resource Manager — browse, inspect, and manage 60+ AWS resource types'

--- a/website/themes/a9s-theme/layouts/_default/baseof.html
+++ b/website/themes/a9s-theme/layouts/_default/baseof.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ .Title }} | a9s</title>
+  <meta name="description" content="Terminal UI AWS Resource Manager — browse, inspect, and manage 60+ AWS resource types">
+  <meta property="og:title" content="a9s — Terminal UI for AWS">
+  <meta property="og:description" content="Like k9s, but for your cloud. Browse 62 AWS resource types from your terminal.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://k2m30.github.io/a9s/">
+  <style>
+    :root {
+      --bg: #1a1b26;
+      --bg-dark: #16161e;
+      --fg: #a9b1d6;
+      --fg-bright: #c0caf5;
+      --accent: #7aa2f7;
+      --accent2: #bb9af7;
+      --green: #9ece6a;
+      --border: #3b4261;
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--fg);
+      line-height: 1.6;
+    }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .container { max-width: 900px; margin: 0 auto; padding: 0 20px; }
+    header {
+      background: var(--bg-dark);
+      border-bottom: 1px solid var(--border);
+      padding: 16px 0;
+    }
+    header .container {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    header h1 { color: var(--accent); font-size: 1.4rem; }
+    header nav a { margin-left: 24px; color: var(--fg); font-size: 0.9rem; }
+    header nav a:hover { color: var(--accent); }
+    .hero {
+      text-align: center;
+      padding: 80px 20px 60px;
+    }
+    .hero h2 {
+      font-size: 2.8rem;
+      color: var(--fg-bright);
+      margin-bottom: 16px;
+    }
+    .hero p {
+      font-size: 1.2rem;
+      color: var(--fg);
+      max-width: 600px;
+      margin: 0 auto 32px;
+    }
+    .hero .tagline {
+      color: var(--accent2);
+      font-style: italic;
+      font-size: 1.1rem;
+      margin-bottom: 32px;
+    }
+    .install-box {
+      background: var(--bg-dark);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 16px 24px;
+      display: inline-block;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-size: 1rem;
+      color: var(--green);
+      margin-bottom: 32px;
+    }
+    .install-box span { color: var(--fg); margin-right: 8px; }
+    .features {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 24px;
+      padding: 60px 0;
+    }
+    .feature {
+      background: var(--bg-dark);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 24px;
+    }
+    .feature h3 { color: var(--accent); margin-bottom: 8px; font-size: 1.1rem; }
+    .feature p { font-size: 0.95rem; }
+    .cta { text-align: center; padding: 40px 0 80px; }
+    .btn {
+      display: inline-block;
+      background: var(--accent);
+      color: var(--bg-dark);
+      padding: 12px 32px;
+      border-radius: 6px;
+      font-weight: 600;
+      font-size: 1rem;
+      margin: 0 8px;
+    }
+    .btn:hover { opacity: 0.9; text-decoration: none; }
+    .btn.secondary {
+      background: transparent;
+      border: 1px solid var(--border);
+      color: var(--fg);
+    }
+    footer {
+      border-top: 1px solid var(--border);
+      padding: 24px 0;
+      text-align: center;
+      font-size: 0.85rem;
+      color: var(--fg);
+    }
+    .stats { display: flex; justify-content: center; gap: 40px; margin: 32px 0; }
+    .stat { text-align: center; }
+    .stat .number { font-size: 2rem; font-weight: 700; color: var(--accent); }
+    .stat .label { font-size: 0.85rem; }
+    /* Demo GIF placeholder */
+    .demo {
+      max-width: 800px;
+      margin: 0 auto 40px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      overflow: hidden;
+      background: var(--bg-dark);
+      padding: 40px;
+      text-align: center;
+      color: var(--fg);
+      font-style: italic;
+    }
+    section { padding: 40px 0; }
+    section h2 { color: var(--fg-bright); margin-bottom: 24px; text-align: center; }
+    table { width: 100%; border-collapse: collapse; margin: 16px 0; }
+    th, td { padding: 8px 12px; text-align: left; border-bottom: 1px solid var(--border); }
+    th { color: var(--accent); font-weight: 600; }
+    code {
+      background: var(--bg-dark);
+      padding: 2px 6px;
+      border-radius: 3px;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-size: 0.9em;
+    }
+    pre {
+      background: var(--bg-dark);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 16px;
+      overflow-x: auto;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-size: 0.9rem;
+      color: var(--green);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="container">
+      <h1>a9s</h1>
+      <nav>
+        <a href="{{ "install/" | relURL }}">Install</a>
+        <a href="{{ "docs/" | relURL }}">Docs</a>
+        <a href="https://github.com/k2m30/a9s">GitHub</a>
+      </nav>
+    </div>
+  </header>
+  <main>{{ block "main" . }}{{ end }}</main>
+  <footer>
+    <div class="container">
+      <p>a9s is open source (GPL-3.0-or-later) | <a href="https://github.com/k2m30/a9s">GitHub</a></p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/website/themes/a9s-theme/layouts/_default/list.html
+++ b/website/themes/a9s-theme/layouts/_default/list.html
@@ -1,0 +1,11 @@
+{{ define "main" }}
+<div class="container" style="padding: 40px 20px 80px;">
+  <h2 style="color: var(--fg-bright); margin-bottom: 24px;">{{ .Title }}</h2>
+  {{ .Content }}
+  {{ range .Pages }}
+  <div style="margin-bottom: 16px;">
+    <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+  </div>
+  {{ end }}
+</div>
+{{ end }}

--- a/website/themes/a9s-theme/layouts/_default/single.html
+++ b/website/themes/a9s-theme/layouts/_default/single.html
@@ -1,0 +1,6 @@
+{{ define "main" }}
+<div class="container" style="padding: 40px 20px 80px;">
+  <h2 style="color: var(--fg-bright); margin-bottom: 24px;">{{ .Title }}</h2>
+  {{ .Content }}
+</div>
+{{ end }}

--- a/website/themes/a9s-theme/layouts/index.html
+++ b/website/themes/a9s-theme/layouts/index.html
@@ -1,0 +1,49 @@
+{{ define "main" }}
+<div class="hero">
+  <h2>a9s</h2>
+  <p class="tagline">Terminal UI for AWS — like k9s, but for your cloud</p>
+  <p>Browse, inspect, and manage 62 AWS resource types from your terminal. Read-only by design. No telemetry.</p>
+  <div class="install-box"><span>$</span> brew install k2m30/a9s/a9s</div>
+  <div class="stats">
+    <div class="stat"><div class="number">62</div><div class="label">AWS Resource Types</div></div>
+    <div class="stat"><div class="number">12</div><div class="label">Service Categories</div></div>
+    <div class="stat"><div class="number">1045+</div><div class="label">Unit Tests</div></div>
+  </div>
+</div>
+<div class="container">
+  <div class="demo">
+    <!-- TODO: Replace with actual demo GIF -->
+    Demo GIF will appear here once generated with VHS
+  </div>
+  <div class="features">
+    <div class="feature">
+      <h3>Read-Only by Design</h3>
+      <p>a9s never makes write calls to AWS. Safe to use in production environments. Enforced by CI.</p>
+    </div>
+    <div class="feature">
+      <h3>Vim-Style Navigation</h3>
+      <p>j/k to move, Enter to open, Esc to go back, / to filter. Feels like home.</p>
+    </div>
+    <div class="feature">
+      <h3>62 Resource Types</h3>
+      <p>EC2, S3, RDS, Lambda, EKS, DynamoDB, SQS, IAM, VPC, and 50+ more. Organized by category.</p>
+    </div>
+    <div class="feature">
+      <h3>YAML Detail View</h3>
+      <p>Press y on any resource to see the full AWS API response as formatted YAML.</p>
+    </div>
+    <div class="feature">
+      <h3>Multi-Profile & Region</h3>
+      <p>Switch AWS profiles and regions on the fly. Works with SSO and standard credentials.</p>
+    </div>
+    <div class="feature">
+      <h3>Zero Config</h3>
+      <p>Uses your existing AWS credentials. Just run a9s and start browsing.</p>
+    </div>
+  </div>
+  <div class="cta">
+    <a href="{{ "install/" | relURL }}" class="btn">Install a9s</a>
+    <a href="https://github.com/k2m30/a9s" class="btn secondary">View on GitHub</a>
+  </div>
+</div>
+{{ end }}

--- a/website/themes/a9s-theme/theme.toml
+++ b/website/themes/a9s-theme/theme.toml
@@ -1,0 +1,6 @@
+name = "a9s-theme"
+license = "GPL-3.0-or-later"
+description = "Custom theme for a9s project website"
+
+[author]
+  name = "k2m30"


### PR DESCRIPTION
## Summary

- Hugo website with Tokyo Night Dark theme for GitHub Pages deployment
- GitHub Actions workflow for auto-deploying website on push
- 3 new verification agents: security-auditor, release-validator, docs-reviewer
- `/release` skill for automated release workflow
- Gitignore Hugo build output

## Test plan

- [x] `hugo -s website/` builds clean (10 pages, 11ms)
- [x] Agent definitions follow existing format in `.claude/agents/`
- [x] Skill placed in `.claude/skills/` alongside existing skills