### PR TITLE
fix: CI runs only on PR, drop Docker multi-arch for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - '*.md'
-      - 'docs/**'
-      - 'website/**'
-      - 'specs/**'
-      - '.claude/**'
-      - 'LICENSE'
   pull_request:
     branches: [main]
     paths-ignore:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -90,7 +90,6 @@ dockers_v2:
       - latest
     platforms:
       - linux/amd64
-      - linux/arm64
     labels:
       "org.opencontainers.image.description": "Terminal UI AWS Resource Manager"
       "org.opencontainers.image.created": "{{ .Date }}"
@@ -101,4 +100,4 @@ dockers_v2:
       "org.opencontainers.image.licenses": "GPL-3.0-or-later"
 
 release:
-  discussion_category_name: Releases
+  prerelease: auto


### PR DESCRIPTION
## Summary
- Remove `push: branches: [main]` from CI — PRs already gate merges, no need to re-run on merge commit
- Drop Docker `linux/arm64` platform — QEMU emulation on x86 runners OOMs/times out. Binary releases still cover all arches.
- Mark pre-releases automatically via semver (`prerelease: auto`)
- Remove `discussion_category_name` (not configured yet)

## Test plan
- [ ] CI runs on this PR (not on merge)
- [ ] Re-tag v3.0.0-alpha.1 after merge, verify release completes