### PR TITLE
fix: Docker home dir, go install version, empty profile display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ coverage.html
 # Internal tooling
 specs/
 .specify/
+release-local.sh
 
 # Generated reference (dev-time only)
 views_reference.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ARG TARGETOS
 ARG TARGETARCH
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=certs /etc/passwd /etc/passwd
+COPY --from=certs /home/a9s /home/a9s
 COPY build/${TARGETOS}-${TARGETARCH}/a9s /usr/local/bin/a9s
 USER a9s
 ENTRYPOINT ["a9s"]

--- a/cmd/a9s/main.go
+++ b/cmd/a9s/main.go
@@ -7,6 +7,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/k2m30/a9s/v3/internal/buildinfo"
 	"github.com/k2m30/a9s/v3/internal/config"
 	"github.com/k2m30/a9s/v3/internal/demo"
 	"github.com/k2m30/a9s/v3/internal/tui"
@@ -17,6 +18,10 @@ var (
 	commit  = "none"
 	date    = "unknown"
 )
+
+func init() {
+	version = buildinfo.ResolveVersion(version)
+}
 
 func main() {
 	var (

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,0 +1,19 @@
+package buildinfo
+
+import "runtime/debug"
+
+// ResolveVersion returns the version string. If v is set by ldflags (anything
+// other than "dev" or ""), it is returned as-is. Otherwise, falls back to the
+// module version embedded by go install.
+func ResolveVersion(v string) string {
+	if v != "dev" && v != "" {
+		return v
+	}
+	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return info.Main.Version
+	}
+	if v == "" {
+		return "dev"
+	}
+	return v
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -304,6 +304,9 @@ func (m Model) handleClientsReady(msg messages.ClientsReadyMsg) (tea.Model, tea.
 	if clients, ok := msg.Clients.(*awsclient.ServiceClients); ok {
 		m.clients = clients
 	}
+	if m.profile == "" && !m.demoMode {
+		m.profile = "default"
+	}
 	if m.region == "" && !m.demoMode {
 		configPath := awsclient.DefaultConfigPath()
 		m.region = awsclient.GetDefaultRegion(configPath, m.profile)

--- a/tests/unit/tui_wiring_test.go
+++ b/tests/unit/tui_wiring_test.go
@@ -1,6 +1,7 @@
 package unit
 
 import (
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -263,6 +264,20 @@ func TestWiring_RevealNotForNonSecrets(t *testing.T) {
 }
 
 // ── View config loading tests ───────────────────────────────────────────────
+
+func TestWiring_EmptyProfileShowsDefaultInHeader(t *testing.T) {
+	// When no profile is specified (empty string), the header should show "default"
+	m := tui.New("", "us-east-1")
+	m, _ = rootApplyMsg(m, tea.WindowSizeMsg{Width: 80, Height: 40})
+
+	// Simulate AWS connection completing
+	m, _ = rootApplyMsg(m, messages.ClientsReadyMsg{Clients: nil, Err: nil})
+
+	rendered := stripANSI(rootViewContent(m))
+	if !strings.Contains(rendered, "default") {
+		t.Errorf("header should show 'default' when profile is empty, got: %s", rendered)
+	}
+}
 
 func TestWiring_ViewConfigLoadedOnClientsReady(t *testing.T) {
 	m := newRootSizedModel()

--- a/tests/unit/version_test.go
+++ b/tests/unit/version_test.go
@@ -1,0 +1,32 @@
+package unit
+
+import (
+	"testing"
+
+	"github.com/k2m30/a9s/v3/internal/buildinfo"
+)
+
+func TestResolveVersion_LdflagsSet(t *testing.T) {
+	// When ldflags set a real version, it should be returned as-is
+	got := buildinfo.ResolveVersion("1.2.3")
+	if got != "1.2.3" {
+		t.Errorf("ResolveVersion(\"1.2.3\") = %q, want \"1.2.3\"", got)
+	}
+}
+
+func TestResolveVersion_DevFallsBackToBuildInfo(t *testing.T) {
+	// When version is "dev", it should fall back to debug.BuildInfo
+	// In test context BuildInfo returns "(devel)" so it stays "dev"
+	got := buildinfo.ResolveVersion("dev")
+	// In test binary, module version is "(devel)", so fallback can't help — stays "dev"
+	if got == "" {
+		t.Error("ResolveVersion(\"dev\") returned empty string")
+	}
+}
+
+func TestResolveVersion_EmptyInput(t *testing.T) {
+	got := buildinfo.ResolveVersion("")
+	if got == "" {
+		t.Error("ResolveVersion(\"\") returned empty string")
+	}
+}


### PR DESCRIPTION
## Summary
- Dockerfile: copy `/home/a9s` from build stage — fixes `mkdir /home: permission denied`
- New `internal/buildinfo` package: `go install` shows real version via `debug.ReadBuildInfo` fallback instead of "dev"
- Show "default" in header when no `-p` flag specified (was empty string → `:us-east-1`)
- Gitignore `release-local.sh`

## Test plan
- [x] `TestWiring_EmptyProfileShowsDefaultInHeader` — new test, passes
- [x] `TestResolveVersion_*` — 3 new tests for buildinfo, pass
- [x] Full unit suite passes (1,045+)
- [x] `golangci-lint run ./...` clean
- [x] `govulncheck ./...` clean
- [x] Docker image builds and runs: `docker run --rm ghcr.io/k2m30/a9s:v3.0.0-alpha.6 --version`