### PR TITLE
fix: codecov uploads on push to main, not on PRs

### DIFF
--- a/.claude/plans/keen-sparking-manatee.md
+++ b/.claude/plans/keen-sparking-manatee.md
@@ -1,0 +1,43 @@
+# Local Release Scripts
+
+## Context
+
+CI workflows can't be easily debugged or run locally. Need a local script to run GoReleaser snapshot, Docker multi-arch build, and GitHub release — all from the local machine. Gitignored so it doesn't ship.
+
+## Plan
+
+### 1. Create `scripts/release-local.sh`
+
+Single script with subcommands: `snapshot`, `docker`, `release`.
+
+```bash
+scripts/release-local.sh snapshot   # goreleaser --snapshot --clean --skip=publish
+scripts/release-local.sh docker     # build + tag multi-arch Docker image locally
+scripts/release-local.sh release    # full: goreleaser release --clean (publishes to GitHub + brew tap)
+scripts/release-local.sh all        # snapshot + docker
+```
+
+**snapshot** — Runs `goreleaser release --snapshot --clean --skip=publish`. Validates config, builds all 4 binaries, generates checksums and Formula. Output in `dist/`.
+
+**docker** — Builds linux/amd64 and linux/arm64 binaries, then `docker buildx build --platform linux/amd64,linux/arm64` with local tag. Optionally pushes to ghcr.io if `--push` flag given.
+
+**release** — Runs `goreleaser release --clean` with `GITHUB_TOKEN` and `HOMEBREW_TAP_TOKEN` from environment. This is the real deal — publishes to GitHub Releases and updates the brew tap.
+
+**all** — Runs snapshot + docker (no publish).
+
+### 2. Update `.gitignore`
+
+Add `scripts/` to the gitignore under "Internal tooling".
+
+### Files to modify
+
+| File | Change |
+|------|--------|
+| `scripts/release-local.sh` | New file — local release runner |
+| `.gitignore` | Add `scripts/` |
+
+### Verification
+
+1. `scripts/release-local.sh snapshot` — builds all 4 archives + Formula in `dist/`
+2. `scripts/release-local.sh docker` — builds multi-arch image tagged locally
+3. Script is not tracked by git after `.gitignore` update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
   pull_request:
     branches: [main]
     paths:
@@ -17,6 +23,7 @@ permissions:
 jobs:
   lint:
     name: Lint
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,6 +36,7 @@ jobs:
 
   test:
     name: Test (${{ matrix.os }})
+    if: github.event_name == 'pull_request'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -47,16 +55,10 @@ jobs:
       - name: Run tests with coverage
         if: matrix.os == 'ubuntu-latest'
         run: xvfb-run go test ./internal/... ./tests/... -coverpkg=./internal/... -coverprofile=coverage.out -covermode=atomic -timeout 120s -race
-      - name: Upload coverage
-        if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v5
-        with:
-          files: coverage.out
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   build:
     name: Build
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -75,6 +77,7 @@ jobs:
 
   security:
     name: Security
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -88,8 +91,29 @@ jobs:
 
   verify-readonly:
     name: Verify Read-Only APIs
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Check for write API calls
         run: make verify-readonly
+
+  coverage:
+    name: Coverage
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Install clipboard utilities
+        run: sudo apt-get install -y xclip xvfb
+      - name: Run tests with coverage
+        run: xvfb-run go test ./internal/... ./tests/... -coverpkg=./internal/... -coverprofile=coverage.out -covermode=atomic -timeout 120s -race
+      - name: Upload coverage
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.out
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Coverage badge showed 0% because codecov only uploaded on PRs, never on main
- Split CI: PR runs lint/test/build/security, push to main runs coverage-only job with codecov upload
- No duplication — each event triggers different jobs

## Test plan
- [x] CI workflow syntax valid
- [ ] After merge, push to main triggers coverage job and codecov badge updates