### PR TITLE
feat: respect AWS_CONFIG_FILE env var for profile discovery

### DIFF
--- a/internal/aws/profile.go
+++ b/internal/aws/profile.go
@@ -9,8 +9,12 @@ import (
 	"gopkg.in/ini.v1"
 )
 
-// DefaultConfigPath returns the default AWS config file path (~/.aws/config).
+// DefaultConfigPath returns the AWS config file path.
+// Default is ~/.aws/config; set $AWS_CONFIG_FILE to override.
 func DefaultConfigPath() string {
+	if p := os.Getenv("AWS_CONFIG_FILE"); p != "" {
+		return p
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return filepath.Join("~", ".aws", "config")
@@ -82,4 +86,3 @@ func parseConfigProfiles(path string, seen map[string]bool) error {
 
 	return nil
 }
-


### PR DESCRIPTION
## Summary

`DefaultConfigPath()` now checks `$AWS_CONFIG_FILE` before falling back
to `~/.aws/config`, enabling per-project AWS config via tools like direnv.

## Related Issues

<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD
- [ ] Other

## Checklist

- [ ] Tests added/updated
- [x] `make test` passes
- [x] `make lint` passes
- [ ] Documentation updated (if applicable)
- [x] Conventional commit message used
