### PR TITLE
fix: enable inter-navigation between detail, JSON, and YAML views

### DIFF
--- a/internal/tui/app_handlers_navigate.go
+++ b/internal/tui/app_handlers_navigate.go
@@ -111,6 +111,9 @@ func (m Model) handleNavigate(msg messages.NavigateMsg) (tea.Model, tea.Cmd) {
 		if msg.Resource == nil {
 			return m, nil
 		}
+		if msg.ReplaceCurrent {
+			m.popView()
+		}
 		resType := msg.ResourceType
 		if resType == "" {
 			switch av := m.activeView().(type) {
@@ -142,6 +145,9 @@ func (m Model) handleNavigate(msg messages.NavigateMsg) (tea.Model, tea.Cmd) {
 	case messages.TargetJSON:
 		if msg.Resource == nil {
 			return m, nil
+		}
+		if msg.ReplaceCurrent {
+			m.popView()
 		}
 		resType := msg.ResourceType
 		if resType == "" {

--- a/internal/tui/views/detail.go
+++ b/internal/tui/views/detail.go
@@ -337,15 +337,17 @@ func (m DetailModel) Update(msg tea.Msg) (DetailModel, tea.Cmd) {
 		case key.Matches(msg, m.keys.YAML):
 			return m, func() tea.Msg {
 				return messages.NavigateMsg{
-					Target:   messages.TargetYAML,
-					Resource: &m.res,
+					Target:       messages.TargetYAML,
+					Resource:     &m.res,
+					ResourceType: m.resourceType,
 				}
 			}
 		case key.Matches(msg, m.keys.JSON):
 			return m, func() tea.Msg {
 				return messages.NavigateMsg{
-					Target:   messages.TargetJSON,
-					Resource: &m.res,
+					Target:       messages.TargetJSON,
+					Resource:     &m.res,
+					ResourceType: m.resourceType,
 				}
 			}
 		case key.Matches(msg, m.keys.ToggleWrap):

--- a/internal/tui/views/json.go
+++ b/internal/tui/views/json.go
@@ -120,6 +120,28 @@ func (m JSONModel) Update(msg tea.Msg) (JSONModel, tea.Cmd) {
 				}
 			}
 			return m, nil
+		case key.Matches(msg, m.keys.Describe):
+			res := m.res
+			return m, func() tea.Msg {
+				return messages.NavigateMsg{
+					Target:         messages.TargetDetail,
+					Resource:       &res,
+					ResourceType:   m.resourceType,
+					ReplaceCurrent: true,
+				}
+			}
+		case key.Matches(msg, m.keys.YAML):
+			res := m.res
+			return m, func() tea.Msg {
+				return messages.NavigateMsg{
+					Target:         messages.TargetYAML,
+					Resource:       &res,
+					ResourceType:   m.resourceType,
+					ReplaceCurrent: true,
+				}
+			}
+		case key.Matches(msg, m.keys.JSON):
+			return m, nil
 		}
 	}
 

--- a/internal/tui/views/yaml.go
+++ b/internal/tui/views/yaml.go
@@ -139,6 +139,28 @@ func (m YAMLModel) Update(msg tea.Msg) (YAMLModel, tea.Cmd) {
 				}
 			}
 			return m, nil
+		case key.Matches(msg, m.keys.Describe):
+			res := m.res
+			return m, func() tea.Msg {
+				return messages.NavigateMsg{
+					Target:         messages.TargetDetail,
+					Resource:       &res,
+					ResourceType:   m.resourceType,
+					ReplaceCurrent: true,
+				}
+			}
+		case key.Matches(msg, m.keys.JSON):
+			res := m.res
+			return m, func() tea.Msg {
+				return messages.NavigateMsg{
+					Target:         messages.TargetJSON,
+					Resource:       &res,
+					ResourceType:   m.resourceType,
+					ReplaceCurrent: true,
+				}
+			}
+		case key.Matches(msg, m.keys.YAML):
+			return m, nil
 		}
 	}
 

--- a/internal/tui/views/yaml.go
+++ b/internal/tui/views/yaml.go
@@ -140,6 +140,9 @@ func (m YAMLModel) Update(msg tea.Msg) (YAMLModel, tea.Cmd) {
 			}
 			return m, nil
 		case key.Matches(msg, m.keys.Describe):
+			if m.rawText != "" {
+				return m, nil
+			}
 			res := m.res
 			return m, func() tea.Msg {
 				return messages.NavigateMsg{
@@ -150,6 +153,9 @@ func (m YAMLModel) Update(msg tea.Msg) (YAMLModel, tea.Cmd) {
 				}
 			}
 		case key.Matches(msg, m.keys.JSON):
+			if m.rawText != "" {
+				return m, nil
+			}
 			res := m.res
 			return m, func() tea.Msg {
 				return messages.NavigateMsg{

--- a/tests/unit/qa_view_switching_test.go
+++ b/tests/unit/qa_view_switching_test.go
@@ -101,12 +101,8 @@ func TestJSONView_PressJ_ReturnsNilCmd(t *testing.T) {
 
 	_, cmd := m.Update(tea.KeyPressMsg{Code: -1, Text: "J"})
 	if cmd != nil {
-		msg := execCmd(cmd)
-		if _, isNav := msg.(messages.NavigateMsg); isNav {
-			t.Errorf("pressing 'J' in JSON view: expected nil cmd (already on JSON), got NavigateMsg")
-		}
+		t.Fatalf("pressing 'J' in JSON view: expected nil cmd (already on JSON), got non-nil cmd")
 	}
-	// nil cmd is the expected outcome — no further assertion needed
 }
 
 // ── YAML view ────────────────────────────────────────────────────────────────
@@ -173,10 +169,6 @@ func TestYAMLView_PressY_ReturnsNilCmd(t *testing.T) {
 
 	_, cmd := m.Update(tea.KeyPressMsg{Code: -1, Text: "y"})
 	if cmd != nil {
-		msg := execCmd(cmd)
-		if _, isNav := msg.(messages.NavigateMsg); isNav {
-			t.Errorf("pressing 'y' in YAML view: expected nil cmd (already on YAML), got NavigateMsg")
-		}
+		t.Fatalf("pressing 'y' in YAML view: expected nil cmd (already on YAML), got non-nil cmd")
 	}
-	// nil cmd is the expected outcome — no further assertion needed
 }

--- a/tests/unit/qa_view_switching_test.go
+++ b/tests/unit/qa_view_switching_test.go
@@ -1,0 +1,182 @@
+package unit
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/k2m30/a9s/v3/internal/resource"
+	"github.com/k2m30/a9s/v3/internal/tui/keys"
+	"github.com/k2m30/a9s/v3/internal/tui/messages"
+	"github.com/k2m30/a9s/v3/internal/tui/views"
+)
+
+// ════════════════════════════════════════════════════════════════════════════
+// QA: Inter-navigation between JSON and YAML views
+//
+// Verifies that pressing d/y/J in JSON or YAML view emits a NavigateMsg
+// targeting the correct view with ReplaceCurrent=true.
+// ════════════════════════════════════════════════════════════════════════════
+
+// switchTestResource returns a minimal resource suitable for JSON/YAML view construction.
+func switchTestResource() resource.Resource {
+	return resource.Resource{
+		ID:   "test-1",
+		Name: "test-resource",
+		Fields: map[string]string{
+			"Name": "test",
+		},
+	}
+}
+
+// execCmd runs a cmd and returns the resulting tea.Msg, or nil if cmd is nil.
+func execCmd(cmd tea.Cmd) tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	return cmd()
+}
+
+// ── JSON view ────────────────────────────────────────────────────────────────
+
+// TestJSONView_PressD_EmitsNavigateToDetail verifies that pressing 'd' in the
+// JSON view emits a NavigateMsg targeting TargetDetail with ReplaceCurrent=true.
+func TestJSONView_PressD_EmitsNavigateToDetail(t *testing.T) {
+	res := switchTestResource()
+	k := keys.Default()
+	m := views.NewJSON(res, "ec2-instances", k)
+	m.SetSize(80, 24)
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: -1, Text: "d"})
+	msg := execCmd(cmd)
+
+	nav, ok := msg.(messages.NavigateMsg)
+	if !ok {
+		t.Fatalf("pressing 'd' in JSON view: expected NavigateMsg, got %T (%v)", msg, msg)
+	}
+	if nav.Target != messages.TargetDetail {
+		t.Errorf("NavigateMsg.Target = %v, want TargetDetail (%v)", nav.Target, messages.TargetDetail)
+	}
+	if !nav.ReplaceCurrent {
+		t.Errorf("NavigateMsg.ReplaceCurrent = false, want true")
+	}
+	if nav.ResourceType != "ec2-instances" {
+		t.Errorf("NavigateMsg.ResourceType = %q, want %q", nav.ResourceType, "ec2-instances")
+	}
+}
+
+// TestJSONView_PressY_EmitsNavigateToYAML verifies that pressing 'y' in the
+// JSON view emits a NavigateMsg targeting TargetYAML with ReplaceCurrent=true.
+func TestJSONView_PressY_EmitsNavigateToYAML(t *testing.T) {
+	res := switchTestResource()
+	k := keys.Default()
+	m := views.NewJSON(res, "ec2-instances", k)
+	m.SetSize(80, 24)
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: -1, Text: "y"})
+	msg := execCmd(cmd)
+
+	nav, ok := msg.(messages.NavigateMsg)
+	if !ok {
+		t.Fatalf("pressing 'y' in JSON view: expected NavigateMsg, got %T (%v)", msg, msg)
+	}
+	if nav.Target != messages.TargetYAML {
+		t.Errorf("NavigateMsg.Target = %v, want TargetYAML (%v)", nav.Target, messages.TargetYAML)
+	}
+	if !nav.ReplaceCurrent {
+		t.Errorf("NavigateMsg.ReplaceCurrent = false, want true")
+	}
+	if nav.ResourceType != "ec2-instances" {
+		t.Errorf("NavigateMsg.ResourceType = %q, want %q", nav.ResourceType, "ec2-instances")
+	}
+}
+
+// TestJSONView_PressJ_ReturnsNilCmd verifies that pressing 'J' in the JSON view
+// returns a nil cmd (no-op — already on JSON).
+func TestJSONView_PressJ_ReturnsNilCmd(t *testing.T) {
+	res := switchTestResource()
+	k := keys.Default()
+	m := views.NewJSON(res, "ec2-instances", k)
+	m.SetSize(80, 24)
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: -1, Text: "J"})
+	if cmd != nil {
+		msg := execCmd(cmd)
+		if _, isNav := msg.(messages.NavigateMsg); isNav {
+			t.Errorf("pressing 'J' in JSON view: expected nil cmd (already on JSON), got NavigateMsg")
+		}
+	}
+	// nil cmd is the expected outcome — no further assertion needed
+}
+
+// ── YAML view ────────────────────────────────────────────────────────────────
+
+// TestYAMLView_PressD_EmitsNavigateToDetail verifies that pressing 'd' in the
+// YAML view emits a NavigateMsg targeting TargetDetail with ReplaceCurrent=true.
+func TestYAMLView_PressD_EmitsNavigateToDetail(t *testing.T) {
+	res := switchTestResource()
+	k := keys.Default()
+	m := views.NewYAML(res, "ec2-instances", k)
+	m.SetSize(80, 24)
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: -1, Text: "d"})
+	msg := execCmd(cmd)
+
+	nav, ok := msg.(messages.NavigateMsg)
+	if !ok {
+		t.Fatalf("pressing 'd' in YAML view: expected NavigateMsg, got %T (%v)", msg, msg)
+	}
+	if nav.Target != messages.TargetDetail {
+		t.Errorf("NavigateMsg.Target = %v, want TargetDetail (%v)", nav.Target, messages.TargetDetail)
+	}
+	if !nav.ReplaceCurrent {
+		t.Errorf("NavigateMsg.ReplaceCurrent = false, want true")
+	}
+	if nav.ResourceType != "ec2-instances" {
+		t.Errorf("NavigateMsg.ResourceType = %q, want %q", nav.ResourceType, "ec2-instances")
+	}
+}
+
+// TestYAMLView_PressJ_EmitsNavigateToJSON verifies that pressing 'J' in the
+// YAML view emits a NavigateMsg targeting TargetJSON with ReplaceCurrent=true.
+func TestYAMLView_PressJ_EmitsNavigateToJSON(t *testing.T) {
+	res := switchTestResource()
+	k := keys.Default()
+	m := views.NewYAML(res, "ec2-instances", k)
+	m.SetSize(80, 24)
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: -1, Text: "J"})
+	msg := execCmd(cmd)
+
+	nav, ok := msg.(messages.NavigateMsg)
+	if !ok {
+		t.Fatalf("pressing 'J' in YAML view: expected NavigateMsg, got %T (%v)", msg, msg)
+	}
+	if nav.Target != messages.TargetJSON {
+		t.Errorf("NavigateMsg.Target = %v, want TargetJSON (%v)", nav.Target, messages.TargetJSON)
+	}
+	if !nav.ReplaceCurrent {
+		t.Errorf("NavigateMsg.ReplaceCurrent = false, want true")
+	}
+	if nav.ResourceType != "ec2-instances" {
+		t.Errorf("NavigateMsg.ResourceType = %q, want %q", nav.ResourceType, "ec2-instances")
+	}
+}
+
+// TestYAMLView_PressY_ReturnsNilCmd verifies that pressing 'y' in the YAML view
+// returns a nil cmd (no-op — already on YAML).
+func TestYAMLView_PressY_ReturnsNilCmd(t *testing.T) {
+	res := switchTestResource()
+	k := keys.Default()
+	m := views.NewYAML(res, "ec2-instances", k)
+	m.SetSize(80, 24)
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: -1, Text: "y"})
+	if cmd != nil {
+		msg := execCmd(cmd)
+		if _, isNav := msg.(messages.NavigateMsg); isNav {
+			t.Errorf("pressing 'y' in YAML view: expected nil cmd (already on YAML), got NavigateMsg")
+		}
+	}
+	// nil cmd is the expected outcome — no further assertion needed
+}


### PR DESCRIPTION
## Summary
- **Bug**: pressing `d`/`y`/`J` in JSON or YAML views did nothing — only Esc (go back) worked
- **Fix**: added key handlers to JSON and YAML views that emit `NavigateMsg` with `ReplaceCurrent: true`, so switching between detail/JSON/YAML replaces the current view in-place while preserving the navigation stack
- **Detail view** now passes `ResourceType` in its YAML/JSON navigate messages (no `ReplaceCurrent`, so Esc still returns from YAML/JSON to detail)

## Test plan
- [x] 6 new unit tests in `qa_view_switching_test.go` covering all navigation directions
- [x] `make test` passes
- [x] `make lint` passes
- [ ] Manual: open a resource detail → press `y` (YAML) → press `J` (JSON) → press `d` (detail) → verify each switch works
- [ ] Manual: from YAML view, press Esc → verify it returns to detail (not list)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard shortcuts now consistently replace the current view when switching between Detail, JSON, and YAML formats.
  * View switches include context so the correct resource type is preserved during navigation.

* **Bug Fixes**
  * Fixed inconsistent replace-current behavior when navigating between representation views.

* **Tests**
  * Added unit tests covering JSON↔YAML↔Detail view switching and replace-current behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->