### PR TITLE
refactor(phase-02-pr02b): IAM PolicyStore + detail fallback fix

### DIFF
--- a/internal/aws/client.go
+++ b/internal/aws/client.go
@@ -53,7 +53,13 @@ import (
 )
 
 // ServiceClients holds AWS service clients for all supported services.
+// IAMPolicies must be set to the session's PolicyStore before any
+// FetchIAMPoliciesByIDsFull calls; see internal/tui/app_handlers.go.
 type ServiceClients struct {
+	// IAMPolicies is the session-scoped IAM policy resource cache. Set by the
+	// TUI layer from session.Session.IAMPolicies on every ClientsReadyMsg.
+	IAMPolicies iamPolicyStore
+
 	EC2              EC2API
 	S3               S3API
 	RDS              RDSAPI

--- a/internal/aws/iam_policies.go
+++ b/internal/aws/iam_policies.go
@@ -186,6 +186,19 @@ func FetchIAMPoliciesPage(ctx context.Context, api IAMListPoliciesAPI, continuat
 // fetchInlineGroupPolicies (same Fields keys) so reverse-scan checkers
 // reading Fields on a lazily-added policy observe the same fields as on a
 // paginated-fetched policy.
+//
+// Concurrency trade-off (acknowledged): no top-level lock is held across the
+// check-build-mark sequence. Two concurrent lazy-add calls can both observe
+// `store.ManagedBuilt() == false` and both invoke buildAllManagedPolicies.
+// The store itself remains correct (writes are mutex-guarded inside the
+// PolicyStore impl), so duplicate Set calls are idempotent — but two AWS
+// ListPolicies pagination walks may run in parallel before one wins the
+// MarkManagedBuilt race. The previous package-global `allPoliciesMu`
+// serialized this. Acceptable here because: (a) lazy-add is the
+// related-panel drill-in path, not high-volume; (b) duplicate Sets converge
+// to the same final cache state; (c) introducing a sync.Once or
+// build-in-progress flag would re-couple the transport layer to a session
+// concern that PR-02b explicitly removed. Same applies to InlineBuilt.
 func FetchIAMPoliciesByIDsFull(ctx context.Context, api IAMAPI, ids []string, store iamPolicyStore) ([]resource.Resource, error) {
 	if len(ids) == 0 {
 		return nil, nil

--- a/internal/aws/iam_policies.go
+++ b/internal/aws/iam_policies.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
@@ -11,6 +10,19 @@ import (
 
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
+
+// iamPolicyStore is the subset of session.PolicyStore consumed by this file.
+// Defined locally to avoid an import cycle (internal/session imports internal/aws).
+// session.PolicyStore satisfies this interface via Go's structural typing.
+type iamPolicyStore interface {
+	Lookup(key string) (resource.Resource, bool)
+	Set(key string, r resource.Resource)
+	ManagedBuilt() bool
+	MarkManagedBuilt()
+	InlineBuilt() bool
+	MarkInlineBuilt()
+	Clear()
+}
 
 func init() {
 	resource.RegisterFieldKeys("policy", []string{"policy_name", "policy_type", "attachment_count", "is_attachable", "path", "create_date"})
@@ -42,7 +54,10 @@ func init() {
 		if !ok || c == nil {
 			return nil, fmt.Errorf("AWS clients not initialized")
 		}
-		return FetchIAMPoliciesByIDsFull(ctx, c.IAM, ids)
+		if c.IAMPolicies == nil {
+			return nil, fmt.Errorf("IAMPolicies store not initialized on ServiceClients")
+		}
+		return FetchIAMPoliciesByIDsFull(ctx, c.IAM, ids, c.IAMPolicies)
 	})
 
 	resource.RegisterRelated("policy", []resource.RelatedDef{
@@ -156,32 +171,6 @@ func FetchIAMPoliciesPage(ctx context.Context, api IAMListPoliciesAPI, continuat
 	}, nil
 }
 
-// allPoliciesCache memoizes the name→Resource map built from
-// ListPolicies(Scope=All). AWS-managed policy names are stable globally;
-// customer-managed names are stable within an account. The cache is cleared
-// on every profile/region switch via ResetIAMPoliciesCache (wired from
-// sessionRuntime.resetForSessionSwitch), so stale policies from a prior
-// account never leak into lazy-add drills in the next account. The mutex
-// guards concurrent rebuilds from parallel related-checks targeting "policy".
-var (
-	allPoliciesMu          sync.Mutex
-	allManagedPoliciesBuilt bool
-	allInlinePoliciesBuilt  bool
-	allPoliciesByID         map[string]resource.Resource
-)
-
-// ResetIAMPoliciesCache clears the process-wide customer+AWS-managed policy
-// cache used by FetchIAMPoliciesByIDsFull. Called on every profile/region
-// switch to prevent account-A policies from being returned for lazy-add
-// drills in account-B.
-func ResetIAMPoliciesCache() {
-	allPoliciesMu.Lock()
-	defer allPoliciesMu.Unlock()
-	allManagedPoliciesBuilt = false
-	allInlinePoliciesBuilt = false
-	allPoliciesByID = nil
-}
-
 // FetchIAMPoliciesByIDsFull is the production entry point called by the
 // related-panel lazy-add path. It resolves policy PolicyNames across BOTH
 // managed (customer + AWS) and inline group policies, so a checker that
@@ -190,40 +179,37 @@ func ResetIAMPoliciesCache() {
 // ListGroupPolicies) drills into a real entry.
 //
 // Managed resolution: ListPolicies(Scope=All) paginated on first call,
-// memoized in allPoliciesByID. Inline resolution: ListGroups +
-// ListGroupPolicies, memoized alongside.
+// memoized via store.MarkManagedBuilt(). Inline resolution: ListGroups +
+// ListGroupPolicies, memoized via store.MarkInlineBuilt().
 //
 // Invariant: the returned Resource shape matches FetchIAMPoliciesPage and
 // fetchInlineGroupPolicies (same Fields keys) so reverse-scan checkers
 // reading Fields on a lazily-added policy observe the same fields as on a
 // paginated-fetched policy.
-func FetchIAMPoliciesByIDsFull(ctx context.Context, api IAMAPI, ids []string) ([]resource.Resource, error) {
+func FetchIAMPoliciesByIDsFull(ctx context.Context, api IAMAPI, ids []string, store iamPolicyStore) ([]resource.Resource, error) {
 	if len(ids) == 0 {
 		return nil, nil
 	}
-	allPoliciesMu.Lock()
-	defer allPoliciesMu.Unlock()
 
-	if !allManagedPoliciesBuilt {
-		allPoliciesByID = make(map[string]resource.Resource)
-		if err := buildAllManagedPolicies(ctx, api); err != nil {
+	if !store.ManagedBuilt() {
+		if err := buildAllManagedPolicies(ctx, api, store); err != nil {
 			// Managed is the trunk — without it we can't resolve any policy.
 			return nil, err
 		}
-		allManagedPoliciesBuilt = true
+		store.MarkManagedBuilt()
 	}
-	if !allInlinePoliciesBuilt {
+	if !store.InlineBuilt() {
 		// Include inline group policies so checkGroupPolicy (which emits
 		// both attached and inline names) finds the inline entries in
 		// cache too. Per-group failures are surfaced via the returned error
 		// and propagated into the composite failure list below.
 		inlines, inlineErr := fetchInlineGroupPolicies(ctx, api)
 		for _, r := range inlines {
-			allPoliciesByID[r.ID] = r
+			store.Set(r.ID, r)
 		}
 		if inlineErr != nil {
 			// Non-fatal: managed policies are already loaded; partial inline
-			// results are incorporated above. Leave allInlinePoliciesBuilt=false
+			// results are incorporated above. Leave InlineBuilt=false
 			// so next call retries the inline fetch — it might succeed after a
 			// transient throttle. Surface as aggregate failure with the partial
 			// results we did recover.
@@ -239,7 +225,7 @@ func FetchIAMPoliciesByIDsFull(ctx context.Context, api IAMAPI, ids []string) ([
 					continue
 				}
 				seen[id] = struct{}{}
-				if r, hit := allPoliciesByID[id]; hit {
+				if r, hit := store.Lookup(id); hit {
 					resources = append(resources, r)
 				} else {
 					failures = append(failures, fmt.Sprintf("%s: not found", id))
@@ -247,7 +233,7 @@ func FetchIAMPoliciesByIDsFull(ctx context.Context, api IAMAPI, ids []string) ([
 			}
 			return resources, AggregateFailures("policy FetchByIDs", failures, len(ids))
 		}
-		allInlinePoliciesBuilt = true
+		store.MarkInlineBuilt()
 	}
 
 	var failures []string
@@ -261,7 +247,7 @@ func FetchIAMPoliciesByIDsFull(ctx context.Context, api IAMAPI, ids []string) ([
 			continue
 		}
 		seen[id] = struct{}{}
-		if r, hit := allPoliciesByID[id]; hit {
+		if r, hit := store.Lookup(id); hit {
 			resources = append(resources, r)
 		} else {
 			failures = append(failures, fmt.Sprintf("%s: not found", id))
@@ -277,19 +263,16 @@ func FetchIAMPoliciesByIDsFull(ctx context.Context, api IAMAPI, ids []string) ([
 //
 // Per-ID failures (IDs not present in the all-policies map) are collected into
 // a composite error returned alongside the partial success list.
-func FetchIAMPoliciesByIDs(ctx context.Context, api IAMListPoliciesAPI, ids []string) ([]resource.Resource, error) {
+func FetchIAMPoliciesByIDs(ctx context.Context, api IAMListPoliciesAPI, ids []string, store iamPolicyStore) ([]resource.Resource, error) {
 	if len(ids) == 0 {
 		return nil, nil
 	}
-	allPoliciesMu.Lock()
-	defer allPoliciesMu.Unlock()
 
-	if !allManagedPoliciesBuilt {
-		allPoliciesByID = make(map[string]resource.Resource)
-		if err := buildAllManagedPolicies(ctx, api); err != nil {
+	if !store.ManagedBuilt() {
+		if err := buildAllManagedPolicies(ctx, api, store); err != nil {
 			return nil, err
 		}
-		allManagedPoliciesBuilt = true
+		store.MarkManagedBuilt()
 	}
 
 	var failures []string
@@ -303,7 +286,7 @@ func FetchIAMPoliciesByIDs(ctx context.Context, api IAMListPoliciesAPI, ids []st
 			continue
 		}
 		seen[id] = struct{}{}
-		if r, hit := allPoliciesByID[id]; hit {
+		if r, hit := store.Lookup(id); hit {
 			resources = append(resources, r)
 		} else {
 			failures = append(failures, fmt.Sprintf("%s: not found", id))
@@ -313,10 +296,10 @@ func FetchIAMPoliciesByIDs(ctx context.Context, api IAMListPoliciesAPI, ids []st
 }
 
 // buildAllManagedPolicies paginates ListPolicies(Scope=All) and populates
-// allPoliciesByID with every managed policy (customer + AWS). Caller MUST
-// hold allPoliciesMu. Each paginated ListPolicies call is wrapped in
-// RetryOnThrottle so throttling during large accounts is handled gracefully.
-func buildAllManagedPolicies(ctx context.Context, api IAMListPoliciesAPI) error {
+// the store with every managed policy (customer + AWS). Each paginated
+// ListPolicies call is wrapped in RetryOnThrottle so throttling during
+// large accounts is handled gracefully.
+func buildAllManagedPolicies(ctx context.Context, api IAMListPoliciesAPI, store iamPolicyStore) error {
 	var marker *string
 	for {
 		out, err := RetryOnThrottle(ctx, DefaultRetryConfig(), func() (*iam.ListPoliciesOutput, error) {
@@ -374,9 +357,9 @@ func buildAllManagedPolicies(ctx context.Context, api IAMListPoliciesAPI) error 
 			// Index by PolicyName AND by ARN so callers that emit ARN-based IDs
 			// (e.g. checkers that embed policy.Arn from SDK structs) can still
 			// resolve the policy via FetchIAMPoliciesByIDsFull.
-			allPoliciesByID[policyName] = r
+			store.Set(policyName, r)
 			if p.Arn != nil && *p.Arn != policyName {
-				allPoliciesByID[*p.Arn] = r
+				store.Set(*p.Arn, r)
 			}
 		}
 		if !out.IsTruncated || out.Marker == nil {

--- a/internal/demo/client.go
+++ b/internal/demo/client.go
@@ -3,6 +3,7 @@ package demo
 import (
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/demo/fakes"
+	"github.com/k2m30/a9s/v3/internal/session"
 )
 
 // DemoRegion is the synthetic region displayed in demo mode.
@@ -61,5 +62,6 @@ func NewServiceClients() *awsclient.ServiceClients {
 	clients.KMS = fakes.NewKMS()
 	clients.MSK = fakes.NewMSK()
 	clients.Backup = fakes.NewBackup()
+	clients.IAMPolicies = session.NewPolicyStore()
 	return clients
 }

--- a/internal/session/policy_store.go
+++ b/internal/session/policy_store.go
@@ -1,44 +1,106 @@
-// policy_store.go — session-scoped IAM policy document store interface and
-// thread-safe map-backed implementation.
+// policy_store.go — session-scoped IAM policy resource cache with per-phase
+// build memoization.
 //
-// NOT load-bearing in PR-02a; wired in PR-02b.
+// Made load-bearing in PR-02b (replaces the package-level globals in
+// internal/aws/iam_policies.go).
 package session
 
-import "sync"
+import (
+	"sync"
 
-// PolicyStore is a session-scoped store for IAM policy documents.
-// Implementations must be safe for concurrent use.
+	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// PolicyStore caches IAM policy resources keyed by both PolicyName and ARN.
+// The cache is built lazily on first lookup that misses, then memoized until
+// Clear (typically called by Session.Rotate on profile/region switch).
+//
+// PolicyStore tracks two independent build phases — managed (ListPolicies
+// Scope=All) and inline (ListGroups + ListGroupPolicies) — so a transient
+// failure during inline enumeration does NOT poison managed-policy lookups.
 type PolicyStore interface {
-	Get(arn string) (policy any, ok bool)
-	Set(arn string, policy any)
+	// Lookup returns the cached resource for the given key (PolicyName or
+	// ARN). Returns (zero, false) if the key isn't present in the cache.
+	Lookup(key string) (resource.Resource, bool)
+
+	// Set inserts a resource under the given key. Used by the build phase to
+	// populate the cache. Concurrent Set calls overwrite each other.
+	Set(key string, r resource.Resource)
+
+	// ManagedBuilt reports whether the managed-policy ListPolicies(Scope=All)
+	// build has completed successfully.
+	ManagedBuilt() bool
+	// MarkManagedBuilt sets the managed-built flag. Call after a successful
+	// ListPolicies(Scope=All) walk.
+	MarkManagedBuilt()
+
+	// InlineBuilt reports whether the inline-group-policy build has completed
+	// successfully. Stays false on partial failure so the next call retries.
+	InlineBuilt() bool
+	// MarkInlineBuilt sets the inline-built flag. Only call after a fully
+	// successful ListGroups + ListGroupPolicies walk.
+	MarkInlineBuilt()
+
+	// Clear empties the cache and resets both build flags.
 	Clear()
 }
 
 type policyStore struct {
-	mu sync.RWMutex
-	m  map[string]any
+	mu           sync.RWMutex
+	byID         map[string]resource.Resource
+	managedBuilt bool
+	inlineBuilt  bool
 }
 
 // NewPolicyStore returns a new thread-safe PolicyStore implementation.
 func NewPolicyStore() PolicyStore {
-	return &policyStore{m: map[string]any{}}
+	return &policyStore{byID: map[string]resource.Resource{}}
 }
 
-func (s *policyStore) Get(arn string) (any, bool) {
+func (s *policyStore) Lookup(key string) (resource.Resource, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	v, ok := s.m[arn]
-	return v, ok
+	r, ok := s.byID[key]
+	return r, ok
 }
 
-func (s *policyStore) Set(arn string, policy any) {
+func (s *policyStore) Set(key string, r resource.Resource) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.m[arn] = policy
+	if s.byID == nil {
+		s.byID = map[string]resource.Resource{}
+	}
+	s.byID[key] = r
+}
+
+func (s *policyStore) ManagedBuilt() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.managedBuilt
+}
+
+func (s *policyStore) MarkManagedBuilt() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.managedBuilt = true
+}
+
+func (s *policyStore) InlineBuilt() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.inlineBuilt
+}
+
+func (s *policyStore) MarkInlineBuilt() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inlineBuilt = true
 }
 
 func (s *policyStore) Clear() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.m = map[string]any{}
+	s.byID = map[string]resource.Resource{}
+	s.managedBuilt = false
+	s.inlineBuilt = false
 }

--- a/internal/session/policy_store_test.go
+++ b/internal/session/policy_store_test.go
@@ -5,95 +5,209 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/session"
 )
 
-// TestPolicyStore_GetMissing verifies that a fresh PolicyStore returns
-// (nil, false) for an absent key.
-func TestPolicyStore_GetMissing(t *testing.T) {
+// TestPolicyStore_LookupMissing verifies that a fresh PolicyStore returns
+// (resource.Resource{}, false) for an absent key, and that both build flags
+// start false.
+func TestPolicyStore_LookupMissing(t *testing.T) {
 	t.Parallel()
 
 	store := session.NewPolicyStore()
 
-	got, ok := store.Get("missing")
+	got, ok := store.Lookup("any")
 	if ok {
 		t.Error("expected ok=false for absent key, got true")
 	}
-	if got != nil {
-		t.Errorf("expected nil for absent key, got %v", got)
+	// Resource contains slice/map fields so direct == is invalid; check the
+	// identifying fields that must be empty on a zero-value return.
+	if got.ID != "" || got.Name != "" {
+		t.Errorf("expected zero Resource for absent key, got %+v", got)
+	}
+
+	if store.ManagedBuilt() {
+		t.Error("expected ManagedBuilt=false on fresh store")
+	}
+	if store.InlineBuilt() {
+		t.Error("expected InlineBuilt=false on fresh store")
 	}
 }
 
-// TestPolicyStore_SetThenGet verifies that a value stored via Set is
-// retrievable via Get with ok=true and the same value.
-func TestPolicyStore_SetThenGet(t *testing.T) {
+// TestPolicyStore_SetThenLookup verifies that a value stored via Set is
+// retrievable via Lookup with ok=true and the same value, and that a
+// different key still misses.
+func TestPolicyStore_SetThenLookup(t *testing.T) {
 	t.Parallel()
 
 	store := session.NewPolicyStore()
-	const arn = "arn:aws:iam::123456789012:policy/MyPolicy"
-	const doc = "policy-doc-string"
+	r := resource.Resource{ID: "policy-A", Name: "policy-A"}
 
-	store.Set(arn, doc)
+	store.Set("policy-A", r)
 
-	got, ok := store.Get(arn)
+	got, ok := store.Lookup("policy-A")
 	if !ok {
 		t.Fatal("expected ok=true after Set, got false")
 	}
-	if got != doc {
-		t.Errorf("Get returned %v, want %q", got, doc)
+	if got.ID != r.ID || got.Name != r.Name {
+		t.Errorf("Lookup returned %+v, want %+v", got, r)
+	}
+
+	_, ok2 := store.Lookup("policy-B")
+	if ok2 {
+		t.Error("expected ok=false for key 'policy-B' that was never set")
 	}
 }
 
 // TestPolicyStore_OverwriteSet verifies that a second Set on the same key
-// replaces the stored value, and Get returns the most recent value.
+// replaces the stored value, and Lookup returns the most recent resource.
 func TestPolicyStore_OverwriteSet(t *testing.T) {
 	t.Parallel()
 
 	store := session.NewPolicyStore()
-	const arn = "arn:aws:iam::123456789012:policy/Foo"
+	res1 := resource.Resource{ID: "id-1", Name: "first"}
+	res2 := resource.Resource{ID: "id-2", Name: "second"}
 
-	store.Set(arn, "first-value")
-	store.Set(arn, "second-value")
+	store.Set("k", res1)
+	store.Set("k", res2)
 
-	got, ok := store.Get(arn)
+	got, ok := store.Lookup("k")
 	if !ok {
 		t.Fatal("expected ok=true after overwrite, got false")
 	}
-	if got != "second-value" {
-		t.Errorf("Get returned %v, want %q", got, "second-value")
+	if got.ID != "id-2" || got.Name != "second" {
+		t.Errorf("Lookup returned %+v, want %+v", got, res2)
 	}
 }
 
-// TestPolicyStore_Clear verifies that Clear() removes all stored entries so
-// subsequent Get calls return (nil, false).
-func TestPolicyStore_Clear(t *testing.T) {
+// TestPolicyStore_KeyByNameAndARN pins the dual-key contract: both the policy
+// short name and its ARN must resolve to the same resource after two Set calls.
+func TestPolicyStore_KeyByNameAndARN(t *testing.T) {
+	t.Parallel()
+
+	store := session.NewPolicyStore()
+	r := resource.Resource{ID: "arn:aws:iam::123456789012:policy/AdminPolicy", Name: "AdminPolicy"}
+
+	store.Set("AdminPolicy", r)
+	store.Set("arn:aws:iam::123456789012:policy/AdminPolicy", r)
+
+	gotName, okName := store.Lookup("AdminPolicy")
+	if !okName {
+		t.Error("expected ok=true for short-name key")
+	}
+	if gotName.ID != r.ID {
+		t.Errorf("Lookup by name returned ID=%q, want %q", gotName.ID, r.ID)
+	}
+
+	gotARN, okARN := store.Lookup("arn:aws:iam::123456789012:policy/AdminPolicy")
+	if !okARN {
+		t.Error("expected ok=true for ARN key")
+	}
+	if gotARN.ID != r.ID {
+		t.Errorf("Lookup by ARN returned ID=%q, want %q", gotARN.ID, r.ID)
+	}
+}
+
+// TestPolicyStore_ManagedBuiltFlag verifies the ManagedBuilt flag lifecycle:
+// starts false, becomes true after MarkManagedBuilt, while InlineBuilt remains
+// independently false.
+func TestPolicyStore_ManagedBuiltFlag(t *testing.T) {
 	t.Parallel()
 
 	store := session.NewPolicyStore()
 
-	arns := []string{
+	if store.ManagedBuilt() {
+		t.Error("expected ManagedBuilt=false on fresh store")
+	}
+
+	store.MarkManagedBuilt()
+
+	if !store.ManagedBuilt() {
+		t.Error("expected ManagedBuilt=true after MarkManagedBuilt")
+	}
+	if store.InlineBuilt() {
+		t.Error("expected InlineBuilt=false — flags are independent")
+	}
+}
+
+// TestPolicyStore_InlineBuiltFlag verifies the InlineBuilt flag lifecycle:
+// starts false, becomes true after MarkInlineBuilt, while ManagedBuilt remains
+// independently false.
+func TestPolicyStore_InlineBuiltFlag(t *testing.T) {
+	t.Parallel()
+
+	store := session.NewPolicyStore()
+
+	if store.InlineBuilt() {
+		t.Error("expected InlineBuilt=false on fresh store")
+	}
+
+	store.MarkInlineBuilt()
+
+	if !store.InlineBuilt() {
+		t.Error("expected InlineBuilt=true after MarkInlineBuilt")
+	}
+	if store.ManagedBuilt() {
+		t.Error("expected ManagedBuilt=false — flags are independent")
+	}
+}
+
+// TestPolicyStore_ClearResetsAll verifies that Clear removes all stored
+// entries and resets both build flags to false.
+func TestPolicyStore_ClearResetsAll(t *testing.T) {
+	t.Parallel()
+
+	store := session.NewPolicyStore()
+
+	keys := []string{
 		"arn:aws:iam::111111111111:policy/A",
 		"arn:aws:iam::222222222222:policy/B",
 		"arn:aws:iam::333333333333:policy/C",
 	}
-	for _, arn := range arns {
-		store.Set(arn, "doc")
+	for i, k := range keys {
+		store.Set(k, resource.Resource{ID: k, Name: fmt.Sprintf("policy-%d", i)})
 	}
+	store.MarkManagedBuilt()
+	store.MarkInlineBuilt()
 
 	store.Clear()
 
-	for _, arn := range arns {
-		got, ok := store.Get(arn)
+	for _, k := range keys {
+		_, ok := store.Lookup(k)
 		if ok {
-			t.Errorf("expected ok=false for %q after Clear(), got true (value=%v)", arn, got)
+			t.Errorf("expected Lookup(%q)=false after Clear, got true", k)
 		}
+	}
+	if store.ManagedBuilt() {
+		t.Error("expected ManagedBuilt=false after Clear")
+	}
+	if store.InlineBuilt() {
+		t.Error("expected InlineBuilt=false after Clear")
 	}
 }
 
-// TestPolicyStore_ConcurrentSafe verifies that the PolicyStore implementation
-// is safe for concurrent use. 100 goroutines each Set and Get on disjoint
-// keys; the race detector validates no data race occurs.
-func TestPolicyStore_ConcurrentSafe(t *testing.T) {
+// TestPolicyStore_ClearIdempotent verifies that calling Clear multiple times
+// on a fresh store does not panic, and that a second Clear on a populated-then-
+// cleared store also does not panic.
+func TestPolicyStore_ClearIdempotent(t *testing.T) {
+	t.Parallel()
+
+	fresh := session.NewPolicyStore()
+	fresh.Clear()
+	fresh.Clear() // must not panic
+
+	populated := session.NewPolicyStore()
+	populated.Set("k", resource.Resource{ID: "k"})
+	populated.MarkManagedBuilt()
+	populated.Clear()
+	populated.Clear() // must not panic
+}
+
+// TestPolicyStore_ConcurrentSetLookup verifies race-free concurrent access:
+// 100 goroutines each Set and Lookup on disjoint keys; the race detector
+// validates no data race occurs.
+func TestPolicyStore_ConcurrentSetLookup(t *testing.T) {
 	t.Parallel()
 
 	store := session.NewPolicyStore()
@@ -106,10 +220,93 @@ func TestPolicyStore_ConcurrentSafe(t *testing.T) {
 		go func(n int) {
 			defer wg.Done()
 			key := fmt.Sprintf("arn:aws:iam::%012d:policy/P%d", n, n)
-			store.Set(key, n)
-			_, _ = store.Get(key)
+			r := resource.Resource{ID: key, Name: fmt.Sprintf("policy-%d", n)}
+			store.Set(key, r)
+			_, _ = store.Lookup(key)
 		}(i)
 	}
 
 	wg.Wait()
+}
+
+// TestPolicyStore_ConcurrentBuildFlagToggle verifies race-free concurrent
+// access to build flags: 50 goroutines mixing MarkManagedBuilt, ManagedBuilt,
+// MarkInlineBuilt, InlineBuilt, and Clear; the race detector validates no data
+// race occurs.
+func TestPolicyStore_ConcurrentBuildFlagToggle(t *testing.T) {
+	t.Parallel()
+
+	store := session.NewPolicyStore()
+
+	const workers = 50
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	for i := range workers {
+		go func(n int) {
+			defer wg.Done()
+			switch n % 5 {
+			case 0:
+				store.MarkManagedBuilt()
+			case 1:
+				_ = store.ManagedBuilt()
+			case 2:
+				store.MarkInlineBuilt()
+			case 3:
+				_ = store.InlineBuilt()
+			case 4:
+				store.Clear()
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+// TestPolicyStore_PartialFailureContract_InlineBuiltStaysFalseOnError pins the
+// IAM two-phase build contract:
+//
+//   - Phase 1 (managed): ListPolicies(Scope=All) — must fully succeed before
+//     MarkManagedBuilt is called.
+//   - Phase 2 (inline): ListGroups + per-group ListGroupPolicies — partial
+//     failures must NOT call MarkInlineBuilt, so that InlineBuilt stays false
+//     and the next call retries the entire inline phase.
+//
+// This test simulates a partial-failure inline build: some entries are Set but
+// MarkInlineBuilt is never called. It asserts InlineBuilt remains false while
+// the partial entries are still findable.
+func TestPolicyStore_PartialFailureContract_InlineBuiltStaysFalseOnError(t *testing.T) {
+	t.Parallel()
+
+	store := session.NewPolicyStore()
+
+	// Phase 1 completes successfully.
+	managed := resource.Resource{ID: "arn:aws:iam::123456789012:policy/Managed", Name: "Managed"}
+	store.Set("Managed", managed)
+	store.Set("arn:aws:iam::123456789012:policy/Managed", managed)
+	store.MarkManagedBuilt()
+
+	if !store.ManagedBuilt() {
+		t.Fatal("expected ManagedBuilt=true after phase 1")
+	}
+
+	// Phase 2 partial failure: some inline entries are written but the build
+	// aborts before completion — MarkInlineBuilt is intentionally NOT called.
+	partial := resource.Resource{ID: "arn:aws:iam::123456789012:policy/InlinePartial", Name: "InlinePartial"}
+	store.Set("InlinePartial", partial)
+
+	// Contract: InlineBuilt must remain false so callers know to retry phase 2.
+	if store.InlineBuilt() {
+		t.Error("InlineBuilt must be false when inline build did not complete — production must retry")
+	}
+
+	// Partial entries written before the failure are still accessible (callers
+	// may use whatever is present as a best-effort cache).
+	got, ok := store.Lookup("InlinePartial")
+	if !ok {
+		t.Error("partial inline entry must be findable via Lookup")
+	}
+	if got.ID != partial.ID {
+		t.Errorf("partial entry ID=%q, want %q", got.ID, partial.ID)
+	}
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -79,6 +79,12 @@ type Session struct {
 	// but that blurred the AWS-transport/session-state boundary; they live
 	// here instead and are passed to detail enrichers via DetailEnrichmentCtx.
 	PolicyDocCache *awsclient.PolicyDocumentCache
+
+	// IAMPolicies is the per-session cache for IAM policy resources, keyed by
+	// both PolicyName and ARN. Replaces the package-level globals previously in
+	// internal/aws/iam_policies.go. Wired into *ServiceClients.IAMPolicies on
+	// every ClientsReadyMsg so FetchIAMPoliciesByIDsFull uses the session store.
+	IAMPolicies PolicyStore
 }
 
 // New constructs a fresh Session with all maps initialized and generation
@@ -99,6 +105,7 @@ func New() *Session {
 		EnrichGen:              1,
 		EnrichmentGen:          1,
 		PolicyDocCache:         &awsclient.PolicyDocumentCache{},
+		IAMPolicies:            NewPolicyStore(),
 	}
 }
 
@@ -137,9 +144,7 @@ func (s *Session) Rotate() {
 	// documents fetched in the previous account cannot leak into the next.
 	s.PolicyDocCache = &awsclient.PolicyDocumentCache{}
 
-	// Process-wide lazy-add caches in internal/aws. These cache AWS names
-	// across drills within a session; they must be reset on session switch
-	// so stale entries from the prior account cannot satisfy FetchByIDs
-	// calls in the next one.
-	awsclient.ResetIAMPoliciesCache()
+	// IAMPolicies: reset to a fresh store so managed/inline entries from the
+	// prior account/profile cannot leak into the next session.
+	s.IAMPolicies = NewPolicyStore()
 }

--- a/internal/tui/app_handlers.go
+++ b/internal/tui/app_handlers.go
@@ -237,10 +237,12 @@ func (m Model) handleClientsReady(msg messages.ClientsReadyMsg) (tea.Model, tea.
 	if msg.Clients == nil {
 		if m.clients == nil && m.preSuppliedClients != nil {
 			// Fall back to pre-supplied clients (demo path) when msg carries no clients.
+			m.preSuppliedClients.IAMPolicies = m.IAMPolicies // wire per-session policy store
 			m.clients = m.preSuppliedClients
 		}
 	} else if clients, ok := msg.Clients.(*awsclient.ServiceClients); ok {
 		awsclient.ClearAllSESRuleSetCaches() // drop stale SES rule-set cache from prior *ServiceClients
+		clients.IAMPolicies = m.IAMPolicies  // wire per-session policy store into transport layer
 		m.clients = clients
 	} else {
 		wrongTypeErr := fmt.Errorf("internal: unexpected ClientsReadyMsg.Clients type %T", msg.Clients)

--- a/internal/tui/views/detail_fields.go
+++ b/internal/tui/views/detail_fields.go
@@ -29,22 +29,33 @@ func (m *DetailModel) buildFieldList() {
 		r.Type = m.resourceType
 	}
 	td := resource.FindResourceType(m.resourceType)
+	// Use m.navProvider to resolve navigable fields. The default (set in
+	// NewDetail) is resource.GetActiveNavigableFields (ACTIVE-only), which
+	// keeps tests isolated from init-time DEFAULT registry entries.
+	// TUI construction paths override this with resource.GetNavigableFields
+	// (merged ACTIVE+DEFAULT) via SetNavProvider.
+	navProv := m.navProvider
+	if navProv == nil {
+		navProv = resource.GetActiveNavigableFields
+	}
+	generic := projection.GenericWithConfigAndNavProvider(m.viewConfig, navProv)
+
 	var proj domain.DetailProjector
 	if td != nil && td.Project != nil {
 		proj = td.Project
 	} else {
-		// Use m.navProvider to resolve navigable fields. The default (set in
-		// NewDetail) is resource.GetActiveNavigableFields (ACTIVE-only), which
-		// keeps tests isolated from init-time DEFAULT registry entries.
-		// TUI construction paths override this with resource.GetNavigableFields
-		// (merged ACTIVE+DEFAULT) via SetNavProvider.
-		navProv := m.navProvider
-		if navProv == nil {
-			navProv = resource.GetActiveNavigableFields
-		}
-		proj = projection.GenericWithConfigAndNavProvider(m.viewConfig, navProv)
+		proj = generic
 	}
 	sections := proj(r)
+	// Fallback: a custom projector may legitimately return nil for resource
+	// shapes it can't render (e.g. ctevent.Project against a stub ct-events
+	// resource that only has ID/Name from a related-cache hit, with no raw
+	// event body). Without this fallback the detail pane regresses to
+	// "No detail data available". The generic projector renders such stubs
+	// from r.Fields just fine.
+	if len(sections) == 0 && td != nil && td.Project != nil {
+		sections = generic(r)
+	}
 	if td != nil && td.Augment != nil {
 		sections = td.Augment(r, sections)
 	}

--- a/tests/unit/aws_iam_policies_reset_test.go
+++ b/tests/unit/aws_iam_policies_reset_test.go
@@ -1,15 +1,12 @@
 package unit
 
-// aws_iam_policies_reset_test.go — Regression pins for ResetIAMPoliciesCache.
+// aws_iam_policies_reset_test.go — Regression pins for the PolicyStore-based
+// IAM policy cache (replaces the former package-level ResetIAMPoliciesCache).
 //
-// The cache (allPoliciesBuilt + allPoliciesByID) is process-wide. Without
-// ResetIAMPoliciesCache, a second call to FetchIAMPoliciesByIDs would return
-// stale data from a prior ListPolicies run even after a profile/region switch.
-//
-// Tests:
-//   TestResetIAMPoliciesCache_ForcesRebuildOnNextCall — proves the cache is rebuilt
-//     from a new mock after Reset, not from the previous mock's data.
-//   TestResetIAMPoliciesCache_Idempotent — calling Reset twice in a row does not panic.
+// Two Scenarios verified:
+//   TestPolicyStore_ClearForcesRebuild — proves the cache is rebuilt
+//     from a new mock after store.Clear(), not from stale prior data.
+//   TestPolicyStore_ClearIdempotent — calling Clear twice in a row must not panic.
 
 import (
 	"context"
@@ -21,6 +18,7 @@ import (
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/session"
 )
 
 // countingListPoliciesAPI is a minimal IAMListPoliciesAPI mock that returns
@@ -49,28 +47,25 @@ func (f *countingListPoliciesAPI) ListPolicies(_ context.Context, _ *iam.ListPol
 // Compile-time: countingListPoliciesAPI satisfies IAMListPoliciesAPI.
 var _ awsclient.IAMListPoliciesAPI = (*countingListPoliciesAPI)(nil)
 
-// TestResetIAMPoliciesCache_ForcesRebuildOnNextCall verifies that after
-// ResetIAMPoliciesCache is called, the next FetchIAMPoliciesByIDs call rebuilds
-// the internal cache from the new API client — not from the stale prior call.
+// TestPolicyStore_ClearForcesRebuild verifies that after store.Clear() is
+// called, the next FetchIAMPoliciesByIDs call rebuilds the cache from the
+// new API client — not from the stale prior call.
 //
 // Steps:
-//  1. Reset (defence against prior-test pollution).
+//  1. Construct a fresh store per test (no global pollution).
 //  2. Call FetchIAMPoliciesByIDs with mock1 (returns "policy-A").
 //     Assert mock1.calls == 1, result contains "policy-A".
 //  3. Call again with the same mock1. Assert mock1.calls still == 1 (cache hit).
-//  4. Call ResetIAMPoliciesCache().
+//  4. Call store.Clear().
 //  5. Call FetchIAMPoliciesByIDs with mock2 (returns "policy-B").
 //     Assert mock2.calls == 1, result contains "policy-B" (not stale "policy-A").
-func TestResetIAMPoliciesCache_ForcesRebuildOnNextCall(t *testing.T) {
-	t.Cleanup(func() { awsclient.ResetIAMPoliciesCache() })
-
-	// Step 1: Reset to eliminate pollution from prior tests.
-	awsclient.ResetIAMPoliciesCache()
+func TestPolicyStore_ClearForcesRebuild(t *testing.T) {
+	store := session.NewPolicyStore()
 
 	mock1 := &countingListPoliciesAPI{policyName: "policy-A"}
 
 	// Step 2: First call — must build the cache (ListPolicies called once).
-	res1, err := awsclient.FetchIAMPoliciesByIDs(context.Background(), mock1, []string{"policy-A"})
+	res1, err := awsclient.FetchIAMPoliciesByIDs(context.Background(), mock1, []string{"policy-A"}, store)
 	if err != nil {
 		t.Fatalf("FetchIAMPoliciesByIDs (mock1, first call): unexpected error: %v", err)
 	}
@@ -82,7 +77,7 @@ func TestResetIAMPoliciesCache_ForcesRebuildOnNextCall(t *testing.T) {
 	}
 
 	// Step 3: Second call with same mock — must be a cache hit (no extra API call).
-	res2, err := awsclient.FetchIAMPoliciesByIDs(context.Background(), mock1, []string{"policy-A"})
+	res2, err := awsclient.FetchIAMPoliciesByIDs(context.Background(), mock1, []string{"policy-A"}, store)
 	if err != nil {
 		t.Fatalf("FetchIAMPoliciesByIDs (mock1, second call): unexpected error: %v", err)
 	}
@@ -93,32 +88,32 @@ func TestResetIAMPoliciesCache_ForcesRebuildOnNextCall(t *testing.T) {
 		t.Errorf("second call: want [{ID:policy-A}], got %v", res2)
 	}
 
-	// Step 4: Reset.
-	awsclient.ResetIAMPoliciesCache()
+	// Step 4: Clear the store.
+	store.Clear()
 
 	// Step 5: Call with mock2 — must rebuild from mock2 (returns "policy-B").
 	mock2 := &countingListPoliciesAPI{policyName: "policy-B"}
-	res3, err := awsclient.FetchIAMPoliciesByIDs(context.Background(), mock2, []string{"policy-B"})
+	res3, err := awsclient.FetchIAMPoliciesByIDs(context.Background(), mock2, []string{"policy-B"}, store)
 	if err != nil {
-		t.Fatalf("FetchIAMPoliciesByIDs (mock2, post-reset): unexpected error: %v", err)
+		t.Fatalf("FetchIAMPoliciesByIDs (mock2, post-clear): unexpected error: %v", err)
 	}
 	if mock2.calls.Load() != 1 {
-		t.Errorf("mock2.calls after reset+fetch: want 1, got %d", mock2.calls.Load())
+		t.Errorf("mock2.calls after clear+fetch: want 1, got %d", mock2.calls.Load())
 	}
 	if len(res3) != 1 || res3[0].ID != "policy-B" {
-		t.Errorf("post-reset call: want [{ID:policy-B}], got %v — stale cache from mock1 not cleared", res3)
+		t.Errorf("post-clear call: want [{ID:policy-B}], got %v — stale cache from mock1 not cleared", res3)
 	}
 }
 
-// TestResetIAMPoliciesCache_Idempotent verifies that calling ResetIAMPoliciesCache
-// twice in a row without an intervening fetch does not panic or produce an error.
+// TestPolicyStore_ClearIdempotent verifies that calling store.Clear() twice
+// in a row without an intervening fetch does not panic or produce an error.
 //
-// Regression: if Reset had non-idempotent cleanup (e.g., double-free of a map)
+// Regression: if Clear had non-idempotent cleanup (e.g., double-free of a map)
 // it would panic here.
-func TestResetIAMPoliciesCache_Idempotent(t *testing.T) {
-	t.Cleanup(func() { awsclient.ResetIAMPoliciesCache() })
+func TestPolicyStore_ClearIdempotent(t *testing.T) {
+	store := session.NewPolicyStore()
 
-	// Two resets in a row — must not panic.
-	awsclient.ResetIAMPoliciesCache()
-	awsclient.ResetIAMPoliciesCache()
+	// Two clears in a row — must not panic.
+	store.Clear()
+	store.Clear()
 }

--- a/tests/unit/qa_iam_policy_lazy_retry_test.go
+++ b/tests/unit/qa_iam_policy_lazy_retry_test.go
@@ -8,10 +8,10 @@ package unit
 // error. This meant a transient ListGroupPolicies throttle permanently prevented
 // inline policy resolution on subsequent calls within the same session.
 //
-// Contract after fix (internal/aws/iam_policies.go:224-228):
+// Contract after fix (internal/aws/iam_policies.go):
 //   - When fetchInlineGroupPolicies returns (inlines, inlineErr) with inlineErr != nil,
-//     allInlinePoliciesBuilt remains false → next call retries the inline fetch.
-//   - When fetchInlineGroupPolicies succeeds, allInlinePoliciesBuilt=true → cached.
+//     store.InlineBuilt() remains false → next call retries the inline fetch.
+//   - When fetchInlineGroupPolicies succeeds, store.MarkInlineBuilt() is called → cached.
 //   - Partial inline results from the first (errored) call are incorporated AND
 //     the composite error is propagated (never-silent-skip).
 //   - The second call (after retry succeeds) finds the inline policy by name.
@@ -26,6 +26,7 @@ import (
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/session"
 )
 
 // iamPolicyRetryFake implements IAMAPI for the inline retry test.
@@ -56,7 +57,7 @@ func (f *iamPolicyRetryFake) ListPolicies(
 	_ ...func(*iam.Options),
 ) (*iam.ListPoliciesOutput, error) {
 	return &iam.ListPoliciesOutput{
-		Policies:   f.managedPolicies,
+		Policies:    f.managedPolicies,
 		IsTruncated: false,
 	}, nil
 }
@@ -87,15 +88,14 @@ func (f *iamPolicyRetryFake) ListGroupPolicies(
 }
 
 // TestFetchIAMPoliciesByIDsFull_InlineRetryOnError verifies the retry contract:
-// first call fails inline fetch → allInlinePoliciesBuilt stays false;
+// first call fails inline fetch → store.InlineBuilt() stays false;
 // second call succeeds → inline policy found in result.
 //
-// Fails pre-fix: allInlinePoliciesBuilt was set true on error, so the second
+// Fails pre-fix: InlineBuilt was set true on error, so the second
 // call skipped inline fetch and never found the inline policy by name.
-// Passes post-fix: allInlinePoliciesBuilt remains false → second call retries.
+// Passes post-fix: InlineBuilt remains false → second call retries.
 func TestFetchIAMPoliciesByIDsFull_InlineRetryOnError(t *testing.T) {
-	awsclient.ResetIAMPoliciesCache()
-	t.Cleanup(awsclient.ResetIAMPoliciesCache)
+	store := session.NewPolicyStore()
 
 	const (
 		managedPolicyID   = "arn:aws:iam::123456789012:policy/MyManagedPolicy"
@@ -130,8 +130,8 @@ func TestFetchIAMPoliciesByIDsFull_InlineRetryOnError(t *testing.T) {
 	// Contract:
 	//   - Managed policy is found (buildAllManagedPolicies succeeds).
 	//   - Inline fetch fails → composite error returned alongside partial results.
-	//   - allInlinePoliciesBuilt must remain false.
-	results1, err1 := awsclient.FetchIAMPoliciesByIDsFull(ctx, fake, []string{managedPolicyID})
+	//   - store.InlineBuilt() must remain false.
+	results1, err1 := awsclient.FetchIAMPoliciesByIDsFull(ctx, fake, []string{managedPolicyID}, store)
 
 	// Managed policy should be found even with inline failure.
 	if len(results1) == 0 {
@@ -156,7 +156,7 @@ func TestFetchIAMPoliciesByIDsFull_InlineRetryOnError(t *testing.T) {
 	// Now remove the inline error so retry can succeed.
 	fake.listGroupPoliciesErr = nil
 
-	results2, err2 := awsclient.FetchIAMPoliciesByIDsFull(ctx, fake, []string{inlinePolicyName})
+	results2, err2 := awsclient.FetchIAMPoliciesByIDsFull(ctx, fake, []string{inlinePolicyName}, store)
 
 	if err2 != nil {
 		t.Errorf("call 2: expected no error after inline retry; got %v", err2)
@@ -168,24 +168,23 @@ func TestFetchIAMPoliciesByIDsFull_InlineRetryOnError(t *testing.T) {
 		}
 	}
 	if !foundInline {
-		// CONTRACT ASSERTION: this fails pre-fix (allInlinePoliciesBuilt=true meant
+		// CONTRACT ASSERTION: this fails pre-fix (InlineBuilt=true meant
 		// inline fetch never retried, so inlinePolicyName was never added to cache).
-		t.Errorf("call 2: inline policy %q not found — " +
-			"PRE-FIX BUG: allInlinePoliciesBuilt was set true on error, preventing retry; " +
-			"allInlinePoliciesBuilt must stay false on inline error so next call retries",
+		t.Errorf("call 2: inline policy %q not found — "+
+			"PRE-FIX BUG: InlineBuilt was set true on error, preventing retry; "+
+			"InlineBuilt must stay false on inline error so next call retries",
 			inlinePolicyName)
 	}
 }
 
 // TestFetchIAMPoliciesByIDsFull_InlineCachedOnSuccess verifies that when
-// inline fetch succeeds, allInlinePoliciesBuilt=true is set, and subsequent
+// inline fetch succeeds, store.InlineBuilt() is set to true, and subsequent
 // calls do NOT re-invoke ListGroupPolicies (cache hit).
 func TestFetchIAMPoliciesByIDsFull_InlineCachedOnSuccess(t *testing.T) {
-	awsclient.ResetIAMPoliciesCache()
-	t.Cleanup(awsclient.ResetIAMPoliciesCache)
+	store := session.NewPolicyStore()
 
 	const inlinePolicyName = "inline-cached-policy"
-	const inlineGroupName  = "dev-team"
+	const inlineGroupName = "dev-team"
 
 	listGroupPoliciesCallCount := 0
 	fake := &iamPolicyRetryFake{
@@ -208,7 +207,7 @@ func TestFetchIAMPoliciesByIDsFull_InlineCachedOnSuccess(t *testing.T) {
 	ctx := context.Background()
 
 	// Call 1: inline fetch succeeds → should call ListGroupPolicies.
-	_, err1 := awsclient.FetchIAMPoliciesByIDsFull(ctx, countingFake, []string{inlinePolicyName})
+	_, err1 := awsclient.FetchIAMPoliciesByIDsFull(ctx, countingFake, []string{inlinePolicyName}, store)
 	if err1 != nil {
 		t.Errorf("call 1: unexpected error: %v", err1)
 	}
@@ -218,7 +217,7 @@ func TestFetchIAMPoliciesByIDsFull_InlineCachedOnSuccess(t *testing.T) {
 	callsAfterFirst := listGroupPoliciesCallCount
 
 	// Call 2: inline cache should be warm — ListGroupPolicies must NOT be called again.
-	_, err2 := awsclient.FetchIAMPoliciesByIDsFull(ctx, countingFake, []string{inlinePolicyName})
+	_, err2 := awsclient.FetchIAMPoliciesByIDsFull(ctx, countingFake, []string{inlinePolicyName}, store)
 	if err2 != nil {
 		t.Errorf("call 2: unexpected error: %v", err2)
 	}

--- a/tests/unit/views_detail_ct_events_test.go
+++ b/tests/unit/views_detail_ct_events_test.go
@@ -229,6 +229,18 @@ func TestDetailViewCTEvents_NoRawJSON_RendersFlatFields(t *testing.T) {
 	if view == "" {
 		t.Error("ct-events detail View() returned empty string for bare stub resource")
 	}
+	// Regression pin: when ctevent.Project returns nil for stub resources
+	// (no raw event body), buildFieldList must fall back to the generic
+	// projector so r.Fields still renders. Without the fallback the pane
+	// shows "No detail data available" instead.
+	if strings.Contains(view, "No detail data available") {
+		t.Errorf("stub ct-events resource rendered as 'No detail data available'; "+
+			"expected fallback to generic projector to render r.Fields. View:\n%s", view)
+	}
+	if !strings.Contains(view, "FallbackEvent") {
+		t.Errorf("stub ct-events resource missing event_name value 'FallbackEvent' in View; "+
+			"generic projector must render r.Fields when ctevent.Project yields nil. View:\n%s", view)
+	}
 }
 
 // TestDetailViewCTEvents_BrokenRawJSON_SurfacesExplicitError pins #280: when a


### PR DESCRIPTION
## Summary

Phase 02 PR-02b per docs/refactor/02-session-owner.md, plus a P2 detail-fallback regression fix.

**Two commits:**

1. **`refactor(phase-02-pr02b): IAM PolicyStore`** — replace 4 package-level globals in `internal/aws/iam_policies.go` (`allPoliciesMu`, `allManagedPoliciesBuilt`, `allInlinePoliciesBuilt`, `allPoliciesByID`) and the exported `ResetIAMPoliciesCache` with a Session-owned `PolicyStore` capability. The IAM-specific interface has typed `resource.Resource` storage and two independent build-phase flags (managed/inline) so the inline-throttle retry contract holds.

2. **`fix(detail): fall back to generic projector when custom yields nil`** — restore the legacy behavior where stub ct-events resources (cache-hit Resources with only ID/Name and no raw event body) render via the generic projector instead of regressing to "No detail data available".

## Stacking

Stacked on PR #302 (`021-phase02-pr02a-session-skeleton`) which is stacked on PR #301 (`020-architecture-refactor`). All three are gated on PR #301 merging to main.

## Exit criteria (PR-02b, all ✓)

- `rg 'allPoliciesMu|allManagedPoliciesBuilt|allInlinePoliciesBuilt|allPoliciesByID|ResetIAMPoliciesCache' internal/` — zero hits in production
- `rg 'sync\.(R?W?)Mutex' internal/aws/iam_policies.go` — zero hits
- `rg 'PolicyStore' internal/aws/` — hits in `iam_policies.go` and `client.go` (now load-bearing)
- `rg 'awsclient\.Reset' internal/session/` — zero hits
- The retry contract pin (`TestFetchIAMPoliciesByIDsFull_InlineRetryOnError`) still passes

## Test plan

- [x] `go build ./...` clean
- [x] `make test` (13,371 pass)
- [x] `make test-race` (50s, race-clean)
- [x] `make lint` (0 issues)
- [x] `make security` (no vulnerabilities)
- [x] `make gofix` PASS
- [x] PolicyStore test suite (11 tests, race-clean)
- [x] Detail-fallback regression test (`TestDetailViewCTEvents_NoRawJSON_RendersFlatFields`) — both new assertions pass

## Out of scope

PR-02c (IdentityStore), PR-02d (RuleSetStore), PR-02e (single rotation path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
