### PR TITLE
fix(prefetch): preserve pagination tokens when seeding ResourceCache

### DIFF
--- a/internal/tui/app_handlers_availability.go
+++ b/internal/tui/app_handlers_availability.go
@@ -145,9 +145,18 @@ func (m Model) handleAvailabilityPrefetched(msg messages.AvailabilityPrefetchedM
 			if _, exists := m.ResourceCache[rt]; exists {
 				continue
 			}
+			// Prefer the full PaginationMeta from the prefetcher when available
+			// (carries NextToken so a later load-more / drill can advance past
+			// page 1). Fall back to the truncation-only synthetic only when the
+			// prefetcher didn't supply pagination metadata — that path keeps
+			// pre-fix behavior for any test or message that omits Pagination.
+			pageMeta := msg.Pagination[rt]
+			if pageMeta == nil {
+				pageMeta = &resource.PaginationMeta{IsTruncated: msg.Truncated[rt]}
+			}
 			m.ResourceCache[rt] = &session.ResourceCacheEntry{
 				Resources:  resources,
-				Pagination: &resource.PaginationMeta{IsTruncated: msg.Truncated[rt]},
+				Pagination: pageMeta,
 			}
 		}
 	}

--- a/internal/tui/app_probes.go
+++ b/internal/tui/app_probes.go
@@ -217,6 +217,7 @@ func (m *Model) demoPrefetchCounts() tea.Cmd {
 		issueCounts := make(map[string]int, len(allNames))
 		issueTruncated := make(map[string]bool)
 		retainedResources := make(map[string][]resource.Resource, len(allNames))
+		pagination := make(map[string]*resource.PaginationMeta, len(allNames))
 		var failures []string
 		attempted := 0
 		for _, shortName := range allNames {
@@ -244,6 +245,12 @@ func (m *Model) demoPrefetchCounts() tea.Cmd {
 				}
 			}
 			entries[shortName] = len(result.Resources)
+			// Preserve full pagination meta (NextToken etc.) so the seeded
+			// ResourceCache entry's pagination state is authoritative — a later
+			// load-more or navigate must be able to advance past page 1.
+			if result.Pagination != nil {
+				pagination[shortName] = result.Pagination
+			}
 			isTrunc := result.Pagination != nil && result.Pagination.IsTruncated
 			if isTrunc {
 				truncated[shortName] = true
@@ -267,6 +274,7 @@ func (m *Model) demoPrefetchCounts() tea.Cmd {
 			IssueCounts:    issueCounts,
 			IssueTruncated: issueTruncated,
 			Resources:      retainedResources,
+			Pagination:     pagination,
 			Gen:            gen,
 			PrefetchErr:    awsclient.AggregateFailures("availability-prefetch", failures, attempted),
 		}

--- a/internal/tui/messages/messages.go
+++ b/internal/tui/messages/messages.go
@@ -222,12 +222,13 @@ type AvailabilityCacheLoadedMsg struct {
 // AvailabilityCacheLoadedMsg it does NOT trigger background probes — all counts
 // are already populated.
 type AvailabilityPrefetchedMsg struct {
-	Entries        map[string]int                 // shortName -> resource count
-	Truncated      map[string]bool                // shortName -> true if truncated
-	IssueCounts    map[string]int                 // shortName -> issue-status resource count
-	IssueTruncated map[string]bool                // shortName -> true if issue count is lower bound
-	Resources      map[string][]resource.Resource // shortName -> retained first-page resources for Wave 2
-	Gen            int                            // availabilityGen captured at dispatch — stale if != current
+	Entries        map[string]int                       // shortName -> resource count
+	Truncated      map[string]bool                      // shortName -> true if truncated
+	IssueCounts    map[string]int                       // shortName -> issue-status resource count
+	IssueTruncated map[string]bool                      // shortName -> true if issue count is lower bound
+	Resources      map[string][]resource.Resource       // shortName -> retained first-page resources for Wave 2
+	Pagination     map[string]*resource.PaginationMeta  // shortName -> full pagination meta (NextToken, etc.) for cache seeding
+	Gen            int                                  // availabilityGen captured at dispatch — stale if != current
 	// PrefetchErr is the composite error aggregating per-type fetch failures
 	// during the synchronous availability prefetch. Non-nil when any paginated
 	// fetcher errored; the app handler surfaces it as a FlashMsg so operators

--- a/tests/unit/qa_prefetch_pagination_seed_test.go
+++ b/tests/unit/qa_prefetch_pagination_seed_test.go
@@ -1,0 +1,118 @@
+package unit
+
+// qa_prefetch_pagination_seed_test.go — regression pin for the prefetch
+// pagination-seed bug (P1 finding).
+//
+// Bug: In demo / --no-cache sessions, the synchronous availability prefetch
+// retains only the first page of each paginated fetcher. Pre-fix, the
+// AvailabilityPrefetchedMsg handler synthesized a PaginationMeta that kept
+// only IsTruncated, discarding the original NextToken. That turned the
+// seeded entry into an apparent full-cache hit on the next OpenList /
+// load-more path, but no further pages could ever be fetched — pagination
+// was dead.
+//
+// Fix: AvailabilityPrefetchedMsg now carries the full per-type
+// PaginationMeta map, and handleAvailabilityPrefetched seeds the
+// ResourceCache with that meta when present. Synthetic IsTruncated-only
+// remains as a fallback for callers (tests / messages) that don't supply
+// the new Pagination field.
+//
+// This test pins both:
+//  1. Full pagination (NextToken etc.) survives the prefetch → cache seed.
+//  2. The legacy fallback still works when Pagination is omitted.
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/k2m30/a9s/v3/internal/resource"
+	"github.com/k2m30/a9s/v3/internal/tui/messages"
+)
+
+// TestPrefetchPaginationSeed_PreservesNextToken — when the prefetched message
+// carries a full PaginationMeta with NextToken, the seeded ResourceCache entry
+// MUST keep that NextToken so a later load-more path can advance.
+func TestPrefetchPaginationSeed_PreservesNextToken(t *testing.T) {
+	m := newRootSizedModel()
+	m, _ = rootApplyMsg(m, tea.WindowSizeMsg{Width: 120, Height: 36})
+
+	const targetType = "ec2"
+	first := resource.Resource{ID: "i-001", Name: "i-001"}
+	second := resource.Resource{ID: "i-002", Name: "i-002"}
+
+	wantMeta := &resource.PaginationMeta{
+		IsTruncated: true,
+		NextToken:   "page-2-cursor",
+		PageSize:    2,
+		TotalHint:   -1,
+	}
+
+	m, _ = rootApplyMsg(m, messages.AvailabilityPrefetchedMsg{
+		Entries:        map[string]int{targetType: 2},
+		Truncated:      map[string]bool{targetType: true},
+		IssueCounts:    map[string]int{targetType: 0},
+		IssueTruncated: map[string]bool{targetType: true},
+		Resources:      map[string][]resource.Resource{targetType: {first, second}},
+		Pagination:     map[string]*resource.PaginationMeta{targetType: wantMeta},
+		Gen:            0,
+	})
+
+	entry, ok := m.ResourceCache[targetType]
+	if !ok {
+		t.Fatalf("expected ResourceCache entry for %q after prefetch seed; got nil", targetType)
+	}
+	if entry.Pagination == nil {
+		t.Fatalf("seeded entry has nil Pagination; expected to be carried over from msg.Pagination")
+	}
+	if entry.Pagination.NextToken != wantMeta.NextToken {
+		t.Errorf("NextToken lost in seed: got %q, want %q — pagination cannot advance past page 1",
+			entry.Pagination.NextToken, wantMeta.NextToken)
+	}
+	if !entry.Pagination.IsTruncated {
+		t.Errorf("IsTruncated lost in seed; want true")
+	}
+	if entry.Pagination.PageSize != wantMeta.PageSize {
+		t.Errorf("PageSize lost: got %d, want %d", entry.Pagination.PageSize, wantMeta.PageSize)
+	}
+	if entry.Pagination.TotalHint != wantMeta.TotalHint {
+		t.Errorf("TotalHint lost: got %d, want %d", entry.Pagination.TotalHint, wantMeta.TotalHint)
+	}
+}
+
+// TestPrefetchPaginationSeed_FallbackWhenPaginationOmitted — when an old-style
+// message arrives without the Pagination field, the seed still produces a
+// minimum-viable PaginationMeta with IsTruncated set from the legacy
+// Truncated map. This preserves backward compatibility for any test/message
+// that doesn't construct Pagination.
+func TestPrefetchPaginationSeed_FallbackWhenPaginationOmitted(t *testing.T) {
+	m := newRootSizedModel()
+	m, _ = rootApplyMsg(m, tea.WindowSizeMsg{Width: 120, Height: 36})
+
+	const targetType = "rds"
+	r := resource.Resource{ID: "db-001", Name: "db-001"}
+
+	m, _ = rootApplyMsg(m, messages.AvailabilityPrefetchedMsg{
+		Entries:        map[string]int{targetType: 1},
+		Truncated:      map[string]bool{targetType: true},
+		IssueCounts:    map[string]int{targetType: 0},
+		IssueTruncated: map[string]bool{targetType: true},
+		Resources:      map[string][]resource.Resource{targetType: {r}},
+		// Pagination intentionally nil — pre-fix shape.
+		Gen: 0,
+	})
+
+	entry, ok := m.ResourceCache[targetType]
+	if !ok {
+		t.Fatalf("expected ResourceCache entry for %q after fallback prefetch seed; got nil", targetType)
+	}
+	if entry.Pagination == nil {
+		t.Fatalf("fallback seed: expected synthetic PaginationMeta, got nil")
+	}
+	if !entry.Pagination.IsTruncated {
+		t.Errorf("fallback seed dropped IsTruncated; expected true from msg.Truncated")
+	}
+	if entry.Pagination.NextToken != "" {
+		t.Errorf("fallback seed leaked NextToken %q; expected empty", entry.Pagination.NextToken)
+	}
+}


### PR DESCRIPTION
## Summary

P1 regression fix: preserve pagination tokens when seeding `ResourceCache` from prefetched first pages.

In demo / `--no-cache` sessions, `AvailabilityPrefetchedMsg` previously seeded the cache with a synthetic `PaginationMeta` that kept only `IsTruncated`, discarding the original `NextToken`. The seeded entry then looked like a complete cache hit on later navigation, but no further pages could be fetched — pagination was effectively dead for any truncated resource type.

## Changes

- `messages/messages.go` — `AvailabilityPrefetchedMsg` gains `Pagination map[string]*resource.PaginationMeta`.
- `app_probes.go` — `demoPrefetchCounts` records full `result.Pagination` per type.
- `app_handlers_availability.go` — seed uses `msg.Pagination[rt]` when present, fallback to synthetic `IsTruncated`-only otherwise (back-compat for tests/messages without the new field).

## Test plan

- [x] `go build ./...` clean
- [x] `make test` (13,373 pass — 2 new regression tests in `qa_prefetch_pagination_seed_test.go`)
- [x] `make lint` (0 issues)
- [x] `TestPrefetchPaginationSeed_PreservesNextToken` — pins NextToken/PageSize/TotalHint round-trip
- [x] `TestPrefetchPaginationSeed_FallbackWhenPaginationOmitted` — pins legacy fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)
