### PR TITLE
refactor(phase-02-pr02c): IdentityStore — replace package globals

### DIFF
--- a/internal/aws/client.go
+++ b/internal/aws/client.go
@@ -53,12 +53,21 @@ import (
 )
 
 // ServiceClients holds AWS service clients for all supported services.
-// IAMPolicies must be set to the session's PolicyStore before any
-// FetchIAMPoliciesByIDsFull calls; see internal/tui/app_handlers.go.
+// IAMPolicies and IdentityStore must be set to the session's stores before
+// any FetchIAMPoliciesByIDsFull / Pattern-C related-check call; see
+// internal/tui/app_handlers.go.
 type ServiceClients struct {
 	// IAMPolicies is the session-scoped IAM policy resource cache. Set by the
 	// TUI layer from session.Session.IAMPolicies on every ClientsReadyMsg.
 	IAMPolicies iamPolicyStore
+
+	// IdentityStore is the session-scoped caller-identity (account ID) cache.
+	// Used by Pattern-C related checkers (Glue tags, EBS Backup) to construct
+	// resource ARNs from the account ID. Set by the TUI layer from
+	// session.Session.Identity on every ClientsReadyMsg. Nil-safe at the
+	// call-site: accountIDFromClients falls back to a fresh STS call if the
+	// store is nil (defensive — production wires it).
+	IdentityStore identityStore
 
 	EC2              EC2API
 	S3               S3API

--- a/internal/aws/ebs_related.go
+++ b/internal/aws/ebs_related.go
@@ -159,7 +159,7 @@ func checkEBSBackup(ctx context.Context, clients any, res resource.Resource, _ r
 		return resource.RelatedCheckResult{TargetType: "backup", Count: -1}
 	}
 	region := regionFromEnv()
-	account := accountIDFromClients(ctx, c)
+	account := accountIDFromClients(ctx, c, c.IdentityStore)
 	if region == "" || account == "" {
 		return resource.RelatedCheckResult{TargetType: "backup", Count: -1}
 	}

--- a/internal/aws/glue_related.go
+++ b/internal/aws/glue_related.go
@@ -124,7 +124,7 @@ func checkGlueCFN(ctx context.Context, clients any, res resource.Resource, cache
 		return resource.RelatedCheckResult{TargetType: "cfn", Count: -1}
 	}
 	region := regionFromEnv()
-	account := accountIDFromClients(ctx, c)
+	account := accountIDFromClients(ctx, c, c.IdentityStore)
 	if region == "" || account == "" {
 		return resource.RelatedCheckResult{TargetType: "cfn", Count: -1}
 	}

--- a/internal/aws/identity_cache.go
+++ b/internal/aws/identity_cache.go
@@ -1,53 +1,90 @@
-// identity_cache.go provides a lazy, per-process cache for the caller's AWS
+// identity_cache.go provides a session-scoped lookup for the caller's AWS
 // account ID and the resolved region. Used by related-panel Pattern C checkers
 // that need to construct resource ARNs for APIs like Backup
 // ListRecoveryPointsByResource and Glue GetTags.
 //
-// Resolution is best-effort: the cache is populated on first access via STS
-// GetCallerIdentity (for account) and falls back to environment AWS_REGION
-// or us-east-1 when region isn't otherwise known. Callers receive "" from
-// these helpers when the info cannot be resolved; honest Count: -1 follows.
+// Resolution is best-effort: the per-session store is populated on first
+// access via STS GetCallerIdentity (for account) and falls back to environment
+// AWS_REGION or us-east-1 when region isn't otherwise known. Callers receive
+// "" from these helpers when the info cannot be resolved; honest Count: -1
+// follows.
+//
+// Concurrency note (PR-02b precedent): no top-level lock is held across the
+// "check store / fetch / set" sequence. Two concurrent Pattern C checks may
+// both observe AccountID()=="" + Err()==nil and both invoke
+// STS.GetCallerIdentity. The store itself remains correct; duplicate Set
+// calls converge. Acceptable because related-panel checks are not
+// high-volume.
 package aws
 
 import (
 	"context"
 	"os"
-	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
-var (
-	identityCacheMu sync.Mutex //nolint:gochecknoglobals // process-scoped Pattern C cache
+// identityStore is the unexported shape internal/aws expects from a
+// per-Session identity cache. session.IdentityStore satisfies this via
+// duck-typing — internal/aws cannot import internal/session without a cycle,
+// so the local interface mirrors the methods needed here.
+type identityStore interface {
+	AccountID() string
+	Err() error
+	Set(id string, err error)
+}
 
-	cachedAccountID string //nolint:gochecknoglobals // set once; cleared on profile/region switch
-
-	cachedAccountErr error //nolint:gochecknoglobals
-)
-
-// accountIDFromClients returns the caller's AWS account ID, fetched and cached
-// via STS GetCallerIdentity on first call. Returns "" on any failure so
-// callers emit Count: -1.
-func accountIDFromClients(ctx context.Context, c *ServiceClients) string {
-	identityCacheMu.Lock()
-	defer identityCacheMu.Unlock()
-	if cachedAccountID != "" {
-		return cachedAccountID
+// accountIDFromClients returns the caller's AWS account ID, fetched and
+// cached via STS GetCallerIdentity on first call. Returns "" on any failure
+// so callers emit Count: -1.
+//
+// The store argument carries per-session state; pass c.IdentityStore at the
+// call site so each profile/region session uses an isolated cache.
+func accountIDFromClients(ctx context.Context, c *ServiceClients, store identityStore) string {
+	if store == nil {
+		// Defensive: store must always be wired by handleClientsReady. Fall
+		// back to a fresh STS call so the related-checker still works (slow
+		// path) but log nothing — surfacing a missing-store error here would
+		// just spam the flash log on every related-check pass.
+		return liveAccountID(ctx, c)
 	}
-	if cachedAccountErr != nil {
+	if id := store.AccountID(); id != "" {
+		return id
+	}
+	if store.Err() != nil {
 		return ""
 	}
+	id := liveAccountID(ctx, c)
+	if id == "" {
+		store.Set("", errAccountUnresolved)
+		return ""
+	}
+	store.Set(id, nil)
+	return id
+}
+
+// liveAccountID issues a fresh STS GetCallerIdentity call and returns the
+// account ID, or "" on any failure (no client, no STS API, API error, nil
+// response).
+func liveAccountID(ctx context.Context, c *ServiceClients) string {
 	if c == nil || c.STS == nil {
 		return ""
 	}
 	out, err := c.STS.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil || out == nil || out.Account == nil {
-		cachedAccountErr = err
 		return ""
 	}
-	cachedAccountID = *out.Account
-	return cachedAccountID
+	return *out.Account
 }
+
+// errAccountUnresolved sentinel marks a sticky failure: the STS fetch was
+// attempted and returned nothing useful. Stored in IdentityStore.Err() so
+// subsequent calls within the session skip retry.
+var errAccountUnresolved = errSentinel("account-unresolved")
+
+type errSentinel string
+
+func (e errSentinel) Error() string { return string(e) }
 
 // regionFromEnv reads the default region from AWS_REGION or AWS_DEFAULT_REGION.
 // Returns "" if neither is set — callers must Count: -1 in that case.

--- a/internal/demo/client.go
+++ b/internal/demo/client.go
@@ -63,5 +63,6 @@ func NewServiceClients() *awsclient.ServiceClients {
 	clients.MSK = fakes.NewMSK()
 	clients.Backup = fakes.NewBackup()
 	clients.IAMPolicies = session.NewPolicyStore()
+	clients.IdentityStore = session.NewIdentityStore()
 	return clients
 }

--- a/internal/session/identity_store.go
+++ b/internal/session/identity_store.go
@@ -1,46 +1,76 @@
 // identity_store.go — session-scoped caller identity store interface and
 // thread-safe implementation.
 //
-// NOT load-bearing in PR-02a; wired in PR-02c.
+// Wired by PR-02c (replaces the package-globals previously in
+// internal/aws/identity_cache.go).
 package session
 
 import "sync"
 
-// IdentityStore is a session-scoped store for the AWS caller identity.
+// IdentityStore is a session-scoped cache for the AWS caller's account ID.
+// Pattern C related-checkers (e.g. Backup ListRecoveryPointsByResource, Glue
+// GetTags) need the caller's account to construct ARNs; this store memoizes
+// the STS GetCallerIdentity result for the lifetime of one Session.
+//
+// The store records BOTH success (cached AccountID) and failure (cached
+// non-nil Err). A cached failure suppresses retry — callers see Err() != nil
+// and skip the STS call rather than thrashing on a permission error every
+// related-check pass. Session.Rotate() clears both on profile/region switch.
+//
 // Implementations must be safe for concurrent use.
 type IdentityStore interface {
-	Get() (identity any, ok bool)
-	Set(identity any)
+	// AccountID returns the cached AWS account ID, or "" if no successful
+	// fetch has been recorded.
+	AccountID() string
+
+	// Err returns the cached error from the last fetch attempt. Non-nil
+	// means a prior call failed AND the failure is sticky — callers must
+	// not retry until Clear() is invoked (e.g. via Session.Rotate).
+	Err() error
+
+	// Set records the result of a fetch. id == "" + err == nil is invalid
+	// (use Clear() instead). On success: id non-empty, err nil. On failure:
+	// id empty, err non-nil. Last-write-wins under contention.
+	Set(id string, err error)
+
+	// Clear resets the cache so the next call falls through to a fresh
+	// fetch. Called by Session.Rotate on profile/region switch.
 	Clear()
 }
 
 type identityStore struct {
-	mu       sync.RWMutex
-	identity any
-	ok       bool
+	mu        sync.RWMutex
+	accountID string
+	err       error
 }
 
-// NewIdentityStore returns a new thread-safe IdentityStore implementation.
+// NewIdentityStore returns a new thread-safe IdentityStore.
 func NewIdentityStore() IdentityStore {
 	return &identityStore{}
 }
 
-func (s *identityStore) Get() (any, bool) {
+func (s *identityStore) AccountID() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.identity, s.ok
+	return s.accountID
 }
 
-func (s *identityStore) Set(identity any) {
+func (s *identityStore) Err() error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.err
+}
+
+func (s *identityStore) Set(id string, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.identity = identity
-	s.ok = true
+	s.accountID = id
+	s.err = err
 }
 
 func (s *identityStore) Clear() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.identity = nil
-	s.ok = false
+	s.accountID = ""
+	s.err = nil
 }

--- a/internal/session/identity_store.go
+++ b/internal/session/identity_store.go
@@ -30,7 +30,15 @@ type IdentityStore interface {
 
 	// Set records the result of a fetch. id == "" + err == nil is invalid
 	// (use Clear() instead). On success: id non-empty, err nil. On failure:
-	// id empty, err non-nil. Last-write-wins under contention.
+	// id empty, err non-nil.
+	//
+	// Concurrent-safety contract: a failure-flavored Set (id == "" + err !=
+	// nil) is silently DROPPED if AccountID() is already non-empty. This
+	// prevents a slow-failing Pattern-C check from overwriting a successful
+	// AccountID written by an earlier-completing concurrent fetch — naive
+	// last-writer-wins would otherwise poison the cache for the rest of
+	// the session. Successful Set (id != "") always overwrites — this
+	// preserves the "Clear then transient-error then retry succeeds" path.
 	Set(id string, err error)
 
 	// Clear resets the cache so the next call falls through to a fresh
@@ -64,6 +72,15 @@ func (s *identityStore) Err() error {
 func (s *identityStore) Set(id string, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// Anti-poison: refuse to overwrite an already-cached successful
+	// AccountID with a later failure. Two concurrent Pattern-C checks may
+	// both observe an empty store and both call STS.GetCallerIdentity;
+	// if the slower one times out (10s checker context) AFTER the faster
+	// one cached a good account ID, the naive write would erase the good
+	// value and leave the session stuck at Count:-1. See store godoc.
+	if id == "" && err != nil && s.accountID != "" {
+		return
+	}
 	s.accountID = id
 	s.err = err
 }

--- a/internal/session/identity_store_test.go
+++ b/internal/session/identity_store_test.go
@@ -1,73 +1,136 @@
 package session_test
 
 import (
+	"errors"
 	"sync"
 	"testing"
 
 	"github.com/k2m30/a9s/v3/internal/session"
 )
 
-// TestIdentityStore_GetUnset verifies that a fresh IdentityStore returns
-// (nil, false) when no identity has been stored yet.
-func TestIdentityStore_GetUnset(t *testing.T) {
+// TestIdentityStore_FreshIsEmpty pins that a freshly constructed store
+// reports no cached account and no error — both AccountID() and Err() must
+// return their zero values.
+func TestIdentityStore_FreshIsEmpty(t *testing.T) {
 	t.Parallel()
 
 	store := session.NewIdentityStore()
 
-	got, ok := store.Get()
-	if ok {
-		t.Error("expected ok=false on fresh store, got true")
+	if id := store.AccountID(); id != "" {
+		t.Errorf("AccountID() on fresh store: got %q, want \"\"", id)
 	}
-	if got != nil {
-		t.Errorf("expected nil on fresh store, got %v", got)
+	if err := store.Err(); err != nil {
+		t.Errorf("Err() on fresh store: got %v, want nil", err)
 	}
 }
 
-// TestIdentityStore_SetThenGet verifies that Set followed by Get returns the
-// stored identity with ok=true.
-func TestIdentityStore_SetThenGet(t *testing.T) {
+// TestIdentityStore_SetSuccessThenAccountID pins the success path: a
+// successful Set(id, nil) is reflected by both AccountID() and Err().
+func TestIdentityStore_SetSuccessThenAccountID(t *testing.T) {
+	t.Parallel()
+
+	store := session.NewIdentityStore()
+	const acct = "111111111111"
+
+	store.Set(acct, nil)
+
+	if got := store.AccountID(); got != acct {
+		t.Errorf("AccountID() after success Set: got %q, want %q", got, acct)
+	}
+	if err := store.Err(); err != nil {
+		t.Errorf("Err() after success Set: got %v, want nil", err)
+	}
+}
+
+// TestIdentityStore_SetFailureThenErr pins the sticky-failure path: when a
+// fetch fails, Set("", err) records the error and AccountID() stays empty.
+// The contract: AccountID()=="" + Err()!=nil → caller skips retry.
+func TestIdentityStore_SetFailureThenErr(t *testing.T) {
+	t.Parallel()
+
+	store := session.NewIdentityStore()
+	failure := errors.New("AccessDenied: sts:GetCallerIdentity")
+
+	store.Set("", failure)
+
+	if got := store.AccountID(); got != "" {
+		t.Errorf("AccountID() after failure Set: got %q, want \"\"", got)
+	}
+	if err := store.Err(); !errors.Is(err, failure) {
+		t.Errorf("Err() after failure Set: got %v, want %v", err, failure)
+	}
+}
+
+// TestIdentityStore_OverwriteSet pins last-write-wins semantics under
+// non-concurrent overwrite — Set followed by another Set replaces the prior
+// value. Important for: a transient error followed by a successful retry
+// (rare in practice — Err() suppresses retry — but the API allows it after
+// Clear or in test setups).
+func TestIdentityStore_OverwriteSet(t *testing.T) {
 	t.Parallel()
 
 	store := session.NewIdentityStore()
 
-	const payload = "identity-payload"
-	store.Set(payload)
+	store.Set("", errors.New("transient"))
+	store.Set("222222222222", nil)
 
-	got, ok := store.Get()
-	if !ok {
-		t.Fatal("expected ok=true after Set, got false")
+	if got := store.AccountID(); got != "222222222222" {
+		t.Errorf("AccountID() after overwrite: got %q, want %q", got, "222222222222")
 	}
-	if got != payload {
-		t.Errorf("Get returned %v, want %q", got, payload)
+	if err := store.Err(); err != nil {
+		t.Errorf("Err() after success overwrite: got %v, want nil", err)
 	}
 }
 
-// TestIdentityStore_Clear verifies that Clear() removes the stored identity
-// so a subsequent Get returns (nil, false).
+// TestIdentityStore_Clear pins that Clear resets BOTH the account and the
+// error so a subsequent fetch path runs fresh.
 func TestIdentityStore_Clear(t *testing.T) {
 	t.Parallel()
 
 	store := session.NewIdentityStore()
-
-	store.Set("identity-payload")
+	store.Set("333333333333", nil)
 	store.Clear()
 
-	got, ok := store.Get()
-	if ok {
-		t.Errorf("expected ok=false after Clear(), got true (value=%v)", got)
+	if got := store.AccountID(); got != "" {
+		t.Errorf("AccountID() after Clear: got %q, want \"\"", got)
 	}
-	if got != nil {
-		t.Errorf("expected nil after Clear(), got %v", got)
+	if err := store.Err(); err != nil {
+		t.Errorf("Err() after Clear: got %v, want nil", err)
+	}
+
+	// And from the failure side.
+	store.Set("", errors.New("sticky"))
+	store.Clear()
+
+	if got := store.AccountID(); got != "" {
+		t.Errorf("AccountID() after Clear (post-failure): got %q, want \"\"", got)
+	}
+	if err := store.Err(); err != nil {
+		t.Errorf("Err() after Clear (post-failure): got %v, want nil", err)
 	}
 }
 
-// TestIdentityStore_ConcurrentSafe verifies that the IdentityStore
-// implementation is safe for concurrent use. 100 goroutines mix Set, Get, and
-// Clear; the race detector validates no data race occurs.
+// TestIdentityStore_ClearIdempotent pins that Clear() on a fresh store and
+// twice in a row do not panic.
+func TestIdentityStore_ClearIdempotent(t *testing.T) {
+	t.Parallel()
+
+	store := session.NewIdentityStore()
+	store.Clear()
+	store.Clear()
+
+	store.Set("444444444444", nil)
+	store.Clear()
+	store.Clear()
+}
+
+// TestIdentityStore_ConcurrentSafe runs 100 goroutines mixing
+// AccountID/Err/Set/Clear; the race detector validates no data race.
 func TestIdentityStore_ConcurrentSafe(t *testing.T) {
 	t.Parallel()
 
 	store := session.NewIdentityStore()
+	failure := errors.New("boom")
 
 	const workers = 100
 	var wg sync.WaitGroup
@@ -76,12 +139,16 @@ func TestIdentityStore_ConcurrentSafe(t *testing.T) {
 	for i := range workers {
 		go func(n int) {
 			defer wg.Done()
-			switch n % 3 {
+			switch n % 5 {
 			case 0:
-				store.Set(n)
+				store.Set("555555555555", nil)
 			case 1:
-				_, _ = store.Get()
+				_ = store.AccountID()
 			case 2:
+				_ = store.Err()
+			case 3:
+				store.Set("", failure)
+			case 4:
 				store.Clear()
 			}
 		}(i)

--- a/internal/session/identity_store_test.go
+++ b/internal/session/identity_store_test.go
@@ -61,11 +61,10 @@ func TestIdentityStore_SetFailureThenErr(t *testing.T) {
 	}
 }
 
-// TestIdentityStore_OverwriteSet pins last-write-wins semantics under
-// non-concurrent overwrite — Set followed by another Set replaces the prior
-// value. Important for: a transient error followed by a successful retry
-// (rare in practice — Err() suppresses retry — but the API allows it after
-// Clear or in test setups).
+// TestIdentityStore_OverwriteSet pins last-write-wins semantics for a
+// SUCCESS overwrite: Set("", err) followed by Set(id, nil) replaces the
+// prior failure. (The failure-overwrite-success case is anti-poisoned —
+// see TestIdentityStore_FailureDoesNotPoisonSuccess.)
 func TestIdentityStore_OverwriteSet(t *testing.T) {
 	t.Parallel()
 
@@ -79,6 +78,54 @@ func TestIdentityStore_OverwriteSet(t *testing.T) {
 	}
 	if err := store.Err(); err != nil {
 		t.Errorf("Err() after success overwrite: got %v, want nil", err)
+	}
+}
+
+// TestIdentityStore_FailureDoesNotPoisonSuccess pins the anti-poison
+// contract (P2 finding): when a successful AccountID is already cached, a
+// subsequent failure-flavored Set("", err) is silently DROPPED.
+//
+// Scenario: handleRelatedCheckStarted runs Pattern-C probes concurrently.
+// Two checks enter accountIDFromClients at the same time when the store is
+// empty; both call STS.GetCallerIdentity. One succeeds and Set(id, nil);
+// the slower one times out and Set("", err). Without anti-poison, the late
+// failure would overwrite the good AccountID — Glue/EBS related checks
+// would then return Count:-1 for the rest of the session.
+func TestIdentityStore_FailureDoesNotPoisonSuccess(t *testing.T) {
+	t.Parallel()
+
+	store := session.NewIdentityStore()
+	const acct = "999999999999"
+
+	store.Set(acct, nil) // earlier-completing successful fetch
+	// Slower fetch times out and tries to record the failure.
+	store.Set("", errors.New("checker context deadline exceeded"))
+
+	if got := store.AccountID(); got != acct {
+		t.Errorf("AccountID() after concurrent failure: got %q, want %q (cache poisoned)", got, acct)
+	}
+	if err := store.Err(); err != nil {
+		t.Errorf("Err() after concurrent failure: got %v, want nil (success must not be marked failed)", err)
+	}
+}
+
+// TestIdentityStore_FailureBeforeSuccess pins the symmetric path: when a
+// failure is cached first (e.g. initial probe failed), a subsequent
+// successful Set DOES overwrite. The anti-poison rule applies only when
+// success is already cached AND the new write is a failure.
+func TestIdentityStore_FailureBeforeSuccess(t *testing.T) {
+	t.Parallel()
+
+	store := session.NewIdentityStore()
+
+	store.Set("", errors.New("transient throttle"))
+	store.Set("888888888888", nil)
+
+	if got := store.AccountID(); got != "888888888888" {
+		t.Errorf("AccountID() after success-after-failure: got %q, want %q", got, "888888888888")
+	}
+	if err := store.Err(); err != nil {
+		t.Errorf("Err() after success-after-failure: got %v, want nil", err)
 	}
 }
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -85,6 +85,14 @@ type Session struct {
 	// internal/aws/iam_policies.go. Wired into *ServiceClients.IAMPolicies on
 	// every ClientsReadyMsg so FetchIAMPoliciesByIDsFull uses the session store.
 	IAMPolicies PolicyStore
+
+	// Identity is the per-session cache for the AWS caller's account ID.
+	// Replaces the package-level globals previously in
+	// internal/aws/identity_cache.go (identityCacheMu / cachedAccountID /
+	// cachedAccountErr). Wired into *ServiceClients.IdentityStore on every
+	// ClientsReadyMsg so Pattern-C related checkers (Glue tags, EBS Backup)
+	// see a per-profile/region scoped cache rather than a process-global one.
+	Identity IdentityStore
 }
 
 // New constructs a fresh Session with all maps initialized and generation
@@ -106,6 +114,7 @@ func New() *Session {
 		EnrichmentGen:          1,
 		PolicyDocCache:         &awsclient.PolicyDocumentCache{},
 		IAMPolicies:            NewPolicyStore(),
+		Identity:               NewIdentityStore(),
 	}
 }
 
@@ -147,4 +156,8 @@ func (s *Session) Rotate() {
 	// IAMPolicies: reset to a fresh store so managed/inline entries from the
 	// prior account/profile cannot leak into the next session.
 	s.IAMPolicies = NewPolicyStore()
+
+	// Identity: reset to a fresh store so the cached account ID + sticky
+	// failure (if any) from the prior session cannot leak into the next.
+	s.Identity = NewIdentityStore()
 }

--- a/internal/tui/app_handlers.go
+++ b/internal/tui/app_handlers.go
@@ -237,12 +237,14 @@ func (m Model) handleClientsReady(msg messages.ClientsReadyMsg) (tea.Model, tea.
 	if msg.Clients == nil {
 		if m.clients == nil && m.preSuppliedClients != nil {
 			// Fall back to pre-supplied clients (demo path) when msg carries no clients.
-			m.preSuppliedClients.IAMPolicies = m.IAMPolicies // wire per-session policy store
+			m.preSuppliedClients.IAMPolicies = m.IAMPolicies   // wire per-session policy store
+			m.preSuppliedClients.IdentityStore = m.Identity    // wire per-session identity cache
 			m.clients = m.preSuppliedClients
 		}
 	} else if clients, ok := msg.Clients.(*awsclient.ServiceClients); ok {
 		awsclient.ClearAllSESRuleSetCaches() // drop stale SES rule-set cache from prior *ServiceClients
 		clients.IAMPolicies = m.IAMPolicies  // wire per-session policy store into transport layer
+		clients.IdentityStore = m.Identity   // wire per-session identity cache into transport layer
 		m.clients = clients
 	} else {
 		wrongTypeErr := fmt.Errorf("internal: unexpected ClientsReadyMsg.Clients type %T", msg.Clients)

--- a/internal/tui/app_handlers.go
+++ b/internal/tui/app_handlers.go
@@ -221,9 +221,20 @@ func (m Model) handleClientsReady(msg messages.ClientsReadyMsg) (tea.Model, tea.
 
 		// The switch attempt cleared identity, resource cache, and availability.
 		// Restore them using the still-valid old clients.
+		//
+		// IMPORTANT: Session.Rotate already swapped in fresh PolicyStore /
+		// IdentityStore on m, so the retained transport clients (m.clients)
+		// still point at the PRE-rotate stores. Without rewiring here,
+		// Pattern-C related checks (Glue tags, EBS Backup) and IAM lazy-add
+		// would read sticky state from the now-discarded old stores — the
+		// header's identity reload could succeed against the new fresh
+		// stores while related-panel rows stayed broken until the next
+		// successful reconnect. Rewire on rollback too. (P3 finding.)
 		var cmds []tea.Cmd
 		cmds = append(cmds, clearFlash)
 		if m.clients != nil {
+			m.clients.IAMPolicies = m.IAMPolicies
+			m.clients.IdentityStore = m.Identity
 			m.identityFetching = true
 			cmds = append(cmds, m.fetchIdentity())
 			if m.noCache {


### PR DESCRIPTION
## Summary

Phase 02 PR-02c per `docs/refactor/02-session-owner.md`.

Replace the 3 package-level globals in `internal/aws/identity_cache.go` (`identityCacheMu`, `cachedAccountID`, `cachedAccountErr`) — including the `//nolint:gochecknoglobals` comment they earned — with a `Session`-scoped `IdentityStore` capability threaded through `*ServiceClients.IdentityStore`.

## Changes

- **`internal/session/identity_store.go`** — REPLACED PR-02a's placeholder `Get/Set/Clear` (any-typed) interface with the IAM-use-case shape: `AccountID() string`, `Err() error`, `Set(id, err)`, `Clear()`. The two-field design preserves the sticky-failure semantics of the original code.
- **`internal/session/session.go`** — added `Identity IdentityStore` field; `New()` initializes via `NewIdentityStore()`; `Rotate()` replaces with a fresh store on profile/region switch.
- **`internal/aws/identity_cache.go`** — deleted all 3 globals + the nolint comment. `accountIDFromClients` takes a local `identityStore` interface (duck-typed; `session.IdentityStore` satisfies it).
- **`internal/aws/client.go`** — added `IdentityStore identityStore` field on `*ServiceClients`.
- **`internal/aws/glue_related.go`, `ebs_related.go`** — pass `c.IdentityStore` to `accountIDFromClients`.
- **`internal/tui/app_handlers.go`** — `handleClientsReady` wires `clients.IdentityStore = m.Identity` (both live + pre-supplied paths).
- **`internal/demo/client.go`** — `NewServiceClients()` initializes a fresh store.

## Tests

- **`internal/session/identity_store_test.go`** (replaced) — 7 tests pin the new interface: fresh-empty, success-then-AccountID, failure-then-Err sticky semantics, overwrite, Clear (both sides), Clear-idempotent, concurrent-safe (race-clean).
- Existing `tests/unit/aws_identity_cache_test.go` unchanged — indirect coverage via `checkEBSBackup`; the nil-store defensive fallback in `accountIDFromClients` preserves observable behaviour.

## Concurrency trade-off (same as PR-02b, acknowledged)

`accountIDFromClients` no longer holds a top-level lock across the check-fetch-set sequence. Two concurrent Pattern-C checks can both invoke `STS.GetCallerIdentity`; the store remains correct (writes mutex-guarded; idempotent Sets). Acceptable for related-panel volume.

## Exit criteria (all ✓)

- `rg 'identityCacheMu|cachedAccountID|cachedAccountErr' internal/` — zero hits
- `rg 'gochecknoglobals' internal/aws/identity_cache.go` — zero hits
- `rg 'IdentityStore' internal/aws/` — hits in `identity_cache.go` and `client.go` (now load-bearing)

## Test plan

- [x] `go build ./...` clean
- [x] `make test` (13,373 pass)
- [x] `make test-race` clean
- [x] `go test ./internal/session/ -race` (36 pass)
- [x] `make lint` (0 issues)
- [x] `make security` (no vulns)
- [x] `make gofix` PASS
- [x] `make snapshot` clean

## Out of scope

PR-02d (RuleSetStore wiring), PR-02e (single rotation path / final cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
