### PR TITLE
feat(phase-03-pr03a-types): Phase 03 finding types + SES singleflight fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/aws/smithy-go v1.25.0
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/sync v0.19.0
 	gopkg.in/ini.v1 v1.67.1
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -91,6 +92,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 )

--- a/internal/aws/ses_related.go
+++ b/internal/aws/ses_related.go
@@ -20,7 +20,7 @@ type ruleSetStore interface {
 	Get() (any, bool)
 	Set(any)
 	Clear()
-	GetOrFetch(fetcher func() (any, error)) (any, error)
+	GetOrFetch(context.Context, func(context.Context) (any, error)) (any, error)
 }
 
 // checkSESR53 searches the R53 cache for hosted zones whose domain matches the
@@ -136,8 +136,8 @@ func sesActiveReceiptRuleSet(ctx context.Context, c *ServiceClients) (*ses.Descr
 		// without caching or coalescing.
 		return c.SES.DescribeActiveReceiptRuleSet(ctx, &ses.DescribeActiveReceiptRuleSetInput{})
 	}
-	v, err := store.GetOrFetch(func() (any, error) {
-		return c.SES.DescribeActiveReceiptRuleSet(ctx, &ses.DescribeActiveReceiptRuleSetInput{})
+	v, err := store.GetOrFetch(ctx, func(fetchCtx context.Context) (any, error) {
+		return c.SES.DescribeActiveReceiptRuleSet(fetchCtx, &ses.DescribeActiveReceiptRuleSetInput{})
 	})
 	if err != nil {
 		return nil, err

--- a/internal/aws/ses_related.go
+++ b/internal/aws/ses_related.go
@@ -20,6 +20,7 @@ type ruleSetStore interface {
 	Get() (any, bool)
 	Set(any)
 	Clear()
+	GetOrFetch(fetcher func() (any, error)) (any, error)
 }
 
 // checkSESR53 searches the R53 cache for hosted zones whose domain matches the
@@ -121,48 +122,32 @@ func sesEventDestinations(ctx context.Context, c *ServiceClients, configSetName 
 	return out, err
 }
 
-// sesActiveReceiptRuleSet calls SES v1 DescribeActiveReceiptRuleSet at most
-// once per session when the call succeeds. The cached output is read on
-// subsequent calls without a network round-trip. Errors are not cached: a
-// follow-up call after an error retries the API.
-//
-// The cache lives on the per-Session RuleSetStore (c.RuleSets()); the legacy
-// process-wide map keyed by *ServiceClients pointer is gone.
-//
-// Invalidation safety (P2 finding): the store reference is CAPTURED ONCE at
-// function entry into a local `store` variable. If a refresh handler swaps
-// `c.RuleSets` for a fresh store while this fetch is blocked on the SES
-// API, the Set below writes to the captured (now orphaned) store rather
-// than re-poisoning the new active slot. This is the swap-vs-clear contract:
-// callers wanting to invalidate MUST REPLACE `c.RuleSets`, not call
-// Clear() on the existing store — otherwise an in-flight late writer would
-// repopulate the same store with the pre-refresh data and the next
-// checker batch would see stale Lambda/S3 relationships.
-//
-// Concurrency trade-off (acknowledged, same as PR-02b/02c): no top-level
-// lock across check-fetch-set. Two concurrent checkSES* calls may both
-// observe an empty store and both invoke the SES API; the store remains
-// correct (mutex-guarded writes; last-write-wins on idempotent Sets). Acceptable
-// because related-panel checks are not high-volume.
+// sesActiveReceiptRuleSet returns the active SES v1 receipt rule set for this
+// session. The store is per-session; singleflight coalesces concurrent misses
+// into one upstream call. Swap (not Clear) is required on Ctrl+R refresh so
+// late-completing fetches land on the orphaned old store, never the new one.
 func sesActiveReceiptRuleSet(ctx context.Context, c *ServiceClients) (*ses.DescribeActiveReceiptRuleSetOutput, error) {
 	if c == nil || c.SES == nil {
 		return nil, nil //nolint:nilnil // no SES v1 client; caller treats nil as "no rule set"
 	}
-	store := c.RuleSets() // capture once — see godoc above
-	if store != nil {
-		if cached, ok := store.Get(); ok {
-			out, isOutput := cached.(*ses.DescribeActiveReceiptRuleSetOutput)
-			if isOutput {
-				return out, nil
-			}
-		}
+	store := c.RuleSets()
+	if store == nil {
+		// No store wired (test path or pre-init); fall back to direct fetch
+		// without caching or coalescing.
+		return c.SES.DescribeActiveReceiptRuleSet(ctx, &ses.DescribeActiveReceiptRuleSetInput{})
 	}
-	out, err := c.SES.DescribeActiveReceiptRuleSet(ctx, &ses.DescribeActiveReceiptRuleSetInput{})
+	v, err := store.GetOrFetch(func() (any, error) {
+		return c.SES.DescribeActiveReceiptRuleSet(ctx, &ses.DescribeActiveReceiptRuleSetInput{})
+	})
 	if err != nil {
 		return nil, err
 	}
-	if store != nil && out != nil {
-		store.Set(out)
+	if v == nil {
+		return nil, nil //nolint:nilnil
+	}
+	out, ok := v.(*ses.DescribeActiveReceiptRuleSetOutput)
+	if !ok {
+		return nil, nil //nolint:nilnil // type mismatch; treat as "no rule set"
 	}
 	return out, nil
 }

--- a/internal/aws/ses_related_export.go
+++ b/internal/aws/ses_related_export.go
@@ -1,0 +1,14 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ses"
+)
+
+// SESActiveReceiptRuleSetForTest is a test-only export of sesActiveReceiptRuleSet.
+// It exists in a non-test file so tests/unit/ (a different package) can call it.
+// The production binary cost is negligible — one extra exported symbol.
+func SESActiveReceiptRuleSetForTest(ctx context.Context, c *ServiceClients) (*ses.DescribeActiveReceiptRuleSetOutput, error) {
+	return sesActiveReceiptRuleSet(ctx, c)
+}

--- a/internal/domain/finding.go
+++ b/internal/domain/finding.go
@@ -1,0 +1,34 @@
+package domain
+
+// FindingCode is a stable identifier for a finding. Never displayed.
+// Codes are namespaced by resource short-name (e.g. "ec2.impaired",
+// "rds.maint.pending"). Phase 03 introduces these as typed constants
+// per enricher; Phase 04 may graduate them to a declarative table.
+type FindingCode string
+
+// Finding is the canonical row/menu/status semantics carrier on Resource.
+// Drives row coloring, list-view Status display, menu issue badges, and
+// the ctrl+z attention filter.
+type Finding struct {
+	Code     FindingCode
+	Phrase   string
+	Severity Severity
+	Source   string // "wave1" | "wave2:<short>"
+}
+
+// AttentionDetail carries the rows shown in the detail-view Attention
+// section for a given FindingCode. Consumed only by the detail view's
+// Attention section — list views read Finding.Phrase / Finding.Severity.
+type AttentionDetail struct {
+	Rows []DetailRow
+}
+
+// DetailRow is a single label/value pair in an AttentionDetail.
+//
+// Tier is the optional display tier — "!" for emphasized, "~" for muted,
+// "" for default (inherits from the parent Finding.Severity).
+type DetailRow struct {
+	Label string
+	Value string
+	Tier  string
+}

--- a/internal/domain/resource.go
+++ b/internal/domain/resource.go
@@ -32,4 +32,12 @@ type Resource struct {
 	// RawStruct holds the original AWS SDK typed struct for reflection-based
 	// field extraction.
 	RawStruct any
+	// Findings is the canonical finding list. Phase 03 populates this; views
+	// read Findings[0].Phrase / Findings[0].Severity for list rendering.
+	// Empty for healthy rows.
+	Findings []Finding
+	// AttentionDetails carries supporting structured facts per finding,
+	// keyed by Finding.Code. Consumed only by the detail view's Attention
+	// section. Nil/empty for rows with no findings or no extra facts.
+	AttentionDetails map[FindingCode]AttentionDetail
 }

--- a/internal/resource/types.go
+++ b/internal/resource/types.go
@@ -116,6 +116,16 @@ type ResourceTypeDef struct {
 	// title equal to "Name" or the type Name → column index 0.
 	// Set this only when the cascade would pick the wrong column.
 	IdentityKey string
+	// LifecycleKey names the Resource.Fields key holding lifecycle state
+	// (e.g. "running", "stopped", "available", "deleted"). Used as the
+	// list-view Status column fallback when r.Findings is empty:
+	//
+	//   list view: r.Findings[0].Phrase if non-empty, else r.Fields[LifecycleKey]
+	//
+	// Empty string defaults to "state" at read time. Per-category PRs
+	// in Phase 03 set explicit non-default values where the structural
+	// Color func already reads a different key.
+	LifecycleKey string
 
 	// Color classifies the row's health. REQUIRED for all registered types.
 	// Reads the resource's structural fields directly.

--- a/internal/session/rule_set_store.go
+++ b/internal/session/rule_set_store.go
@@ -6,7 +6,9 @@
 package session
 
 import (
+	"context"
 	"sync"
+	"time"
 
 	"golang.org/x/sync/singleflight"
 )
@@ -42,13 +44,19 @@ type RuleSetStore interface {
 	// GetOrFetch returns the cached value if present; otherwise calls fetcher
 	// once across all concurrent callers (single-flight) and caches its result.
 	// The "active" key is fixed because this store has a single slot.
-	GetOrFetch(fetcher func() (any, error)) (any, error)
+	//
+	// The fetcher receives a detached context built from ctx so that leader
+	// cancellation does not abort in-flight upstream calls on behalf of
+	// followers whose own ctx remains alive. Each waiting caller selects on
+	// its own ctx.Done() and may bail early without cancelling the fetch.
+	GetOrFetch(ctx context.Context, fetcher func(context.Context) (any, error)) (any, error)
 }
 
 type ruleSetStore struct {
 	mu      sync.RWMutex
 	ruleSet any
 	ok      bool
+	gen     uint64 // bumped on Clear() to detect stale writes from in-flight fetches
 	sf      singleflight.Group
 }
 
@@ -75,27 +83,67 @@ func (s *ruleSetStore) Clear() {
 	defer s.mu.Unlock()
 	s.ruleSet = nil
 	s.ok = false
+	s.gen++
 }
 
-// GetOrFetch returns the cached value if present; otherwise calls fetcher
-// once across all concurrent callers (single-flight) and caches its result.
-// The "active" key is fixed because this store has a single slot.
-func (s *ruleSetStore) GetOrFetch(fetcher func() (any, error)) (any, error) {
+// GetOrFetch returns the cached value if present; otherwise coalesces all
+// concurrent callers into a single upstream fetch via singleflight.
+//
+// Key design decisions:
+//
+//  1. DoChan — the caller selects on the result channel OR its own ctx.Done().
+//     A follower with a live ctx waits for the channel; a follower whose ctx
+//     fires bails early with its own error WITHOUT aborting the in-flight fetch.
+//
+//  2. Detached context — the fetcher runs with context.WithoutCancel(ctx) so
+//     the leader's cancellation does not propagate to the upstream API call.
+//     A 30-second timeout is applied so a stuck upstream eventually releases.
+//
+//  3. Generation counter — if Clear() is called while a fetch is in flight,
+//     the post-fetch Set is skipped (gen mismatch) so stale data from an old
+//     profile never poisons the active cache.
+func (s *ruleSetStore) GetOrFetch(ctx context.Context, fetcher func(context.Context) (any, error)) (any, error) {
 	if v, ok := s.Get(); ok {
 		return v, nil
 	}
-	v, err, _ := s.sf.Do("active", func() (any, error) {
+
+	// Snapshot generation before entering the flight so we can detect
+	// a Clear() that happens while the fetch is in progress.
+	s.mu.RLock()
+	startGen := s.gen
+	s.mu.RUnlock()
+
+	ch := s.sf.DoChan("active", func() (any, error) {
 		// Re-check inside the singleflight in case another caller filled it
 		// between our miss and acquiring the flight. Cheap.
 		if v, ok := s.Get(); ok {
 			return v, nil
 		}
-		v, err := fetcher()
+		// Detach from the leader's context so its cancellation does not abort
+		// the upstream API call on behalf of waiting followers.
+		fetchCtx := context.WithoutCancel(ctx)
+		fetchCtx, cancel := context.WithTimeout(fetchCtx, 30*time.Second)
+		defer cancel()
+		v, err := fetcher(fetchCtx)
 		if err != nil {
 			return nil, err
 		}
-		s.Set(v)
+		// Only commit the value if the store has not been cleared since we
+		// started — a bumped generation means a profile/region switch happened
+		// and this result is stale.
+		s.mu.Lock()
+		if s.gen == startGen {
+			s.ruleSet = v
+			s.ok = true
+		}
+		s.mu.Unlock()
 		return v, nil
 	})
-	return v, err
+
+	select {
+	case res := <-ch:
+		return res.Val, res.Err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }

--- a/internal/session/rule_set_store.go
+++ b/internal/session/rule_set_store.go
@@ -5,7 +5,11 @@
 // by *ServiceClients pointer).
 package session
 
-import "sync"
+import (
+	"sync"
+
+	"golang.org/x/sync/singleflight"
+)
 
 // RuleSetStore is a session-scoped, single-slot cache for the SES v1
 // DescribeActiveReceiptRuleSet response. Each Session owns one store; the
@@ -34,12 +38,18 @@ type RuleSetStore interface {
 	// switch and by Ctrl+R on the SES detail view (so receipt-rule changes
 	// are picked up without waiting for a full reconnect).
 	Clear()
+
+	// GetOrFetch returns the cached value if present; otherwise calls fetcher
+	// once across all concurrent callers (single-flight) and caches its result.
+	// The "active" key is fixed because this store has a single slot.
+	GetOrFetch(fetcher func() (any, error)) (any, error)
 }
 
 type ruleSetStore struct {
 	mu      sync.RWMutex
 	ruleSet any
 	ok      bool
+	sf      singleflight.Group
 }
 
 // NewRuleSetStore returns a new thread-safe RuleSetStore.
@@ -65,4 +75,27 @@ func (s *ruleSetStore) Clear() {
 	defer s.mu.Unlock()
 	s.ruleSet = nil
 	s.ok = false
+}
+
+// GetOrFetch returns the cached value if present; otherwise calls fetcher
+// once across all concurrent callers (single-flight) and caches its result.
+// The "active" key is fixed because this store has a single slot.
+func (s *ruleSetStore) GetOrFetch(fetcher func() (any, error)) (any, error) {
+	if v, ok := s.Get(); ok {
+		return v, nil
+	}
+	v, err, _ := s.sf.Do("active", func() (any, error) {
+		// Re-check inside the singleflight in case another caller filled it
+		// between our miss and acquiring the flight. Cheap.
+		if v, ok := s.Get(); ok {
+			return v, nil
+		}
+		v, err := fetcher()
+		if err != nil {
+			return nil, err
+		}
+		s.Set(v)
+		return v, nil
+	})
+	return v, err
 }

--- a/internal/session/rule_set_store.go
+++ b/internal/session/rule_set_store.go
@@ -7,6 +7,7 @@ package session
 
 import (
 	"context"
+	"reflect"
 	"sync"
 	"time"
 
@@ -63,6 +64,22 @@ type ruleSetStore struct {
 // NewRuleSetStore returns a new thread-safe RuleSetStore.
 func NewRuleSetStore() RuleSetStore {
 	return &ruleSetStore{}
+}
+
+// isNilAny reports whether v is nil or is a nil pointer (or other nilable kind)
+// wrapped inside an any/interface value. A plain == nil check is insufficient
+// because a typed nil pointer stored as any produces a non-nil interface value.
+func isNilAny(v any) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Pointer, reflect.Interface, reflect.Slice,
+		reflect.Map, reflect.Chan, reflect.Func:
+		return rv.IsNil()
+	}
+	return false
 }
 
 func (s *ruleSetStore) Get() (any, bool) {
@@ -127,6 +144,16 @@ func (s *ruleSetStore) GetOrFetch(ctx context.Context, fetcher func(context.Cont
 		v, err := fetcher(fetchCtx)
 		if err != nil {
 			return nil, err
+		}
+		if isNilAny(v) {
+			// Don't cache nil successes — `(nil, nil)` is a legitimate "no
+			// active rule set" response from AWS SES; caching it would make
+			// the absence sticky and prevent future refetches when a rule
+			// set is later activated. A typed nil pointer (e.g.
+			// (*DescribeActiveReceiptRuleSetOutput)(nil) wrapped in any) must
+			// also be treated as absent — a non-nil interface holding a nil
+			// pointer is not nil under ==. See PIN 5 regression test.
+			return nil, nil
 		}
 		// Only commit the value if the store has not been cleared since we
 		// started — a bumped generation means a profile/region switch happened

--- a/tests/unit/aws_ses_invalidation_test.go
+++ b/tests/unit/aws_ses_invalidation_test.go
@@ -25,6 +25,7 @@ package unit_test
 
 import (
 	"context"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -439,18 +440,33 @@ func TestSESActiveReceiptRuleSet_Singleflight_CoalescesConcurrentMisses(t *testi
 	var wg sync.WaitGroup
 	wg.Add(N)
 
+	// started is a hard barrier: each goroutine signals it BEFORE entering
+	// the SES helper, giving us a strong guarantee that all N goroutines have
+	// been scheduled before we release the stub. This eliminates the flaky
+	// 50ms sleep while still being bounded (100 Gosched iterations cap the
+	// wait so a stuck test fails fast instead of hanging the suite).
+	started := make(chan struct{}, N)
 	for i := range N {
 		go func(idx int) {
 			defer wg.Done()
+			started <- struct{}{} // signal: "I'm about to call"
 			out, err := awsclient.SESActiveReceiptRuleSetForTest(context.Background(), clients)
 			results[idx] = result{out: out, err: err}
 		}(i)
 	}
 
-	// Allow goroutines time to enter the blocking stub before releasing it.
-	// 50 ms matches the style used in TestSESRuleSetSwap_LateWriterDoesNotPoisonNewStore.
+	// Wait for all N goroutines to signal they are about to call.
+	for range N {
+		<-started
+	}
+	// Wait for the leader to enter the blocking stub.
 	<-mock.inFlightCh
-	time.Sleep(50 * time.Millisecond)
+	// Yield repeatedly to give the remaining N-1 goroutines a chance to reach
+	// the singleflight wait point before we release. Bounded at 100 iterations
+	// so a stuck test fails fast rather than hanging the suite indefinitely.
+	for i := 0; i < 100; i++ {
+		runtime.Gosched()
+	}
 
 	// Release all blocked callers.
 	close(mock.releaseCh)
@@ -480,4 +496,166 @@ func TestSESActiveReceiptRuleSet_Singleflight_CoalescesConcurrentMisses(t *testi
 			t.Errorf("goroutine %d: rule name = %q, want %q", i, got, want)
 		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// PIN 4 — singleflight ctx-coupling: leader cancellation must NOT poison followers
+// ---------------------------------------------------------------------------
+// Bug (post-PR-307): sesActiveReceiptRuleSet passes the caller's ctx directly
+// into the singleflight.Group.Do closure. When the leader's ctx is canceled,
+// the singleflight fetcher aborts with context.Canceled and propagates that
+// error to every follower — even followers whose own ctx was not canceled.
+//
+// Pre-fix behaviour: follower receives errB == context.Canceled (leader's error).
+// Post-fix behaviour: follower receives a successful result despite leader cancellation.
+
+// ctxAwareSESV1 is a ctx-respecting SES v1 mock used only for PIN 4.
+// It blocks each call on releaseCh OR the call's ctx.Done — whichever fires first.
+// When ctx fires, it returns ctx.Err() so the caller observes cancellation.
+// calls is atomic so concurrent goroutines can increment it safely.
+type ctxAwareSESV1 struct {
+	calls      atomic.Int32
+	releaseCh  chan struct{}
+	inFlightCh chan struct{} // closed once the first call enters
+	closeOnce  sync.Once
+	output     *ses.DescribeActiveReceiptRuleSetOutput
+}
+
+func (c *ctxAwareSESV1) DescribeActiveReceiptRuleSet(
+	ctx context.Context,
+	_ *ses.DescribeActiveReceiptRuleSetInput,
+	_ ...func(*ses.Options),
+) (*ses.DescribeActiveReceiptRuleSetOutput, error) {
+	c.calls.Add(1)
+	c.closeOnce.Do(func() { close(c.inFlightCh) })
+	select {
+	case <-c.releaseCh:
+		return c.output, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// Compile-time check: ctxAwareSESV1 satisfies SESV1API.
+var _ awsclient.SESV1API = (*ctxAwareSESV1)(nil)
+
+// TestSESActiveReceiptRuleSet_Singleflight_LeaderCancelDoesNotPoisonFollower
+// is the regression pin for the ctx-coupling bug introduced in PR #307.
+//
+// The invariant pinned here is: a follower goroutine with a long-lived ctx
+// must succeed even when the singleflight leader's ctx is canceled before
+// the upstream API call completes.
+//
+// Regarding call count: we accept 1 or 2 upstream calls. A correct fix may
+// either (a) detach the fetcher from the leader's ctx so the single in-flight
+// call completes for everyone (1 call), or (b) retry with a context-independent
+// ctx when the leader's ctx fires (2 calls). Both are valid — we pin only the
+// follower-success invariant, not the exact implementation strategy.
+//
+// Leader outcome (errA): NOT asserted strictly. Depending on the fix, the leader
+// may receive context.Canceled (if it cancelled before the API responded) or a
+// successful result (if the fix retries on a background ctx and shares the result).
+// Leader's outcome is an impl-detail; follower's success is the regression pin.
+func TestSESActiveReceiptRuleSet_Singleflight_LeaderCancelDoesNotPoisonFollower(t *testing.T) {
+	ruleSetOutput := &ses.DescribeActiveReceiptRuleSetOutput{
+		Rules: []sestypes.ReceiptRule{
+			{
+				Name:       aws.String("follower-rule"),
+				Recipients: nil, // global — applies to all identities
+				Actions: []sestypes.ReceiptAction{
+					{LambdaAction: &sestypes.LambdaAction{
+						FunctionArn: aws.String("arn:aws:lambda:us-east-1:123456789012:function:follower"),
+					}},
+				},
+			},
+		},
+	}
+
+	mock := &ctxAwareSESV1{
+		releaseCh:  make(chan struct{}),
+		inFlightCh: make(chan struct{}),
+		output:     ruleSetOutput,
+	}
+
+	clients := &awsclient.ServiceClients{SES: mock}
+	clients.SetRuleSets(session.NewRuleSetStore())
+
+	type result struct {
+		out *ses.DescribeActiveReceiptRuleSetOutput
+		err error
+	}
+	var (
+		resA, resB result
+		wg         sync.WaitGroup
+	)
+	wg.Add(2)
+
+	// Goroutine A — the leader. Its ctx will be canceled while the API is blocking.
+	ctxA, cancelA := context.WithCancel(context.Background())
+	go func() {
+		defer wg.Done()
+		out, err := awsclient.SESActiveReceiptRuleSetForTest(ctxA, clients)
+		resA = result{out: out, err: err}
+	}()
+
+	// Wait for goroutine A to enter the blocking stub.
+	<-mock.inFlightCh
+
+	// Brief barrier — matches the 50ms convention used in PIN 3 — to let A park
+	// inside the singleflight .Do before we start goroutine B.
+	time.Sleep(30 * time.Millisecond)
+
+	// Goroutine B — the follower. Uses a long-lived context (never canceled).
+	go func() {
+		defer wg.Done()
+		out, err := awsclient.SESActiveReceiptRuleSetForTest(context.Background(), clients)
+		resB = result{out: out, err: err}
+	}()
+
+	// Brief barrier — let B park waiting on the singleflight result before we cancel A.
+	time.Sleep(30 * time.Millisecond)
+
+	// Cancel the leader's ctx. This is the trigger that exposes the bug:
+	// a naive singleflight implementation propagates ctxA's error to B.
+	cancelA()
+
+	// Let the leader observe its cancellation and return from .Do.
+	time.Sleep(30 * time.Millisecond)
+
+	// Release the mock so any continuing or retry fetch can complete.
+	close(mock.releaseCh)
+
+	// Wait for both goroutines to finish.
+	wg.Wait()
+
+	// ---- REGRESSION PIN (follower must succeed) ----
+
+	// errB must be nil: the follower's context was never canceled.
+	// Pre-fix failure: errB == context.Canceled (poisoned by leader).
+	if resB.err != nil {
+		t.Errorf("follower errB = %v, want nil — follower's ctx was not canceled; leader cancellation must not propagate to follower", resB.err)
+	}
+
+	// outB must be non-nil when errB is nil.
+	if resB.out == nil {
+		t.Errorf("follower outB = nil, want non-nil successful result")
+	}
+
+	// outB must carry the expected fixture data (not a zero-value struct).
+	if resB.out != nil {
+		if len(resB.out.Rules) == 0 {
+			t.Errorf("follower outB.Rules is empty, want at least 1 rule")
+		} else if got, want := aws.ToString(resB.out.Rules[0].Name), "follower-rule"; got != want {
+			t.Errorf("follower outB.Rules[0].Name = %q, want %q", got, want)
+		}
+	}
+
+	// call count must be 1 or 2 — see comment above for rationale.
+	// Fewer than 1 is impossible; more than 2 suggests an unbounded retry loop.
+	if got := mock.calls.Load(); got < 1 || got > 2 {
+		t.Errorf("DescribeActiveReceiptRuleSet called %d times, want 1 or 2 (coalesced or detached re-fetch)", got)
+	}
+
+	// leader outcome intentionally not asserted — see package-level comment.
+	_ = resA
 }

--- a/tests/unit/aws_ses_invalidation_test.go
+++ b/tests/unit/aws_ses_invalidation_test.go
@@ -668,3 +668,78 @@ func TestSESActiveReceiptRuleSet_Singleflight_LeaderCancelDoesNotPoisonFollower(
 	// leader outcome intentionally not asserted — see package-level comment.
 	_ = resA
 }
+
+// ---------------------------------------------------------------------------
+// PIN 5 — nil result must NOT be cached as a successful entry
+// ---------------------------------------------------------------------------
+// Regression introduced in the GetOrFetch refactor (PR-307): GetOrFetch calls
+// s.Set(v) whenever err == nil, even when v == nil. This stores (ruleSet=nil,
+// ok=true). Subsequent Get() calls return (nil, true) and the fetcher is
+// never invoked again — the nil result is sticky.
+//
+// AWS SES DescribeActiveReceiptRuleSet legitimately returns (nil, nil) when
+// no rule set is active, so this regression is reachable in production.
+//
+// Pre-fix expected failure mode: mock.calls == 1 after the second call
+// (the nil was cached on the first call; the fetcher is never invoked again).
+//
+// Post-fix expected pass mode: mock.calls == 2 (the nil result was not cached;
+// the fetcher is invoked on the second call too).
+
+// nilReturnSESV1 is a minimal SESV1API mock that always returns (nil, nil)
+// — emulating an AWS account with no active SES receipt rule set.
+// calls is an atomic counter so the test can assert exact invocation count.
+type nilReturnSESV1 struct {
+	calls atomic.Int32
+}
+
+func (n *nilReturnSESV1) DescribeActiveReceiptRuleSet(
+	_ context.Context,
+	_ *ses.DescribeActiveReceiptRuleSetInput,
+	_ ...func(*ses.Options),
+) (*ses.DescribeActiveReceiptRuleSetOutput, error) {
+	n.calls.Add(1)
+	return nil, nil
+}
+
+// Compile-time check: nilReturnSESV1 satisfies SESV1API.
+var _ awsclient.SESV1API = (*nilReturnSESV1)(nil)
+
+// TestSESActiveReceiptRuleSet_NilResultIsNotCached is the regression pin for the
+// nil-caching bug in GetOrFetch.
+//
+// The invariant pinned: when the AWS API returns (nil, nil), the store must NOT
+// record a successful cache entry. The next call must invoke the fetcher again.
+func TestSESActiveReceiptRuleSet_NilResultIsNotCached(t *testing.T) {
+	mock := &nilReturnSESV1{}
+
+	clients := &awsclient.ServiceClients{SES: mock}
+	clients.SetRuleSets(session.NewRuleSetStore())
+
+	ctx := context.Background()
+
+	// ---- Call 1: fetcher returns (nil, nil). ----
+	out1, err1 := awsclient.SESActiveReceiptRuleSetForTest(ctx, clients)
+	if err1 != nil {
+		t.Fatalf("call 1: unexpected error: %v", err1)
+	}
+	if out1 != nil {
+		t.Fatalf("call 1: expected nil output, got %v", out1)
+	}
+	if got := mock.calls.Load(); got != 1 {
+		t.Fatalf("after call 1: mock.calls = %d, want 1", got)
+	}
+
+	// ---- Call 2: nil must NOT have been cached — fetcher must be called again. ----
+	out2, err2 := awsclient.SESActiveReceiptRuleSetForTest(ctx, clients)
+	if err2 != nil {
+		t.Fatalf("call 2: unexpected error: %v", err2)
+	}
+	if out2 != nil {
+		t.Fatalf("call 2: expected nil output, got %v", out2)
+	}
+	// REGRESSION PIN: pre-fix mock.calls == 1 (sticky nil); post-fix mock.calls == 2.
+	if got := mock.calls.Load(); got != 2 {
+		t.Errorf("mock.calls = %d, want 2 — nil result was cached as a success (sticky nil regression)", got)
+	}
+}

--- a/tests/unit/aws_ses_invalidation_test.go
+++ b/tests/unit/aws_ses_invalidation_test.go
@@ -29,7 +29,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ses"
@@ -600,29 +599,39 @@ func TestSESActiveReceiptRuleSet_Singleflight_LeaderCancelDoesNotPoisonFollower(
 
 	// Wait for goroutine A to enter the blocking stub.
 	<-mock.inFlightCh
-
-	// Brief barrier — matches the 50ms convention used in PIN 3 — to let A park
-	// inside the singleflight .Do before we start goroutine B.
-	time.Sleep(30 * time.Millisecond)
+	// A is now inside the fetcher closure inside singleflight.Do. A few yields
+	// for paranoia (singleflight bookkeeping after fetcher invocation).
+	for range 10 {
+		runtime.Gosched()
+	}
 
 	// Goroutine B — the follower. Uses a long-lived context (never canceled).
+	// bStarted is closed immediately before B calls the helper, giving us a
+	// deterministic signal that B has been scheduled.
+	bStarted := make(chan struct{})
 	go func() {
 		defer wg.Done()
+		close(bStarted)
 		out, err := awsclient.SESActiveReceiptRuleSetForTest(context.Background(), clients)
 		resB = result{out: out, err: err}
 	}()
 
-	// Brief barrier — let B park waiting on the singleflight result before we cancel A.
-	time.Sleep(30 * time.Millisecond)
+	// Wait for B to start, then yield aggressively to let it reach the
+	// singleflight DoChan wait point before we cancel A.
+	// 100 yields matches PIN 3's barrier idiom; bounded so a stuck test
+	// fails fast rather than hanging the suite indefinitely.
+	<-bStarted
+	for range 100 {
+		runtime.Gosched()
+	}
 
 	// Cancel the leader's ctx. This is the trigger that exposes the bug:
 	// a naive singleflight implementation propagates ctxA's error to B.
 	cancelA()
 
-	// Let the leader observe its cancellation and return from .Do.
-	time.Sleep(30 * time.Millisecond)
-
-	// Release the mock so any continuing or retry fetch can complete.
+	// Release the mock — any continuing detached fetch (Fix 1: WithoutCancel)
+	// finishes the work for B. wg.Wait() below ensures both goroutines finish
+	// before we check results, so no sleep is needed after cancelA.
 	close(mock.releaseCh)
 
 	// Wait for both goroutines to finish.

--- a/tests/unit/aws_ses_invalidation_test.go
+++ b/tests/unit/aws_ses_invalidation_test.go
@@ -6,11 +6,29 @@
 // Also contains Pin 2: regression pin verifying that Ctrl+R on a detail view for
 // a ses resource type calls InvalidateSESRuleSetCache, so the next related-panel
 // check re-fetches the receipt-rule-set instead of serving stale cached data.
+//
+// Also contains Pin 3: singleflight coalescing regression pin verifying that N
+// concurrent callers of SESActiveReceiptRuleSetForTest (which delegates to the
+// unexported sesActiveReceiptRuleSet) result in exactly 1 upstream API call when
+// singleflight is in place.
+//
+// NOTE TO CODER: This test requires the following exported test helper to be added
+// to internal/aws/ses_related.go (or a new ses_related_export_test.go file):
+//
+//	// SESActiveReceiptRuleSetForTest is a test-only export of sesActiveReceiptRuleSet.
+//	func SESActiveReceiptRuleSetForTest(ctx context.Context, c *ServiceClients) (*ses.DescribeActiveReceiptRuleSetOutput, error) {
+//	    return sesActiveReceiptRuleSet(ctx, c)
+//	}
+//
+// The test will fail to compile until this export exists.
 package unit_test
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ses"
@@ -332,5 +350,134 @@ func TestSESRuleSetSwap_LateWriterDoesNotPoisonNewStore(t *testing.T) {
 	// passing).
 	if _, ok := oldStore.Get(); !ok {
 		t.Errorf("orphaned old store has NO cached entry — late writer didn't fire; test is vacuous")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PIN 3 — singleflight coalescing of concurrent sesActiveReceiptRuleSet callers
+// ---------------------------------------------------------------------------
+// Pre-fix: two concurrent callers both observe a cache miss and both invoke
+// DescribeActiveReceiptRuleSet. When one succeeds and the sibling transiently
+// fails (throttle / 5xx), the failing checker returns Count:-1 even though the
+// cache now holds the successful result.
+//
+// Post-fix: singleflight ensures exactly one upstream call is issued; all
+// concurrent waiters share the single result.
+//
+// This test calls the unexported sesActiveReceiptRuleSet via the exported
+// test wrapper SESActiveReceiptRuleSetForTest. The coder MUST add that
+// wrapper to internal/aws/ses_related.go (see the package-level NOTE at the
+// top of this file). Until the wrapper exists the test fails to compile —
+// that IS the intended red light for Plan B.
+
+// atomicBlockingSESV1 is a goroutine-safe SES v1 mock that:
+//   - counts calls atomically
+//   - blocks every DescribeActiveReceiptRuleSet call on releaseCh
+//   - signals inFlightCh when at least one call is in progress
+type atomicBlockingSESV1 struct {
+	calls      atomic.Int32
+	releaseCh  chan struct{}
+	inFlightCh chan struct{} // closed once the first call enters the stub
+	closeOnce  sync.Once
+	output     *ses.DescribeActiveReceiptRuleSetOutput
+}
+
+func (a *atomicBlockingSESV1) DescribeActiveReceiptRuleSet(
+	_ context.Context,
+	_ *ses.DescribeActiveReceiptRuleSetInput,
+	_ ...func(*ses.Options),
+) (*ses.DescribeActiveReceiptRuleSetOutput, error) {
+	a.calls.Add(1)
+	a.closeOnce.Do(func() { close(a.inFlightCh) })
+	<-a.releaseCh
+	return a.output, nil
+}
+
+// Compile-time check: atomicBlockingSESV1 satisfies SESV1API.
+var _ awsclient.SESV1API = (*atomicBlockingSESV1)(nil)
+
+// TestSESActiveReceiptRuleSet_Singleflight_CoalescesConcurrentMisses verifies
+// that N concurrent callers of sesActiveReceiptRuleSet result in exactly 1
+// upstream API invocation when singleflight coalescing is in place.
+//
+// Expected red light (pre-fix): a.calls == 5 (one per goroutine) — the assertion
+// `a.calls.Load() == 1` fires, failing the test.
+//
+// Expected green light (post-fix): a.calls == 1; all goroutines received the
+// same successful output.
+func TestSESActiveReceiptRuleSet_Singleflight_CoalescesConcurrentMisses(t *testing.T) {
+	const N = 5
+
+	ruleSetOutput := &ses.DescribeActiveReceiptRuleSetOutput{
+		Rules: []sestypes.ReceiptRule{
+			{
+				Name:       aws.String("coalesced-rule"),
+				Recipients: nil, // global — applies to all identities
+				Actions: []sestypes.ReceiptAction{
+					{LambdaAction: &sestypes.LambdaAction{
+						FunctionArn: aws.String("arn:aws:lambda:us-east-1:123456789012:function:coalesced"),
+					}},
+				},
+			},
+		},
+	}
+
+	mock := &atomicBlockingSESV1{
+		releaseCh:  make(chan struct{}),
+		inFlightCh: make(chan struct{}),
+		output:     ruleSetOutput,
+	}
+
+	clients := &awsclient.ServiceClients{SES: mock}
+	clients.SetRuleSets(session.NewRuleSetStore())
+
+	type result struct {
+		out *ses.DescribeActiveReceiptRuleSetOutput
+		err error
+	}
+	results := make([]result, N)
+	var wg sync.WaitGroup
+	wg.Add(N)
+
+	for i := range N {
+		go func(idx int) {
+			defer wg.Done()
+			out, err := awsclient.SESActiveReceiptRuleSetForTest(context.Background(), clients)
+			results[idx] = result{out: out, err: err}
+		}(i)
+	}
+
+	// Allow goroutines time to enter the blocking stub before releasing it.
+	// 50 ms matches the style used in TestSESRuleSetSwap_LateWriterDoesNotPoisonNewStore.
+	<-mock.inFlightCh
+	time.Sleep(50 * time.Millisecond)
+
+	// Release all blocked callers.
+	close(mock.releaseCh)
+	wg.Wait()
+
+	// With singleflight, the API must have been called exactly once.
+	if got := mock.calls.Load(); got != 1 {
+		t.Errorf("DescribeActiveReceiptRuleSet called %d times, want 1 — singleflight not coalescing concurrent misses", got)
+	}
+
+	// Every goroutine must have received a non-nil, non-error result with the
+	// expected rule-set name (no caller should see a failure while another succeeded).
+	for i, r := range results {
+		if r.err != nil {
+			t.Errorf("goroutine %d: unexpected error: %v", i, r.err)
+			continue
+		}
+		if r.out == nil {
+			t.Errorf("goroutine %d: got nil output, want non-nil", i)
+			continue
+		}
+		if len(r.out.Rules) == 0 {
+			t.Errorf("goroutine %d: got empty Rules, want at least 1", i)
+			continue
+		}
+		if got, want := aws.ToString(r.out.Rules[0].Name), "coalesced-rule"; got != want {
+			t.Errorf("goroutine %d: rule name = %q, want %q", i, got, want)
+		}
 	}
 }

--- a/tests/unit/phase03_finding_model_types_test.go
+++ b/tests/unit/phase03_finding_model_types_test.go
@@ -1,0 +1,159 @@
+// phase03_finding_model_types_test.go — TDD red-light tests for PR-03a-types.
+//
+// These tests MUST fail to compile until the following are added:
+//   - domain.FindingCode, domain.Finding, domain.AttentionDetail, domain.DetailRow
+//   - Resource.Findings and Resource.AttentionDetails fields
+//   - ResourceTypeDef.LifecycleKey field
+//
+// Spec: docs/refactor/03-finding-model.md
+package unit_test
+
+import (
+	"testing"
+
+	"github.com/k2m30/a9s/v3/internal/domain"
+	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// TestPhase03_FindingStructShape verifies that domain.Finding carries all four
+// expected fields and that each field round-trips correctly.
+func TestPhase03_FindingStructShape(t *testing.T) {
+	f := domain.Finding{
+		Code:     "ec2.impaired",
+		Phrase:   "impaired",
+		Severity: domain.SevBroken,
+		Source:   "wave1",
+	}
+	if f.Code != "ec2.impaired" {
+		t.Errorf("Code: got %q, want %q", f.Code, "ec2.impaired")
+	}
+	if f.Phrase != "impaired" {
+		t.Errorf("Phrase: got %q, want %q", f.Phrase, "impaired")
+	}
+	if f.Severity != domain.SevBroken {
+		t.Errorf("Severity: got %v, want SevBroken", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPhase03_FindingCodeIsString verifies that FindingCode is a string
+// alias and that string() conversion is lossless.
+func TestPhase03_FindingCodeIsString(t *testing.T) {
+	if string(domain.FindingCode("foo")) != "foo" {
+		t.Errorf("string(FindingCode(%q)) != %q", "foo", "foo")
+	}
+}
+
+// TestPhase03_AttentionDetailShape verifies that AttentionDetail holds a Rows
+// slice and that the first DetailRow exposes Label, Value, and Tier.
+func TestPhase03_AttentionDetailShape(t *testing.T) {
+	ad := domain.AttentionDetail{
+		Rows: []domain.DetailRow{
+			{Label: "L", Value: "V", Tier: "!"},
+		},
+	}
+	if len(ad.Rows) != 1 {
+		t.Fatalf("len(Rows): got %d, want 1", len(ad.Rows))
+	}
+	r := ad.Rows[0]
+	if r.Label != "L" {
+		t.Errorf("Label: got %q, want %q", r.Label, "L")
+	}
+	if r.Value != "V" {
+		t.Errorf("Value: got %q, want %q", r.Value, "V")
+	}
+	if r.Tier != "!" {
+		t.Errorf("Tier: got %q, want %q", r.Tier, "!")
+	}
+}
+
+// TestPhase03_DetailRowTierZeroValue documents the contract that an omitted
+// Tier field defaults to the empty string.
+func TestPhase03_DetailRowTierZeroValue(t *testing.T) {
+	r := domain.DetailRow{Label: "L", Value: "V"}
+	if r.Tier != "" {
+		t.Errorf("Tier zero value: got %q, want %q", r.Tier, "")
+	}
+}
+
+// TestPhase03_ResourceFindingsField verifies that Resource accepts both
+// Findings and AttentionDetails and that the stored values are retrievable.
+func TestPhase03_ResourceFindingsField(t *testing.T) {
+	r := domain.Resource{
+		Findings: []domain.Finding{
+			{Code: "x", Phrase: "y", Severity: domain.SevWarn, Source: "wave2:ec2"},
+		},
+		AttentionDetails: map[domain.FindingCode]domain.AttentionDetail{
+			"x": {Rows: []domain.DetailRow{{Label: "L", Value: "V"}}},
+		},
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("len(Findings): got %d, want 1", len(r.Findings))
+	}
+	if r.Findings[0].Code != "x" {
+		t.Errorf("Findings[0].Code: got %q, want %q", r.Findings[0].Code, "x")
+	}
+	if len(r.AttentionDetails) != 1 {
+		t.Fatalf("len(AttentionDetails): got %d, want 1", len(r.AttentionDetails))
+	}
+	if r.AttentionDetails["x"].Rows[0].Label != "L" {
+		t.Errorf("AttentionDetails[x].Rows[0].Label: got %q, want %q",
+			r.AttentionDetails["x"].Rows[0].Label, "L")
+	}
+}
+
+// TestPhase03_ResourceLegacyFieldsStillPresent is a sentinel guard for PR-03n:
+// the legacy fields (Status, Issues, Fields, RawStruct) must remain present on
+// Resource until they are explicitly migrated away.
+func TestPhase03_ResourceLegacyFieldsStillPresent(t *testing.T) {
+	r := domain.Resource{
+		ID:        "i-abc123",
+		Name:      "my-instance",
+		Type:      "ec2",
+		Status:    "running",
+		Issues:    []string{"check-failed"},
+		Fields:    map[string]string{"az": "us-east-1a"},
+		RawStruct: struct{}{},
+	}
+	if r.ID != "i-abc123" {
+		t.Errorf("ID: got %q, want %q", r.ID, "i-abc123")
+	}
+	if r.Name != "my-instance" {
+		t.Errorf("Name: got %q, want %q", r.Name, "my-instance")
+	}
+	if r.Type != "ec2" {
+		t.Errorf("Type: got %q, want %q", r.Type, "ec2")
+	}
+	if r.Status != "running" {
+		t.Errorf("Status: got %q, want %q", r.Status, "running")
+	}
+	if len(r.Issues) != 1 || r.Issues[0] != "check-failed" {
+		t.Errorf("Issues: got %v, want [check-failed]", r.Issues)
+	}
+	if r.Fields["az"] != "us-east-1a" {
+		t.Errorf("Fields[az]: got %q, want %q", r.Fields["az"], "us-east-1a")
+	}
+	if r.RawStruct == nil {
+		t.Error("RawStruct: got nil, want non-nil")
+	}
+}
+
+// TestPhase03_ResourceTypeDefLifecycleKey verifies that ResourceTypeDef
+// accepts and returns the LifecycleKey field.
+func TestPhase03_ResourceTypeDefLifecycleKey(t *testing.T) {
+	td := resource.ResourceTypeDef{ShortName: "ec2", LifecycleKey: "state"}
+	if td.LifecycleKey != "state" {
+		t.Errorf("LifecycleKey: got %q, want %q", td.LifecycleKey, "state")
+	}
+}
+
+// TestPhase03_LifecycleKeyZeroValueIsEmpty verifies that LifecycleKey defaults
+// to the empty string when not set.
+func TestPhase03_LifecycleKeyZeroValueIsEmpty(t *testing.T) {
+	td := resource.ResourceTypeDef{}
+	if td.LifecycleKey != "" {
+		t.Errorf("LifecycleKey zero value: got %q, want %q", td.LifecycleKey, "")
+	}
+}


### PR DESCRIPTION
## Summary

Two changes on one branch (per user direction — no overbranching).

### 1. PR-03a-types (Phase 03 of architecture refactor)

Pure additive type declarations for the canonical finding model. No consumers, no shim, no view changes — types are unread until PR-03a-shim. Legacy \`Resource.Status\` / \`Resource.Issues\` fields stay until PR-03n.

Adds in \`internal/domain\`:
- \`FindingCode string\` — namespaced stable identifier (e.g. \`ec2.impaired\`)
- \`Finding{Code, Phrase, Severity, Source}\` — drives row coloring, list-view Status, menu badges, ctrl+z filter
- \`AttentionDetail{Rows []DetailRow}\` — supporting facts per finding for detail-view Attention section
- \`DetailRow{Label, Value, Tier}\` — \`Tier\` is \`!\` / \`~\` / \`\"\"\`

Adds on \`Resource\`:
- \`Findings []Finding\`
- \`AttentionDetails map[FindingCode]AttentionDetail\`

Adds on \`ResourceTypeDef\`:
- \`LifecycleKey string\` — empty defaults to \`state\` at read time. Per-category PRs (03b–m) set explicit non-default values.

Design note: an earlier attempt placed \`AttentionDetail\` in \`internal/semantics/attention\` with an \`AttentionDetailRef\` marker interface to keep \`internal/domain\` import-leaf-clean. Abandoned because Go's unexported-method rule prevents cross-package interface satisfaction. Collapsed into \`internal/domain\` directly.

### 2. SES singleflight fix (CodeRabbit P2 on PR #306)

**Bug.** Post-PR-02d, two concurrent \`sesActiveReceiptRuleSet\` callers (\`checkSESLambda\` + \`checkSESS3\` dispatched in parallel from a single detail-view open) could both miss the cache and both invoke \`DescribeActiveReceiptRuleSet\`. If one transiently failed (throttle, 5xx, timeout) while the sibling succeeded and populated the store, the failing checker returned \`Count:-1\` even though the cache held the successful result.

**Cause.** PR-02d removed the package-global \`sesRuleSetCachesMu\` along with the \`*ServiceClients\`-keyed map; the per-Session \`RuleSetStore\` had no equivalent coalescing.

**Fix.** Add \`singleflight.Group\` to \`ruleSetStore\` + new \`GetOrFetch(fetcher func() (any, error)) (any, error)\` method. Concurrent misses share one upstream fetch. The capture-store-reference pattern is preserved (\`store := c.RuleSets()\` at function entry) — late writers from orphaned fetches land on the captured store, never the post-rotation new store.

## Test plan

- [x] 8 new \`TestPhase03_*\` tests pin every new type/field shape (failing-compile TDD red light → green)
- [x] \`TestSESActiveReceiptRuleSet_Singleflight_CoalescesConcurrentMisses\` — 5 goroutines, blocked mock SES, asserts \`mock.calls == 1\` and identical successful result for every caller
- [x] \`make test-race\` clean across the new singleflight code path
- [x] Full suite: 13,383 tests pass (was 13,374 — 9 new)
- [x] \`make lint\`, \`make security\`: zero issues

## Out of scope

- Per-category cutover (PR-03b through PR-03m) — separate PRs.
- DeriveFindings shim (PR-03a-shim) and applyEnrichment fold (PR-03a-fold).
- Deleting \`Status\` / \`Issues\` (PR-03n).