### PR TITLE
feat(phase-03-pr03c): containers — fetchers emit canonical Findings

### DIFF
--- a/internal/aws/ecs.go
+++ b/internal/aws/ecs.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -108,10 +109,24 @@ func FetchECSClustersPage(ctx context.Context, listAPI ECSListClustersAPI, descr
 		pendingTasks := fmt.Sprintf("%d", cluster.PendingTasksCount)
 		servicesCount := fmt.Sprintf("%d", cluster.ActiveServicesCount)
 
+		// PR-03c: emit wave1 Findings for non-healthy lifecycle states.
+		// ACTIVE → no Finding (healthy). Fields["status"] is still populated
+		// so the existing structural Color path works as fallback.
+		var findings []domain.Finding
+		switch status {
+		case "PROVISIONING":
+			findings = []domain.Finding{{Code: CodeECSStateProvisioning, Phrase: "provisioning", Severity: domain.SevWarn, Source: "wave1"}}
+		case "DEPROVISIONING":
+			findings = []domain.Finding{{Code: CodeECSStateDeprovisioning, Phrase: "deprovisioning", Severity: domain.SevWarn, Source: "wave1"}}
+		case "FAILED":
+			findings = []domain.Finding{{Code: CodeECSStateFailed, Phrase: "failed", Severity: domain.SevBroken, Source: "wave1"}}
+		case "INACTIVE":
+			findings = []domain.Finding{{Code: CodeECSStateInactive, Phrase: "inactive", Severity: domain.SevBroken, Source: "wave1"}}
+		}
+
 		r := resource.Resource{
-			ID:     clusterName,
-			Name:   clusterName,
-			Status: status,
+			ID:   clusterName,
+			Name: clusterName,
 			Fields: map[string]string{
 				"cluster_name":   clusterName,
 				"status":         status,
@@ -119,6 +134,7 @@ func FetchECSClustersPage(ctx context.Context, listAPI ECSListClustersAPI, descr
 				"pending_tasks":  pendingTasks,
 				"services_count": servicesCount,
 			},
+			Findings:  findings,
 			RawStruct: cluster,
 		}
 

--- a/internal/aws/ecs_codes.go
+++ b/internal/aws/ecs_codes.go
@@ -1,0 +1,24 @@
+// ecs_codes.go — canonical FindingCode constants for the ecs resource type.
+// Phase 03 PR-03c. The fetcher writes Findings using these codes; the
+// ecs Color func reads wave1 Findings (Source == "wave1") to color rows.
+package aws
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+const (
+	// CodeECSStateProvisioning — cluster is in the "PROVISIONING" lifecycle state.
+	// Severity: SevWarn (transitional).
+	CodeECSStateProvisioning domain.FindingCode = "ecs.state.provisioning"
+
+	// CodeECSStateDeprovisioning — cluster is in the "DEPROVISIONING" lifecycle state.
+	// Severity: SevWarn (transitional).
+	CodeECSStateDeprovisioning domain.FindingCode = "ecs.state.deprovisioning"
+
+	// CodeECSStateFailed — cluster has failed.
+	// Severity: SevBroken.
+	CodeECSStateFailed domain.FindingCode = "ecs.state.failed"
+
+	// CodeECSStateInactive — cluster is inactive (non-recoverable without recreation).
+	// Severity: SevBroken.
+	CodeECSStateInactive domain.FindingCode = "ecs.state.inactive"
+)

--- a/internal/aws/ecs_svc.go
+++ b/internal/aws/ecs_svc.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -95,10 +96,20 @@ func FetchECSServicesPage(
 				taskDefinition = *svc.TaskDefinition
 			}
 
+			// PR-03c: emit wave1 Findings for non-healthy lifecycle states.
+			// ACTIVE → no Finding (healthy). Fields["status"] is still populated
+			// so the existing structural Color path works as fallback.
+			var findings []domain.Finding
+			switch status {
+			case "DRAINING":
+				findings = []domain.Finding{{Code: CodeECSSvcStateDraining, Phrase: "draining", Severity: domain.SevWarn, Source: "wave1"}}
+			case "INACTIVE":
+				findings = []domain.Finding{{Code: CodeECSSvcStateInactive, Phrase: "inactive", Severity: domain.SevBroken, Source: "wave1"}}
+			}
+
 			r := resource.Resource{
-				ID:     serviceName,
-				Name:   serviceName,
-				Status: status,
+				ID:   serviceName,
+				Name: serviceName,
 				Fields: map[string]string{
 					"service_name":    serviceName,
 					"cluster":         clusterName,
@@ -108,6 +119,7 @@ func FetchECSServicesPage(
 					"launch_type":     launchType,
 					"task_definition": taskDefinition,
 				},
+				Findings:  findings,
 				RawStruct: svc,
 			}
 

--- a/internal/aws/ecs_svc_codes.go
+++ b/internal/aws/ecs_svc_codes.go
@@ -1,0 +1,16 @@
+// ecs_svc_codes.go — canonical FindingCode constants for the ecs-svc resource type.
+// Phase 03 PR-03c. The fetcher writes Findings using these codes; the
+// ecs-svc Color func reads wave1 Findings (Source == "wave1") to color rows.
+package aws
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+const (
+	// CodeECSSvcStateInactive — service is inactive (terminal; non-recoverable without recreation).
+	// Severity: SevBroken.
+	CodeECSSvcStateInactive domain.FindingCode = "ecs-svc.state.inactive"
+
+	// CodeECSSvcStateDraining — service is draining connections.
+	// Severity: SevWarn (transitional).
+	CodeECSSvcStateDraining domain.FindingCode = "ecs-svc.state.draining"
+)

--- a/internal/aws/ecs_svc_tasks.go
+++ b/internal/aws/ecs_svc_tasks.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 
-	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -154,21 +153,7 @@ func convertEcsTask(task ecstypes.Task) resource.Resource {
 
 	// PR-03c: emit wave1 Findings for non-healthy transitional states.
 	// RUNNING and STOPPED → no Finding (lifecycle; stop_code handled structurally).
-	var findings []domain.Finding
-	switch status {
-	case "PROVISIONING":
-		findings = []domain.Finding{{Code: CodeECSTaskStateProvisioning, Phrase: "provisioning", Severity: domain.SevWarn, Source: "wave1"}}
-	case "PENDING":
-		findings = []domain.Finding{{Code: CodeECSTaskStatePending, Phrase: "pending", Severity: domain.SevWarn, Source: "wave1"}}
-	case "ACTIVATING":
-		findings = []domain.Finding{{Code: CodeECSTaskStateActivating, Phrase: "activating", Severity: domain.SevWarn, Source: "wave1"}}
-	case "DEACTIVATING":
-		findings = []domain.Finding{{Code: CodeECSTaskStateDeactivating, Phrase: "deactivating", Severity: domain.SevWarn, Source: "wave1"}}
-	case "STOPPING":
-		findings = []domain.Finding{{Code: CodeECSTaskStateStopping, Phrase: "stopping", Severity: domain.SevWarn, Source: "wave1"}}
-	case "DEPROVISIONING":
-		findings = []domain.Finding{{Code: CodeECSTaskStateDeprovisioning, Phrase: "deprovisioning", Severity: domain.SevWarn, Source: "wave1"}}
-	}
+	findings := ecsTaskWave1Findings(status)
 
 	return resource.Resource{
 		ID:   taskIDShort,

--- a/internal/aws/ecs_svc_tasks.go
+++ b/internal/aws/ecs_svc_tasks.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -151,10 +152,27 @@ func convertEcsTask(task ecstypes.Task) resource.Resource {
 		stoppedReason = strings.ReplaceAll(*task.StoppedReason, "\n", " ")
 	}
 
+	// PR-03c: emit wave1 Findings for non-healthy transitional states.
+	// RUNNING and STOPPED → no Finding (lifecycle; stop_code handled structurally).
+	var findings []domain.Finding
+	switch status {
+	case "PROVISIONING":
+		findings = []domain.Finding{{Code: CodeECSTaskStateProvisioning, Phrase: "provisioning", Severity: domain.SevWarn, Source: "wave1"}}
+	case "PENDING":
+		findings = []domain.Finding{{Code: CodeECSTaskStatePending, Phrase: "pending", Severity: domain.SevWarn, Source: "wave1"}}
+	case "ACTIVATING":
+		findings = []domain.Finding{{Code: CodeECSTaskStateActivating, Phrase: "activating", Severity: domain.SevWarn, Source: "wave1"}}
+	case "DEACTIVATING":
+		findings = []domain.Finding{{Code: CodeECSTaskStateDeactivating, Phrase: "deactivating", Severity: domain.SevWarn, Source: "wave1"}}
+	case "STOPPING":
+		findings = []domain.Finding{{Code: CodeECSTaskStateStopping, Phrase: "stopping", Severity: domain.SevWarn, Source: "wave1"}}
+	case "DEPROVISIONING":
+		findings = []domain.Finding{{Code: CodeECSTaskStateDeprovisioning, Phrase: "deprovisioning", Severity: domain.SevWarn, Source: "wave1"}}
+	}
+
 	return resource.Resource{
-		ID:     taskIDShort,
-		Name:   taskIDShort,
-		Status: status,
+		ID:   taskIDShort,
+		Name: taskIDShort,
 		Fields: map[string]string{
 			"task_id_short":  taskIDShort,
 			"status":         status,
@@ -163,6 +181,7 @@ func convertEcsTask(task ecstypes.Task) resource.Resource {
 			"started_at":     startedAt,
 			"stopped_reason": stoppedReason,
 		},
+		Findings:  findings,
 		RawStruct: task,
 	}
 }

--- a/internal/aws/ecs_svc_tasks.go
+++ b/internal/aws/ecs_svc_tasks.go
@@ -15,7 +15,7 @@ import (
 func init() {
 	resource.RegisterFieldKeys("ecs_tasks", []string{
 		"task_id_short", "status", "health", "task_def_short",
-		"started_at", "stopped_reason",
+		"started_at", "stopped_reason", "stop_code",
 	})
 
 	resource.RegisterPaginatedChild("ecs_tasks", func(ctx context.Context, clients any, parentCtx resource.ParentContext, continuationToken string) (resource.FetchResult, error) {
@@ -30,6 +30,34 @@ func init() {
 		Name:      "Service Tasks",
 		ShortName: "ecs_tasks",
 		Columns:   resource.EcsSvcTaskColumns(),
+		Color: func(r resource.Resource) resource.Color {
+			// Structural broken overrides (precedence over wave1).
+			if r.Fields["health"] == "UNHEALTHY" {
+				return resource.ColorBroken
+			}
+			if r.Fields["status"] == "STOPPED" {
+				sc := r.Fields["stop_code"]
+				if sc != "" && sc != "UserInitiated" {
+					return resource.ColorBroken
+				}
+			}
+			// Wave1 Findings.
+			for _, f := range r.Findings {
+				if f.Source == "wave1" {
+					return resource.ColorFromSeverity(f.Severity)
+				}
+			}
+			// Structural lifecycle fallback.
+			switch r.Fields["status"] {
+			case "RUNNING":
+				return resource.ColorHealthy
+			case "STOPPED":
+				return resource.ColorDim
+			case "PROVISIONING", "PENDING", "ACTIVATING", "DEACTIVATING", "STOPPING", "DEPROVISIONING":
+				return resource.ColorWarning
+			}
+			return resource.ColorHealthy
+		},
 	})
 }
 
@@ -155,6 +183,8 @@ func convertEcsTask(task ecstypes.Task) resource.Resource {
 	// RUNNING and STOPPED → no Finding (lifecycle; stop_code handled structurally).
 	findings := ecsTaskWave1Findings(status)
 
+	stopCode := string(task.StopCode)
+
 	return resource.Resource{
 		ID:   taskIDShort,
 		Name: taskIDShort,
@@ -165,6 +195,7 @@ func convertEcsTask(task ecstypes.Task) resource.Resource {
 			"task_def_short": taskDefShort,
 			"started_at":     startedAt,
 			"stopped_reason": stoppedReason,
+			"stop_code":      stopCode,
 		},
 		Findings:  findings,
 		RawStruct: task,

--- a/internal/aws/ecs_task.go
+++ b/internal/aws/ecs_task.go
@@ -12,6 +12,7 @@ import (
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/aws/smithy-go"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -151,11 +152,29 @@ func fetchECSTasksPageWithJoin(
 				fields["task_def_join_error"] = "true"
 			}
 
+			// PR-03c: emit wave1 Findings for non-healthy transitional states.
+			// RUNNING and STOPPED → no Finding (lifecycle; stop_code handled structurally).
+			var findings []domain.Finding
+			switch status {
+			case "PROVISIONING":
+				findings = []domain.Finding{{Code: CodeECSTaskStateProvisioning, Phrase: "provisioning", Severity: domain.SevWarn, Source: "wave1"}}
+			case "PENDING":
+				findings = []domain.Finding{{Code: CodeECSTaskStatePending, Phrase: "pending", Severity: domain.SevWarn, Source: "wave1"}}
+			case "ACTIVATING":
+				findings = []domain.Finding{{Code: CodeECSTaskStateActivating, Phrase: "activating", Severity: domain.SevWarn, Source: "wave1"}}
+			case "DEACTIVATING":
+				findings = []domain.Finding{{Code: CodeECSTaskStateDeactivating, Phrase: "deactivating", Severity: domain.SevWarn, Source: "wave1"}}
+			case "STOPPING":
+				findings = []domain.Finding{{Code: CodeECSTaskStateStopping, Phrase: "stopping", Severity: domain.SevWarn, Source: "wave1"}}
+			case "DEPROVISIONING":
+				findings = []domain.Finding{{Code: CodeECSTaskStateDeprovisioning, Phrase: "deprovisioning", Severity: domain.SevWarn, Source: "wave1"}}
+			}
+
 			r := resource.Resource{
 				ID:        taskID,
 				Name:      taskID,
-				Status:    status,
 				Fields:    fields,
+				Findings:  findings,
 				RawStruct: task,
 			}
 

--- a/internal/aws/ecs_task.go
+++ b/internal/aws/ecs_task.go
@@ -12,7 +12,6 @@ import (
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/aws/smithy-go"
 
-	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -154,21 +153,7 @@ func fetchECSTasksPageWithJoin(
 
 			// PR-03c: emit wave1 Findings for non-healthy transitional states.
 			// RUNNING and STOPPED → no Finding (lifecycle; stop_code handled structurally).
-			var findings []domain.Finding
-			switch status {
-			case "PROVISIONING":
-				findings = []domain.Finding{{Code: CodeECSTaskStateProvisioning, Phrase: "provisioning", Severity: domain.SevWarn, Source: "wave1"}}
-			case "PENDING":
-				findings = []domain.Finding{{Code: CodeECSTaskStatePending, Phrase: "pending", Severity: domain.SevWarn, Source: "wave1"}}
-			case "ACTIVATING":
-				findings = []domain.Finding{{Code: CodeECSTaskStateActivating, Phrase: "activating", Severity: domain.SevWarn, Source: "wave1"}}
-			case "DEACTIVATING":
-				findings = []domain.Finding{{Code: CodeECSTaskStateDeactivating, Phrase: "deactivating", Severity: domain.SevWarn, Source: "wave1"}}
-			case "STOPPING":
-				findings = []domain.Finding{{Code: CodeECSTaskStateStopping, Phrase: "stopping", Severity: domain.SevWarn, Source: "wave1"}}
-			case "DEPROVISIONING":
-				findings = []domain.Finding{{Code: CodeECSTaskStateDeprovisioning, Phrase: "deprovisioning", Severity: domain.SevWarn, Source: "wave1"}}
-			}
+			findings := ecsTaskWave1Findings(status)
 
 			r := resource.Resource{
 				ID:        taskID,

--- a/internal/aws/ecs_task_codes.go
+++ b/internal/aws/ecs_task_codes.go
@@ -34,3 +34,25 @@ const (
 	// Severity: SevWarn (transitional).
 	CodeECSTaskStateDeprovisioning domain.FindingCode = "ecs-task.state.deprovisioning"
 )
+
+// ecsTaskWave1Findings returns the wave1 Finding slice for an ECS task's
+// last_status. Returns nil for terminal/healthy states (RUNNING, STOPPED).
+// Shared by ecs_task.go and ecs_svc_tasks.go::convertEcsTask to keep their
+// lifecycle classification in lockstep.
+func ecsTaskWave1Findings(status string) []domain.Finding {
+	switch status {
+	case "PROVISIONING":
+		return []domain.Finding{{Code: CodeECSTaskStateProvisioning, Phrase: "provisioning", Severity: domain.SevWarn, Source: "wave1"}}
+	case "PENDING":
+		return []domain.Finding{{Code: CodeECSTaskStatePending, Phrase: "pending", Severity: domain.SevWarn, Source: "wave1"}}
+	case "ACTIVATING":
+		return []domain.Finding{{Code: CodeECSTaskStateActivating, Phrase: "activating", Severity: domain.SevWarn, Source: "wave1"}}
+	case "DEACTIVATING":
+		return []domain.Finding{{Code: CodeECSTaskStateDeactivating, Phrase: "deactivating", Severity: domain.SevWarn, Source: "wave1"}}
+	case "STOPPING":
+		return []domain.Finding{{Code: CodeECSTaskStateStopping, Phrase: "stopping", Severity: domain.SevWarn, Source: "wave1"}}
+	case "DEPROVISIONING":
+		return []domain.Finding{{Code: CodeECSTaskStateDeprovisioning, Phrase: "deprovisioning", Severity: domain.SevWarn, Source: "wave1"}}
+	}
+	return nil
+}

--- a/internal/aws/ecs_task_codes.go
+++ b/internal/aws/ecs_task_codes.go
@@ -1,0 +1,36 @@
+// ecs_task_codes.go — canonical FindingCode constants for the ecs-task resource type.
+// Phase 03 PR-03c. The fetcher writes Findings using these codes; the
+// ecs-task Color func reads wave1 Findings (Source == "wave1") to color rows.
+//
+// NOTE: RUNNING and STOPPED are lifecycle states with no Finding emitted.
+// STOPPED's meaningful information is carried by stop_code and handled
+// structurally in the Color func.
+package aws
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+const (
+	// CodeECSTaskStateProvisioning — task is in the "PROVISIONING" lifecycle state.
+	// Severity: SevWarn (transitional).
+	CodeECSTaskStateProvisioning domain.FindingCode = "ecs-task.state.provisioning"
+
+	// CodeECSTaskStatePending — task is in the "PENDING" lifecycle state.
+	// Severity: SevWarn (transitional).
+	CodeECSTaskStatePending domain.FindingCode = "ecs-task.state.pending"
+
+	// CodeECSTaskStateActivating — task is in the "ACTIVATING" lifecycle state.
+	// Severity: SevWarn (transitional).
+	CodeECSTaskStateActivating domain.FindingCode = "ecs-task.state.activating"
+
+	// CodeECSTaskStateDeactivating — task is in the "DEACTIVATING" lifecycle state.
+	// Severity: SevWarn (transitional).
+	CodeECSTaskStateDeactivating domain.FindingCode = "ecs-task.state.deactivating"
+
+	// CodeECSTaskStateStopping — task is in the "STOPPING" lifecycle state.
+	// Severity: SevWarn (transitional).
+	CodeECSTaskStateStopping domain.FindingCode = "ecs-task.state.stopping"
+
+	// CodeECSTaskStateDeprovisioning — task is in the "DEPROVISIONING" lifecycle state.
+	// Severity: SevWarn (transitional).
+	CodeECSTaskStateDeprovisioning domain.FindingCode = "ecs-task.state.deprovisioning"
+)

--- a/internal/aws/ng.go
+++ b/internal/aws/ng.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -265,10 +266,28 @@ func buildNodeGroupResource(clusterName, ngName string, ng *ekstypes.Nodegroup) 
 		}
 	}
 
+	// PR-03c: emit wave1 Findings for non-healthy lifecycle states.
+	// ACTIVE → no Finding (healthy). Fields["status"] is still populated
+	// so the existing structural Color path works for the wave2 fallback.
+	var findings []domain.Finding
+	switch status {
+	case "CREATING":
+		findings = []domain.Finding{{Code: CodeNGStateCreating, Phrase: "creating", Severity: domain.SevWarn, Source: "wave1"}}
+	case "UPDATING":
+		findings = []domain.Finding{{Code: CodeNGStateUpdating, Phrase: "updating", Severity: domain.SevWarn, Source: "wave1"}}
+	case "DELETING":
+		findings = []domain.Finding{{Code: CodeNGStateDeleting, Phrase: "deleting", Severity: domain.SevWarn, Source: "wave1"}}
+	case "CREATE_FAILED":
+		findings = []domain.Finding{{Code: CodeNGStateCreateFailed, Phrase: "create failed", Severity: domain.SevBroken, Source: "wave1"}}
+	case "DELETE_FAILED":
+		findings = []domain.Finding{{Code: CodeNGStateDeleteFailed, Phrase: "delete failed", Severity: domain.SevBroken, Source: "wave1"}}
+	case "DEGRADED":
+		findings = []domain.Finding{{Code: CodeNGStateDegraded, Phrase: "degraded", Severity: domain.SevBroken, Source: "wave1"}}
+	}
+
 	return resource.Resource{
-		ID:     nodegroupName,
-		Name:   nodegroupName,
-		Status: status,
+		ID:   nodegroupName,
+		Name: nodegroupName,
 		Fields: map[string]string{
 			"nodegroup_name":      nodegroupName,
 			"cluster_name":        ngClusterName,
@@ -278,6 +297,7 @@ func buildNodeGroupResource(clusterName, ngName string, ng *ekstypes.Nodegroup) 
 			"health_issues_count": strconv.Itoa(healthIssuesCount),
 			"health_issues":       strings.Join(issueCodes, ","),
 		},
+		Findings:  findings,
 		RawStruct: ng,
 	}
 }

--- a/internal/aws/ng_codes.go
+++ b/internal/aws/ng_codes.go
@@ -1,0 +1,32 @@
+// ng_codes.go — canonical FindingCode constants for the ng resource type.
+// Phase 03 PR-03c. The fetcher writes Findings using these codes; the
+// ng Color func reads wave1 Findings (Source == "wave1") to color rows.
+package aws
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+const (
+	// CodeNGStateCreating — node group is in the "CREATING" lifecycle state.
+	// Severity: SevWarn (transitional).
+	CodeNGStateCreating domain.FindingCode = "ng.state.creating"
+
+	// CodeNGStateUpdating — node group is in the "UPDATING" lifecycle state.
+	// Severity: SevWarn (transitional).
+	CodeNGStateUpdating domain.FindingCode = "ng.state.updating"
+
+	// CodeNGStateDeleting — node group is in the "DELETING" lifecycle state.
+	// Severity: SevWarn (transitional; non-terminal from operator's perspective).
+	CodeNGStateDeleting domain.FindingCode = "ng.state.deleting"
+
+	// CodeNGStateCreateFailed — node group creation failed.
+	// Severity: SevBroken.
+	CodeNGStateCreateFailed domain.FindingCode = "ng.state.create-failed"
+
+	// CodeNGStateDeleteFailed — node group deletion failed.
+	// Severity: SevBroken.
+	CodeNGStateDeleteFailed domain.FindingCode = "ng.state.delete-failed"
+
+	// CodeNGStateDegraded — node group is degraded.
+	// Severity: SevBroken.
+	CodeNGStateDegraded domain.FindingCode = "ng.state.degraded"
+)

--- a/internal/resource/types_compute.go
+++ b/internal/resource/types_compute.go
@@ -128,6 +128,14 @@ func computeResourceTypes() []ResourceTypeDef {
 				{Key: "launch_type", Title: "Launch Type", Width: 12, Sortable: true},
 			},
 			Color: func(r Resource) Color {
+				// PR-03c: wave1 Findings (lifecycle/state) drive color first.
+				for _, f := range r.Findings {
+					if f.Source == "wave1" {
+						return ColorFromSeverity(f.Severity)
+					}
+				}
+				// Structural fallback: covers lifecycle states when Findings is
+				// empty (e.g. test probes with nil Findings) and wave2 signals.
 				switch r.Fields["status"] {
 				case "INACTIVE":
 					return ColorBroken
@@ -182,6 +190,13 @@ func computeResourceTypes() []ResourceTypeDef {
 				{Key: "services_count", Title: "Services", Width: 10, Sortable: true},
 			},
 			Color: func(r Resource) Color {
+				// PR-03c: wave1 Findings (lifecycle/state) drive color first.
+				for _, f := range r.Findings {
+					if f.Source == "wave1" {
+						return ColorFromSeverity(f.Severity)
+					}
+				}
+				// Structural fallback: covers healthy/terminal states when Findings is empty.
 				switch r.Fields["status"] {
 				case "ACTIVE":
 					return ColorHealthy
@@ -209,20 +224,29 @@ func computeResourceTypes() []ResourceTypeDef {
 				{Key: "memory", Title: "Memory", Width: 8, Sortable: true},
 			},
 			Color: func(r Resource) Color {
-				// health_status == UNHEALTHY overrides everything (Broken wins).
+				// Structural broken overrides — precedence over wave1 Findings.
+				// health_status == UNHEALTHY and stopped-with-non-user-stop-code
+				// are wave2-class signals that always win.
 				if r.Fields["health_status"] == "UNHEALTHY" {
 					return ColorBroken
 				}
+				if r.Fields["last_status"] == "STOPPED" && r.Fields["stop_code"] != "" && r.Fields["stop_code"] != "UserInitiated" {
+					return ColorBroken
+				}
+				// PR-03c: wave1 Findings (transitional lifecycle states) drive color.
+				for _, f := range r.Findings {
+					if f.Source == "wave1" {
+						return ColorFromSeverity(f.Severity)
+					}
+				}
+				// Structural fallback: covers all lifecycle states when Findings
+				// is empty (e.g. test probes with nil Findings).
 				switch r.Fields["last_status"] {
 				case "RUNNING":
 					return ColorHealthy
 				case "PROVISIONING", "PENDING", "ACTIVATING", "DEACTIVATING", "STOPPING", "DEPROVISIONING":
 					return ColorWarning
 				case "STOPPED":
-					sc := r.Fields["stop_code"]
-					if sc != "" && sc != "UserInitiated" {
-						return ColorBroken
-					}
 					return ColorDim
 				}
 				return ColorHealthy

--- a/internal/resource/types_containers.go
+++ b/internal/resource/types_containers.go
@@ -66,12 +66,14 @@ func containersResourceTypes() []ResourceTypeDef {
 				{Key: "desired_size", Title: "Desired", Width: 9, Sortable: true},
 			},
 			Color: func(r Resource) Color {
-				// Status-failed states are Broken (highest precedence).
-				if r.Fields["status"] == "CREATE_FAILED" ||
-					r.Fields["status"] == "DELETE_FAILED" ||
-					r.Fields["status"] == "DEGRADED" {
-					return ColorBroken
+				// PR-03c: wave1 Findings (lifecycle/state) drive color first.
+				for _, f := range r.Findings {
+					if f.Source == "wave1" {
+						return ColorFromSeverity(f.Severity)
+					}
 				}
+				// Structural fallback: covers wave2 signals (health_issues_count)
+				// and healthy/terminal lifecycle states when Findings is empty.
 				hasIssues := false
 				if n, err := strconv.Atoi(r.Fields["health_issues_count"]); err == nil && n > 0 {
 					hasIssues = true
@@ -84,6 +86,8 @@ func containersResourceTypes() []ResourceTypeDef {
 					return ColorHealthy
 				case "CREATING", "UPDATING", "DELETING":
 					return ColorWarning
+				case "CREATE_FAILED", "DELETE_FAILED", "DEGRADED":
+					return ColorBroken
 				}
 				// Empty / unknown status: healthy unless health.issues set.
 				if hasIssues {

--- a/tests/unit/aws_ecs_clusters_test.go
+++ b/tests/unit/aws_ecs_clusters_test.go
@@ -78,8 +78,13 @@ func TestFetchECSClusters_ParsesMultipleClusters(t *testing.T) {
 	if r0.Name != "prod-cluster" {
 		t.Errorf("resource[0].Name: expected %q, got %q", "prod-cluster", r0.Name)
 	}
-	if r0.Status != "ACTIVE" {
-		t.Errorf("resource[0].Status: expected %q, got %q", "ACTIVE", r0.Status)
+	// Post-PR-03c: fetcher no longer writes Status for ACTIVE clusters.
+	// State lives in Fields["status"]; ACTIVE clusters emit no Finding.
+	if r0.Status != "" {
+		t.Errorf("resource[0].Status leaked: got %q, want %q (fetcher must stop writing Status)", r0.Status, "")
+	}
+	if len(r0.Findings) != 0 {
+		t.Errorf("resource[0].Findings: got %d, want 0 for ACTIVE cluster", len(r0.Findings))
 	}
 	if r0.Fields["cluster_name"] != "prod-cluster" {
 		t.Errorf("resource[0].Fields[\"cluster_name\"]: expected %q, got %q", "prod-cluster", r0.Fields["cluster_name"])

--- a/tests/unit/aws_ecs_services_test.go
+++ b/tests/unit/aws_ecs_services_test.go
@@ -96,8 +96,13 @@ func TestFetchECSServices_ParsesMultipleServices(t *testing.T) {
 	if r0.Name != "web-service" {
 		t.Errorf("resource[0].Name: expected %q, got %q", "web-service", r0.Name)
 	}
-	if r0.Status != "ACTIVE" {
-		t.Errorf("resource[0].Status: expected %q, got %q", "ACTIVE", r0.Status)
+	// Post-PR-03c: fetcher no longer writes Status for ACTIVE services.
+	// State lives in Fields["status"]; ACTIVE services emit no Finding.
+	if r0.Status != "" {
+		t.Errorf("resource[0].Status leaked: got %q, want %q (fetcher must stop writing Status)", r0.Status, "")
+	}
+	if len(r0.Findings) != 0 {
+		t.Errorf("resource[0].Findings: got %d, want 0 for ACTIVE service", len(r0.Findings))
 	}
 	if r0.Fields["service_name"] != "web-service" {
 		t.Errorf("resource[0].Fields[\"service_name\"]: expected %q, got %q", "web-service", r0.Fields["service_name"])

--- a/tests/unit/aws_ecs_svc_tasks_test.go
+++ b/tests/unit/aws_ecs_svc_tasks_test.go
@@ -221,15 +221,32 @@ func TestFetchEcsSvcTasks_MixedStatus(t *testing.T) {
 		t.Fatalf("expected 2 resources, got %d", len(result.Resources))
 	}
 
+	// Post-PR-03c: fetcher no longer writes Status for RUNNING/STOPPED tasks.
+	// RUNNING and STOPPED are healthy/terminal states — no Finding emitted.
+	// State lives in Fields["status"].
 	t.Run("running_task_status", func(t *testing.T) {
-		if result.Resources[0].Status != "RUNNING" {
-			t.Errorf("Status: expected %q, got %q", "RUNNING", result.Resources[0].Status)
+		r := result.Resources[0]
+		if r.Status != "" {
+			t.Errorf("Status leaked: got %q, want %q (fetcher must stop writing Status for RUNNING task)", r.Status, "")
+		}
+		if r.Fields["status"] != "RUNNING" {
+			t.Errorf("Fields[status]: expected %q, got %q", "RUNNING", r.Fields["status"])
+		}
+		if len(r.Findings) != 0 {
+			t.Errorf("Findings: got %d, want 0 for RUNNING task", len(r.Findings))
 		}
 	})
 
 	t.Run("stopped_task_status", func(t *testing.T) {
-		if result.Resources[1].Status != "STOPPED" {
-			t.Errorf("Status: expected %q, got %q", "STOPPED", result.Resources[1].Status)
+		r := result.Resources[1]
+		if r.Status != "" {
+			t.Errorf("Status leaked: got %q, want %q (fetcher must stop writing Status for STOPPED task)", r.Status, "")
+		}
+		if r.Fields["status"] != "STOPPED" {
+			t.Errorf("Fields[status]: expected %q, got %q", "STOPPED", r.Fields["status"])
+		}
+		if len(r.Findings) != 0 {
+			t.Errorf("Findings: got %d, want 0 for STOPPED task (stop_code carries actionable info)", len(r.Findings))
 		}
 	})
 

--- a/tests/unit/aws_nodegroups_test.go
+++ b/tests/unit/aws_nodegroups_test.go
@@ -11,6 +11,7 @@ import (
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/tests/testdata"
 )
 
@@ -119,8 +120,13 @@ func TestFetchNodeGroups_ParsesMultipleClustersAndGroups(t *testing.T) {
 	if r0.Name != "ng-web" {
 		t.Errorf("resource[0].Name: expected %q, got %q", "ng-web", r0.Name)
 	}
-	if r0.Status != "ACTIVE" {
-		t.Errorf("resource[0].Status: expected %q, got %q", "ACTIVE", r0.Status)
+	// Post-PR-03c: fetcher no longer writes Status for ACTIVE node groups.
+	// State lives in Fields["status"]; ACTIVE node groups emit no Finding.
+	if r0.Status != "" {
+		t.Errorf("resource[0].Status leaked: got %q, want %q (fetcher must stop writing Status)", r0.Status, "")
+	}
+	if len(r0.Findings) != 0 {
+		t.Errorf("resource[0].Findings: got %d, want 0 for ACTIVE node group", len(r0.Findings))
 	}
 	if r0.Fields["nodegroup_name"] != "ng-web" {
 		t.Errorf("resource[0].Fields[\"nodegroup_name\"]: expected %q, got %q", "ng-web", r0.Fields["nodegroup_name"])
@@ -161,8 +167,22 @@ func TestFetchNodeGroups_ParsesMultipleClustersAndGroups(t *testing.T) {
 	if r2.Fields["cluster_name"] != "cluster-b" {
 		t.Errorf("resource[2].Fields[\"cluster_name\"]: expected %q, got %q", "cluster-b", r2.Fields["cluster_name"])
 	}
-	if r2.Status != "CREATING" {
-		t.Errorf("resource[2].Status: expected %q, got %q", "CREATING", r2.Status)
+	// Post-PR-03c: CREATING is a transitional state — fetcher emits SevWarn Finding,
+	// stops writing Status. State lives in Fields["status"].
+	if r2.Status != "" {
+		t.Errorf("resource[2].Status leaked: got %q, want %q (fetcher must stop writing Status for CREATING)", r2.Status, "")
+	}
+	if r2.Fields["status"] != "CREATING" {
+		t.Errorf("resource[2].Fields[status]: expected %q, got %q", "CREATING", r2.Fields["status"])
+	}
+	if len(r2.Findings) != 1 {
+		t.Fatalf("resource[2].Findings: got %d, want 1 for CREATING node group", len(r2.Findings))
+	}
+	if r2.Findings[0].Code != awsclient.CodeNGStateCreating {
+		t.Errorf("resource[2].Findings[0].Code: got %q, want %q", r2.Findings[0].Code, awsclient.CodeNGStateCreating)
+	}
+	if r2.Findings[0].Severity != domain.SevWarn {
+		t.Errorf("resource[2].Findings[0].Severity: got %v, want domain.SevWarn", r2.Findings[0].Severity)
 	}
 }
 
@@ -437,8 +457,22 @@ func TestFetchNodeGroups_RealAWSData(t *testing.T) {
 		t.Fatal("missing gpu node group in results")
 	}
 	gpu := resources[gpuIdx]
-	if gpu.Status != "CREATE_FAILED" {
-		t.Errorf("gpu node group Status: expected %q, got %q", "CREATE_FAILED", gpu.Status)
+	// Post-PR-03c: CREATE_FAILED is a broken state — fetcher emits SevBroken Finding,
+	// stops writing Status. State lives in Fields["status"].
+	if gpu.Status != "" {
+		t.Errorf("gpu node group Status leaked: got %q, want %q (fetcher must stop writing Status)", gpu.Status, "")
+	}
+	if gpu.Fields["status"] != "CREATE_FAILED" {
+		t.Errorf("gpu node group Fields[status]: expected %q, got %q", "CREATE_FAILED", gpu.Fields["status"])
+	}
+	if len(gpu.Findings) != 1 {
+		t.Fatalf("gpu node group Findings: got %d, want 1 for CREATE_FAILED", len(gpu.Findings))
+	}
+	if gpu.Findings[0].Code != awsclient.CodeNGStateCreateFailed {
+		t.Errorf("gpu Findings[0].Code: got %q, want %q", gpu.Findings[0].Code, awsclient.CodeNGStateCreateFailed)
+	}
+	if gpu.Findings[0].Severity != domain.SevBroken {
+		t.Errorf("gpu Findings[0].Severity: got %v, want domain.SevBroken", gpu.Findings[0].Severity)
 	}
 	if gpu.Fields["cluster_name"] != "test-cluster-1" {
 		t.Errorf("gpu node group cluster_name: expected %q, got %q", "test-cluster-1", gpu.Fields["cluster_name"])
@@ -471,8 +505,12 @@ func TestFetchNodeGroups_RealAWSData(t *testing.T) {
 		t.Fatal("missing kafka node group in results")
 	}
 	kafka := resources[kafkaIdx]
-	if kafka.Status != "ACTIVE" {
-		t.Errorf("kafka node group Status: expected %q, got %q", "ACTIVE", kafka.Status)
+	// Post-PR-03c: fetcher no longer writes Status for ACTIVE node groups.
+	if kafka.Status != "" {
+		t.Errorf("kafka node group Status leaked: got %q, want %q (fetcher must stop writing Status)", kafka.Status, "")
+	}
+	if len(kafka.Findings) != 0 {
+		t.Errorf("kafka node group Findings: got %d, want 0 for ACTIVE", len(kafka.Findings))
 	}
 	if kafka.Fields["instance_types"] != "t3.large" {
 		t.Errorf("kafka node group instance_types: expected %q, got %q", "t3.large", kafka.Fields["instance_types"])
@@ -506,8 +544,12 @@ func TestFetchNodeGroups_RealAWSData(t *testing.T) {
 		t.Fatal("missing system node group in results")
 	}
 	system := resources[systemIdx]
-	if system.Status != "ACTIVE" {
-		t.Errorf("system node group Status: expected %q, got %q", "ACTIVE", system.Status)
+	// Post-PR-03c: fetcher no longer writes Status for ACTIVE node groups.
+	if system.Status != "" {
+		t.Errorf("system node group Status leaked: got %q, want %q (fetcher must stop writing Status)", system.Status, "")
+	}
+	if len(system.Findings) != 0 {
+		t.Errorf("system node group Findings: got %d, want 0 for ACTIVE", len(system.Findings))
 	}
 	if system.Fields["instance_types"] != "t3.large" {
 		t.Errorf("system instance_types: expected %q, got %q", "t3.large", system.Fields["instance_types"])

--- a/tests/unit/phase03_containers_pr03c_test.go
+++ b/tests/unit/phase03_containers_pr03c_test.go
@@ -1,0 +1,793 @@
+package unit_test
+
+// phase03_containers_pr03c_test.go — regression-pin tests for Wave 1 finding
+// migration, covering the 4 container types in PR-03c:
+// ng, ecs, ecs-svc, ecs-task.
+//
+// Migration contract (PR-03c — NOT YET implemented; tests are intentionally RED):
+//   - Fetchers STOP writing Resource.Status for lifecycle states.
+//   - Fetchers EMIT canonical Finding entries (Source: "wave1") for non-healthy
+//     states.
+//   - Each type has a corresponding internal/aws/<svc>_codes.go with constants.
+//   - Each type's Color func reads Findings first, then falls back to structural
+//     fields.
+//
+// State → Severity mapping decisions:
+//
+//   ng:
+//     ACTIVE       → no Finding (healthy)
+//     CREATING     → SevWarn  (transitional)
+//     UPDATING     → SevWarn  (transitional)
+//     DELETING     → SevWarn  (transitional; emit-as-Warn consistent with ECS;
+//                              DELETING is non-terminal from the operator's
+//                              perspective — the nodegroup may re-appear)
+//     CREATE_FAILED → SevBroken
+//     DELETE_FAILED → SevBroken
+//     DEGRADED      → SevBroken
+//
+//   ecs:
+//     ACTIVE         → no Finding (healthy)
+//     PROVISIONING   → SevWarn  (transitional)
+//     DEPROVISIONING → SevWarn  (transitional)
+//     FAILED         → SevBroken
+//     INACTIVE       → SevBroken (cluster is dead — non-recoverable without
+//                                recreation; Color func currently maps to
+//                                ColorBroken)
+//
+//   ecs-svc:
+//     ACTIVE   → no Finding (healthy)
+//     DRAINING → SevWarn  (transitional)
+//     INACTIVE → SevBroken (service has been deleted; non-recoverable)
+//     running_count vs desired_count check stays structural (Wave 2-class).
+//
+//   ecs-task:
+//     RUNNING      → no Finding (healthy)
+//     STOPPED      → no Finding (lifecycle-terminal; stop_code carries the
+//                    meaningful info; structural Color func reads stop_code)
+//     PROVISIONING   → SevWarn  (transitional)
+//     PENDING        → SevWarn  (transitional)
+//     ACTIVATING     → SevWarn  (transitional)
+//     DEACTIVATING   → SevWarn  (transitional)
+//     STOPPING       → SevWarn  (transitional)
+//     DEPROVISIONING → SevWarn  (transitional)
+//     health_status and stop_code checks stay structural (Wave 2-class).
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ecssvc "github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	ekssvc "github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+
+	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
+)
+
+// =============================================================================
+// NG (EKS Node Groups)
+// =============================================================================
+
+// TestPR03c_NGCodes_ConstantsExist verifies that ng_codes.go declares the Wave 1
+// finding constants. Fails to compile until the file is created.
+func TestPR03c_NGCodes_ConstantsExist(t *testing.T) {
+	t.Helper()
+	var _ domain.FindingCode = awsclient.CodeNGStateCreating
+	var _ domain.FindingCode = awsclient.CodeNGStateUpdating
+	var _ domain.FindingCode = awsclient.CodeNGStateDeleting
+	var _ domain.FindingCode = awsclient.CodeNGStateCreateFailed
+	var _ domain.FindingCode = awsclient.CodeNGStateDeleteFailed
+	var _ domain.FindingCode = awsclient.CodeNGStateDegraded
+}
+
+// TestPR03c_NGFetcher_ActiveEmitsNoFinding asserts that an ACTIVE node group
+// emits no Finding and no Status after migration.
+func TestPR03c_NGFetcher_ActiveEmitsNoFinding(t *testing.T) {
+	listClustersMock := &pr03cEKSListMock{clusters: []string{"prod-cluster"}}
+	listNGMock := &pr03cEKSListNodegroupsMock{
+		nodegroups: map[string][]string{
+			"prod-cluster": {"prod-ng"},
+		},
+	}
+	describeNGMock := &pr03cEKSDescribeNodegroupMock{
+		nodegroups: map[string]*ekstypes.Nodegroup{
+			"prod-cluster/prod-ng": {
+				NodegroupName: aws.String("prod-ng"),
+				ClusterName:   aws.String("prod-cluster"),
+				Status:        ekstypes.NodegroupStatusActive,
+				ScalingConfig: &ekstypes.NodegroupScalingConfig{
+					DesiredSize: aws.Int32(3),
+				},
+			},
+		},
+	}
+
+	resources, err := awsclient.FetchNodeGroups(context.Background(), listClustersMock, listNGMock, describeNGMock)
+	if err != nil {
+		t.Fatalf("FetchNodeGroups: unexpected error: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resources))
+	}
+	r := resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status for ACTIVE node group)", r.Status, "")
+	}
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings: got %d, want 0 for ACTIVE node group", len(r.Findings))
+	}
+}
+
+// TestPR03c_NGFetcher_BrokenEmitsFinding asserts that a CREATE_FAILED node group
+// emits one SevBroken Finding with CodeNGStateCreateFailed.
+func TestPR03c_NGFetcher_BrokenEmitsFinding(t *testing.T) {
+	listClustersMock := &pr03cEKSListMock{clusters: []string{"prod-cluster"}}
+	listNGMock := &pr03cEKSListNodegroupsMock{
+		nodegroups: map[string][]string{
+			"prod-cluster": {"broken-ng"},
+		},
+	}
+	describeNGMock := &pr03cEKSDescribeNodegroupMock{
+		nodegroups: map[string]*ekstypes.Nodegroup{
+			"prod-cluster/broken-ng": {
+				NodegroupName: aws.String("broken-ng"),
+				ClusterName:   aws.String("prod-cluster"),
+				Status:        ekstypes.NodegroupStatusCreateFailed,
+			},
+		},
+	}
+
+	resources, err := awsclient.FetchNodeGroups(context.Background(), listClustersMock, listNGMock, describeNGMock)
+	if err != nil {
+		t.Fatalf("FetchNodeGroups: unexpected error: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resources))
+	}
+	r := resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for CREATE_FAILED node group", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeNGStateCreateFailed {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeNGStateCreateFailed)
+	}
+	if f.Severity != domain.SevBroken {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevBroken", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03c_NGFetcher_TransitionalEmitsWarn asserts that a CREATING node group
+// emits one SevWarn Finding with CodeNGStateCreating.
+func TestPR03c_NGFetcher_TransitionalEmitsWarn(t *testing.T) {
+	listClustersMock := &pr03cEKSListMock{clusters: []string{"dev-cluster"}}
+	listNGMock := &pr03cEKSListNodegroupsMock{
+		nodegroups: map[string][]string{
+			"dev-cluster": {"new-ng"},
+		},
+	}
+	describeNGMock := &pr03cEKSDescribeNodegroupMock{
+		nodegroups: map[string]*ekstypes.Nodegroup{
+			"dev-cluster/new-ng": {
+				NodegroupName: aws.String("new-ng"),
+				ClusterName:   aws.String("dev-cluster"),
+				Status:        ekstypes.NodegroupStatusCreating,
+				ScalingConfig: &ekstypes.NodegroupScalingConfig{
+					DesiredSize: aws.Int32(2),
+				},
+			},
+		},
+	}
+
+	resources, err := awsclient.FetchNodeGroups(context.Background(), listClustersMock, listNGMock, describeNGMock)
+	if err != nil {
+		t.Fatalf("FetchNodeGroups: unexpected error: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resources))
+	}
+	r := resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for CREATING node group", len(r.Findings))
+	}
+	if r.Findings[0].Severity != domain.SevWarn {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevWarn", r.Findings[0].Severity)
+	}
+	if r.Findings[0].Code != awsclient.CodeNGStateCreating {
+		t.Errorf("Findings[0].Code: got %q, want %q", r.Findings[0].Code, awsclient.CodeNGStateCreating)
+	}
+	if r.Findings[0].Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", r.Findings[0].Source, "wave1")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ng mocks
+// ---------------------------------------------------------------------------
+
+type pr03cEKSListMock struct {
+	clusters []string
+}
+
+func (m *pr03cEKSListMock) ListClusters(
+	_ context.Context,
+	_ *ekssvc.ListClustersInput,
+	_ ...func(*ekssvc.Options),
+) (*ekssvc.ListClustersOutput, error) {
+	return &ekssvc.ListClustersOutput{Clusters: m.clusters}, nil
+}
+
+type pr03cEKSListNodegroupsMock struct {
+	// keyed by cluster name
+	nodegroups map[string][]string
+}
+
+func (m *pr03cEKSListNodegroupsMock) ListNodegroups(
+	_ context.Context,
+	input *ekssvc.ListNodegroupsInput,
+	_ ...func(*ekssvc.Options),
+) (*ekssvc.ListNodegroupsOutput, error) {
+	clusterName := ""
+	if input.ClusterName != nil {
+		clusterName = *input.ClusterName
+	}
+	return &ekssvc.ListNodegroupsOutput{Nodegroups: m.nodegroups[clusterName]}, nil
+}
+
+type pr03cEKSDescribeNodegroupMock struct {
+	// keyed by "<clusterName>/<nodegroupName>"
+	nodegroups map[string]*ekstypes.Nodegroup
+}
+
+func (m *pr03cEKSDescribeNodegroupMock) DescribeNodegroup(
+	_ context.Context,
+	input *ekssvc.DescribeNodegroupInput,
+	_ ...func(*ekssvc.Options),
+) (*ekssvc.DescribeNodegroupOutput, error) {
+	key := ""
+	if input.ClusterName != nil && input.NodegroupName != nil {
+		key = *input.ClusterName + "/" + *input.NodegroupName
+	}
+	return &ekssvc.DescribeNodegroupOutput{Nodegroup: m.nodegroups[key]}, nil
+}
+
+// =============================================================================
+// ECS (ECS Clusters)
+// =============================================================================
+
+// TestPR03c_ECSCodes_ConstantsExist verifies that ecs_codes.go declares the Wave 1
+// finding constants. Fails to compile until the file is created.
+func TestPR03c_ECSCodes_ConstantsExist(t *testing.T) {
+	t.Helper()
+	var _ domain.FindingCode = awsclient.CodeECSStateProvisioning
+	var _ domain.FindingCode = awsclient.CodeECSStateDeprovisioning
+	var _ domain.FindingCode = awsclient.CodeECSStateFailed
+	var _ domain.FindingCode = awsclient.CodeECSStateInactive
+}
+
+// TestPR03c_ECSFetcher_ActiveEmitsNoFinding asserts that an ACTIVE ECS cluster
+// emits no Finding and no Status after migration.
+func TestPR03c_ECSFetcher_ActiveEmitsNoFinding(t *testing.T) {
+	listMock := &pr03cECSListClustersMock{
+		arns: []string{"arn:aws:ecs:us-east-1:000000000000:cluster/prod-cluster"},
+	}
+	describeMock := &pr03cECSDescribeClustersMock{
+		clusters: []ecstypes.Cluster{
+			{
+				ClusterName:         aws.String("prod-cluster"),
+				Status:              aws.String("ACTIVE"),
+				RunningTasksCount:   5,
+				PendingTasksCount:   0,
+				ActiveServicesCount: 3,
+			},
+		},
+	}
+
+	result, err := awsclient.FetchECSClustersPage(context.Background(), listMock, describeMock, "")
+	if err != nil {
+		t.Fatalf("FetchECSClustersPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status for ACTIVE cluster)", r.Status, "")
+	}
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings: got %d, want 0 for ACTIVE cluster", len(r.Findings))
+	}
+}
+
+// TestPR03c_ECSFetcher_BrokenEmitsFinding asserts that a FAILED ECS cluster
+// emits one SevBroken Finding with CodeECSStateFailed.
+func TestPR03c_ECSFetcher_BrokenEmitsFinding(t *testing.T) {
+	listMock := &pr03cECSListClustersMock{
+		arns: []string{"arn:aws:ecs:us-east-1:000000000000:cluster/failed-cluster"},
+	}
+	describeMock := &pr03cECSDescribeClustersMock{
+		clusters: []ecstypes.Cluster{
+			{
+				ClusterName: aws.String("failed-cluster"),
+				Status:      aws.String("FAILED"),
+			},
+		},
+	}
+
+	result, err := awsclient.FetchECSClustersPage(context.Background(), listMock, describeMock, "")
+	if err != nil {
+		t.Fatalf("FetchECSClustersPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for FAILED cluster", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeECSStateFailed {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeECSStateFailed)
+	}
+	if f.Severity != domain.SevBroken {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevBroken", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03c_ECSFetcher_TransitionalEmitsWarn asserts that a PROVISIONING ECS
+// cluster emits one SevWarn Finding with CodeECSStateProvisioning.
+func TestPR03c_ECSFetcher_TransitionalEmitsWarn(t *testing.T) {
+	listMock := &pr03cECSListClustersMock{
+		arns: []string{"arn:aws:ecs:us-east-1:000000000000:cluster/new-cluster"},
+	}
+	describeMock := &pr03cECSDescribeClustersMock{
+		clusters: []ecstypes.Cluster{
+			{
+				ClusterName: aws.String("new-cluster"),
+				Status:      aws.String("PROVISIONING"),
+			},
+		},
+	}
+
+	result, err := awsclient.FetchECSClustersPage(context.Background(), listMock, describeMock, "")
+	if err != nil {
+		t.Fatalf("FetchECSClustersPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for PROVISIONING cluster", len(r.Findings))
+	}
+	if r.Findings[0].Severity != domain.SevWarn {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevWarn", r.Findings[0].Severity)
+	}
+	if r.Findings[0].Code != awsclient.CodeECSStateProvisioning {
+		t.Errorf("Findings[0].Code: got %q, want %q", r.Findings[0].Code, awsclient.CodeECSStateProvisioning)
+	}
+	if r.Findings[0].Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", r.Findings[0].Source, "wave1")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ecs mocks
+// ---------------------------------------------------------------------------
+
+type pr03cECSListClustersMock struct {
+	arns []string
+}
+
+func (m *pr03cECSListClustersMock) ListClusters(
+	_ context.Context,
+	_ *ecssvc.ListClustersInput,
+	_ ...func(*ecssvc.Options),
+) (*ecssvc.ListClustersOutput, error) {
+	return &ecssvc.ListClustersOutput{ClusterArns: m.arns}, nil
+}
+
+type pr03cECSDescribeClustersMock struct {
+	clusters []ecstypes.Cluster
+}
+
+func (m *pr03cECSDescribeClustersMock) DescribeClusters(
+	_ context.Context,
+	_ *ecssvc.DescribeClustersInput,
+	_ ...func(*ecssvc.Options),
+) (*ecssvc.DescribeClustersOutput, error) {
+	return &ecssvc.DescribeClustersOutput{Clusters: m.clusters}, nil
+}
+
+// =============================================================================
+// ECS-SVC (ECS Services)
+// =============================================================================
+
+// TestPR03c_ECSSvcCodes_ConstantsExist verifies that ecs_svc_codes.go declares
+// the Wave 1 finding constants. Fails to compile until the file is created.
+func TestPR03c_ECSSvcCodes_ConstantsExist(t *testing.T) {
+	t.Helper()
+	var _ domain.FindingCode = awsclient.CodeECSSvcStateInactive
+	var _ domain.FindingCode = awsclient.CodeECSSvcStateDraining
+}
+
+// TestPR03c_ECSSvcFetcher_ActiveEmitsNoFinding asserts that an ACTIVE ECS service
+// emits no Finding and no Status after migration.
+func TestPR03c_ECSSvcFetcher_ActiveEmitsNoFinding(t *testing.T) {
+	listClustersMock := &pr03cECSListClustersMock{
+		arns: []string{"arn:aws:ecs:us-east-1:000000000000:cluster/prod-cluster"},
+	}
+	listSvcMock := &pr03cECSListServicesMock{
+		serviceArns: []string{"arn:aws:ecs:us-east-1:000000000000:service/prod-cluster/api-svc"},
+	}
+	describeSvcMock := &pr03cECSDescribeServicesMock{
+		services: []ecstypes.Service{
+			{
+				ServiceName:    aws.String("api-svc"),
+				ClusterArn:     aws.String("arn:aws:ecs:us-east-1:000000000000:cluster/prod-cluster"),
+				Status:         aws.String("ACTIVE"),
+				DesiredCount:   3,
+				RunningCount:   3,
+				LaunchType:     ecstypes.LaunchTypeFargate,
+				TaskDefinition: aws.String("arn:aws:ecs:us-east-1:000000000000:task-definition/api:5"),
+			},
+		},
+	}
+
+	result, err := awsclient.FetchECSServicesPage(context.Background(), listClustersMock, listSvcMock, describeSvcMock, "")
+	if err != nil {
+		t.Fatalf("FetchECSServicesPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status for ACTIVE service)", r.Status, "")
+	}
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings: got %d, want 0 for ACTIVE service", len(r.Findings))
+	}
+}
+
+// TestPR03c_ECSSvcFetcher_BrokenEmitsFinding asserts that an INACTIVE ECS service
+// emits one SevBroken Finding with CodeECSSvcStateInactive.
+//
+// INACTIVE is the terminal state for a deleted service — non-recoverable without
+// recreation. The Color func currently maps INACTIVE → ColorBroken.
+func TestPR03c_ECSSvcFetcher_BrokenEmitsFinding(t *testing.T) {
+	listClustersMock := &pr03cECSListClustersMock{
+		arns: []string{"arn:aws:ecs:us-east-1:000000000000:cluster/prod-cluster"},
+	}
+	listSvcMock := &pr03cECSListServicesMock{
+		serviceArns: []string{"arn:aws:ecs:us-east-1:000000000000:service/prod-cluster/dead-svc"},
+	}
+	describeSvcMock := &pr03cECSDescribeServicesMock{
+		services: []ecstypes.Service{
+			{
+				ServiceName:  aws.String("dead-svc"),
+				ClusterArn:   aws.String("arn:aws:ecs:us-east-1:000000000000:cluster/prod-cluster"),
+				Status:       aws.String("INACTIVE"),
+				DesiredCount: 0,
+				RunningCount: 0,
+			},
+		},
+	}
+
+	result, err := awsclient.FetchECSServicesPage(context.Background(), listClustersMock, listSvcMock, describeSvcMock, "")
+	if err != nil {
+		t.Fatalf("FetchECSServicesPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for INACTIVE service", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeECSSvcStateInactive {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeECSSvcStateInactive)
+	}
+	if f.Severity != domain.SevBroken {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevBroken", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03c_ECSSvcFetcher_TransitionalEmitsWarn asserts that a DRAINING ECS
+// service emits one SevWarn Finding with CodeECSSvcStateDraining.
+func TestPR03c_ECSSvcFetcher_TransitionalEmitsWarn(t *testing.T) {
+	listClustersMock := &pr03cECSListClustersMock{
+		arns: []string{"arn:aws:ecs:us-east-1:000000000000:cluster/prod-cluster"},
+	}
+	listSvcMock := &pr03cECSListServicesMock{
+		serviceArns: []string{"arn:aws:ecs:us-east-1:000000000000:service/prod-cluster/draining-svc"},
+	}
+	describeSvcMock := &pr03cECSDescribeServicesMock{
+		services: []ecstypes.Service{
+			{
+				ServiceName:  aws.String("draining-svc"),
+				ClusterArn:   aws.String("arn:aws:ecs:us-east-1:000000000000:cluster/prod-cluster"),
+				Status:       aws.String("DRAINING"),
+				DesiredCount: 0,
+				RunningCount: 1,
+			},
+		},
+	}
+
+	result, err := awsclient.FetchECSServicesPage(context.Background(), listClustersMock, listSvcMock, describeSvcMock, "")
+	if err != nil {
+		t.Fatalf("FetchECSServicesPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for DRAINING service", len(r.Findings))
+	}
+	if r.Findings[0].Severity != domain.SevWarn {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevWarn", r.Findings[0].Severity)
+	}
+	if r.Findings[0].Code != awsclient.CodeECSSvcStateDraining {
+		t.Errorf("Findings[0].Code: got %q, want %q", r.Findings[0].Code, awsclient.CodeECSSvcStateDraining)
+	}
+	if r.Findings[0].Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", r.Findings[0].Source, "wave1")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ecs-svc mocks
+// ---------------------------------------------------------------------------
+
+type pr03cECSListServicesMock struct {
+	serviceArns []string
+}
+
+func (m *pr03cECSListServicesMock) ListServices(
+	_ context.Context,
+	_ *ecssvc.ListServicesInput,
+	_ ...func(*ecssvc.Options),
+) (*ecssvc.ListServicesOutput, error) {
+	return &ecssvc.ListServicesOutput{ServiceArns: m.serviceArns}, nil
+}
+
+type pr03cECSDescribeServicesMock struct {
+	services []ecstypes.Service
+}
+
+func (m *pr03cECSDescribeServicesMock) DescribeServices(
+	_ context.Context,
+	_ *ecssvc.DescribeServicesInput,
+	_ ...func(*ecssvc.Options),
+) (*ecssvc.DescribeServicesOutput, error) {
+	return &ecssvc.DescribeServicesOutput{Services: m.services}, nil
+}
+
+// =============================================================================
+// ECS-TASK (ECS Tasks)
+// =============================================================================
+
+// TestPR03c_ECSTaskCodes_ConstantsExist verifies that ecs_task_codes.go declares
+// the Wave 1 finding constants. Fails to compile until the file is created.
+//
+// NOTE: CodeECSTaskStateStopped is intentionally excluded. STOPPED is a
+// lifecycle-terminal state where the stop_code carries the meaningful information.
+// The structural Color func reads stop_code directly; emitting a wave1 Finding for
+// STOPPED would interfere with that override (same precedent as Lambda Inactive).
+func TestPR03c_ECSTaskCodes_ConstantsExist(t *testing.T) {
+	t.Helper()
+	var _ domain.FindingCode = awsclient.CodeECSTaskStateProvisioning
+	var _ domain.FindingCode = awsclient.CodeECSTaskStatePending
+	var _ domain.FindingCode = awsclient.CodeECSTaskStateActivating
+	var _ domain.FindingCode = awsclient.CodeECSTaskStateDeactivating
+	var _ domain.FindingCode = awsclient.CodeECSTaskStateStopping
+	var _ domain.FindingCode = awsclient.CodeECSTaskStateDeprovisioning
+}
+
+// TestPR03c_ECSTaskFetcher_RunningEmitsNoFinding asserts that a RUNNING ECS task
+// emits no Finding and no Status after migration.
+func TestPR03c_ECSTaskFetcher_RunningEmitsNoFinding(t *testing.T) {
+	taskARN := "arn:aws:ecs:us-east-1:000000000000:task/prod-cluster/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"
+	clusterARN := "arn:aws:ecs:us-east-1:000000000000:cluster/prod-cluster"
+	taskDefARN := "arn:aws:ecs:us-east-1:000000000000:task-definition/api:5"
+
+	listClustersMock := &pr03cECSListClustersMock{arns: []string{clusterARN}}
+	listTasksMock := &pr03cECSListTasksMock{taskArns: []string{taskARN}}
+	describeTasksMock := &pr03cECSDescribeTasksMock{
+		tasks: []ecstypes.Task{
+			{
+				TaskArn:           aws.String(taskARN),
+				ClusterArn:        aws.String(clusterARN),
+				LastStatus:        aws.String("RUNNING"),
+				TaskDefinitionArn: aws.String(taskDefARN),
+				LaunchType:        ecstypes.LaunchTypeFargate,
+				Cpu:               aws.String("256"),
+				Memory:            aws.String("512"),
+				HealthStatus:      ecstypes.HealthStatusHealthy,
+			},
+		},
+	}
+
+	result, err := awsclient.FetchECSTasksPage(context.Background(), listClustersMock, listTasksMock, describeTasksMock, "")
+	if err != nil {
+		t.Fatalf("FetchECSTasksPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status for RUNNING task)", r.Status, "")
+	}
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings: got %d, want 0 for RUNNING task", len(r.Findings))
+	}
+}
+
+// TestPR03c_ECSTaskFetcher_StoppedEmitsNoFinding asserts that a STOPPED ECS task
+// emits no Finding (lifecycle-terminal; structural Color reads stop_code directly).
+//
+// This is the same pattern as Lambda Inactive and EC2 shutting-down:
+// lifecycle-terminal states are NOT promoted to wave1 Findings.
+func TestPR03c_ECSTaskFetcher_StoppedEmitsNoFinding(t *testing.T) {
+	taskARN := "arn:aws:ecs:us-east-1:000000000000:task/prod-cluster/b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5"
+	clusterARN := "arn:aws:ecs:us-east-1:000000000000:cluster/prod-cluster"
+	taskDefARN := "arn:aws:ecs:us-east-1:000000000000:task-definition/api:5"
+
+	listClustersMock := &pr03cECSListClustersMock{arns: []string{clusterARN}}
+	listTasksMock := &pr03cECSListTasksMock{taskArns: []string{taskARN}}
+	describeTasksMock := &pr03cECSDescribeTasksMock{
+		tasks: []ecstypes.Task{
+			{
+				TaskArn:           aws.String(taskARN),
+				ClusterArn:        aws.String(clusterARN),
+				LastStatus:        aws.String("STOPPED"),
+				StopCode:          ecstypes.TaskStopCodeUserInitiated,
+				TaskDefinitionArn: aws.String(taskDefARN),
+				LaunchType:        ecstypes.LaunchTypeFargate,
+				Cpu:               aws.String("256"),
+				Memory:            aws.String("512"),
+			},
+		},
+	}
+
+	result, err := awsclient.FetchECSTasksPage(context.Background(), listClustersMock, listTasksMock, describeTasksMock, "")
+	if err != nil {
+		t.Fatalf("FetchECSTasksPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status for STOPPED task)", r.Status, "")
+	}
+	// STOPPED is lifecycle-terminal — no wave1 Finding (stop_code handled structurally).
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings: got %d, want 0 for STOPPED task (lifecycle-terminal; stop_code is structural)", len(r.Findings))
+	}
+}
+
+// TestPR03c_ECSTaskFetcher_TransitionalEmitsWarn asserts that a PENDING ECS task
+// emits one SevWarn Finding with CodeECSTaskStatePending.
+func TestPR03c_ECSTaskFetcher_TransitionalEmitsWarn(t *testing.T) {
+	taskARN := "arn:aws:ecs:us-east-1:000000000000:task/prod-cluster/c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6"
+	clusterARN := "arn:aws:ecs:us-east-1:000000000000:cluster/prod-cluster"
+	taskDefARN := "arn:aws:ecs:us-east-1:000000000000:task-definition/api:5"
+
+	listClustersMock := &pr03cECSListClustersMock{arns: []string{clusterARN}}
+	listTasksMock := &pr03cECSListTasksMock{taskArns: []string{taskARN}}
+	describeTasksMock := &pr03cECSDescribeTasksMock{
+		tasks: []ecstypes.Task{
+			{
+				TaskArn:           aws.String(taskARN),
+				ClusterArn:        aws.String(clusterARN),
+				LastStatus:        aws.String("PENDING"),
+				TaskDefinitionArn: aws.String(taskDefARN),
+				LaunchType:        ecstypes.LaunchTypeFargate,
+				Cpu:               aws.String("256"),
+				Memory:            aws.String("512"),
+			},
+		},
+	}
+
+	result, err := awsclient.FetchECSTasksPage(context.Background(), listClustersMock, listTasksMock, describeTasksMock, "")
+	if err != nil {
+		t.Fatalf("FetchECSTasksPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for PENDING task", len(r.Findings))
+	}
+	if r.Findings[0].Severity != domain.SevWarn {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevWarn", r.Findings[0].Severity)
+	}
+	if r.Findings[0].Code != awsclient.CodeECSTaskStatePending {
+		t.Errorf("Findings[0].Code: got %q, want %q", r.Findings[0].Code, awsclient.CodeECSTaskStatePending)
+	}
+	if r.Findings[0].Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", r.Findings[0].Source, "wave1")
+	}
+}
+
+// NOTE: ECS Tasks have no separate SevBroken lifecycle state at the fetcher
+// level. The broken classification (stop_code != UserInitiated, health_status ==
+// UNHEALTHY) is structural — handled by the Color func reading Fields directly.
+// No TestPR03c_ECSTaskFetcher_BrokenEmitsFinding is needed.
+
+// ---------------------------------------------------------------------------
+// ecs-task mocks
+// ---------------------------------------------------------------------------
+
+type pr03cECSListTasksMock struct {
+	taskArns []string
+}
+
+func (m *pr03cECSListTasksMock) ListTasks(
+	_ context.Context,
+	_ *ecssvc.ListTasksInput,
+	_ ...func(*ecssvc.Options),
+) (*ecssvc.ListTasksOutput, error) {
+	return &ecssvc.ListTasksOutput{TaskArns: m.taskArns}, nil
+}
+
+type pr03cECSDescribeTasksMock struct {
+	tasks []ecstypes.Task
+}
+
+func (m *pr03cECSDescribeTasksMock) DescribeTasks(
+	_ context.Context,
+	_ *ecssvc.DescribeTasksInput,
+	_ ...func(*ecssvc.Options),
+) (*ecssvc.DescribeTasksOutput, error) {
+	return &ecssvc.DescribeTasksOutput{Tasks: m.tasks}, nil
+}

--- a/tests/unit/phase03_containers_pr03c_test.go
+++ b/tests/unit/phase03_containers_pr03c_test.go
@@ -73,7 +73,6 @@ import (
 // TestPR03c_NGCodes_ConstantsExist verifies that ng_codes.go declares the Wave 1
 // finding constants. Fails to compile until the file is created.
 func TestPR03c_NGCodes_ConstantsExist(t *testing.T) {
-	t.Helper()
 	var _ domain.FindingCode = awsclient.CodeNGStateCreating
 	var _ domain.FindingCode = awsclient.CodeNGStateUpdating
 	var _ domain.FindingCode = awsclient.CodeNGStateDeleting
@@ -272,7 +271,6 @@ func (m *pr03cEKSDescribeNodegroupMock) DescribeNodegroup(
 // TestPR03c_ECSCodes_ConstantsExist verifies that ecs_codes.go declares the Wave 1
 // finding constants. Fails to compile until the file is created.
 func TestPR03c_ECSCodes_ConstantsExist(t *testing.T) {
-	t.Helper()
 	var _ domain.FindingCode = awsclient.CodeECSStateProvisioning
 	var _ domain.FindingCode = awsclient.CodeECSStateDeprovisioning
 	var _ domain.FindingCode = awsclient.CodeECSStateFailed
@@ -432,7 +430,6 @@ func (m *pr03cECSDescribeClustersMock) DescribeClusters(
 // TestPR03c_ECSSvcCodes_ConstantsExist verifies that ecs_svc_codes.go declares
 // the Wave 1 finding constants. Fails to compile until the file is created.
 func TestPR03c_ECSSvcCodes_ConstantsExist(t *testing.T) {
-	t.Helper()
 	var _ domain.FindingCode = awsclient.CodeECSSvcStateInactive
 	var _ domain.FindingCode = awsclient.CodeECSSvcStateDraining
 }
@@ -615,7 +612,6 @@ func (m *pr03cECSDescribeServicesMock) DescribeServices(
 // The structural Color func reads stop_code directly; emitting a wave1 Finding for
 // STOPPED would interfere with that override (same precedent as Lambda Inactive).
 func TestPR03c_ECSTaskCodes_ConstantsExist(t *testing.T) {
-	t.Helper()
 	var _ domain.FindingCode = awsclient.CodeECSTaskStateProvisioning
 	var _ domain.FindingCode = awsclient.CodeECSTaskStatePending
 	var _ domain.FindingCode = awsclient.CodeECSTaskStateActivating

--- a/tests/unit/phase03_containers_pr03c_test.go
+++ b/tests/unit/phase03_containers_pr03c_test.go
@@ -64,6 +64,7 @@ import (
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/domain"
+	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 // =============================================================================
@@ -786,4 +787,72 @@ func (m *pr03cECSDescribeTasksMock) DescribeTasks(
 	_ ...func(*ecssvc.Options),
 ) (*ecssvc.DescribeTasksOutput, error) {
 	return &ecssvc.DescribeTasksOutput{Tasks: m.tasks}, nil
+}
+
+// =============================================================================
+// ECS-TASKS child type (per-service task list)
+// =============================================================================
+
+// TestPR03c_EcsTasksChildType_ColorReadsFindings asserts that the "ecs_tasks"
+// child type has a Color func that (a) reads wave1 Findings first and (b) applies
+// structural overrides for UNHEALTHY health status and STOPPED + non-UserInitiated
+// stop_code. Without the Color func the child type falls back to fallbackColor,
+// which returns ColorHealthy for every status — masking PROVISIONING/STOPPING/
+// DEPROVISIONING tasks in the per-service task list view.
+func TestPR03c_EcsTasksChildType_ColorReadsFindings(t *testing.T) {
+	td := resource.GetChildType("ecs_tasks")
+	if td == nil {
+		t.Fatal("ecs_tasks child type not registered")
+	}
+	if td.Color == nil {
+		t.Fatal("ecs_tasks child type Color func not set — CR P2 regression")
+	}
+
+	// PROVISIONING via wave1 Finding → ColorWarning
+	r := resource.Resource{
+		Type: "ecs_tasks",
+		Findings: []domain.Finding{
+			{Code: awsclient.CodeECSTaskStateProvisioning, Phrase: "provisioning", Severity: domain.SevWarn, Source: "wave1"},
+		},
+		Fields: map[string]string{"status": "PROVISIONING"},
+	}
+	if got := td.Color(r); got != resource.ColorWarning {
+		t.Errorf("PROVISIONING task: Color = %v, want ColorWarning", got)
+	}
+
+	// STOPPED + non-UserInitiated stop_code → ColorBroken (structural override).
+	r2 := resource.Resource{
+		Type:     "ecs_tasks",
+		Findings: nil,
+		Fields: map[string]string{
+			"status":    "STOPPED",
+			"stop_code": "EssentialContainerExited",
+		},
+	}
+	if got := td.Color(r2); got != resource.ColorBroken {
+		t.Errorf("STOPPED + non-UserInitiated stop_code: Color = %v, want ColorBroken", got)
+	}
+
+	// RUNNING → ColorHealthy
+	r3 := resource.Resource{
+		Type:     "ecs_tasks",
+		Findings: nil,
+		Fields:   map[string]string{"status": "RUNNING"},
+	}
+	if got := td.Color(r3); got != resource.ColorHealthy {
+		t.Errorf("RUNNING task: Color = %v, want ColorHealthy", got)
+	}
+
+	// health == UNHEALTHY → ColorBroken (structural override).
+	r4 := resource.Resource{
+		Type:     "ecs_tasks",
+		Findings: nil,
+		Fields: map[string]string{
+			"status": "RUNNING",
+			"health": "UNHEALTHY",
+		},
+	}
+	if got := td.Color(r4); got != resource.ColorBroken {
+		t.Errorf("UNHEALTHY task: Color = %v, want ColorBroken", got)
+	}
 }

--- a/tests/unit/qa_ecs_tasks_test.go
+++ b/tests/unit/qa_ecs_tasks_test.go
@@ -73,8 +73,16 @@ func TestQA_ECSTasks_FetchSuccess(t *testing.T) {
 	if r.Name != "abc123def456" {
 		t.Errorf("expected Name 'abc123def456', got %q", r.Name)
 	}
-	if r.Status != "RUNNING" {
-		t.Errorf("expected Status 'RUNNING', got %q", r.Status)
+	// Post-PR-03c: fetcher no longer writes Status for RUNNING tasks.
+	// State lives in Fields["status"]; RUNNING tasks emit no Finding.
+	if r.Status != "" {
+		t.Errorf("Status leaked: got %q, want %q (fetcher must stop writing Status for RUNNING task)", r.Status, "")
+	}
+	if r.Fields["status"] != "RUNNING" {
+		t.Errorf("Fields[status]: expected %q, got %q", "RUNNING", r.Fields["status"])
+	}
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings: got %d, want 0 for RUNNING task", len(r.Findings))
 	}
 	if r.Fields["task_id"] != "abc123def456" {
 		t.Errorf("expected task_id 'abc123def456', got %q", r.Fields["task_id"])
@@ -93,8 +101,16 @@ func TestQA_ECSTasks_FetchSuccess(t *testing.T) {
 	}
 
 	r2 := resources[1]
-	if r2.Status != "STOPPED" {
-		t.Errorf("expected Status 'STOPPED', got %q", r2.Status)
+	// Post-PR-03c: fetcher no longer writes Status for STOPPED tasks.
+	// STOPPED is lifecycle-terminal — no Finding emitted; stop_code carries actionable info.
+	if r2.Status != "" {
+		t.Errorf("r2 Status leaked: got %q, want %q (fetcher must stop writing Status for STOPPED task)", r2.Status, "")
+	}
+	if r2.Fields["status"] != "STOPPED" {
+		t.Errorf("r2 Fields[status]: expected %q, got %q", "STOPPED", r2.Fields["status"])
+	}
+	if len(r2.Findings) != 0 {
+		t.Errorf("r2 Findings: got %d, want 0 for STOPPED task (stop_code carries actionable info)", len(r2.Findings))
 	}
 	if r2.RawStruct == nil {
 		t.Error("expected RawStruct to be set")


### PR DESCRIPTION
## Summary

Phase 03 PR-03c per \`docs/refactor/03-finding-model.md\` L277-333. Migrates the 4 container resource types (ng, ecs, ecs-svc, ecs-task) from legacy \`Resource.Status\` to canonical \`Findings\`.

### Per-type \`FindingCode\` constants (new files)

- \`internal/aws/ng_codes.go\` — 6 constants
- \`internal/aws/ecs_codes.go\` — 4 constants
- \`internal/aws/ecs_svc_codes.go\` — 2 constants
- \`internal/aws/ecs_task_codes.go\` — 6 constants

### Fetcher migrations

| Type | Healthy | SevWarn | SevBroken |
|---|---|---|---|
| ng | ACTIVE | CREATING, UPDATING, DELETING | CREATE_FAILED, DELETE_FAILED, DEGRADED |
| ecs | ACTIVE | PROVISIONING, DEPROVISIONING | FAILED, INACTIVE |
| ecs-svc | ACTIVE | DRAINING | INACTIVE |
| ecs-task | RUNNING, STOPPED | PENDING, PROVISIONING, ACTIVATING, DEACTIVATING, STOPPING, DEPROVISIONING | — (broken via structural override) |

### Color func updates

- ng / ecs / ecs-svc — wave1-first; existing structural fallback for Wave 2 signals (health_issues_count, running_count vs desired_count) preserved.
- ecs-task — structural broken overrides (health_status==UNHEALTHY, STOPPED + non-UserInitiated stop_code) evaluated BEFORE wave1, same pattern as Lambda's deprecated-runtime override.

## Test plan

- [x] 16 new \`TestPR03c_*\` tests across 4 types
- [x] 8 pre-existing fetcher tests migrated to \`Status == ""\` + Findings shape
- [x] Full suite: 13,603 pass
- [x] \`make test-race\` clean (60.5s)
- [x] \`make lint\`, \`make security\`, \`make gofix\` zero issues

## Out of scope

- Wave 2 enrichers (still use \`EnrichmentFinding\` wire format)
- Per-category PRs 03d–03m
- PR-03n cleanup