### PR TITLE
feat(phase-03-pr03d): networking — fetchers emit canonical Findings

### DIFF
--- a/internal/aws/elb.go
+++ b/internal/aws/elb.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -107,10 +108,19 @@ func FetchLoadBalancersPage(ctx context.Context, api ELBv2DescribeLoadBalancersA
 			lbArn = *lb.LoadBalancerArn
 		}
 
+		var findings []domain.Finding
+		switch state {
+		case "provisioning":
+			findings = []domain.Finding{{Code: CodeELBStateProvisioning, Phrase: "provisioning", Severity: domain.SevWarn, Source: "wave1"}}
+		case "active_impaired":
+			findings = []domain.Finding{{Code: CodeELBStateActiveImpaired, Phrase: "active impaired", Severity: domain.SevWarn, Source: "wave1"}}
+		case "failed":
+			findings = []domain.Finding{{Code: CodeELBStateFailed, Phrase: "failed", Severity: domain.SevBroken, Source: "wave1"}}
+		}
+
 		r := resource.Resource{
-			ID:     lbName,
-			Name:   lbName,
-			Status: state,
+			ID:   lbName,
+			Name: lbName,
 			Fields: map[string]string{
 				"name":              lbName,
 				"dns_name":          dnsName,
@@ -120,6 +130,7 @@ func FetchLoadBalancersPage(ctx context.Context, api ELBv2DescribeLoadBalancersA
 				"vpc_id":            vpcID,
 				"load_balancer_arn": lbArn,
 			},
+			Findings:  findings,
 			RawStruct: lb,
 		}
 

--- a/internal/aws/elb_codes.go
+++ b/internal/aws/elb_codes.go
@@ -1,20 +1,9 @@
-// elb_codes.go — canonical FindingCode constants for the elb resource type.
-// The fetcher writes Findings using these codes; the ELB Color func reads
-// wave1 Findings (Source == "wave1") to color rows.
 package aws
 
 import "github.com/k2m30/a9s/v3/internal/domain"
 
 const (
-	// CodeELBStateProvisioning — load balancer is in the "provisioning" lifecycle state.
-	// Severity: SevWarn (transitional).
-	CodeELBStateProvisioning domain.FindingCode = "elb.state.provisioning"
-
-	// CodeELBStateActiveImpaired — load balancer is active but impaired.
-	// Severity: SevWarn (degraded).
-	CodeELBStateActiveImpaired domain.FindingCode = "elb.state.active-impaired"
-
-	// CodeELBStateFailed — load balancer has failed.
-	// Severity: SevBroken.
-	CodeELBStateFailed domain.FindingCode = "elb.state.failed"
+	CodeELBStateProvisioning   domain.FindingCode = "elb.state.provisioning"
+	CodeELBStateActiveImpaired domain.FindingCode = "elb.state.active_impaired"
+	CodeELBStateFailed         domain.FindingCode = "elb.state.failed"
 )

--- a/internal/aws/elb_codes.go
+++ b/internal/aws/elb_codes.go
@@ -1,0 +1,20 @@
+// elb_codes.go — canonical FindingCode constants for the elb resource type.
+// The fetcher writes Findings using these codes; the ELB Color func reads
+// wave1 Findings (Source == "wave1") to color rows.
+package aws
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+const (
+	// CodeELBStateProvisioning — load balancer is in the "provisioning" lifecycle state.
+	// Severity: SevWarn (transitional).
+	CodeELBStateProvisioning domain.FindingCode = "elb.state.provisioning"
+
+	// CodeELBStateActiveImpaired — load balancer is active but impaired.
+	// Severity: SevWarn (degraded).
+	CodeELBStateActiveImpaired domain.FindingCode = "elb.state.active-impaired"
+
+	// CodeELBStateFailed — load balancer has failed.
+	// Severity: SevBroken.
+	CodeELBStateFailed domain.FindingCode = "elb.state.failed"
+)

--- a/internal/aws/igw.go
+++ b/internal/aws/igw.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -92,10 +93,17 @@ func FetchInternetGatewaysPage(ctx context.Context, api EC2DescribeInternetGatew
 			state = string(igw.Attachments[0].State)
 		}
 
+		var findings []domain.Finding
+		switch state {
+		case "attaching":
+			findings = []domain.Finding{{Code: CodeIGWStateAttaching, Phrase: "attaching", Severity: domain.SevWarn, Source: "wave1"}}
+		case "detaching":
+			findings = []domain.Finding{{Code: CodeIGWStateDetaching, Phrase: "detaching", Severity: domain.SevWarn, Source: "wave1"}}
+		}
+
 		r := resource.Resource{
-			ID:     igwID,
-			Name:   name,
-			Status: state,
+			ID:   igwID,
+			Name: name,
 			Fields: map[string]string{
 				"igw_id":            igwID,
 				"name":              name,
@@ -103,6 +111,7 @@ func FetchInternetGatewaysPage(ctx context.Context, api EC2DescribeInternetGatew
 				"state":             state,
 				"attachments_count": fmt.Sprintf("%d", len(igw.Attachments)),
 			},
+			Findings:  findings,
 			RawStruct: igw,
 		}
 

--- a/internal/aws/igw_codes.go
+++ b/internal/aws/igw_codes.go
@@ -1,16 +1,8 @@
-// igw_codes.go — canonical FindingCode constants for the igw resource type.
-// The fetcher writes Findings using these codes; the IGW Color func reads
-// wave1 Findings (Source == "wave1") to color rows.
 package aws
 
 import "github.com/k2m30/a9s/v3/internal/domain"
 
 const (
-	// CodeIGWStateAttaching — internet gateway is attaching to a VPC.
-	// Severity: SevWarn (transitional).
 	CodeIGWStateAttaching domain.FindingCode = "igw.state.attaching"
-
-	// CodeIGWStateDetaching — internet gateway is detaching from a VPC.
-	// Severity: SevWarn (transitional).
 	CodeIGWStateDetaching domain.FindingCode = "igw.state.detaching"
 )

--- a/internal/aws/igw_codes.go
+++ b/internal/aws/igw_codes.go
@@ -1,0 +1,16 @@
+// igw_codes.go — canonical FindingCode constants for the igw resource type.
+// The fetcher writes Findings using these codes; the IGW Color func reads
+// wave1 Findings (Source == "wave1") to color rows.
+package aws
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+const (
+	// CodeIGWStateAttaching — internet gateway is attaching to a VPC.
+	// Severity: SevWarn (transitional).
+	CodeIGWStateAttaching domain.FindingCode = "igw.state.attaching"
+
+	// CodeIGWStateDetaching — internet gateway is detaching from a VPC.
+	// Severity: SevWarn (transitional).
+	CodeIGWStateDetaching domain.FindingCode = "igw.state.detaching"
+)

--- a/internal/aws/nat.go
+++ b/internal/aws/nat.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -108,10 +109,19 @@ func FetchNatGatewaysPage(ctx context.Context, api EC2DescribeNatGatewaysAPI, co
 			}
 		}
 
+		var findings []domain.Finding
+		switch state {
+		case "pending":
+			findings = []domain.Finding{{Code: CodeNATStatePending, Phrase: "pending", Severity: domain.SevWarn, Source: "wave1"}}
+		case "deleting":
+			findings = []domain.Finding{{Code: CodeNATStateDeleting, Phrase: "deleting", Severity: domain.SevWarn, Source: "wave1"}}
+		case "failed":
+			findings = []domain.Finding{{Code: CodeNATStateFailed, Phrase: "failed", Severity: domain.SevBroken, Source: "wave1"}}
+		}
+
 		r := resource.Resource{
-			ID:     natID,
-			Name:   name,
-			Status: state,
+			ID:   natID,
+			Name: name,
 			Fields: map[string]string{
 				"nat_gateway_id": natID,
 				"name":           name,
@@ -120,6 +130,7 @@ func FetchNatGatewaysPage(ctx context.Context, api EC2DescribeNatGatewaysAPI, co
 				"state":          state,
 				"public_ip":      publicIP,
 			},
+			Findings:  findings,
 			RawStruct: nat,
 		}
 

--- a/internal/aws/nat_codes.go
+++ b/internal/aws/nat_codes.go
@@ -1,0 +1,20 @@
+// nat_codes.go — canonical FindingCode constants for the nat resource type.
+// The fetcher writes Findings using these codes; the NAT Color func reads
+// wave1 Findings (Source == "wave1") to color rows.
+package aws
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+const (
+	// CodeNATStatePending — NAT gateway is in the "pending" lifecycle state.
+	// Severity: SevWarn (transitional).
+	CodeNATStatePending domain.FindingCode = "nat.state.pending"
+
+	// CodeNATStateDeleting — NAT gateway is being deleted.
+	// Severity: SevWarn (transitional).
+	CodeNATStateDeleting domain.FindingCode = "nat.state.deleting"
+
+	// CodeNATStateFailed — NAT gateway has failed.
+	// Severity: SevBroken.
+	CodeNATStateFailed domain.FindingCode = "nat.state.failed"
+)

--- a/internal/aws/nat_codes.go
+++ b/internal/aws/nat_codes.go
@@ -1,20 +1,9 @@
-// nat_codes.go — canonical FindingCode constants for the nat resource type.
-// The fetcher writes Findings using these codes; the NAT Color func reads
-// wave1 Findings (Source == "wave1") to color rows.
 package aws
 
 import "github.com/k2m30/a9s/v3/internal/domain"
 
 const (
-	// CodeNATStatePending — NAT gateway is in the "pending" lifecycle state.
-	// Severity: SevWarn (transitional).
-	CodeNATStatePending domain.FindingCode = "nat.state.pending"
-
-	// CodeNATStateDeleting — NAT gateway is being deleted.
-	// Severity: SevWarn (transitional).
+	CodeNATStatePending  domain.FindingCode = "nat.state.pending"
 	CodeNATStateDeleting domain.FindingCode = "nat.state.deleting"
-
-	// CodeNATStateFailed — NAT gateway has failed.
-	// Severity: SevBroken.
-	CodeNATStateFailed domain.FindingCode = "nat.state.failed"
+	CodeNATStateFailed   domain.FindingCode = "nat.state.failed"
 )

--- a/internal/aws/rtb.go
+++ b/internal/aws/rtb.go
@@ -100,9 +100,8 @@ func FetchRouteTablesPage(ctx context.Context, api EC2DescribeRouteTablesAPI, co
 		}
 
 		r := resource.Resource{
-			ID:     rtbID,
-			Name:   name,
-			Status: isMain,
+			ID:   rtbID,
+			Name: name,
 			Fields: map[string]string{
 				"route_table_id":         rtbID,
 				"name":                   name,

--- a/internal/aws/subnet.go
+++ b/internal/aws/subnet.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -95,10 +96,21 @@ func FetchSubnetsPage(ctx context.Context, api EC2DescribeSubnetsAPI, continuati
 			availableIPs = fmt.Sprintf("%d", *subnet.AvailableIpAddressCount)
 		}
 
+		var findings []domain.Finding
+		switch state {
+		case "pending":
+			findings = []domain.Finding{{Code: CodeSubnetStatePending, Phrase: "pending", Severity: domain.SevWarn, Source: "wave1"}}
+		case "unavailable":
+			findings = []domain.Finding{{Code: CodeSubnetStateUnavailable, Phrase: "unavailable", Severity: domain.SevBroken, Source: "wave1"}}
+		case "failed":
+			findings = []domain.Finding{{Code: CodeSubnetStateFailed, Phrase: "failed", Severity: domain.SevBroken, Source: "wave1"}}
+		case "failed-insufficient-capacity":
+			findings = []domain.Finding{{Code: CodeSubnetStateFailedInsufficientCapacity, Phrase: "failed-insufficient-capacity", Severity: domain.SevBroken, Source: "wave1"}}
+		}
+
 		r := resource.Resource{
-			ID:     subnetID,
-			Name:   name,
-			Status: state,
+			ID:   subnetID,
+			Name: name,
 			Fields: map[string]string{
 				"subnet_id":         subnetID,
 				"name":              name,
@@ -108,6 +120,7 @@ func FetchSubnetsPage(ctx context.Context, api EC2DescribeSubnetsAPI, continuati
 				"state":             state,
 				"available_ips":     availableIPs,
 			},
+			Findings:  findings,
 			RawStruct: subnet,
 		}
 

--- a/internal/aws/subnet_codes.go
+++ b/internal/aws/subnet_codes.go
@@ -1,0 +1,25 @@
+// subnet_codes.go — canonical FindingCode constants for the subnet resource type.
+// The fetcher writes Findings using these codes; the Subnet Color func reads
+// wave1 Findings (Source == "wave1") to color rows.
+package aws
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+const (
+	// CodeSubnetStatePending — subnet is in the "pending" lifecycle state.
+	// Severity: SevWarn (transitional).
+	CodeSubnetStatePending domain.FindingCode = "subnet.state.pending"
+
+	// CodeSubnetStateUnavailable — subnet is unavailable.
+	// Severity: SevBroken.
+	CodeSubnetStateUnavailable domain.FindingCode = "subnet.state.unavailable"
+
+	// CodeSubnetStateFailed — subnet has failed.
+	// Severity: SevBroken.
+	CodeSubnetStateFailed domain.FindingCode = "subnet.state.failed"
+
+	// CodeSubnetStateFailedInsufficientCapacity — subnet failed due to
+	// insufficient capacity.
+	// Severity: SevBroken.
+	CodeSubnetStateFailedInsufficientCapacity domain.FindingCode = "subnet.state.failed-insufficient-capacity"
+)

--- a/internal/aws/subnet_codes.go
+++ b/internal/aws/subnet_codes.go
@@ -1,25 +1,10 @@
-// subnet_codes.go — canonical FindingCode constants for the subnet resource type.
-// The fetcher writes Findings using these codes; the Subnet Color func reads
-// wave1 Findings (Source == "wave1") to color rows.
 package aws
 
 import "github.com/k2m30/a9s/v3/internal/domain"
 
 const (
-	// CodeSubnetStatePending — subnet is in the "pending" lifecycle state.
-	// Severity: SevWarn (transitional).
-	CodeSubnetStatePending domain.FindingCode = "subnet.state.pending"
-
-	// CodeSubnetStateUnavailable — subnet is unavailable.
-	// Severity: SevBroken.
-	CodeSubnetStateUnavailable domain.FindingCode = "subnet.state.unavailable"
-
-	// CodeSubnetStateFailed — subnet has failed.
-	// Severity: SevBroken.
-	CodeSubnetStateFailed domain.FindingCode = "subnet.state.failed"
-
-	// CodeSubnetStateFailedInsufficientCapacity — subnet failed due to
-	// insufficient capacity.
-	// Severity: SevBroken.
+	CodeSubnetStatePending                    domain.FindingCode = "subnet.state.pending"
+	CodeSubnetStateUnavailable                domain.FindingCode = "subnet.state.unavailable"
+	CodeSubnetStateFailed                     domain.FindingCode = "subnet.state.failed"
 	CodeSubnetStateFailedInsufficientCapacity domain.FindingCode = "subnet.state.failed-insufficient-capacity"
 )

--- a/internal/aws/tgw.go
+++ b/internal/aws/tgw.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -86,10 +87,21 @@ func FetchTransitGatewaysPage(ctx context.Context, api EC2DescribeTransitGateway
 			description = *tgw.Description
 		}
 
+		var findings []domain.Finding
+		switch state {
+		case "pending":
+			findings = []domain.Finding{{Code: CodeTGWStatePending, Phrase: "pending", Severity: domain.SevWarn, Source: "wave1"}}
+		case "modifying":
+			findings = []domain.Finding{{Code: CodeTGWStateModifying, Phrase: "modifying", Severity: domain.SevWarn, Source: "wave1"}}
+		case "deleting":
+			findings = []domain.Finding{{Code: CodeTGWStateDeleting, Phrase: "deleting", Severity: domain.SevWarn, Source: "wave1"}}
+		case "failed":
+			findings = []domain.Finding{{Code: CodeTGWStateFailed, Phrase: "failed", Severity: domain.SevBroken, Source: "wave1"}}
+		}
+
 		r := resource.Resource{
-			ID:     tgwID,
-			Name:   name,
-			Status: state,
+			ID:   tgwID,
+			Name: name,
 			Fields: map[string]string{
 				"tgw_id":      tgwID,
 				"name":        name,
@@ -97,6 +109,7 @@ func FetchTransitGatewaysPage(ctx context.Context, api EC2DescribeTransitGateway
 				"owner_id":    ownerID,
 				"description": description,
 			},
+			Findings:  findings,
 			RawStruct: tgw,
 		}
 

--- a/internal/aws/tgw_codes.go
+++ b/internal/aws/tgw_codes.go
@@ -1,24 +1,10 @@
-// tgw_codes.go — canonical FindingCode constants for the tgw resource type.
-// The fetcher writes Findings using these codes; the TGW Color func reads
-// wave1 Findings (Source == "wave1") to color rows.
 package aws
 
 import "github.com/k2m30/a9s/v3/internal/domain"
 
 const (
-	// CodeTGWStatePending — transit gateway is in the "pending" lifecycle state.
-	// Severity: SevWarn (transitional).
-	CodeTGWStatePending domain.FindingCode = "tgw.state.pending"
-
-	// CodeTGWStateModifying — transit gateway is being modified.
-	// Severity: SevWarn (transitional).
+	CodeTGWStatePending   domain.FindingCode = "tgw.state.pending"
 	CodeTGWStateModifying domain.FindingCode = "tgw.state.modifying"
-
-	// CodeTGWStateDeleting — transit gateway is being deleted.
-	// Severity: SevWarn (transitional).
-	CodeTGWStateDeleting domain.FindingCode = "tgw.state.deleting"
-
-	// CodeTGWStateFailed — transit gateway has failed.
-	// Severity: SevBroken.
-	CodeTGWStateFailed domain.FindingCode = "tgw.state.failed"
+	CodeTGWStateDeleting  domain.FindingCode = "tgw.state.deleting"
+	CodeTGWStateFailed    domain.FindingCode = "tgw.state.failed"
 )

--- a/internal/aws/tgw_codes.go
+++ b/internal/aws/tgw_codes.go
@@ -1,0 +1,24 @@
+// tgw_codes.go — canonical FindingCode constants for the tgw resource type.
+// The fetcher writes Findings using these codes; the TGW Color func reads
+// wave1 Findings (Source == "wave1") to color rows.
+package aws
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+const (
+	// CodeTGWStatePending — transit gateway is in the "pending" lifecycle state.
+	// Severity: SevWarn (transitional).
+	CodeTGWStatePending domain.FindingCode = "tgw.state.pending"
+
+	// CodeTGWStateModifying — transit gateway is being modified.
+	// Severity: SevWarn (transitional).
+	CodeTGWStateModifying domain.FindingCode = "tgw.state.modifying"
+
+	// CodeTGWStateDeleting — transit gateway is being deleted.
+	// Severity: SevWarn (transitional).
+	CodeTGWStateDeleting domain.FindingCode = "tgw.state.deleting"
+
+	// CodeTGWStateFailed — transit gateway has failed.
+	// Severity: SevBroken.
+	CodeTGWStateFailed domain.FindingCode = "tgw.state.failed"
+)

--- a/internal/aws/vpc.go
+++ b/internal/aws/vpc.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -90,10 +91,15 @@ func FetchVPCsPage(ctx context.Context, api EC2DescribeVpcsAPI, continuationToke
 			isDefault = "true"
 		}
 
+		var findings []domain.Finding
+		switch state {
+		case "pending":
+			findings = []domain.Finding{{Code: CodeVPCStatePending, Phrase: "pending", Severity: domain.SevWarn, Source: "wave1"}}
+		}
+
 		r := resource.Resource{
-			ID:     vpcID,
-			Name:   name,
-			Status: state,
+			ID:   vpcID,
+			Name: name,
 			Fields: map[string]string{
 				"vpc_id":     vpcID,
 				"name":       name,
@@ -101,6 +107,7 @@ func FetchVPCsPage(ctx context.Context, api EC2DescribeVpcsAPI, continuationToke
 				"state":      state,
 				"is_default": isDefault,
 			},
+			Findings:  findings,
 			RawStruct: vpc,
 		}
 

--- a/internal/aws/vpc_codes.go
+++ b/internal/aws/vpc_codes.go
@@ -1,12 +1,7 @@
-// vpc_codes.go — canonical FindingCode constants for the vpc resource type.
-// The fetcher writes Findings using these codes; the VPC Color func reads
-// wave1 Findings (Source == "wave1") to color rows.
 package aws
 
 import "github.com/k2m30/a9s/v3/internal/domain"
 
 const (
-	// CodeVPCStatePending — VPC is in the "pending" lifecycle state.
-	// Severity: SevWarn (transitional).
 	CodeVPCStatePending domain.FindingCode = "vpc.state.pending"
 )

--- a/internal/aws/vpc_codes.go
+++ b/internal/aws/vpc_codes.go
@@ -1,0 +1,12 @@
+// vpc_codes.go — canonical FindingCode constants for the vpc resource type.
+// The fetcher writes Findings using these codes; the VPC Color func reads
+// wave1 Findings (Source == "wave1") to color rows.
+package aws
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+const (
+	// CodeVPCStatePending — VPC is in the "pending" lifecycle state.
+	// Severity: SevWarn (transitional).
+	CodeVPCStatePending domain.FindingCode = "vpc.state.pending"
+)

--- a/internal/aws/vpce.go
+++ b/internal/aws/vpce.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -76,10 +77,27 @@ func FetchVPCEndpointsPage(ctx context.Context, api EC2DescribeVpcEndpointsAPI, 
 			vpcID = *vpce.VpcId
 		}
 
+		var findings []domain.Finding
+		switch state {
+		case "PendingAcceptance":
+			findings = []domain.Finding{{Code: CodeVPCEStatePendingAcceptance, Phrase: "pending acceptance", Severity: domain.SevWarn, Source: "wave1"}}
+		case "Pending":
+			findings = []domain.Finding{{Code: CodeVPCEStatePending, Phrase: "pending", Severity: domain.SevWarn, Source: "wave1"}}
+		case "Deleting":
+			findings = []domain.Finding{{Code: CodeVPCEStateDeleting, Phrase: "deleting", Severity: domain.SevWarn, Source: "wave1"}}
+		case "Failed":
+			findings = []domain.Finding{{Code: CodeVPCEStateFailed, Phrase: "failed", Severity: domain.SevBroken, Source: "wave1"}}
+		case "Rejected":
+			findings = []domain.Finding{{Code: CodeVPCEStateRejected, Phrase: "rejected", Severity: domain.SevBroken, Source: "wave1"}}
+		case "Expired":
+			findings = []domain.Finding{{Code: CodeVPCEStateExpired, Phrase: "expired", Severity: domain.SevBroken, Source: "wave1"}}
+		case "Partial":
+			findings = []domain.Finding{{Code: CodeVPCEStatePartial, Phrase: "partial", Severity: domain.SevBroken, Source: "wave1"}}
+		}
+
 		r := resource.Resource{
-			ID:     vpceID,
-			Name:   serviceName,
-			Status: state,
+			ID:   vpceID,
+			Name: serviceName,
 			Fields: map[string]string{
 				"vpce_id":      vpceID,
 				"service_name": serviceName,
@@ -87,6 +105,7 @@ func FetchVPCEndpointsPage(ctx context.Context, api EC2DescribeVpcEndpointsAPI, 
 				"state":        state,
 				"vpc_id":       vpcID,
 			},
+			Findings:  findings,
 			RawStruct: vpce,
 		}
 

--- a/internal/aws/vpce_codes.go
+++ b/internal/aws/vpce_codes.go
@@ -1,0 +1,36 @@
+// vpce_codes.go — canonical FindingCode constants for the vpce resource type.
+// The fetcher writes Findings using these codes; the VPCE Color func reads
+// wave1 Findings (Source == "wave1") to color rows.
+package aws
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+const (
+	// CodeVPCEStatePendingAcceptance — VPC endpoint is awaiting acceptance.
+	// Severity: SevWarn (transitional).
+	CodeVPCEStatePendingAcceptance domain.FindingCode = "vpce.state.pending-acceptance"
+
+	// CodeVPCEStatePending — VPC endpoint is in the "Pending" lifecycle state.
+	// Severity: SevWarn (transitional).
+	CodeVPCEStatePending domain.FindingCode = "vpce.state.pending"
+
+	// CodeVPCEStateDeleting — VPC endpoint is being deleted.
+	// Severity: SevWarn (transitional).
+	CodeVPCEStateDeleting domain.FindingCode = "vpce.state.deleting"
+
+	// CodeVPCEStateFailed — VPC endpoint has failed.
+	// Severity: SevBroken.
+	CodeVPCEStateFailed domain.FindingCode = "vpce.state.failed"
+
+	// CodeVPCEStateRejected — VPC endpoint was rejected.
+	// Severity: SevBroken.
+	CodeVPCEStateRejected domain.FindingCode = "vpce.state.rejected"
+
+	// CodeVPCEStateExpired — VPC endpoint has expired.
+	// Severity: SevBroken.
+	CodeVPCEStateExpired domain.FindingCode = "vpce.state.expired"
+
+	// CodeVPCEStatePartial — VPC endpoint is in a partial state.
+	// Severity: SevBroken.
+	CodeVPCEStatePartial domain.FindingCode = "vpce.state.partial"
+)

--- a/internal/aws/vpce_codes.go
+++ b/internal/aws/vpce_codes.go
@@ -1,36 +1,13 @@
-// vpce_codes.go — canonical FindingCode constants for the vpce resource type.
-// The fetcher writes Findings using these codes; the VPCE Color func reads
-// wave1 Findings (Source == "wave1") to color rows.
 package aws
 
 import "github.com/k2m30/a9s/v3/internal/domain"
 
 const (
-	// CodeVPCEStatePendingAcceptance — VPC endpoint is awaiting acceptance.
-	// Severity: SevWarn (transitional).
-	CodeVPCEStatePendingAcceptance domain.FindingCode = "vpce.state.pending-acceptance"
-
-	// CodeVPCEStatePending — VPC endpoint is in the "Pending" lifecycle state.
-	// Severity: SevWarn (transitional).
-	CodeVPCEStatePending domain.FindingCode = "vpce.state.pending"
-
-	// CodeVPCEStateDeleting — VPC endpoint is being deleted.
-	// Severity: SevWarn (transitional).
-	CodeVPCEStateDeleting domain.FindingCode = "vpce.state.deleting"
-
-	// CodeVPCEStateFailed — VPC endpoint has failed.
-	// Severity: SevBroken.
-	CodeVPCEStateFailed domain.FindingCode = "vpce.state.failed"
-
-	// CodeVPCEStateRejected — VPC endpoint was rejected.
-	// Severity: SevBroken.
-	CodeVPCEStateRejected domain.FindingCode = "vpce.state.rejected"
-
-	// CodeVPCEStateExpired — VPC endpoint has expired.
-	// Severity: SevBroken.
-	CodeVPCEStateExpired domain.FindingCode = "vpce.state.expired"
-
-	// CodeVPCEStatePartial — VPC endpoint is in a partial state.
-	// Severity: SevBroken.
-	CodeVPCEStatePartial domain.FindingCode = "vpce.state.partial"
+	CodeVPCEStatePendingAcceptance domain.FindingCode = "vpce.state.pending_acceptance"
+	CodeVPCEStatePending           domain.FindingCode = "vpce.state.pending"
+	CodeVPCEStateDeleting          domain.FindingCode = "vpce.state.deleting"
+	CodeVPCEStateFailed            domain.FindingCode = "vpce.state.failed"
+	CodeVPCEStateRejected          domain.FindingCode = "vpce.state.rejected"
+	CodeVPCEStateExpired           domain.FindingCode = "vpce.state.expired"
+	CodeVPCEStatePartial           domain.FindingCode = "vpce.state.partial"
 )

--- a/internal/resource/severity_color.go
+++ b/internal/resource/severity_color.go
@@ -23,3 +23,15 @@ func ColorFromSeverity(sev domain.Severity) Color {
 		return ColorHealthy
 	}
 }
+
+// ColorFromWave1 returns the Color implied by the first wave1 Finding on r and
+// ok=true. ok=false signals no wave1 Finding — the caller should fall through
+// to its structural classifier.
+func ColorFromWave1(r Resource) (Color, bool) {
+	for i := range r.Findings {
+		if r.Findings[i].Source == "wave1" {
+			return ColorFromSeverity(r.Findings[i].Severity), true
+		}
+	}
+	return ColorHealthy, false
+}

--- a/internal/resource/types_networking.go
+++ b/internal/resource/types_networking.go
@@ -19,8 +19,13 @@ func networkingResourceTypes() []ResourceTypeDef {
 				{Key: "vpc_id", Title: "VPC ID", Width: 24, Sortable: true},
 			},
 			Color: func(r Resource) Color {
+				for _, f := range r.Findings {
+					if f.Source == "wave1" {
+						return ColorFromSeverity(f.Severity)
+					}
+				}
 				switch r.Fields["state"] {
-				case "active":
+				case "active", "":
 					return ColorHealthy
 				case "provisioning", "active_impaired":
 					return ColorWarning
@@ -95,8 +100,13 @@ func networkingResourceTypes() []ResourceTypeDef {
 				{Key: "is_default", Title: "Default", Width: 9, Sortable: true},
 			},
 			Color: func(r Resource) Color {
+				for _, f := range r.Findings {
+					if f.Source == "wave1" {
+						return ColorFromSeverity(f.Severity)
+					}
+				}
 				switch r.Fields["state"] {
-				case "available":
+				case "available", "":
 					return ColorHealthy
 				case "pending":
 					return ColorWarning
@@ -120,8 +130,13 @@ func networkingResourceTypes() []ResourceTypeDef {
 				{Key: "available_ips", Title: "Available IPs", Width: 14, Sortable: true},
 			},
 			Color: func(r Resource) Color {
+				for _, f := range r.Findings {
+					if f.Source == "wave1" {
+						return ColorFromSeverity(f.Severity)
+					}
+				}
 				switch r.Fields["state"] {
-				case "available":
+				case "available", "":
 					return ColorHealthy
 				case "pending":
 					return ColorWarning
@@ -171,8 +186,13 @@ func networkingResourceTypes() []ResourceTypeDef {
 				{Key: "public_ip", Title: "Public IP", Width: 16, Sortable: false},
 			},
 			Color: func(r Resource) Color {
+				for _, f := range r.Findings {
+					if f.Source == "wave1" {
+						return ColorFromSeverity(f.Severity)
+					}
+				}
 				switch r.Fields["state"] {
-				case "available":
+				case "available", "":
 					return ColorHealthy
 				case "pending", "deleting":
 					return ColorWarning
@@ -197,12 +217,17 @@ func networkingResourceTypes() []ResourceTypeDef {
 				{Key: "state", Title: "State", Width: 12, Sortable: true},
 			},
 			Color: func(r Resource) Color {
-				attachments, _ := strconv.Atoi(r.Fields["attachments_count"])
-				if attachments == 0 {
-					return ColorWarning
+				for _, f := range r.Findings {
+					if f.Source == "wave1" {
+						return ColorFromSeverity(f.Severity)
+					}
 				}
 				switch r.Fields["state"] {
 				case "attaching", "detaching":
+					return ColorWarning
+				}
+				attachments, _ := strconv.Atoi(r.Fields["attachments_count"])
+				if attachments == 0 {
 					return ColorWarning
 				}
 				return ColorHealthy
@@ -252,8 +277,13 @@ func networkingResourceTypes() []ResourceTypeDef {
 				{Key: "vpc_id", Title: "VPC ID", Width: 24, Sortable: true},
 			},
 			Color: func(r Resource) Color {
+				for _, f := range r.Findings {
+					if f.Source == "wave1" {
+						return ColorFromSeverity(f.Severity)
+					}
+				}
 				switch r.Fields["state"] {
-				case "Available":
+				case "Available", "":
 					return ColorHealthy
 				case "PendingAcceptance", "Pending", "Deleting":
 					return ColorWarning
@@ -279,15 +309,20 @@ func networkingResourceTypes() []ResourceTypeDef {
 				{Key: "description", Title: "Description", Width: 30, Sortable: false},
 			},
 			Color: func(r Resource) Color {
+				for _, f := range r.Findings {
+					if f.Source == "wave1" {
+						return ColorFromSeverity(f.Severity)
+					}
+				}
 				switch r.Fields["state"] {
-				case "available":
+				case "available", "":
 					return ColorHealthy
 				case "pending", "modifying", "deleting":
 					return ColorWarning
-				case "deleted":
-					return ColorDim
 				case "failed":
 					return ColorBroken
+				case "deleted":
+					return ColorDim
 				}
 				return ColorHealthy
 			},

--- a/internal/resource/types_networking.go
+++ b/internal/resource/types_networking.go
@@ -19,10 +19,8 @@ func networkingResourceTypes() []ResourceTypeDef {
 				{Key: "vpc_id", Title: "VPC ID", Width: 24, Sortable: true},
 			},
 			Color: func(r Resource) Color {
-				for _, f := range r.Findings {
-					if f.Source == "wave1" {
-						return ColorFromSeverity(f.Severity)
-					}
+				if c, ok := ColorFromWave1(r); ok {
+					return c
 				}
 				switch r.Fields["state"] {
 				case "active", "":
@@ -100,10 +98,8 @@ func networkingResourceTypes() []ResourceTypeDef {
 				{Key: "is_default", Title: "Default", Width: 9, Sortable: true},
 			},
 			Color: func(r Resource) Color {
-				for _, f := range r.Findings {
-					if f.Source == "wave1" {
-						return ColorFromSeverity(f.Severity)
-					}
+				if c, ok := ColorFromWave1(r); ok {
+					return c
 				}
 				switch r.Fields["state"] {
 				case "available", "":
@@ -130,10 +126,8 @@ func networkingResourceTypes() []ResourceTypeDef {
 				{Key: "available_ips", Title: "Available IPs", Width: 14, Sortable: true},
 			},
 			Color: func(r Resource) Color {
-				for _, f := range r.Findings {
-					if f.Source == "wave1" {
-						return ColorFromSeverity(f.Severity)
-					}
+				if c, ok := ColorFromWave1(r); ok {
+					return c
 				}
 				switch r.Fields["state"] {
 				case "available", "":
@@ -186,10 +180,8 @@ func networkingResourceTypes() []ResourceTypeDef {
 				{Key: "public_ip", Title: "Public IP", Width: 16, Sortable: false},
 			},
 			Color: func(r Resource) Color {
-				for _, f := range r.Findings {
-					if f.Source == "wave1" {
-						return ColorFromSeverity(f.Severity)
-					}
+				if c, ok := ColorFromWave1(r); ok {
+					return c
 				}
 				switch r.Fields["state"] {
 				case "available", "":
@@ -217,10 +209,8 @@ func networkingResourceTypes() []ResourceTypeDef {
 				{Key: "state", Title: "State", Width: 12, Sortable: true},
 			},
 			Color: func(r Resource) Color {
-				for _, f := range r.Findings {
-					if f.Source == "wave1" {
-						return ColorFromSeverity(f.Severity)
-					}
+				if c, ok := ColorFromWave1(r); ok {
+					return c
 				}
 				switch r.Fields["state"] {
 				case "attaching", "detaching":
@@ -250,13 +240,9 @@ func networkingResourceTypes() []ResourceTypeDef {
 			// Elastic IPs without an association are allocated-but-unused and
 			// continue to incur hourly charges. Surface those as warning.
 			Color: func(r Resource) Color {
-				// PR-03b: Findings-first for wave1 lifecycle entries.
-				for _, f := range r.Findings {
-					if f.Source == "wave1" {
-						return ColorFromSeverity(f.Severity)
-					}
+				if c, ok := ColorFromWave1(r); ok {
+					return c
 				}
-
 				if r.Fields["association_id"] == "" && r.Fields["instance_id"] == "" {
 					return ColorWarning
 				}
@@ -277,10 +263,8 @@ func networkingResourceTypes() []ResourceTypeDef {
 				{Key: "vpc_id", Title: "VPC ID", Width: 24, Sortable: true},
 			},
 			Color: func(r Resource) Color {
-				for _, f := range r.Findings {
-					if f.Source == "wave1" {
-						return ColorFromSeverity(f.Severity)
-					}
+				if c, ok := ColorFromWave1(r); ok {
+					return c
 				}
 				switch r.Fields["state"] {
 				case "Available", "":
@@ -309,10 +293,8 @@ func networkingResourceTypes() []ResourceTypeDef {
 				{Key: "description", Title: "Description", Width: 30, Sortable: false},
 			},
 			Color: func(r Resource) Color {
-				for _, f := range r.Findings {
-					if f.Source == "wave1" {
-						return ColorFromSeverity(f.Severity)
-					}
+				if c, ok := ColorFromWave1(r); ok {
+					return c
 				}
 				switch r.Fields["state"] {
 				case "available", "":
@@ -342,13 +324,9 @@ func networkingResourceTypes() []ResourceTypeDef {
 				{Key: "private_ip", Title: "Private IP", Width: 16, Sortable: false},
 			},
 			Color: func(r Resource) Color {
-				// PR-03b: Findings-first for wave1 lifecycle entries.
-				for _, f := range r.Findings {
-					if f.Source == "wave1" {
-						return ColorFromSeverity(f.Severity)
-					}
+				if c, ok := ColorFromWave1(r); ok {
+					return c
 				}
-
 				switch r.Fields["status"] {
 				case "in-use":
 					return ColorHealthy

--- a/tests/unit/aws_elb_test.go
+++ b/tests/unit/aws_elb_test.go
@@ -80,8 +80,8 @@ func TestFetchLoadBalancers_ParsesMultipleLoadBalancers(t *testing.T) {
 	if r0.Name != "prod-alb" {
 		t.Errorf("resource[0].Name: expected %q, got %q", "prod-alb", r0.Name)
 	}
-	if r0.Status != "active" {
-		t.Errorf("resource[0].Status: expected %q, got %q", "active", r0.Status)
+	if r0.Status != "" {
+		t.Errorf("resource[0].Status: expected empty (PR-03d migration), got %q", r0.Status)
 	}
 	if r0.Fields["name"] != "prod-alb" {
 		t.Errorf("resource[0].Fields[\"name\"]: expected %q, got %q", "prod-alb", r0.Fields["name"])

--- a/tests/unit/aws_elb_test.go
+++ b/tests/unit/aws_elb_test.go
@@ -83,6 +83,9 @@ func TestFetchLoadBalancers_ParsesMultipleLoadBalancers(t *testing.T) {
 	if r0.Status != "" {
 		t.Errorf("resource[0].Status: expected empty, got %q", r0.Status)
 	}
+	if len(r0.Findings) != 0 {
+		t.Errorf("resource[0].Findings: expected none for active ELB, got %d", len(r0.Findings))
+	}
 	if r0.Fields["name"] != "prod-alb" {
 		t.Errorf("resource[0].Fields[\"name\"]: expected %q, got %q", "prod-alb", r0.Fields["name"])
 	}

--- a/tests/unit/aws_elb_test.go
+++ b/tests/unit/aws_elb_test.go
@@ -32,7 +32,7 @@ func TestFetchLoadBalancers_ParsesMultipleLoadBalancers(t *testing.T) {
 						Code: elbv2types.LoadBalancerStateEnumActive,
 					},
 					VpcId:                 aws.String("vpc-abc123"),
-					LoadBalancerArn:       aws.String("arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/prod-alb/abc123"),
+					LoadBalancerArn:       aws.String("arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/prod-alb/abc123"),
 					CanonicalHostedZoneId: aws.String("Z35SXDOTRQ7X7K"),
 					CreatedTime:           &createdTime,
 					IpAddressType:         elbv2types.IpAddressTypeIpv4,
@@ -46,7 +46,7 @@ func TestFetchLoadBalancers_ParsesMultipleLoadBalancers(t *testing.T) {
 						Code: elbv2types.LoadBalancerStateEnumActive,
 					},
 					VpcId:           aws.String("vpc-def456"),
-					LoadBalancerArn: aws.String("arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/net/internal-nlb/def456"),
+					LoadBalancerArn: aws.String("arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/net/internal-nlb/def456"),
 					IpAddressType:   elbv2types.IpAddressTypeIpv4,
 				},
 			},
@@ -81,7 +81,7 @@ func TestFetchLoadBalancers_ParsesMultipleLoadBalancers(t *testing.T) {
 		t.Errorf("resource[0].Name: expected %q, got %q", "prod-alb", r0.Name)
 	}
 	if r0.Status != "" {
-		t.Errorf("resource[0].Status: expected empty (PR-03d migration), got %q", r0.Status)
+		t.Errorf("resource[0].Status: expected empty, got %q", r0.Status)
 	}
 	if r0.Fields["name"] != "prod-alb" {
 		t.Errorf("resource[0].Fields[\"name\"]: expected %q, got %q", "prod-alb", r0.Fields["name"])

--- a/tests/unit/aws_igw_test.go
+++ b/tests/unit/aws_igw_test.go
@@ -69,6 +69,9 @@ func TestFetchInternetGateways_ParsesMultipleIGWs(t *testing.T) {
 	if r0.Status != "" {
 		t.Errorf("resource[0].Status: expected empty, got %q", r0.Status)
 	}
+	if len(r0.Findings) != 0 {
+		t.Errorf("resource[0].Findings: expected none for attached IGW, got %d", len(r0.Findings))
+	}
 
 	// Verify Fields on all resources
 	requiredFields := []string{"igw_id", "name", "vpc_id", "state"}

--- a/tests/unit/aws_igw_test.go
+++ b/tests/unit/aws_igw_test.go
@@ -22,7 +22,7 @@ func TestFetchInternetGateways_ParsesMultipleIGWs(t *testing.T) {
 			InternetGateways: []ec2types.InternetGateway{
 				{
 					InternetGatewayId: aws.String("igw-0001"),
-					OwnerId:           aws.String("123456789012"),
+					OwnerId:           aws.String("000000000000"),
 					Attachments: []ec2types.InternetGatewayAttachment{
 						{
 							VpcId: aws.String("vpc-aaa"),
@@ -36,7 +36,7 @@ func TestFetchInternetGateways_ParsesMultipleIGWs(t *testing.T) {
 				},
 				{
 					InternetGatewayId: aws.String("igw-0002"),
-					OwnerId:           aws.String("123456789012"),
+					OwnerId:           aws.String("000000000000"),
 					Attachments: []ec2types.InternetGatewayAttachment{
 						{
 							VpcId: aws.String("vpc-bbb"),
@@ -67,7 +67,7 @@ func TestFetchInternetGateways_ParsesMultipleIGWs(t *testing.T) {
 		t.Errorf("resource[0].Name: expected %q, got %q", "main-igw", r0.Name)
 	}
 	if r0.Status != "" {
-		t.Errorf("resource[0].Status: expected empty (PR-03d migration), got %q", r0.Status)
+		t.Errorf("resource[0].Status: expected empty, got %q", r0.Status)
 	}
 
 	// Verify Fields on all resources
@@ -103,7 +103,7 @@ func TestFetchInternetGateways_ParsesMultipleIGWs(t *testing.T) {
 		t.Errorf("resource[1].Name: expected empty string, got %q", r1.Name)
 	}
 	if r1.Status != "" {
-		t.Errorf("resource[1].Status: expected empty (PR-03d migration), got %q", r1.Status)
+		t.Errorf("resource[1].Status: expected empty, got %q", r1.Status)
 	}
 	if r1.Fields["vpc_id"] != "vpc-bbb" {
 		t.Errorf("resource[1].Fields[\"vpc_id\"]: expected %q, got %q", "vpc-bbb", r1.Fields["vpc_id"])

--- a/tests/unit/aws_igw_test.go
+++ b/tests/unit/aws_igw_test.go
@@ -66,8 +66,8 @@ func TestFetchInternetGateways_ParsesMultipleIGWs(t *testing.T) {
 	if r0.Name != "main-igw" {
 		t.Errorf("resource[0].Name: expected %q, got %q", "main-igw", r0.Name)
 	}
-	if r0.Status != "attached" {
-		t.Errorf("resource[0].Status: expected %q, got %q", "attached", r0.Status)
+	if r0.Status != "" {
+		t.Errorf("resource[0].Status: expected empty (PR-03d migration), got %q", r0.Status)
 	}
 
 	// Verify Fields on all resources
@@ -102,8 +102,8 @@ func TestFetchInternetGateways_ParsesMultipleIGWs(t *testing.T) {
 	if r1.Name != "" {
 		t.Errorf("resource[1].Name: expected empty string, got %q", r1.Name)
 	}
-	if r1.Status != "attached" {
-		t.Errorf("resource[1].Status: expected %q, got %q", "attached", r1.Status)
+	if r1.Status != "" {
+		t.Errorf("resource[1].Status: expected empty (PR-03d migration), got %q", r1.Status)
 	}
 	if r1.Fields["vpc_id"] != "vpc-bbb" {
 		t.Errorf("resource[1].Fields[\"vpc_id\"]: expected %q, got %q", "vpc-bbb", r1.Fields["vpc_id"])

--- a/tests/unit/aws_natgateways_test.go
+++ b/tests/unit/aws_natgateways_test.go
@@ -69,7 +69,7 @@ func TestFetchNatGateways_ParsesMultipleNatGateways(t *testing.T) {
 		t.Errorf("resource[0].Name: expected %q, got %q", "main-nat", r0.Name)
 	}
 	if r0.Status != "" {
-		t.Errorf("resource[0].Status: expected empty (PR-03d migration), got %q", r0.Status)
+		t.Errorf("resource[0].Status: expected empty, got %q", r0.Status)
 	}
 
 	// Verify Fields on all resources
@@ -111,7 +111,7 @@ func TestFetchNatGateways_ParsesMultipleNatGateways(t *testing.T) {
 		t.Errorf("resource[1].Name: expected empty string, got %q", r1.Name)
 	}
 	if r1.Status != "" {
-		t.Errorf("resource[1].Status: expected empty (PR-03d migration), got %q", r1.Status)
+		t.Errorf("resource[1].Status: expected empty, got %q", r1.Status)
 	}
 	if r1.Fields["state"] != "pending" {
 		t.Errorf("resource[1].Fields[\"state\"]: expected %q, got %q", "pending", r1.Fields["state"])

--- a/tests/unit/aws_natgateways_test.go
+++ b/tests/unit/aws_natgateways_test.go
@@ -68,8 +68,8 @@ func TestFetchNatGateways_ParsesMultipleNatGateways(t *testing.T) {
 	if r0.Name != "main-nat" {
 		t.Errorf("resource[0].Name: expected %q, got %q", "main-nat", r0.Name)
 	}
-	if r0.Status != "available" {
-		t.Errorf("resource[0].Status: expected %q, got %q", "available", r0.Status)
+	if r0.Status != "" {
+		t.Errorf("resource[0].Status: expected empty (PR-03d migration), got %q", r0.Status)
 	}
 
 	// Verify Fields on all resources
@@ -110,8 +110,11 @@ func TestFetchNatGateways_ParsesMultipleNatGateways(t *testing.T) {
 	if r1.Name != "" {
 		t.Errorf("resource[1].Name: expected empty string, got %q", r1.Name)
 	}
-	if r1.Status != "pending" {
-		t.Errorf("resource[1].Status: expected %q, got %q", "pending", r1.Status)
+	if r1.Status != "" {
+		t.Errorf("resource[1].Status: expected empty (PR-03d migration), got %q", r1.Status)
+	}
+	if r1.Fields["state"] != "pending" {
+		t.Errorf("resource[1].Fields[\"state\"]: expected %q, got %q", "pending", r1.Fields["state"])
 	}
 	if r1.Fields["public_ip"] != "" {
 		t.Errorf("resource[1].Fields[\"public_ip\"]: expected empty string, got %q", r1.Fields["public_ip"])

--- a/tests/unit/aws_natgateways_test.go
+++ b/tests/unit/aws_natgateways_test.go
@@ -71,6 +71,9 @@ func TestFetchNatGateways_ParsesMultipleNatGateways(t *testing.T) {
 	if r0.Status != "" {
 		t.Errorf("resource[0].Status: expected empty, got %q", r0.Status)
 	}
+	if len(r0.Findings) != 0 {
+		t.Errorf("resource[0].Findings: expected none for available NAT, got %d", len(r0.Findings))
+	}
 
 	// Verify Fields on all resources
 	requiredFields := []string{"nat_gateway_id", "name", "vpc_id", "subnet_id", "state", "public_ip"}

--- a/tests/unit/aws_routetables_test.go
+++ b/tests/unit/aws_routetables_test.go
@@ -70,6 +70,9 @@ func TestFetchRouteTables_ParsesMultipleRouteTables(t *testing.T) {
 	if r0.Status != "" {
 		t.Errorf("resource[0].Status: expected empty, got %q", r0.Status)
 	}
+	if len(r0.Findings) != 0 {
+		t.Errorf("resource[0].Findings: expected none for rtb (never emits), got %d", len(r0.Findings))
+	}
 	if r0.Fields["is_main"] != "true" {
 		t.Errorf("resource[0].Fields[\"is_main\"]: expected %q, got %q", "true", r0.Fields["is_main"])
 	}

--- a/tests/unit/aws_routetables_test.go
+++ b/tests/unit/aws_routetables_test.go
@@ -67,9 +67,12 @@ func TestFetchRouteTables_ParsesMultipleRouteTables(t *testing.T) {
 	if r0.Name != "main-rtb" {
 		t.Errorf("resource[0].Name: expected %q, got %q", "main-rtb", r0.Name)
 	}
-	// Status is "true" when Main association exists, "false" otherwise
-	if r0.Status != "true" {
-		t.Errorf("resource[0].Status: expected %q, got %q", "true", r0.Status)
+	// PR-03d: Status no longer set; is_main lives in Fields.
+	if r0.Status != "" {
+		t.Errorf("resource[0].Status: expected empty (PR-03d migration), got %q", r0.Status)
+	}
+	if r0.Fields["is_main"] != "true" {
+		t.Errorf("resource[0].Fields[\"is_main\"]: expected %q, got %q", "true", r0.Fields["is_main"])
 	}
 
 	// Verify Fields on all resources
@@ -107,8 +110,11 @@ func TestFetchRouteTables_ParsesMultipleRouteTables(t *testing.T) {
 	if r1.Name != "" {
 		t.Errorf("resource[1].Name: expected empty string, got %q", r1.Name)
 	}
-	if r1.Status != "false" {
-		t.Errorf("resource[1].Status: expected %q, got %q", "false", r1.Status)
+	if r1.Status != "" {
+		t.Errorf("resource[1].Status: expected empty (PR-03d migration), got %q", r1.Status)
+	}
+	if r1.Fields["is_main"] != "false" {
+		t.Errorf("resource[1].Fields[\"is_main\"]: expected %q, got %q", "false", r1.Fields["is_main"])
 	}
 	if r1.Fields["vpc_id"] != "vpc-bbb" {
 		t.Errorf("resource[1].Fields[\"vpc_id\"]: expected %q, got %q", "vpc-bbb", r1.Fields["vpc_id"])

--- a/tests/unit/aws_routetables_test.go
+++ b/tests/unit/aws_routetables_test.go
@@ -23,7 +23,7 @@ func TestFetchRouteTables_ParsesMultipleRouteTables(t *testing.T) {
 				{
 					RouteTableId: aws.String("rtb-0001"),
 					VpcId:        aws.String("vpc-aaa"),
-					OwnerId:      aws.String("123456789012"),
+					OwnerId:      aws.String("000000000000"),
 					Routes: []ec2types.Route{
 						{DestinationCidrBlock: aws.String("0.0.0.0/0")},
 						{DestinationCidrBlock: aws.String("10.0.0.0/16")},
@@ -39,7 +39,7 @@ func TestFetchRouteTables_ParsesMultipleRouteTables(t *testing.T) {
 				{
 					RouteTableId: aws.String("rtb-0002"),
 					VpcId:        aws.String("vpc-bbb"),
-					OwnerId:      aws.String("123456789012"),
+					OwnerId:      aws.String("000000000000"),
 					Routes: []ec2types.Route{
 						{DestinationCidrBlock: aws.String("10.1.0.0/16")},
 					},
@@ -67,9 +67,8 @@ func TestFetchRouteTables_ParsesMultipleRouteTables(t *testing.T) {
 	if r0.Name != "main-rtb" {
 		t.Errorf("resource[0].Name: expected %q, got %q", "main-rtb", r0.Name)
 	}
-	// PR-03d: Status no longer set; is_main lives in Fields.
 	if r0.Status != "" {
-		t.Errorf("resource[0].Status: expected empty (PR-03d migration), got %q", r0.Status)
+		t.Errorf("resource[0].Status: expected empty, got %q", r0.Status)
 	}
 	if r0.Fields["is_main"] != "true" {
 		t.Errorf("resource[0].Fields[\"is_main\"]: expected %q, got %q", "true", r0.Fields["is_main"])
@@ -111,7 +110,7 @@ func TestFetchRouteTables_ParsesMultipleRouteTables(t *testing.T) {
 		t.Errorf("resource[1].Name: expected empty string, got %q", r1.Name)
 	}
 	if r1.Status != "" {
-		t.Errorf("resource[1].Status: expected empty (PR-03d migration), got %q", r1.Status)
+		t.Errorf("resource[1].Status: expected empty, got %q", r1.Status)
 	}
 	if r1.Fields["is_main"] != "false" {
 		t.Errorf("resource[1].Fields[\"is_main\"]: expected %q, got %q", "false", r1.Fields["is_main"])

--- a/tests/unit/aws_subnets_test.go
+++ b/tests/unit/aws_subnets_test.go
@@ -29,8 +29,8 @@ func TestFetchSubnets_ParsesMultipleSubnets(t *testing.T) {
 					AvailableIpAddressCount: aws.Int32(251),
 					MapPublicIpOnLaunch:     aws.Bool(true),
 					DefaultForAz:            aws.Bool(false),
-					OwnerId:                 aws.String("123456789012"),
-					SubnetArn:               aws.String("arn:aws:ec2:us-east-1:123456789012:subnet/subnet-0001"),
+					OwnerId:                 aws.String("000000000000"),
+					SubnetArn:               aws.String("arn:aws:ec2:us-east-1:000000000000:subnet/subnet-0001"),
 					Tags: []ec2types.Tag{
 						{Key: aws.String("Name"), Value: aws.String("public-subnet-1a")},
 						{Key: aws.String("Env"), Value: aws.String("prod")},
@@ -45,7 +45,7 @@ func TestFetchSubnets_ParsesMultipleSubnets(t *testing.T) {
 					AvailableIpAddressCount: aws.Int32(245),
 					MapPublicIpOnLaunch:     aws.Bool(false),
 					DefaultForAz:            aws.Bool(false),
-					OwnerId:                 aws.String("123456789012"),
+					OwnerId:                 aws.String("000000000000"),
 					Tags:                    []ec2types.Tag{},
 				},
 			},
@@ -70,7 +70,7 @@ func TestFetchSubnets_ParsesMultipleSubnets(t *testing.T) {
 		t.Errorf("resource[0].Name: expected %q, got %q", "public-subnet-1a", r0.Name)
 	}
 	if r0.Status != "" {
-		t.Errorf("resource[0].Status: expected empty (PR-03d migration), got %q", r0.Status)
+		t.Errorf("resource[0].Status: expected empty, got %q", r0.Status)
 	}
 
 	// Verify Fields on all resources
@@ -115,7 +115,7 @@ func TestFetchSubnets_ParsesMultipleSubnets(t *testing.T) {
 		t.Errorf("resource[1].Name: expected empty string, got %q", r1.Name)
 	}
 	if r1.Status != "" {
-		t.Errorf("resource[1].Status: expected empty (PR-03d migration), got %q", r1.Status)
+		t.Errorf("resource[1].Status: expected empty, got %q", r1.Status)
 	}
 	if r1.Fields["state"] != "pending" {
 		t.Errorf("resource[1].Fields[\"state\"]: expected %q, got %q", "pending", r1.Fields["state"])

--- a/tests/unit/aws_subnets_test.go
+++ b/tests/unit/aws_subnets_test.go
@@ -69,8 +69,8 @@ func TestFetchSubnets_ParsesMultipleSubnets(t *testing.T) {
 	if r0.Name != "public-subnet-1a" {
 		t.Errorf("resource[0].Name: expected %q, got %q", "public-subnet-1a", r0.Name)
 	}
-	if r0.Status != "available" {
-		t.Errorf("resource[0].Status: expected %q, got %q", "available", r0.Status)
+	if r0.Status != "" {
+		t.Errorf("resource[0].Status: expected empty (PR-03d migration), got %q", r0.Status)
 	}
 
 	// Verify Fields on all resources
@@ -114,8 +114,11 @@ func TestFetchSubnets_ParsesMultipleSubnets(t *testing.T) {
 	if r1.Name != "" {
 		t.Errorf("resource[1].Name: expected empty string, got %q", r1.Name)
 	}
-	if r1.Status != "pending" {
-		t.Errorf("resource[1].Status: expected %q, got %q", "pending", r1.Status)
+	if r1.Status != "" {
+		t.Errorf("resource[1].Status: expected empty (PR-03d migration), got %q", r1.Status)
+	}
+	if r1.Fields["state"] != "pending" {
+		t.Errorf("resource[1].Fields[\"state\"]: expected %q, got %q", "pending", r1.Fields["state"])
 	}
 	if r1.Fields["vpc_id"] != "vpc-bbb" {
 		t.Errorf("resource[1].Fields[\"vpc_id\"]: expected %q, got %q", "vpc-bbb", r1.Fields["vpc_id"])

--- a/tests/unit/aws_subnets_test.go
+++ b/tests/unit/aws_subnets_test.go
@@ -72,6 +72,9 @@ func TestFetchSubnets_ParsesMultipleSubnets(t *testing.T) {
 	if r0.Status != "" {
 		t.Errorf("resource[0].Status: expected empty, got %q", r0.Status)
 	}
+	if len(r0.Findings) != 0 {
+		t.Errorf("resource[0].Findings: expected none for available subnet, got %d", len(r0.Findings))
+	}
 
 	// Verify Fields on all resources
 	requiredFields := []string{"subnet_id", "name", "vpc_id", "cidr_block", "availability_zone", "state", "available_ips"}

--- a/tests/unit/aws_vpc_test.go
+++ b/tests/unit/aws_vpc_test.go
@@ -28,7 +28,7 @@ func TestFetchVPCs_ParsesMultipleVPCs(t *testing.T) {
 					IsDefault:       aws.Bool(true),
 					DhcpOptionsId:   aws.String("dopt-abc123"),
 					InstanceTenancy: ec2types.TenancyDefault,
-					OwnerId:         aws.String("123456789012"),
+					OwnerId:         aws.String("000000000000"),
 					Tags: []ec2types.Tag{
 						{Key: aws.String("Name"), Value: aws.String("main-vpc")},
 						{Key: aws.String("Env"), Value: aws.String("prod")},
@@ -41,7 +41,7 @@ func TestFetchVPCs_ParsesMultipleVPCs(t *testing.T) {
 					IsDefault:       aws.Bool(false),
 					DhcpOptionsId:   aws.String("dopt-def456"),
 					InstanceTenancy: ec2types.TenancyDedicated,
-					OwnerId:         aws.String("123456789012"),
+					OwnerId:         aws.String("000000000000"),
 					Tags:            []ec2types.Tag{},
 				},
 			},
@@ -66,7 +66,7 @@ func TestFetchVPCs_ParsesMultipleVPCs(t *testing.T) {
 		t.Errorf("resource[0].Name: expected %q, got %q", "main-vpc", r0.Name)
 	}
 	if r0.Status != "" {
-		t.Errorf("resource[0].Status: expected empty (PR-03d migration), got %q", r0.Status)
+		t.Errorf("resource[0].Status: expected empty, got %q", r0.Status)
 	}
 
 	// Verify Fields
@@ -105,7 +105,7 @@ func TestFetchVPCs_ParsesMultipleVPCs(t *testing.T) {
 		t.Errorf("resource[1].Name: expected empty string, got %q", r1.Name)
 	}
 	if r1.Status != "" {
-		t.Errorf("resource[1].Status: expected empty (PR-03d migration), got %q", r1.Status)
+		t.Errorf("resource[1].Status: expected empty, got %q", r1.Status)
 	}
 	if r1.Fields["state"] != "pending" {
 		t.Errorf("resource[1].Fields[\"state\"]: expected %q, got %q", "pending", r1.Fields["state"])
@@ -216,7 +216,7 @@ func TestFetchVPCs_RealAWSData(t *testing.T) {
 		t.Errorf("resource[0].Name: expected %q, got %q", "dev-vpc", r0.Name)
 	}
 	if r0.Status != "" {
-		t.Errorf("resource[0].Status: expected empty (PR-03d migration), got %q", r0.Status)
+		t.Errorf("resource[0].Status: expected empty, got %q", r0.Status)
 	}
 	if r0.Fields["vpc_id"] != "vpc-0aaa1111bbb2222cc" {
 		t.Errorf("resource[0].Fields[\"vpc_id\"]: expected %q, got %q", "vpc-0aaa1111bbb2222cc", r0.Fields["vpc_id"])
@@ -255,7 +255,7 @@ func TestFetchVPCs_RealAWSData(t *testing.T) {
 		t.Errorf("resource[1].Name: expected empty (no Name tag on default VPC), got %q", r1.Name)
 	}
 	if r1.Status != "" {
-		t.Errorf("resource[1].Status: expected empty (PR-03d migration), got %q", r1.Status)
+		t.Errorf("resource[1].Status: expected empty, got %q", r1.Status)
 	}
 	if r1.Fields["state"] != "available" {
 		t.Errorf("resource[1].Fields[\"state\"]: expected %q, got %q", "available", r1.Fields["state"])

--- a/tests/unit/aws_vpc_test.go
+++ b/tests/unit/aws_vpc_test.go
@@ -68,6 +68,9 @@ func TestFetchVPCs_ParsesMultipleVPCs(t *testing.T) {
 	if r0.Status != "" {
 		t.Errorf("resource[0].Status: expected empty, got %q", r0.Status)
 	}
+	if len(r0.Findings) != 0 {
+		t.Errorf("resource[0].Findings: expected none for available VPC, got %d", len(r0.Findings))
+	}
 
 	// Verify Fields
 	requiredFields := []string{"vpc_id", "name", "cidr_block", "state", "is_default"}
@@ -218,6 +221,9 @@ func TestFetchVPCs_RealAWSData(t *testing.T) {
 	if r0.Status != "" {
 		t.Errorf("resource[0].Status: expected empty, got %q", r0.Status)
 	}
+	if len(r0.Findings) != 0 {
+		t.Errorf("resource[0].Findings: expected none for available VPC, got %d", len(r0.Findings))
+	}
 	if r0.Fields["vpc_id"] != "vpc-0aaa1111bbb2222cc" {
 		t.Errorf("resource[0].Fields[\"vpc_id\"]: expected %q, got %q", "vpc-0aaa1111bbb2222cc", r0.Fields["vpc_id"])
 	}
@@ -256,6 +262,9 @@ func TestFetchVPCs_RealAWSData(t *testing.T) {
 	}
 	if r1.Status != "" {
 		t.Errorf("resource[1].Status: expected empty, got %q", r1.Status)
+	}
+	if len(r1.Findings) != 0 {
+		t.Errorf("resource[1].Findings: expected none for available VPC, got %d", len(r1.Findings))
 	}
 	if r1.Fields["state"] != "available" {
 		t.Errorf("resource[1].Fields[\"state\"]: expected %q, got %q", "available", r1.Fields["state"])

--- a/tests/unit/aws_vpc_test.go
+++ b/tests/unit/aws_vpc_test.go
@@ -65,8 +65,8 @@ func TestFetchVPCs_ParsesMultipleVPCs(t *testing.T) {
 	if r0.Name != "main-vpc" {
 		t.Errorf("resource[0].Name: expected %q, got %q", "main-vpc", r0.Name)
 	}
-	if r0.Status != "available" {
-		t.Errorf("resource[0].Status: expected %q, got %q", "available", r0.Status)
+	if r0.Status != "" {
+		t.Errorf("resource[0].Status: expected empty (PR-03d migration), got %q", r0.Status)
 	}
 
 	// Verify Fields
@@ -104,8 +104,11 @@ func TestFetchVPCs_ParsesMultipleVPCs(t *testing.T) {
 	if r1.Name != "" {
 		t.Errorf("resource[1].Name: expected empty string, got %q", r1.Name)
 	}
-	if r1.Status != "pending" {
-		t.Errorf("resource[1].Status: expected %q, got %q", "pending", r1.Status)
+	if r1.Status != "" {
+		t.Errorf("resource[1].Status: expected empty (PR-03d migration), got %q", r1.Status)
+	}
+	if r1.Fields["state"] != "pending" {
+		t.Errorf("resource[1].Fields[\"state\"]: expected %q, got %q", "pending", r1.Fields["state"])
 	}
 	if r1.Fields["is_default"] != "false" {
 		t.Errorf("resource[1].Fields[\"is_default\"]: expected %q, got %q", "false", r1.Fields["is_default"])
@@ -212,8 +215,8 @@ func TestFetchVPCs_RealAWSData(t *testing.T) {
 	if r0.Name != "dev-vpc" {
 		t.Errorf("resource[0].Name: expected %q, got %q", "dev-vpc", r0.Name)
 	}
-	if r0.Status != "available" {
-		t.Errorf("resource[0].Status: expected %q, got %q", "available", r0.Status)
+	if r0.Status != "" {
+		t.Errorf("resource[0].Status: expected empty (PR-03d migration), got %q", r0.Status)
 	}
 	if r0.Fields["vpc_id"] != "vpc-0aaa1111bbb2222cc" {
 		t.Errorf("resource[0].Fields[\"vpc_id\"]: expected %q, got %q", "vpc-0aaa1111bbb2222cc", r0.Fields["vpc_id"])
@@ -251,8 +254,11 @@ func TestFetchVPCs_RealAWSData(t *testing.T) {
 	if r1.Name != "" {
 		t.Errorf("resource[1].Name: expected empty (no Name tag on default VPC), got %q", r1.Name)
 	}
-	if r1.Status != "available" {
-		t.Errorf("resource[1].Status: expected %q, got %q", "available", r1.Status)
+	if r1.Status != "" {
+		t.Errorf("resource[1].Status: expected empty (PR-03d migration), got %q", r1.Status)
+	}
+	if r1.Fields["state"] != "available" {
+		t.Errorf("resource[1].Fields[\"state\"]: expected %q, got %q", "available", r1.Fields["state"])
 	}
 	if r1.Fields["cidr_block"] != "172.31.0.0/16" {
 		t.Errorf("resource[1].Fields[\"cidr_block\"]: expected %q, got %q", "172.31.0.0/16", r1.Fields["cidr_block"])

--- a/tests/unit/phase03_networking_pr03d_test.go
+++ b/tests/unit/phase03_networking_pr03d_test.go
@@ -1,28 +1,8 @@
 package unit_test
 
-// phase03_networking_pr03d_test.go — failing TDD pins for Wave 1 finding
-// migration across 7 networking types: vpc, subnet, elb, igw, nat, vpce, tgw.
-// Plus rtb special-case (Status: isMain → drop entirely).
-//
-// Migration contract (PR-03d — NOT YET IMPLEMENTED):
-//   - Fetchers STOP writing Resource.Status for lifecycle states.
-//   - Fetchers EMIT canonical Finding entries (Source: "wave1") for
-//     non-healthy, non-terminal states.
-//   - Each type has a corresponding internal/aws/<svc>_codes.go with constants.
-//   - Each type's Color func reads Findings first, then falls back to
-//     structural fields.
-//
-// Design decisions:
-//   - _HealthyEmitsNoFinding tests are intentionally omitted here.
-//     The existing TestFetch<Type>_* tests in aws_<type>_test.go own the
-//     healthy invariant; once those are migrated (separate coder dispatch),
-//     they will assert r.Status == "" && len(r.Findings) == 0 for healthy.
-//   - rtb has no lifecycle state — Status: isMain is structural metadata, not
-//     a health signal. The migration drops the Status write; Fields["is_main"]
-//     remains. No Findings are emitted for rtb.
-//   - tgw "failed" does not appear in the SDK TransitGatewayState enum but IS
-//     used as a string case in types_networking.go Color func. The test uses a
-//     raw cast ec2types.TransitGatewayState("failed") to match the Color branch.
+// Why: tgw "failed" is not in the SDK TransitGatewayState enum but is
+// handled as a string case in types_networking.go Color func — the test
+// uses a raw ec2types.TransitGatewayState("failed") cast to match.
 
 import (
 	"context"
@@ -42,13 +22,6 @@ import (
 // =============================================================================
 // VPC
 // =============================================================================
-
-// TestPR03d_VPCCodes_ConstantsExist verifies that vpc_codes.go declares
-// Wave 1 finding constants. Fails to compile until the file is created.
-func TestPR03d_VPCCodes_ConstantsExist(t *testing.T) {
-	t.Helper()
-	var _ domain.FindingCode = awsclient.CodeVPCStatePending
-}
 
 // TestPR03d_VPCFetcher_PendingEmitsWarnFinding asserts that a VPC in the
 // "pending" state emits one SevWarn Finding with CodeVPCStatePending and
@@ -140,16 +113,6 @@ func (m *pr03dVPCMock) DescribeVpcs(
 // =============================================================================
 // SUBNET
 // =============================================================================
-
-// TestPR03d_SubnetCodes_ConstantsExist verifies that subnet_codes.go declares
-// Wave 1 finding constants. Fails to compile until the file is created.
-func TestPR03d_SubnetCodes_ConstantsExist(t *testing.T) {
-	t.Helper()
-	var _ domain.FindingCode = awsclient.CodeSubnetStatePending
-	var _ domain.FindingCode = awsclient.CodeSubnetStateUnavailable
-	var _ domain.FindingCode = awsclient.CodeSubnetStateFailed
-	var _ domain.FindingCode = awsclient.CodeSubnetStateFailedInsufficientCapacity
-}
 
 // TestPR03d_SubnetFetcher_PendingEmitsWarnFinding asserts that a subnet in
 // "pending" state emits one SevWarn Finding with CodeSubnetStatePending.
@@ -280,15 +243,6 @@ func (m *pr03dSubnetMock) DescribeSubnets(
 // =============================================================================
 // ELB (Elastic Load Balancer v2)
 // =============================================================================
-
-// TestPR03d_ELBCodes_ConstantsExist verifies that elb_codes.go declares
-// Wave 1 finding constants. Fails to compile until the file is created.
-func TestPR03d_ELBCodes_ConstantsExist(t *testing.T) {
-	t.Helper()
-	var _ domain.FindingCode = awsclient.CodeELBStateProvisioning
-	var _ domain.FindingCode = awsclient.CodeELBStateActiveImpaired
-	var _ domain.FindingCode = awsclient.CodeELBStateFailed
-}
 
 // TestPR03d_ELBFetcher_ProvisioningEmitsWarnFinding asserts that a load
 // balancer in "provisioning" state emits one SevWarn Finding with
@@ -426,18 +380,6 @@ func (m *pr03dELBMock) DescribeLoadBalancers(
 // IGW (Internet Gateway)
 // =============================================================================
 
-// TestPR03d_IGWCodes_ConstantsExist verifies that igw_codes.go declares
-// Wave 1 finding constants. Fails to compile until the file is created.
-//
-// NOTE: IGW has no SevBroken lifecycle state. "attachments_count == 0" is
-// a structural orphan check owned by Color, not a wave1 Finding. The only
-// wave1 Findings are for transitional attachment states: attaching/detaching.
-func TestPR03d_IGWCodes_ConstantsExist(t *testing.T) {
-	t.Helper()
-	var _ domain.FindingCode = awsclient.CodeIGWStateAttaching
-	var _ domain.FindingCode = awsclient.CodeIGWStateDetaching
-}
-
 // TestPR03d_IGWFetcher_AttachingEmitsWarnFinding asserts that an IGW in the
 // "attaching" attachment state emits one SevWarn Finding with
 // CodeIGWStateAttaching.
@@ -529,15 +471,6 @@ func (m *pr03dIGWMock) DescribeInternetGateways(
 // =============================================================================
 // NAT (NAT Gateway)
 // =============================================================================
-
-// TestPR03d_NATCodes_ConstantsExist verifies that nat_codes.go declares
-// Wave 1 finding constants. Fails to compile until the file is created.
-func TestPR03d_NATCodes_ConstantsExist(t *testing.T) {
-	t.Helper()
-	var _ domain.FindingCode = awsclient.CodeNATStatePending
-	var _ domain.FindingCode = awsclient.CodeNATStateDeleting
-	var _ domain.FindingCode = awsclient.CodeNATStateFailed
-}
 
 // TestPR03d_NATFetcher_PendingEmitsWarnFinding asserts that a NAT gateway in
 // "pending" state emits one SevWarn Finding with CodeNATStatePending.
@@ -667,19 +600,6 @@ func (m *pr03dNATMock) DescribeNatGateways(
 // VPCE (VPC Endpoint)
 // =============================================================================
 
-// TestPR03d_VPCECodes_ConstantsExist verifies that vpce_codes.go declares
-// Wave 1 finding constants. Fails to compile until the file is created.
-func TestPR03d_VPCECodes_ConstantsExist(t *testing.T) {
-	t.Helper()
-	var _ domain.FindingCode = awsclient.CodeVPCEStatePendingAcceptance
-	var _ domain.FindingCode = awsclient.CodeVPCEStatePending
-	var _ domain.FindingCode = awsclient.CodeVPCEStateDeleting
-	var _ domain.FindingCode = awsclient.CodeVPCEStateFailed
-	var _ domain.FindingCode = awsclient.CodeVPCEStateRejected
-	var _ domain.FindingCode = awsclient.CodeVPCEStateExpired
-	var _ domain.FindingCode = awsclient.CodeVPCEStatePartial
-}
-
 // TestPR03d_VPCEFetcher_PendingEmitsWarnFinding asserts that a VPC endpoint
 // in "Pending" state emits one SevWarn Finding with CodeVPCEStatePending.
 func TestPR03d_VPCEFetcher_PendingEmitsWarnFinding(t *testing.T) {
@@ -806,21 +726,6 @@ func (m *pr03dVPCEMock) DescribeVpcEndpoints(
 // =============================================================================
 // TGW (Transit Gateway)
 // =============================================================================
-
-// TestPR03d_TGWCodes_ConstantsExist verifies that tgw_codes.go declares
-// Wave 1 finding constants. Fails to compile until the file is created.
-//
-// NOTE: TransitGatewayState SDK enum does not include "failed" as of
-// aws-sdk-go-v2 ec2@v1.296.0 — but the Color func in types_networking.go
-// does handle it as a string case. The constant is tested here; the fetcher
-// uses a raw ec2types.TransitGatewayState("failed") cast below.
-func TestPR03d_TGWCodes_ConstantsExist(t *testing.T) {
-	t.Helper()
-	var _ domain.FindingCode = awsclient.CodeTGWStatePending
-	var _ domain.FindingCode = awsclient.CodeTGWStateModifying
-	var _ domain.FindingCode = awsclient.CodeTGWStateDeleting
-	var _ domain.FindingCode = awsclient.CodeTGWStateFailed
-}
 
 // TestPR03d_TGWFetcher_PendingEmitsWarnFinding asserts that a transit gateway
 // in "pending" state emits one SevWarn Finding with CodeTGWStatePending.

--- a/tests/unit/phase03_networking_pr03d_test.go
+++ b/tests/unit/phase03_networking_pr03d_test.go
@@ -1,0 +1,1046 @@
+package unit_test
+
+// phase03_networking_pr03d_test.go — failing TDD pins for Wave 1 finding
+// migration across 7 networking types: vpc, subnet, elb, igw, nat, vpce, tgw.
+// Plus rtb special-case (Status: isMain → drop entirely).
+//
+// Migration contract (PR-03d — NOT YET IMPLEMENTED):
+//   - Fetchers STOP writing Resource.Status for lifecycle states.
+//   - Fetchers EMIT canonical Finding entries (Source: "wave1") for
+//     non-healthy, non-terminal states.
+//   - Each type has a corresponding internal/aws/<svc>_codes.go with constants.
+//   - Each type's Color func reads Findings first, then falls back to
+//     structural fields.
+//
+// Design decisions:
+//   - _HealthyEmitsNoFinding tests are intentionally omitted here.
+//     The existing TestFetch<Type>_* tests in aws_<type>_test.go own the
+//     healthy invariant; once those are migrated (separate coder dispatch),
+//     they will assert r.Status == "" && len(r.Findings) == 0 for healthy.
+//   - rtb has no lifecycle state — Status: isMain is structural metadata, not
+//     a health signal. The migration drops the Status write; Fields["is_main"]
+//     remains. No Findings are emitted for rtb.
+//   - tgw "failed" does not appear in the SDK TransitGatewayState enum but IS
+//     used as a string case in types_networking.go Color func. The test uses a
+//     raw cast ec2types.TransitGatewayState("failed") to match the Color branch.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2svc "github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	elbv2svc "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+
+	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
+	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// =============================================================================
+// VPC
+// =============================================================================
+
+// TestPR03d_VPCCodes_ConstantsExist verifies that vpc_codes.go declares
+// Wave 1 finding constants. Fails to compile until the file is created.
+func TestPR03d_VPCCodes_ConstantsExist(t *testing.T) {
+	t.Helper()
+	var _ domain.FindingCode = awsclient.CodeVPCStatePending
+}
+
+// TestPR03d_VPCFetcher_PendingEmitsWarnFinding asserts that a VPC in the
+// "pending" state emits one SevWarn Finding with CodeVPCStatePending and
+// no Status string.
+func TestPR03d_VPCFetcher_PendingEmitsWarnFinding(t *testing.T) {
+	mock := &pr03dVPCMock{
+		vpcs: []ec2types.Vpc{
+			{
+				VpcId:     aws.String("vpc-0pending12345"),
+				CidrBlock: aws.String("10.10.0.0/16"),
+				State:     ec2types.VpcStatePending,
+				IsDefault: aws.Bool(false),
+				OwnerId:   aws.String("000000000000"),
+			},
+		},
+	}
+
+	resources, err := awsclient.FetchVPCs(context.Background(), mock)
+	if err != nil {
+		t.Fatalf("FetchVPCs: unexpected error: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resources))
+	}
+	r := resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status for pending VPC)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for pending VPC", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeVPCStatePending {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeVPCStatePending)
+	}
+	if f.Severity != domain.SevWarn {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevWarn", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+	if r.Fields["state"] != "pending" {
+		t.Errorf("Fields[\"state\"]: got %q, want %q (state must be preserved in Fields)", r.Fields["state"], "pending")
+	}
+}
+
+// TestPR03d_VPCColor_ReadsWave1First pins that the vpc Color func evaluates
+// Findings before the legacy Fields["state"] switch. Pre-migration the Color
+// func does not read Findings at all, so this test will fail until the Color
+// func is updated.
+//
+// Setup: Finding{SevBroken, wave1} + Fields["state"]="available"
+// Expect: ColorBroken (Findings wins, not legacy "available"→ColorHealthy)
+func TestPR03d_VPCColor_ReadsWave1First(t *testing.T) {
+	td := resource.FindResourceType("vpc")
+	if td == nil {
+		t.Fatal("vpc type def not found in registry")
+	}
+
+	r := resource.Resource{
+		Type: "vpc",
+		Findings: []domain.Finding{
+			{Code: awsclient.CodeVPCStatePending, Phrase: "pending", Severity: domain.SevBroken, Source: "wave1"},
+		},
+		Fields: map[string]string{"state": "available"},
+	}
+	if got := td.Color(r); got != resource.ColorBroken {
+		t.Errorf("vpc Color with wave1 SevBroken + state=available: got %v, want ColorBroken (Findings must take precedence over legacy state switch)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// VPC mock
+// ---------------------------------------------------------------------------
+
+type pr03dVPCMock struct {
+	vpcs []ec2types.Vpc
+}
+
+func (m *pr03dVPCMock) DescribeVpcs(
+	_ context.Context,
+	_ *ec2svc.DescribeVpcsInput,
+	_ ...func(*ec2svc.Options),
+) (*ec2svc.DescribeVpcsOutput, error) {
+	return &ec2svc.DescribeVpcsOutput{Vpcs: m.vpcs}, nil
+}
+
+// =============================================================================
+// SUBNET
+// =============================================================================
+
+// TestPR03d_SubnetCodes_ConstantsExist verifies that subnet_codes.go declares
+// Wave 1 finding constants. Fails to compile until the file is created.
+func TestPR03d_SubnetCodes_ConstantsExist(t *testing.T) {
+	t.Helper()
+	var _ domain.FindingCode = awsclient.CodeSubnetStatePending
+	var _ domain.FindingCode = awsclient.CodeSubnetStateUnavailable
+	var _ domain.FindingCode = awsclient.CodeSubnetStateFailed
+	var _ domain.FindingCode = awsclient.CodeSubnetStateFailedInsufficientCapacity
+}
+
+// TestPR03d_SubnetFetcher_PendingEmitsWarnFinding asserts that a subnet in
+// "pending" state emits one SevWarn Finding with CodeSubnetStatePending.
+func TestPR03d_SubnetFetcher_PendingEmitsWarnFinding(t *testing.T) {
+	mock := &pr03dSubnetMock{
+		subnets: []ec2types.Subnet{
+			{
+				SubnetId:                aws.String("subnet-0abc1234pending"),
+				VpcId:                   aws.String("vpc-01234abcd"),
+				CidrBlock:               aws.String("10.0.1.0/24"),
+				AvailabilityZone:        aws.String("us-east-1a"),
+				State:                   ec2types.SubnetStatePending,
+				AvailableIpAddressCount: aws.Int32(0),
+			},
+		},
+	}
+
+	result, err := awsclient.FetchSubnetsPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchSubnetsPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status for pending subnet)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for pending subnet", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeSubnetStatePending {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeSubnetStatePending)
+	}
+	if f.Severity != domain.SevWarn {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevWarn", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03d_SubnetFetcher_UnavailableEmitsBrokenFinding asserts that a subnet
+// in "unavailable" state emits one SevBroken Finding with
+// CodeSubnetStateUnavailable.
+func TestPR03d_SubnetFetcher_UnavailableEmitsBrokenFinding(t *testing.T) {
+	mock := &pr03dSubnetMock{
+		subnets: []ec2types.Subnet{
+			{
+				SubnetId:                aws.String("subnet-0def5678unavail"),
+				VpcId:                   aws.String("vpc-01234abcd"),
+				CidrBlock:               aws.String("10.0.2.0/24"),
+				AvailabilityZone:        aws.String("us-east-1b"),
+				State:                   ec2types.SubnetStateUnavailable,
+				AvailableIpAddressCount: aws.Int32(0),
+			},
+		},
+	}
+
+	result, err := awsclient.FetchSubnetsPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchSubnetsPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for unavailable subnet", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeSubnetStateUnavailable {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeSubnetStateUnavailable)
+	}
+	if f.Severity != domain.SevBroken {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevBroken", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03d_SubnetColor_ReadsWave1First pins that the subnet Color func
+// evaluates Findings before the legacy Fields["state"] switch.
+//
+// Setup: Finding{SevBroken, wave1} + Fields["state"]="available"
+// Expect: ColorBroken (Findings wins over legacy "available"→ColorHealthy)
+func TestPR03d_SubnetColor_ReadsWave1First(t *testing.T) {
+	td := resource.FindResourceType("subnet")
+	if td == nil {
+		t.Fatal("subnet type def not found in registry")
+	}
+
+	r := resource.Resource{
+		Type: "subnet",
+		Findings: []domain.Finding{
+			{Code: awsclient.CodeSubnetStateUnavailable, Phrase: "unavailable", Severity: domain.SevBroken, Source: "wave1"},
+		},
+		Fields: map[string]string{"state": "available"},
+	}
+	if got := td.Color(r); got != resource.ColorBroken {
+		t.Errorf("subnet Color with wave1 SevBroken + state=available: got %v, want ColorBroken", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Subnet mock
+// ---------------------------------------------------------------------------
+
+type pr03dSubnetMock struct {
+	subnets []ec2types.Subnet
+}
+
+func (m *pr03dSubnetMock) DescribeSubnets(
+	_ context.Context,
+	_ *ec2svc.DescribeSubnetsInput,
+	_ ...func(*ec2svc.Options),
+) (*ec2svc.DescribeSubnetsOutput, error) {
+	return &ec2svc.DescribeSubnetsOutput{Subnets: m.subnets}, nil
+}
+
+// =============================================================================
+// ELB (Elastic Load Balancer v2)
+// =============================================================================
+
+// TestPR03d_ELBCodes_ConstantsExist verifies that elb_codes.go declares
+// Wave 1 finding constants. Fails to compile until the file is created.
+func TestPR03d_ELBCodes_ConstantsExist(t *testing.T) {
+	t.Helper()
+	var _ domain.FindingCode = awsclient.CodeELBStateProvisioning
+	var _ domain.FindingCode = awsclient.CodeELBStateActiveImpaired
+	var _ domain.FindingCode = awsclient.CodeELBStateFailed
+}
+
+// TestPR03d_ELBFetcher_ProvisioningEmitsWarnFinding asserts that a load
+// balancer in "provisioning" state emits one SevWarn Finding with
+// CodeELBStateProvisioning.
+func TestPR03d_ELBFetcher_ProvisioningEmitsWarnFinding(t *testing.T) {
+	mock := &pr03dELBMock{
+		lbs: []elbv2types.LoadBalancer{
+			{
+				LoadBalancerName: aws.String("staging-alb"),
+				LoadBalancerArn:  aws.String("arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/staging-alb/abc123"),
+				DNSName:          aws.String("staging-alb.us-east-1.elb.amazonaws.com"),
+				Type:             elbv2types.LoadBalancerTypeEnumApplication,
+				Scheme:           elbv2types.LoadBalancerSchemeEnumInternetFacing,
+				State: &elbv2types.LoadBalancerState{
+					Code: elbv2types.LoadBalancerStateEnumProvisioning,
+				},
+				VpcId: aws.String("vpc-01234abcd"),
+			},
+		},
+	}
+
+	result, err := awsclient.FetchLoadBalancersPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchLoadBalancersPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status for provisioning ELB)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for provisioning ELB", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeELBStateProvisioning {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeELBStateProvisioning)
+	}
+	if f.Severity != domain.SevWarn {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevWarn", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03d_ELBFetcher_FailedEmitsBrokenFinding asserts that a load balancer
+// in "failed" state emits one SevBroken Finding with CodeELBStateFailed.
+func TestPR03d_ELBFetcher_FailedEmitsBrokenFinding(t *testing.T) {
+	mock := &pr03dELBMock{
+		lbs: []elbv2types.LoadBalancer{
+			{
+				LoadBalancerName: aws.String("broken-nlb"),
+				LoadBalancerArn:  aws.String("arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/net/broken-nlb/def456"),
+				DNSName:          aws.String("broken-nlb.us-east-1.elb.amazonaws.com"),
+				Type:             elbv2types.LoadBalancerTypeEnumNetwork,
+				Scheme:           elbv2types.LoadBalancerSchemeEnumInternal,
+				State: &elbv2types.LoadBalancerState{
+					Code: elbv2types.LoadBalancerStateEnumFailed,
+				},
+				VpcId: aws.String("vpc-01234abcd"),
+			},
+		},
+	}
+
+	result, err := awsclient.FetchLoadBalancersPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchLoadBalancersPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for failed ELB", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeELBStateFailed {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeELBStateFailed)
+	}
+	if f.Severity != domain.SevBroken {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevBroken", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03d_ELBColor_ReadsWave1First pins that the elb Color func evaluates
+// Findings before the legacy Fields["state"] switch.
+//
+// Setup: Finding{SevBroken, wave1} + Fields["state"]="active"
+// Expect: ColorBroken (Findings wins over legacy "active"→ColorHealthy)
+func TestPR03d_ELBColor_ReadsWave1First(t *testing.T) {
+	td := resource.FindResourceType("elb")
+	if td == nil {
+		t.Fatal("elb type def not found in registry")
+	}
+
+	r := resource.Resource{
+		Type: "elb",
+		Findings: []domain.Finding{
+			{Code: awsclient.CodeELBStateFailed, Phrase: "failed", Severity: domain.SevBroken, Source: "wave1"},
+		},
+		Fields: map[string]string{"state": "active"},
+	}
+	if got := td.Color(r); got != resource.ColorBroken {
+		t.Errorf("elb Color with wave1 SevBroken + state=active: got %v, want ColorBroken", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ELB mock
+// ---------------------------------------------------------------------------
+
+type pr03dELBMock struct {
+	lbs []elbv2types.LoadBalancer
+}
+
+func (m *pr03dELBMock) DescribeLoadBalancers(
+	_ context.Context,
+	_ *elbv2svc.DescribeLoadBalancersInput,
+	_ ...func(*elbv2svc.Options),
+) (*elbv2svc.DescribeLoadBalancersOutput, error) {
+	return &elbv2svc.DescribeLoadBalancersOutput{LoadBalancers: m.lbs}, nil
+}
+
+// =============================================================================
+// IGW (Internet Gateway)
+// =============================================================================
+
+// TestPR03d_IGWCodes_ConstantsExist verifies that igw_codes.go declares
+// Wave 1 finding constants. Fails to compile until the file is created.
+//
+// NOTE: IGW has no SevBroken lifecycle state. "attachments_count == 0" is
+// a structural orphan check owned by Color, not a wave1 Finding. The only
+// wave1 Findings are for transitional attachment states: attaching/detaching.
+func TestPR03d_IGWCodes_ConstantsExist(t *testing.T) {
+	t.Helper()
+	var _ domain.FindingCode = awsclient.CodeIGWStateAttaching
+	var _ domain.FindingCode = awsclient.CodeIGWStateDetaching
+}
+
+// TestPR03d_IGWFetcher_AttachingEmitsWarnFinding asserts that an IGW in the
+// "attaching" attachment state emits one SevWarn Finding with
+// CodeIGWStateAttaching.
+func TestPR03d_IGWFetcher_AttachingEmitsWarnFinding(t *testing.T) {
+	mock := &pr03dIGWMock{
+		igws: []ec2types.InternetGateway{
+			{
+				InternetGatewayId: aws.String("igw-0abc1234attaching"),
+				Attachments: []ec2types.InternetGatewayAttachment{
+					{
+						VpcId: aws.String("vpc-01234abcd"),
+						State: ec2types.AttachmentStatusAttaching,
+					},
+				},
+			},
+		},
+	}
+
+	result, err := awsclient.FetchInternetGatewaysPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchInternetGatewaysPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status for attaching IGW)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for attaching IGW", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeIGWStateAttaching {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeIGWStateAttaching)
+	}
+	if f.Severity != domain.SevWarn {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevWarn", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03d_IGWColor_ReadsWave1First pins that the igw Color func evaluates
+// Findings before the legacy Fields["state"] / attachments_count switch.
+//
+// Setup: Finding{SevWarn, wave1} + Fields["state"]="attached", attachments_count="1"
+// Expect: ColorWarning (Findings wins; without Findings the legacy switch
+// returns ColorHealthy for state=attached + attachments=1).
+func TestPR03d_IGWColor_ReadsWave1First(t *testing.T) {
+	td := resource.FindResourceType("igw")
+	if td == nil {
+		t.Fatal("igw type def not found in registry")
+	}
+
+	r := resource.Resource{
+		Type: "igw",
+		Findings: []domain.Finding{
+			{Code: awsclient.CodeIGWStateAttaching, Phrase: "attaching", Severity: domain.SevWarn, Source: "wave1"},
+		},
+		Fields: map[string]string{
+			"state":             "attached",
+			"attachments_count": "1",
+		},
+	}
+	if got := td.Color(r); got != resource.ColorWarning {
+		t.Errorf("igw Color with wave1 SevWarn + state=attached,attachments=1: got %v, want ColorWarning", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IGW mock
+// ---------------------------------------------------------------------------
+
+type pr03dIGWMock struct {
+	igws []ec2types.InternetGateway
+}
+
+func (m *pr03dIGWMock) DescribeInternetGateways(
+	_ context.Context,
+	_ *ec2svc.DescribeInternetGatewaysInput,
+	_ ...func(*ec2svc.Options),
+) (*ec2svc.DescribeInternetGatewaysOutput, error) {
+	return &ec2svc.DescribeInternetGatewaysOutput{InternetGateways: m.igws}, nil
+}
+
+// =============================================================================
+// NAT (NAT Gateway)
+// =============================================================================
+
+// TestPR03d_NATCodes_ConstantsExist verifies that nat_codes.go declares
+// Wave 1 finding constants. Fails to compile until the file is created.
+func TestPR03d_NATCodes_ConstantsExist(t *testing.T) {
+	t.Helper()
+	var _ domain.FindingCode = awsclient.CodeNATStatePending
+	var _ domain.FindingCode = awsclient.CodeNATStateDeleting
+	var _ domain.FindingCode = awsclient.CodeNATStateFailed
+}
+
+// TestPR03d_NATFetcher_PendingEmitsWarnFinding asserts that a NAT gateway in
+// "pending" state emits one SevWarn Finding with CodeNATStatePending.
+func TestPR03d_NATFetcher_PendingEmitsWarnFinding(t *testing.T) {
+	mock := &pr03dNATMock{
+		nats: []ec2types.NatGateway{
+			{
+				NatGatewayId: aws.String("nat-0abc1234pending56"),
+				VpcId:        aws.String("vpc-01234abcd"),
+				SubnetId:     aws.String("subnet-01234abcd"),
+				State:        ec2types.NatGatewayStatePending,
+				Tags: []ec2types.Tag{
+					{Key: aws.String("Name"), Value: aws.String("prod-nat")},
+				},
+			},
+		},
+	}
+
+	result, err := awsclient.FetchNatGatewaysPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchNatGatewaysPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status for pending NAT)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for pending NAT", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeNATStatePending {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeNATStatePending)
+	}
+	if f.Severity != domain.SevWarn {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevWarn", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03d_NATFetcher_FailedEmitsBrokenFinding asserts that a NAT gateway
+// in "failed" state emits one SevBroken Finding with CodeNATStateFailed.
+func TestPR03d_NATFetcher_FailedEmitsBrokenFinding(t *testing.T) {
+	mock := &pr03dNATMock{
+		nats: []ec2types.NatGateway{
+			{
+				NatGatewayId: aws.String("nat-0def5678failed90"),
+				VpcId:        aws.String("vpc-01234abcd"),
+				SubnetId:     aws.String("subnet-01234abcd"),
+				State:        ec2types.NatGatewayStateFailed,
+			},
+		},
+	}
+
+	result, err := awsclient.FetchNatGatewaysPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchNatGatewaysPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for failed NAT", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeNATStateFailed {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeNATStateFailed)
+	}
+	if f.Severity != domain.SevBroken {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevBroken", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03d_NATColor_ReadsWave1First pins that the nat Color func evaluates
+// Findings before the legacy Fields["state"] switch.
+//
+// Setup: Finding{SevBroken, wave1} + Fields["state"]="available"
+// Expect: ColorBroken (Findings wins over legacy "available"→ColorHealthy)
+func TestPR03d_NATColor_ReadsWave1First(t *testing.T) {
+	td := resource.FindResourceType("nat")
+	if td == nil {
+		t.Fatal("nat type def not found in registry")
+	}
+
+	r := resource.Resource{
+		Type: "nat",
+		Findings: []domain.Finding{
+			{Code: awsclient.CodeNATStateFailed, Phrase: "failed", Severity: domain.SevBroken, Source: "wave1"},
+		},
+		Fields: map[string]string{"state": "available"},
+	}
+	if got := td.Color(r); got != resource.ColorBroken {
+		t.Errorf("nat Color with wave1 SevBroken + state=available: got %v, want ColorBroken", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NAT mock
+// ---------------------------------------------------------------------------
+
+type pr03dNATMock struct {
+	nats []ec2types.NatGateway
+}
+
+func (m *pr03dNATMock) DescribeNatGateways(
+	_ context.Context,
+	_ *ec2svc.DescribeNatGatewaysInput,
+	_ ...func(*ec2svc.Options),
+) (*ec2svc.DescribeNatGatewaysOutput, error) {
+	return &ec2svc.DescribeNatGatewaysOutput{NatGateways: m.nats}, nil
+}
+
+// =============================================================================
+// VPCE (VPC Endpoint)
+// =============================================================================
+
+// TestPR03d_VPCECodes_ConstantsExist verifies that vpce_codes.go declares
+// Wave 1 finding constants. Fails to compile until the file is created.
+func TestPR03d_VPCECodes_ConstantsExist(t *testing.T) {
+	t.Helper()
+	var _ domain.FindingCode = awsclient.CodeVPCEStatePendingAcceptance
+	var _ domain.FindingCode = awsclient.CodeVPCEStatePending
+	var _ domain.FindingCode = awsclient.CodeVPCEStateDeleting
+	var _ domain.FindingCode = awsclient.CodeVPCEStateFailed
+	var _ domain.FindingCode = awsclient.CodeVPCEStateRejected
+	var _ domain.FindingCode = awsclient.CodeVPCEStateExpired
+	var _ domain.FindingCode = awsclient.CodeVPCEStatePartial
+}
+
+// TestPR03d_VPCEFetcher_PendingEmitsWarnFinding asserts that a VPC endpoint
+// in "Pending" state emits one SevWarn Finding with CodeVPCEStatePending.
+func TestPR03d_VPCEFetcher_PendingEmitsWarnFinding(t *testing.T) {
+	mock := &pr03dVPCEMock{
+		endpoints: []ec2types.VpcEndpoint{
+			{
+				VpcEndpointId:   aws.String("vpce-0abc1234pending56"),
+				ServiceName:     aws.String("com.amazonaws.us-east-1.s3"),
+				VpcEndpointType: ec2types.VpcEndpointTypeInterface,
+				State:           ec2types.StatePending,
+				VpcId:           aws.String("vpc-01234abcd"),
+			},
+		},
+	}
+
+	result, err := awsclient.FetchVPCEndpointsPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchVPCEndpointsPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status for pending VPCE)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for pending VPCE", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeVPCEStatePending {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeVPCEStatePending)
+	}
+	if f.Severity != domain.SevWarn {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevWarn", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03d_VPCEFetcher_FailedEmitsBrokenFinding asserts that a VPC endpoint
+// in "Failed" state emits one SevBroken Finding with CodeVPCEStateFailed.
+func TestPR03d_VPCEFetcher_FailedEmitsBrokenFinding(t *testing.T) {
+	mock := &pr03dVPCEMock{
+		endpoints: []ec2types.VpcEndpoint{
+			{
+				VpcEndpointId:   aws.String("vpce-0def5678failed90"),
+				ServiceName:     aws.String("com.amazonaws.us-east-1.ec2"),
+				VpcEndpointType: ec2types.VpcEndpointTypeInterface,
+				State:           ec2types.StateFailed,
+				VpcId:           aws.String("vpc-01234abcd"),
+			},
+		},
+	}
+
+	result, err := awsclient.FetchVPCEndpointsPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchVPCEndpointsPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for failed VPCE", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeVPCEStateFailed {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeVPCEStateFailed)
+	}
+	if f.Severity != domain.SevBroken {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevBroken", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03d_VPCEColor_ReadsWave1First pins that the vpce Color func evaluates
+// Findings before the legacy Fields["state"] switch.
+//
+// Setup: Finding{SevBroken, wave1} + Fields["state"]="Available"
+// Expect: ColorBroken (Findings wins over legacy "Available"→ColorHealthy)
+func TestPR03d_VPCEColor_ReadsWave1First(t *testing.T) {
+	td := resource.FindResourceType("vpce")
+	if td == nil {
+		t.Fatal("vpce type def not found in registry")
+	}
+
+	r := resource.Resource{
+		Type: "vpce",
+		Findings: []domain.Finding{
+			{Code: awsclient.CodeVPCEStateFailed, Phrase: "Failed", Severity: domain.SevBroken, Source: "wave1"},
+		},
+		Fields: map[string]string{"state": "Available"},
+	}
+	if got := td.Color(r); got != resource.ColorBroken {
+		t.Errorf("vpce Color with wave1 SevBroken + state=Available: got %v, want ColorBroken", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// VPCE mock
+// ---------------------------------------------------------------------------
+
+type pr03dVPCEMock struct {
+	endpoints []ec2types.VpcEndpoint
+}
+
+func (m *pr03dVPCEMock) DescribeVpcEndpoints(
+	_ context.Context,
+	_ *ec2svc.DescribeVpcEndpointsInput,
+	_ ...func(*ec2svc.Options),
+) (*ec2svc.DescribeVpcEndpointsOutput, error) {
+	return &ec2svc.DescribeVpcEndpointsOutput{VpcEndpoints: m.endpoints}, nil
+}
+
+// =============================================================================
+// TGW (Transit Gateway)
+// =============================================================================
+
+// TestPR03d_TGWCodes_ConstantsExist verifies that tgw_codes.go declares
+// Wave 1 finding constants. Fails to compile until the file is created.
+//
+// NOTE: TransitGatewayState SDK enum does not include "failed" as of
+// aws-sdk-go-v2 ec2@v1.296.0 — but the Color func in types_networking.go
+// does handle it as a string case. The constant is tested here; the fetcher
+// uses a raw ec2types.TransitGatewayState("failed") cast below.
+func TestPR03d_TGWCodes_ConstantsExist(t *testing.T) {
+	t.Helper()
+	var _ domain.FindingCode = awsclient.CodeTGWStatePending
+	var _ domain.FindingCode = awsclient.CodeTGWStateModifying
+	var _ domain.FindingCode = awsclient.CodeTGWStateDeleting
+	var _ domain.FindingCode = awsclient.CodeTGWStateFailed
+}
+
+// TestPR03d_TGWFetcher_PendingEmitsWarnFinding asserts that a transit gateway
+// in "pending" state emits one SevWarn Finding with CodeTGWStatePending.
+func TestPR03d_TGWFetcher_PendingEmitsWarnFinding(t *testing.T) {
+	mock := &pr03dTGWMock{
+		tgws: []ec2types.TransitGateway{
+			{
+				TransitGatewayId: aws.String("tgw-0abc1234pending56"),
+				OwnerId:          aws.String("000000000000"),
+				State:            ec2types.TransitGatewayStatePending,
+				Description:      aws.String("main transit gateway"),
+				Tags: []ec2types.Tag{
+					{Key: aws.String("Name"), Value: aws.String("prod-tgw")},
+				},
+			},
+		},
+	}
+
+	result, err := awsclient.FetchTransitGatewaysPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchTransitGatewaysPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status for pending TGW)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for pending TGW", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeTGWStatePending {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeTGWStatePending)
+	}
+	if f.Severity != domain.SevWarn {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevWarn", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03d_TGWFetcher_FailedEmitsBrokenFinding asserts that a transit gateway
+// in "failed" state emits one SevBroken Finding with CodeTGWStateFailed.
+//
+// NOTE: "failed" is not in the TransitGatewayState SDK enum but IS handled
+// by the Color func. The test uses a raw cast to match that Color branch.
+func TestPR03d_TGWFetcher_FailedEmitsBrokenFinding(t *testing.T) {
+	mock := &pr03dTGWMock{
+		tgws: []ec2types.TransitGateway{
+			{
+				TransitGatewayId: aws.String("tgw-0def5678failed90"),
+				OwnerId:          aws.String("000000000000"),
+				State:            ec2types.TransitGatewayState("failed"), // raw cast: not in SDK enum
+			},
+		},
+	}
+
+	result, err := awsclient.FetchTransitGatewaysPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchTransitGatewaysPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for failed TGW", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeTGWStateFailed {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeTGWStateFailed)
+	}
+	if f.Severity != domain.SevBroken {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevBroken", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03d_TGWColor_ReadsWave1First pins that the tgw Color func evaluates
+// Findings before the legacy Fields["state"] switch.
+//
+// Setup: Finding{SevBroken, wave1} + Fields["state"]="available"
+// Expect: ColorBroken (Findings wins over legacy "available"→ColorHealthy)
+func TestPR03d_TGWColor_ReadsWave1First(t *testing.T) {
+	td := resource.FindResourceType("tgw")
+	if td == nil {
+		t.Fatal("tgw type def not found in registry")
+	}
+
+	r := resource.Resource{
+		Type: "tgw",
+		Findings: []domain.Finding{
+			{Code: awsclient.CodeTGWStateFailed, Phrase: "failed", Severity: domain.SevBroken, Source: "wave1"},
+		},
+		Fields: map[string]string{"state": "available"},
+	}
+	if got := td.Color(r); got != resource.ColorBroken {
+		t.Errorf("tgw Color with wave1 SevBroken + state=available: got %v, want ColorBroken", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TGW mock
+// ---------------------------------------------------------------------------
+
+type pr03dTGWMock struct {
+	tgws []ec2types.TransitGateway
+}
+
+func (m *pr03dTGWMock) DescribeTransitGateways(
+	_ context.Context,
+	_ *ec2svc.DescribeTransitGatewaysInput,
+	_ ...func(*ec2svc.Options),
+) (*ec2svc.DescribeTransitGatewaysOutput, error) {
+	return &ec2svc.DescribeTransitGatewaysOutput{TransitGateways: m.tgws}, nil
+}
+
+// =============================================================================
+// RTB (Route Table) — special case: drop Status write, no Findings emitted
+// =============================================================================
+
+// TestPR03d_RTBFetcher_NeverEmitsFindingsOrStatus asserts that the route table
+// fetcher NEVER writes Status (isMain is structural metadata, not a health
+// state) and NEVER emits Findings (rtb's Color is structural: blackhole routes
+// and unassociated non-main tables). Fields["is_main"] must still be present.
+//
+// Migration: remove `Status: isMain` from the Resource literal in rtb.go.
+// Findings: none — rtb has no lifecycle findings to emit.
+func TestPR03d_RTBFetcher_NeverEmitsFindingsOrStatus(t *testing.T) {
+	cases := []struct {
+		name    string
+		isMain  bool
+		assocs  []ec2types.RouteTableAssociation
+	}{
+		{
+			name:   "main route table",
+			isMain: true,
+			assocs: []ec2types.RouteTableAssociation{
+				{Main: aws.Bool(true)},
+			},
+		},
+		{
+			name:   "non-main route table with subnet association",
+			isMain: false,
+			assocs: []ec2types.RouteTableAssociation{
+				{Main: aws.Bool(false), SubnetId: aws.String("subnet-01234abcd")},
+			},
+		},
+		{
+			name:   "non-main unassociated route table",
+			isMain: false,
+			assocs: []ec2types.RouteTableAssociation{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expectedIsMain := "false"
+			if tc.isMain {
+				expectedIsMain = "true"
+			}
+
+			mock := &pr03dRTBMock{
+				rtbs: []ec2types.RouteTable{
+					{
+						RouteTableId: aws.String("rtb-0abc1234567890ef"),
+						VpcId:        aws.String("vpc-01234abcd"),
+						Associations: tc.assocs,
+						Routes:       []ec2types.Route{},
+					},
+				},
+			}
+
+			result, err := awsclient.FetchRouteTablesPage(context.Background(), mock, "")
+			if err != nil {
+				t.Fatalf("FetchRouteTablesPage: unexpected error: %v", err)
+			}
+			if len(result.Resources) != 1 {
+				t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+			}
+			r := result.Resources[0]
+
+			// Status must be empty — "is_main" is NOT a lifecycle state.
+			if r.Status != "" {
+				t.Errorf("Status: got %q, want %q (is_main is structural metadata, not a lifecycle state — fetcher must not write Status)", r.Status, "")
+			}
+			// No Findings — rtb has no lifecycle states to emit.
+			if len(r.Findings) != 0 {
+				t.Errorf("Findings: got %d, want 0 (rtb emits no wave1 Findings)", len(r.Findings))
+			}
+			// Fields["is_main"] must still be present for Color's structural check.
+			if got := r.Fields["is_main"]; got != expectedIsMain {
+				t.Errorf("Fields[\"is_main\"]: got %q, want %q", got, expectedIsMain)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RTB mock
+// ---------------------------------------------------------------------------
+
+type pr03dRTBMock struct {
+	rtbs []ec2types.RouteTable
+}
+
+func (m *pr03dRTBMock) DescribeRouteTables(
+	_ context.Context,
+	_ *ec2svc.DescribeRouteTablesInput,
+	_ ...func(*ec2svc.Options),
+) (*ec2svc.DescribeRouteTablesOutput, error) {
+	return &ec2svc.DescribeRouteTablesOutput{RouteTables: m.rtbs}, nil
+}

--- a/tests/unit/qa_transit_gateways_test.go
+++ b/tests/unit/qa_transit_gateways_test.go
@@ -54,6 +54,9 @@ func TestQA_TransitGateways_FetchSuccess(t *testing.T) {
 	if r.Status != "" {
 		t.Errorf("expected empty Status, got %q", r.Status)
 	}
+	if len(r.Findings) != 0 {
+		t.Errorf("expected no Findings for available TGW, got %d", len(r.Findings))
+	}
 	if r.Fields["state"] != "available" {
 		t.Errorf("expected Fields[\"state\"]='available', got %q", r.Fields["state"])
 	}

--- a/tests/unit/qa_transit_gateways_test.go
+++ b/tests/unit/qa_transit_gateways_test.go
@@ -51,8 +51,11 @@ func TestQA_TransitGateways_FetchSuccess(t *testing.T) {
 	if r.Name != "main-tgw" {
 		t.Errorf("expected Name 'main-tgw', got %q", r.Name)
 	}
-	if r.Status != "available" {
-		t.Errorf("expected Status 'available', got %q", r.Status)
+	if r.Status != "" {
+		t.Errorf("expected empty Status (PR-03d migration), got %q", r.Status)
+	}
+	if r.Fields["state"] != "available" {
+		t.Errorf("expected Fields[\"state\"]='available', got %q", r.Fields["state"])
 	}
 	if r.Fields["tgw_id"] != "tgw-0123456789abcdef0" {
 		t.Errorf("expected tgw_id 'tgw-0123456789abcdef0', got %q", r.Fields["tgw_id"])

--- a/tests/unit/qa_transit_gateways_test.go
+++ b/tests/unit/qa_transit_gateways_test.go
@@ -52,7 +52,7 @@ func TestQA_TransitGateways_FetchSuccess(t *testing.T) {
 		t.Errorf("expected Name 'main-tgw', got %q", r.Name)
 	}
 	if r.Status != "" {
-		t.Errorf("expected empty Status (PR-03d migration), got %q", r.Status)
+		t.Errorf("expected empty Status, got %q", r.Status)
 	}
 	if r.Fields["state"] != "available" {
 		t.Errorf("expected Fields[\"state\"]='available', got %q", r.Fields["state"])


### PR DESCRIPTION
## Summary

Phase 03 PR-03d: migrate networking-category fetchers from legacy `Resource.Status` to canonical Wave 1 `Findings` (Source: `wave1`).

Types migrated: **vpc, subnet, elb, igw, nat, vpce, tgw** (+ **rtb** special case: drop `Status: isMain` entirely).

## Changes

- **7 new** `internal/aws/<svc>_codes.go` files with canonical `FindingCode` constants for each lifecycle state.
- **8 fetcher migrations** (`vpc.go`, `subnet.go`, `elb.go`, `igw.go`, `nat.go`, `vpce.go`, `tgw.go`, `rtb.go`):
  - Stop writing `Resource.Status` for lifecycle/state.
  - Emit canonical wave1 Findings for non-healthy, non-terminal states.
  - rtb: `is_main` lives in `Fields` (no Status, no Findings — not a health signal).
- **Color func updates** in `types_networking.go`: read wave1 Findings first, then fall back to structural state cases. Matches EC2 pattern.
- **29 fetcher-test Status assertions migrated**: `r.Status == "<state>"` → `r.Status == "" && r.Fields["state"] == "<state>"`.

## Note on Color func design

Structural switch arms (e.g. `case "pending": return ColorWarning`) are kept after the wave1 loop, matching EC2's pattern. In production this branch is dead (fetcher always emits Findings for non-healthy states), but it serves as a fallback for synthetic test data injected by cross-cutting tests (CR273, legacy color tests).

## Test plan

- [x] `go test ./tests/unit/ -count=1` — 13,634 passed
- [x] `make lint` — 0 issues
- [x] `make security` — no vulnerabilities
- [x] `make test-race` — passed (53s)
- [x] `make gofix` — clean
- [x] `make build` — built