### PR TITLE
test: shared fixtures via sync.OnceValue — allocs -29% (AS-6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,16 +73,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            race: true
+          - os: macos-latest
+            race: false
+          - os: windows-latest
+            race: false
     steps:
       - uses: actions/checkout@v6
       - if: needs.changes.outputs.go == 'true'
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - if: needs.changes.outputs.go == 'true'
-        name: Run tests
-        run: go test ./tests/unit/ -count=1 -timeout 120s -race
+      - name: Run tests (with race detector)
+        if: needs.changes.outputs.go == 'true' && matrix.race
+        run: go test ./tests/unit/... -count=1 -timeout 600s -shuffle=on -race
+      - name: Run tests
+        if: needs.changes.outputs.go == 'true' && !matrix.race
+        run: go test ./tests/unit/... -count=1 -timeout 600s -shuffle=on
       - if: needs.changes.outputs.go != 'true'
         name: Docs-only PR — Test stub
         run: echo "No Go-affecting paths changed; Test stub passing per docs-only CI shim."

--- a/.github/workflows/nightly-race-matrix.yml
+++ b/.github/workflows/nightly-race-matrix.yml
@@ -1,0 +1,45 @@
+name: Nightly Race Matrix
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  race:
+    name: Race (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Run tests with race detector
+        run: go test -race ./tests/unit/... -timeout 1200s -shuffle=on
+
+  open-issue-on-failure:
+    name: Report failure
+    needs: race
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `Nightly race detector failure — ${new Date().toISOString().slice(0,10)}`;
+            const body = `The nightly race matrix failed.\n\nRun: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['bug', 'ci'],
+            });

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -1,6 +1,9 @@
 package config
 
-import "maps"
+import (
+	"maps"
+	"sync"
+)
 
 // defaultViews holds the built-in view definitions for all supported resource types.
 // Paths use Go field names from AWS SDK v2 structs. ExtractValue matches case-insensitively.
@@ -23,8 +26,13 @@ func mergeDefaultViews() map[string]ViewDef {
 	return m
 }
 
-// DefaultConfig returns a copy of the built-in default configuration.
-func DefaultConfig() *ViewsConfig {
+// sharedReadOnlyDefault is the lazily-built, never-mutated default config
+// instance shared across all callers that need read-only access.
+var sharedReadOnlyDefault = sync.OnceValue(func() *ViewsConfig {
+	return buildDefaultConfig()
+})
+
+func buildDefaultConfig() *ViewsConfig {
 	cp := ViewsConfig{
 		Views: make(map[string]ViewDef, len(defaultViews.Views)),
 	}
@@ -36,6 +44,19 @@ func DefaultConfig() *ViewsConfig {
 		cp.Views[k] = ViewDef{List: cols, Detail: detail}
 	}
 	return &cp
+}
+
+// DefaultConfig returns a copy of the built-in default configuration.
+// Each call returns a new, independently-mutable copy.
+func DefaultConfig() *ViewsConfig {
+	return buildDefaultConfig()
+}
+
+// SharedDefaultConfig returns the shared read-only default configuration.
+// The caller MUST NOT mutate the returned value or any of its nested slices/maps.
+// Use DefaultConfig when a mutable copy is required.
+func SharedDefaultConfig() *ViewsConfig {
+	return sharedReadOnlyDefault()
 }
 
 // DefaultViewDef returns the built-in default ViewDef for the given resource

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -28,9 +28,7 @@ func mergeDefaultViews() map[string]ViewDef {
 
 // sharedReadOnlyDefault is the lazily-built, never-mutated default config
 // instance shared across all callers that need read-only access.
-var sharedReadOnlyDefault = sync.OnceValue(func() *ViewsConfig {
-	return buildDefaultConfig()
-})
+var sharedReadOnlyDefault = sync.OnceValue(buildDefaultConfig)
 
 func buildDefaultConfig() *ViewsConfig {
 	cp := ViewsConfig{

--- a/internal/demo/fixtures/acm.go
+++ b/internal/demo/fixtures/acm.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -23,7 +24,7 @@ func mustParseACMTime(s string) time.Time {
 }
 
 // NewACMFixtures constructs ACMFixtures from the canonical demo data.
-func NewACMFixtures() *ACMFixtures {
+var sharedACMFixtures = sync.OnceValue(func() *ACMFixtures {
 	return &ACMFixtures{
 		Certificates: []acmtypes.CertificateSummary{
 			{
@@ -173,4 +174,8 @@ func NewACMFixtures() *ACMFixtures {
 			},
 		},
 	}
+})
+
+func NewACMFixtures() *ACMFixtures {
+	return sharedACMFixtures()
 }

--- a/internal/demo/fixtures/apigw.go
+++ b/internal/demo/fixtures/apigw.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -13,7 +14,7 @@ type APIGWFixtures struct {
 }
 
 // NewAPIGWFixtures constructs APIGWFixtures from the canonical demo data.
-func NewAPIGWFixtures() *APIGWFixtures {
+var sharedAPIGWFixtures = sync.OnceValue(func() *APIGWFixtures {
 	return &APIGWFixtures{
 		APIs: []apigwtypes.Api{
 			{
@@ -48,4 +49,8 @@ func NewAPIGWFixtures() *APIGWFixtures {
 			},
 		},
 	}
+})
+
+func NewAPIGWFixtures() *APIGWFixtures {
+	return sharedAPIGWFixtures()
 }

--- a/internal/demo/fixtures/asg.go
+++ b/internal/demo/fixtures/asg.go
@@ -2,6 +2,7 @@
 package fixtures
 
 import (
+	"sync"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	asgtypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 )
@@ -17,7 +18,7 @@ type ASGFixtures struct {
 }
 
 // NewASGFixtures builds and returns a fully-populated ASGFixtures struct.
-func NewASGFixtures() *ASGFixtures {
+var sharedASGFixtures = sync.OnceValue(func() *ASGFixtures {
 	groups := buildASGGroups()
 	activities := buildASGActivities()
 	lcs := buildLaunchConfigurations()
@@ -26,6 +27,10 @@ func NewASGFixtures() *ASGFixtures {
 		Activities:           activities,
 		LaunchConfigurations: lcs,
 	}
+})
+
+func NewASGFixtures() *ASGFixtures {
+	return sharedASGFixtures()
 }
 
 const (

--- a/internal/demo/fixtures/athena.go
+++ b/internal/demo/fixtures/athena.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -20,7 +21,7 @@ func mustParseAthenaTime(s string) time.Time {
 }
 
 // NewAthenaFixtures constructs AthenaFixtures from the canonical demo data.
-func NewAthenaFixtures() *AthenaFixtures {
+var sharedAthenaFixtures = sync.OnceValue(func() *AthenaFixtures {
 	return &AthenaFixtures{
 		WorkGroups: []athenatypes.WorkGroupSummary{
 			{
@@ -82,4 +83,8 @@ func NewAthenaFixtures() *AthenaFixtures {
 			},
 		},
 	}
+})
+
+func NewAthenaFixtures() *AthenaFixtures {
+	return sharedAthenaFixtures()
 }

--- a/internal/demo/fixtures/backup.go
+++ b/internal/demo/fixtures/backup.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -488,7 +489,7 @@ func buildBackupSelections() map[string][]backuptypes.BackupSelection {
 // NewBackupFixtures constructs BackupFixtures from the canonical demo data.
 // Every plan in the impl-plan §2 is represented here; adversarial fixtures
 // (nil CreatedBy, nil CreationDate, API errors) stay inline in QA test files.
-func NewBackupFixtures() *BackupFixtures {
+var sharedBackupFixtures = sync.OnceValue(func() *BackupFixtures {
 	return &BackupFixtures{
 		RecoveryPoints:      buildBackupRecoveryPoints(),
 		Selections:          buildBackupSelections(),
@@ -595,4 +596,8 @@ func NewBackupFixtures() *BackupFixtures {
 			},
 		},
 	}
+})
+
+func NewBackupFixtures() *BackupFixtures {
+	return sharedBackupFixtures()
 }

--- a/internal/demo/fixtures/cfn.go
+++ b/internal/demo/fixtures/cfn.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -67,7 +68,7 @@ func minimalCreateEventSequence(stackName, startTime, primaryResLogicalID, prima
 }
 
 // NewCFNFixtures constructs CFNFixtures from the canonical demo data.
-func NewCFNFixtures() *CFNFixtures {
+var sharedCFNFixtures = sync.OnceValue(func() *CFNFixtures {
 	const prodCIDeployRoleARN = "arn:aws:iam::123456789012:role/prod-ci-deploy-role"
 
 	stacks := []cfntypes.Stack{
@@ -384,4 +385,8 @@ func NewCFNFixtures() *CFNFixtures {
 		StackEvents:    stackEvents,
 		StackResources: stackResources,
 	}
+})
+
+func NewCFNFixtures() *CFNFixtures {
+	return sharedCFNFixtures()
 }

--- a/internal/demo/fixtures/cloudfront.go
+++ b/internal/demo/fixtures/cloudfront.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -13,7 +14,7 @@ type CloudFrontFixtures struct {
 }
 
 // NewCloudFrontFixtures constructs CloudFrontFixtures from the canonical demo data.
-func NewCloudFrontFixtures() *CloudFrontFixtures {
+var sharedCloudFrontFixtures = sync.OnceValue(func() *CloudFrontFixtures {
 	return &CloudFrontFixtures{
 		Distributions: []cftypes.DistributionSummary{
 			{
@@ -212,4 +213,8 @@ func NewCloudFrontFixtures() *CloudFrontFixtures {
 			},
 		},
 	}
+})
+
+func NewCloudFrontFixtures() *CloudFrontFixtures {
+	return sharedCloudFrontFixtures()
 }

--- a/internal/demo/fixtures/cloudtrail.go
+++ b/internal/demo/fixtures/cloudtrail.go
@@ -2,6 +2,7 @@
 package fixtures
 
 import (
+	"sync"
 	"fmt"
 	"time"
 
@@ -18,12 +19,16 @@ type CloudTrailFixtures struct {
 }
 
 // NewCloudTrailFixtures builds and returns a fully-populated CloudTrailFixtures struct.
-func NewCloudTrailFixtures() *CloudTrailFixtures {
+var sharedCloudTrailFixtures = sync.OnceValue(func() *CloudTrailFixtures {
 	return &CloudTrailFixtures{
 		Trails:      buildCTTrails(),
 		TrailStatus: buildCTTrailStatus(),
 		Events:      buildCTEvents(),
 	}
+})
+
+func NewCloudTrailFixtures() *CloudTrailFixtures {
+	return sharedCloudTrailFixtures()
 }
 
 // buildCTTrailStatus keys GetTrailStatus responses by trail ARN. One trail is

--- a/internal/demo/fixtures/cloudwatch.go
+++ b/internal/demo/fixtures/cloudwatch.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -20,7 +21,7 @@ type CloudWatchFixtures struct {
 const relatedAlarmSNSARN = "arn:aws:sns:us-east-1:123456789012:ops-alerts"
 
 // NewCloudWatchFixtures constructs CloudWatchFixtures from the canonical demo data.
-func NewCloudWatchFixtures() *CloudWatchFixtures {
+var sharedCloudWatchFixtures = sync.OnceValue(func() *CloudWatchFixtures {
 	return &CloudWatchFixtures{
 		Alarms: []cwtypes.MetricAlarm{
 			{
@@ -475,6 +476,10 @@ func NewCloudWatchFixtures() *CloudWatchFixtures {
 			"prod-efs-percent-io-high":     minimalAlarmHistory("prod-efs-percent-io-high"),
 		},
 	}
+})
+
+func NewCloudWatchFixtures() *CloudWatchFixtures {
+	return sharedCloudWatchFixtures()
 }
 
 // minimalAlarmHistory returns a canonical 3-item state sequence

--- a/internal/demo/fixtures/codeartifact.go
+++ b/internal/demo/fixtures/codeartifact.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -18,7 +19,7 @@ func mustParseCATime(s string) time.Time {
 }
 
 // NewCodeArtifactFixtures constructs CodeArtifactFixtures from the canonical demo data.
-func NewCodeArtifactFixtures() *CodeArtifactFixtures {
+var sharedCodeArtifactFixtures = sync.OnceValue(func() *CodeArtifactFixtures {
 	return &CodeArtifactFixtures{
 		Repositories: []codeartifacttypes.RepositorySummary{
 			{
@@ -50,4 +51,8 @@ func NewCodeArtifactFixtures() *CodeArtifactFixtures {
 			},
 		},
 	}
+})
+
+func NewCodeArtifactFixtures() *CodeArtifactFixtures {
+	return sharedCodeArtifactFixtures()
 }

--- a/internal/demo/fixtures/codebuild.go
+++ b/internal/demo/fixtures/codebuild.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -22,7 +23,7 @@ func mustParseCBTime(s string) time.Time {
 }
 
 // NewCodeBuildFixtures constructs CodeBuildFixtures from the canonical demo data.
-func NewCodeBuildFixtures() *CodeBuildFixtures {
+var sharedCodeBuildFixtures = sync.OnceValue(func() *CodeBuildFixtures {
 	projects := []cbtypes.Project{
 		{
 			Name:                 aws.String("acme-api-build"),
@@ -148,4 +149,8 @@ func NewCodeBuildFixtures() *CodeBuildFixtures {
 		Projects: projects,
 		Builds:   buildsByProject,
 	}
+})
+
+func NewCodeBuildFixtures() *CodeBuildFixtures {
+	return sharedCodeBuildFixtures()
 }

--- a/internal/demo/fixtures/codepipeline.go
+++ b/internal/demo/fixtures/codepipeline.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -18,7 +19,7 @@ func mustParseCPTime(s string) time.Time {
 }
 
 // NewCodePipelineFixtures constructs CodePipelineFixtures from the canonical demo data.
-func NewCodePipelineFixtures() *CodePipelineFixtures {
+var sharedCodePipelineFixtures = sync.OnceValue(func() *CodePipelineFixtures {
 	return &CodePipelineFixtures{
 		Pipelines: []cptypes.PipelineSummary{
 			{
@@ -45,4 +46,8 @@ func NewCodePipelineFixtures() *CodePipelineFixtures {
 			},
 		},
 	}
+})
+
+func NewCodePipelineFixtures() *CodePipelineFixtures {
+	return sharedCodePipelineFixtures()
 }

--- a/internal/demo/fixtures/cwlogs.go
+++ b/internal/demo/fixtures/cwlogs.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	cwlogstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 )
@@ -15,7 +16,7 @@ type CWLogsFixtures struct {
 }
 
 // NewCWLogsFixtures constructs CWLogsFixtures from the canonical demo data.
-func NewCWLogsFixtures() *CWLogsFixtures {
+var sharedCWLogsFixtures = sync.OnceValue(func() *CWLogsFixtures {
 	logGroups := []cwlogstypes.LogGroup{
 		{
 			LogGroupName:              aws.String("/aws/lambda/api-gateway-authorizer"),
@@ -360,6 +361,10 @@ func NewCWLogsFixtures() *CWLogsFixtures {
 		LogStreams: logStreams,
 		LogEvents:  logEvents,
 	}
+})
+
+func NewCWLogsFixtures() *CWLogsFixtures {
+	return sharedCWLogsFixtures()
 }
 
 // minimalLogStreams returns one canonical "2026/04/20/[$LATEST]<suffix>"

--- a/internal/demo/fixtures/dbc.go
+++ b/internal/demo/fixtures/dbc.go
@@ -2,6 +2,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -87,13 +88,17 @@ const (
 )
 
 // NewDBCFixtures builds and returns a fully-populated DBCFixtures struct.
-func NewDBCFixtures() *DBCFixtures {
+var sharedDBCFixtures = sync.OnceValue(func() *DBCFixtures {
 	return &DBCFixtures{
 		DBClusters:                buildDBCClusters(),
 		DBClusterSnapshots:        buildDBCSnapshots(),
 		DBSubnetGroups:            buildDBCSubnetGroups(),
 		PendingMaintenanceActions: buildDBCPendingMaintenance(),
 	}
+})
+
+func NewDBCFixtures() *DBCFixtures {
+	return sharedDBCFixtures()
 }
 
 // dbcBaseline returns a healthy DocumentDB cluster with all fields set.

--- a/internal/demo/fixtures/dbi-snap.go
+++ b/internal/demo/fixtures/dbi-snap.go
@@ -2,6 +2,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -81,10 +82,14 @@ const (
 // Every fixture in the impl-plan §2 is represented here; adversarial fixtures
 // (nil DBSnapshotIdentifier, nil Status, malformed ARN, nil SnapshotCreateTime)
 // stay inline in tests/unit/aws_rds_snap_test.go.
-func NewDBISnapFixtures() *DBISnapFixtures {
+var sharedDBISnapFixtures = sync.OnceValue(func() *DBISnapFixtures {
 	return &DBISnapFixtures{
 		Instances: buildDBISnapInstances(),
 	}
+})
+
+func NewDBISnapFixtures() *DBISnapFixtures {
+	return sharedDBISnapFixtures()
 }
 
 func buildDBISnapInstances() []rdstypes.DBSnapshot {

--- a/internal/demo/fixtures/dbi.go
+++ b/internal/demo/fixtures/dbi.go
@@ -2,6 +2,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -101,11 +102,15 @@ const (
 // NewDBIFixtures builds and returns a fully-populated DBIFixtures struct.
 // The Instances slice contains all non-adversarial fixtures from the spec §2.
 // PendingMaintenanceActions contains the Wave 2 enrichment data for maint-dbi-scheduled.
-func NewDBIFixtures() *DBIFixtures {
+var sharedDBIFixtures = sync.OnceValue(func() *DBIFixtures {
 	return &DBIFixtures{
 		Instances:                 buildDBIInstances(),
 		PendingMaintenanceActions: buildDBIPendingMaintenance(),
 	}
+})
+
+func NewDBIFixtures() *DBIFixtures {
+	return sharedDBIFixtures()
 }
 
 // dbiBaselineHealthy builds a fully-configured healthy DBInstance.

--- a/internal/demo/fixtures/ddb.go
+++ b/internal/demo/fixtures/ddb.go
@@ -2,6 +2,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -73,12 +74,16 @@ const (
 )
 
 // NewDDBFixtures returns a fully-populated DDBFixtures for demo and tests.
-func NewDDBFixtures() *DDBFixtures {
+var sharedDDBFixtures = sync.OnceValue(func() *DDBFixtures {
 	return &DDBFixtures{
 		Tables:              buildDDBTables(),
 		ContinuousBackups:   buildDDBContinuousBackups(),
 		KinesisDestinations: buildDDBKinesisDestinations(),
 	}
+})
+
+func NewDDBFixtures() *DDBFixtures {
+	return sharedDDBFixtures()
 }
 
 // pitrEnabled returns a ContinuousBackupsDescription with PITR enabled.

--- a/internal/demo/fixtures/eb.go
+++ b/internal/demo/fixtures/eb.go
@@ -2,6 +2,7 @@
 package fixtures
 
 import (
+	"sync"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ebtypes "github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk/types"
 )
@@ -13,10 +14,14 @@ type EBFixtures struct {
 }
 
 // NewEBFixtures builds and returns a fully-populated EBFixtures struct.
-func NewEBFixtures() *EBFixtures {
+var sharedEBFixtures = sync.OnceValue(func() *EBFixtures {
 	return &EBFixtures{
 		Environments: buildEBEnvironments(),
 	}
+})
+
+func NewEBFixtures() *EBFixtures {
+	return sharedEBFixtures()
 }
 
 func buildEBEnvironments() []ebtypes.EnvironmentDescription {

--- a/internal/demo/fixtures/ec2.go
+++ b/internal/demo/fixtures/ec2.go
@@ -2,6 +2,7 @@
 package fixtures
 
 import (
+	"sync"
 	"fmt"
 	"strings"
 	"time"
@@ -57,7 +58,7 @@ const (
 // NewEC2Fixtures builds and returns a fully-populated EC2Fixtures struct
 // with deterministic demo data that matches the data served by the old demo code paths.
 // This is the single source of truth for all EC2 fake responses.
-func NewEC2Fixtures() *EC2Fixtures {
+var sharedEC2Fixtures = sync.OnceValue(func() *EC2Fixtures {
 	f := &EC2Fixtures{}
 	f.Reservations = buildReservations()
 	f.InstanceStatuses = buildInstanceStatuses(f.Reservations)
@@ -76,6 +77,10 @@ func NewEC2Fixtures() *EC2Fixtures {
 	f.Snapshots = buildSnapshots()
 	f.Images = buildImages()
 	return f
+})
+
+func NewEC2Fixtures() *EC2Fixtures {
+	return sharedEC2Fixtures()
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/demo/fixtures/ecr.go
+++ b/internal/demo/fixtures/ecr.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -22,7 +23,7 @@ func mustParseECRTime(s string) time.Time {
 }
 
 // NewECRFixtures constructs ECRFixtures from the canonical demo data.
-func NewECRFixtures() *ECRFixtures {
+var sharedECRFixtures = sync.OnceValue(func() *ECRFixtures {
 	repos := []ecrtypes.Repository{
 		{
 			RepositoryName:             aws.String("acme/api-service"),
@@ -103,4 +104,8 @@ func NewECRFixtures() *ECRFixtures {
 		Repositories: repos,
 		Images:       images,
 	}
+})
+
+func NewECRFixtures() *ECRFixtures {
+	return sharedECRFixtures()
 }

--- a/internal/demo/fixtures/ecs.go
+++ b/internal/demo/fixtures/ecs.go
@@ -2,6 +2,7 @@
 package fixtures
 
 import (
+	"sync"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -21,7 +22,7 @@ type ECSFixtures struct {
 }
 
 // NewECSFixtures builds and returns a fully-populated ECSFixtures struct.
-func NewECSFixtures() *ECSFixtures {
+var sharedECSFixtures = sync.OnceValue(func() *ECSFixtures {
 	clusters := buildECSClusters()
 	services := buildECSServices()
 	tasks := buildECSTasks()
@@ -32,6 +33,10 @@ func NewECSFixtures() *ECSFixtures {
 		Tasks:           tasks,
 		TaskDefinitions: tdefs,
 	}
+})
+
+func NewECSFixtures() *ECSFixtures {
+	return sharedECSFixtures()
 }
 
 const (

--- a/internal/demo/fixtures/efs.go
+++ b/internal/demo/fixtures/efs.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -117,12 +118,16 @@ func mustParseEFSTime(s string) time.Time {
 }
 
 // NewEFSFixtures constructs EFSFixtures from the canonical demo data.
-func NewEFSFixtures() *EFSFixtures {
+var sharedEFSFixtures = sync.OnceValue(func() *EFSFixtures {
 	return &EFSFixtures{
 		FileSystems:  buildEFSFileSystems(),
 		MountTargets: buildEFSMountTargets(),
 		AccessPoints: buildEFSAccessPoints(),
 	}
+})
+
+func NewEFSFixtures() *EFSFixtures {
+	return sharedEFSFixtures()
 }
 
 func buildEFSFileSystems() []efstypes.FileSystemDescription {

--- a/internal/demo/fixtures/eks.go
+++ b/internal/demo/fixtures/eks.go
@@ -2,6 +2,7 @@
 package fixtures
 
 import (
+	"sync"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 )
@@ -17,13 +18,17 @@ type EKSFixtures struct {
 }
 
 // NewEKSFixtures builds and returns a fully-populated EKSFixtures struct.
-func NewEKSFixtures() *EKSFixtures {
+var sharedEKSFixtures = sync.OnceValue(func() *EKSFixtures {
 	clusters := buildEKSClusters()
 	ngs := buildEKSNodegroups()
 	return &EKSFixtures{
 		Clusters:   clusters,
 		Nodegroups: ngs,
 	}
+})
+
+func NewEKSFixtures() *EKSFixtures {
+	return sharedEKSFixtures()
 }
 
 const (

--- a/internal/demo/fixtures/elb.go
+++ b/internal/demo/fixtures/elb.go
@@ -2,6 +2,7 @@
 package fixtures
 
 import (
+	"sync"
 	"fmt"
 	"time"
 
@@ -37,7 +38,7 @@ const (
 )
 
 // NewELBFixtures builds and returns a fully-populated ELBFixtures struct.
-func NewELBFixtures() *ELBFixtures {
+var sharedELBFixtures = sync.OnceValue(func() *ELBFixtures {
 	f := &ELBFixtures{
 		Listeners:    make(map[string][]elbv2types.Listener),
 		TargetHealth: make(map[string][]elbv2types.TargetHealthDescription),
@@ -49,6 +50,10 @@ func NewELBFixtures() *ELBFixtures {
 	buildTargetHealth(f)
 	buildRules(f)
 	return f
+})
+
+func NewELBFixtures() *ELBFixtures {
+	return sharedELBFixtures()
 }
 
 func buildLoadBalancers() []elbv2types.LoadBalancer {

--- a/internal/demo/fixtures/eventbridge.go
+++ b/internal/demo/fixtures/eventbridge.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	eventbridgetypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
 )
@@ -15,7 +16,7 @@ type EventBridgeFixtures struct {
 const prodEBRoleARN = "arn:aws:iam::123456789012:role/prod-ci-deploy-role"
 
 // NewEventBridgeFixtures constructs EventBridgeFixtures from the canonical demo data.
-func NewEventBridgeFixtures() *EventBridgeFixtures {
+var sharedEventBridgeFixtures = sync.OnceValue(func() *EventBridgeFixtures {
 	rules := []eventbridgetypes.Rule{
 		{
 			Name:               aws.String("nightly-db-backup"),
@@ -117,4 +118,8 @@ func NewEventBridgeFixtures() *EventBridgeFixtures {
 		Rules:         rules,
 		TargetsByRule: targetsByRule,
 	}
+})
+
+func NewEventBridgeFixtures() *EventBridgeFixtures {
+	return sharedEventBridgeFixtures()
 }

--- a/internal/demo/fixtures/glue.go
+++ b/internal/demo/fixtures/glue.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -19,7 +20,7 @@ func mustParseGlueTime(s string) time.Time {
 }
 
 // NewGlueFixtures constructs GlueFixtures from the canonical demo data.
-func NewGlueFixtures() *GlueFixtures {
+var sharedGlueFixtures = sync.OnceValue(func() *GlueFixtures {
 	dpuSucceeded := 45000.0
 	dpuFailed := 12000.0
 	dpuTimeout := 72000.0
@@ -164,4 +165,8 @@ func NewGlueFixtures() *GlueFixtures {
 			},
 		},
 	}
+})
+
+func NewGlueFixtures() *GlueFixtures {
+	return sharedGlueFixtures()
 }

--- a/internal/demo/fixtures/iam.go
+++ b/internal/demo/fixtures/iam.go
@@ -2,6 +2,7 @@
 package fixtures
 
 import (
+	"sync"
 	"fmt"
 	"net/url"
 	"strings"
@@ -57,7 +58,7 @@ func IsCustomerManagedPolicyARN(policyARN string) bool {
 }
 
 // NewIAMFixtures builds and returns a fully-populated IAMFixtures struct.
-func NewIAMFixtures() *IAMFixtures {
+var sharedIAMFixtures = sync.OnceValue(func() *IAMFixtures {
 	f := &IAMFixtures{
 		AttachedRolePolicies:  make(map[string][]iamtypes.AttachedPolicy),
 		InlineRolePolicies:    make(map[string][]string),
@@ -79,6 +80,10 @@ func NewIAMFixtures() *IAMFixtures {
 	f.InlineGroupPolicies["developers"] = []string{"AllowAssumeRole", "AllowChangeOwnPassword"}
 	f.InlineGroupPolicies["readonly"] = []string{"DenyS3Delete"}
 	return f
+})
+
+func NewIAMFixtures() *IAMFixtures {
+	return sharedIAMFixtures()
 }
 
 func buildIAMRoles() []iamtypes.Role {

--- a/internal/demo/fixtures/kinesis.go
+++ b/internal/demo/fixtures/kinesis.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -18,7 +19,7 @@ func mustParseKinesisTime(s string) time.Time {
 }
 
 // NewKinesisFixtures constructs KinesisFixtures from the canonical demo data.
-func NewKinesisFixtures() *KinesisFixtures {
+var sharedKinesisFixtures = sync.OnceValue(func() *KinesisFixtures {
 	return &KinesisFixtures{
 		Streams: []kinesistypes.StreamSummary{
 			{
@@ -71,4 +72,8 @@ func NewKinesisFixtures() *KinesisFixtures {
 			},
 		},
 	}
+})
+
+func NewKinesisFixtures() *KinesisFixtures {
+	return sharedKinesisFixtures()
 }

--- a/internal/demo/fixtures/kms.go
+++ b/internal/demo/fixtures/kms.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -16,7 +17,7 @@ type KMSFixtures struct {
 }
 
 // NewKMSFixtures constructs KMSFixtures from the canonical demo data.
-func NewKMSFixtures() *KMSFixtures {
+var sharedKMSFixtures = sync.OnceValue(func() *KMSFixtures {
 	keyMetadata := []*kmstypes.KeyMetadata{
 		{
 			KeyId:                aws.String("a1b2c3d4-5678-90ab-cdef-111111111111"),
@@ -353,4 +354,8 @@ func NewKMSFixtures() *KMSFixtures {
 	}
 
 	return &KMSFixtures{Keys: keys, Aliases: aliases}
+})
+
+func NewKMSFixtures() *KMSFixtures {
+	return sharedKMSFixtures()
 }

--- a/internal/demo/fixtures/lambda.go
+++ b/internal/demo/fixtures/lambda.go
@@ -2,6 +2,7 @@
 package fixtures
 
 import (
+	"sync"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -17,12 +18,16 @@ type LambdaFixtures struct {
 }
 
 // NewLambdaFixtures builds and returns a fully-populated LambdaFixtures struct.
-func NewLambdaFixtures() *LambdaFixtures {
+var sharedLambdaFixtures = sync.OnceValue(func() *LambdaFixtures {
 	fns := buildLambdaFunctions()
 	return &LambdaFixtures{
 		Functions:           fns,
 		EventSourceMappings: buildLambdaEventSourceMappings(fns),
 	}
+})
+
+func NewLambdaFixtures() *LambdaFixtures {
+	return sharedLambdaFixtures()
 }
 
 const (

--- a/internal/demo/fixtures/msk.go
+++ b/internal/demo/fixtures/msk.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -18,7 +19,7 @@ func mustParseMSKTime(s string) time.Time {
 }
 
 // NewMSKFixtures constructs MSKFixtures from the canonical demo data.
-func NewMSKFixtures() *MSKFixtures {
+var sharedMSKFixtures = sync.OnceValue(func() *MSKFixtures {
 	return &MSKFixtures{
 		Clusters: []kafkatypes.Cluster{
 			{
@@ -97,4 +98,8 @@ func NewMSKFixtures() *MSKFixtures {
 			},
 		},
 	}
+})
+
+func NewMSKFixtures() *MSKFixtures {
+	return sharedMSKFixtures()
 }

--- a/internal/demo/fixtures/opensearch.go
+++ b/internal/demo/fixtures/opensearch.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -91,7 +92,7 @@ type OpenSearchFixtures struct {
 // 1. healthy_baseline, 2. graph_root, 3. update_available_bang,
 // 4. encryption_off_tilde, 5. multi_background, 6. processing_warning,
 // 7. processing_plus_update, 8. isolated_broken, 9. deleting_dim.
-func NewOpenSearchFixtures() *OpenSearchFixtures {
+var sharedOpenSearchFixtures = sync.OnceValue(func() *OpenSearchFixtures {
 	return &OpenSearchFixtures{
 		Domains: []ostypes.DomainStatus{
 			osHealthyBaseline(),
@@ -105,6 +106,10 @@ func NewOpenSearchFixtures() *OpenSearchFixtures {
 			osDeletingDim(),
 		},
 	}
+})
+
+func NewOpenSearchFixtures() *OpenSearchFixtures {
+	return sharedOpenSearchFixtures()
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/demo/fixtures/r53.go
+++ b/internal/demo/fixtures/r53.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
 )
@@ -13,7 +14,7 @@ type R53Fixtures struct {
 }
 
 // NewR53Fixtures constructs R53Fixtures from the canonical demo data.
-func NewR53Fixtures() *R53Fixtures {
+var sharedR53Fixtures = sync.OnceValue(func() *R53Fixtures {
 	return &R53Fixtures{
 		HostedZones: []r53types.HostedZone{
 			{
@@ -202,4 +203,8 @@ func NewR53Fixtures() *R53Fixtures {
 			},
 		},
 	}
+})
+
+func NewR53Fixtures() *R53Fixtures {
+	return sharedR53Fixtures()
 }

--- a/internal/demo/fixtures/rds.go
+++ b/internal/demo/fixtures/rds.go
@@ -2,6 +2,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -31,7 +32,7 @@ type RDSFixtures struct {
 // DBInstances are sourced from DBIFixtures (single source of truth) plus the
 // legacy bulk-generated pool. Callers that only need DBInstances should use
 // NewDBIFixtures() directly.
-func NewRDSFixtures() *RDSFixtures {
+var sharedRDSFixtures = sync.OnceValue(func() *RDSFixtures {
 	dbi := NewDBIFixtures()
 	legacy := buildRDSInstances()
 	return &RDSFixtures{
@@ -42,6 +43,10 @@ func NewRDSFixtures() *RDSFixtures {
 		DBClusterSnapshots: buildRDSDBClusterSnapshots(),
 		DBSubnetGroups:     buildRDSDBSubnetGroups(),
 	}
+})
+
+func NewRDSFixtures() *RDSFixtures {
+	return sharedRDSFixtures()
 }
 
 const (

--- a/internal/demo/fixtures/redis.go
+++ b/internal/demo/fixtures/redis.go
@@ -4,6 +4,7 @@
 package fixtures
 
 import (
+	"sync"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	elasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 )
@@ -119,13 +120,17 @@ type RedisFixtures struct {
 // Fixtures cover every §3.1 signal from docs/resources/redis.md plus the
 // multi-W1 case (U7a). The graph-root (prod-redis-sessions) carries matching
 // sibling entries for all 10 registered related-panel pivots.
-func NewRedisFixtures() *RedisFixtures {
+var sharedRedisFixtures = sync.OnceValue(func() *RedisFixtures {
 	return &RedisFixtures{
 		ReplicationGroups: buildRedisReplicationGroups(),
 		CacheClusters:     buildRedisCacheClusters(),
 		SubnetGroups:      buildRedisCacheSubnetGroups(),
 		TagLists:          buildRedisTagLists(),
 	}
+})
+
+func NewRedisFixtures() *RedisFixtures {
+	return sharedRedisFixtures()
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/demo/fixtures/redshift.go
+++ b/internal/demo/fixtures/redshift.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"fmt"
 	"time"
 
@@ -95,10 +96,14 @@ const (
 // Every fixture in docs/resources/redshift-impl-plan.md §2 is present.
 // Adversarial fixtures (nil-pointer Cluster, malformed Tags) are excluded —
 // those live inline in QA test files per the a9s-create-demo-fixture skill rule.
-func NewRedshiftFixtures() *RedshiftFixtures {
+var sharedRedshiftFixtures = sync.OnceValue(func() *RedshiftFixtures {
 	return &RedshiftFixtures{
 		Clusters: buildRedshiftClusters(),
 	}
+})
+
+func NewRedshiftFixtures() *RedshiftFixtures {
+	return sharedRedshiftFixtures()
 }
 
 // redshiftBaselineHealthy returns a fully-configured Redshift cluster with all

--- a/internal/demo/fixtures/s3.go
+++ b/internal/demo/fixtures/s3.go
@@ -2,6 +2,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -71,7 +72,7 @@ func mustTime(s string) time.Time {
 
 // NewS3Fixtures builds and returns a fully-populated S3Fixtures struct
 // with deterministic demo data.
-func NewS3Fixtures() *S3Fixtures {
+var sharedS3Fixtures = sync.OnceValue(func() *S3Fixtures {
 	f := &S3Fixtures{
 		NotificationConfigs:      buildS3NotificationConfigs(),
 		PublicAccessBlockConfigs: buildS3PublicAccessBlockConfigs(),
@@ -84,6 +85,10 @@ func NewS3Fixtures() *S3Fixtures {
 	}
 	f.Buckets = buildS3Buckets()
 	return f
+})
+
+func NewS3Fixtures() *S3Fixtures {
+	return sharedS3Fixtures()
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/demo/fixtures/secrets.go
+++ b/internal/demo/fixtures/secrets.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"fmt"
 	"time"
 
@@ -34,7 +35,7 @@ var secretDescPool = []string{
 }
 
 // NewSecretsFixtures constructs SecretsFixtures from the canonical demo data.
-func NewSecretsFixtures() *SecretsFixtures {
+var sharedSecretsFixtures = sync.OnceValue(func() *SecretsFixtures {
 	secrets := []smtypes.SecretListEntry{
 		// RDS-managed secret for prod-dbi-1 — required for dbi→secrets related-panel pivot.
 		// ARN matches DBIFixtures.ProdDbiMasterSecretARN (MasterUserSecret.SecretArn on prod-dbi-1).
@@ -235,4 +236,8 @@ func NewSecretsFixtures() *SecretsFixtures {
 			"staging/database/mysql":     `{"host":"staging-mysql.c9xyz123.us-east-1.rds.amazonaws.com","port":"3306","username":"staginguser","password":"[REDACTED]"}`,
 		},
 	}
+})
+
+func NewSecretsFixtures() *SecretsFixtures {
+	return sharedSecretsFixtures()
 }

--- a/internal/demo/fixtures/ses.go
+++ b/internal/demo/fixtures/ses.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -85,7 +86,7 @@ type SESFixtures struct {
 }
 
 // NewSESFixtures constructs SESFixtures from the canonical demo data.
-func NewSESFixtures() *SESFixtures {
+var sharedSESFixtures = sync.OnceValue(func() *SESFixtures {
 	return &SESFixtures{
 		Identities:                   buildSESIdentities(),
 		GetAccountDefault:            buildSESAccountHealthy(),
@@ -93,6 +94,10 @@ func NewSESFixtures() *SESFixtures {
 		EventDestinationsByConfigSet: buildSESEventDestinations(),
 		ActiveReceiptRuleSet:         buildSESActiveReceiptRuleSet(),
 	}
+})
+
+func NewSESFixtures() *SESFixtures {
+	return sharedSESFixtures()
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/demo/fixtures/sfn.go
+++ b/internal/demo/fixtures/sfn.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -14,7 +15,7 @@ type SFNFixtures struct {
 }
 
 // NewSFNFixtures constructs SFNFixtures from the canonical demo data.
-func NewSFNFixtures() *SFNFixtures {
+var sharedSFNFixtures = sync.OnceValue(func() *SFNFixtures {
 	const smARNOrderFulfillment = "arn:aws:states:us-east-1:123456789012:stateMachine:order-fulfillment-workflow"
 
 	redriveCount := int32(1)
@@ -123,4 +124,8 @@ func NewSFNFixtures() *SFNFixtures {
 			},
 		},
 	}
+})
+
+func NewSFNFixtures() *SFNFixtures {
+	return sharedSFNFixtures()
 }

--- a/internal/demo/fixtures/sns.go
+++ b/internal/demo/fixtures/sns.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	snstypes "github.com/aws/aws-sdk-go-v2/service/sns/types"
 )
@@ -14,7 +15,7 @@ type SNSFixtures struct {
 }
 
 // NewSNSFixtures constructs SNSFixtures from the canonical demo data.
-func NewSNSFixtures() *SNSFixtures {
+var sharedSNSFixtures = sync.OnceValue(func() *SNSFixtures {
 	topics := []snstypes.Topic{
 		{TopicArn: aws.String("arn:aws:sns:us-east-1:123456789012:alarm-notifications")},
 		{TopicArn: aws.String("arn:aws:sns:us-east-1:123456789012:order-events")},
@@ -89,6 +90,10 @@ func NewSNSFixtures() *SNSFixtures {
 		Subscriptions:        subscriptions,
 		SubscriptionsByTopic: subsByTopic,
 	}
+})
+
+func NewSNSFixtures() *SNSFixtures {
+	return sharedSNSFixtures()
 }
 
 // minimalSubscriptions returns a single canonical confirmed subscription so

--- a/internal/demo/fixtures/sqs.go
+++ b/internal/demo/fixtures/sqs.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 )
 
@@ -11,7 +12,7 @@ type SQSFixtures struct {
 }
 
 // NewSQSFixtures constructs SQSFixtures from the canonical demo data.
-func NewSQSFixtures() *SQSFixtures {
+var sharedSQSFixtures = sync.OnceValue(func() *SQSFixtures {
 	return &SQSFixtures{
 		Queues: []awsclient.SQSQueueAttributesRow{
 			{
@@ -69,4 +70,8 @@ func NewSQSFixtures() *SQSFixtures {
 			},
 		},
 	}
+})
+
+func NewSQSFixtures() *SQSFixtures {
+	return sharedSQSFixtures()
 }

--- a/internal/demo/fixtures/ssm.go
+++ b/internal/demo/fixtures/ssm.go
@@ -1,6 +1,7 @@
 package fixtures
 
 import (
+	"sync"
 	"fmt"
 	"time"
 
@@ -39,7 +40,7 @@ func mustParseSSMTime(s string) time.Time {
 }
 
 // NewSSMFixtures constructs SSMFixtures from the canonical demo data.
-func NewSSMFixtures() *SSMFixtures {
+var sharedSSMFixtures = sync.OnceValue(func() *SSMFixtures {
 	ssmTypeMap := map[string]ssmtypes.ParameterType{
 		"String":       ssmtypes.ParameterTypeString,
 		"SecureString": ssmtypes.ParameterTypeSecureString,
@@ -137,4 +138,8 @@ func NewSSMFixtures() *SSMFixtures {
 			"/acme/staging/ami-id":            "ami-0123456789abcdef0",
 		},
 	}
+})
+
+func NewSSMFixtures() *SSMFixtures {
+	return sharedSSMFixtures()
 }

--- a/internal/demo/fixtures/waf.go
+++ b/internal/demo/fixtures/waf.go
@@ -2,6 +2,7 @@
 package fixtures
 
 import (
+	"sync"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	wafv2types "github.com/aws/aws-sdk-go-v2/service/wafv2/types"
 )
@@ -14,7 +15,7 @@ type WAFFixtures struct {
 }
 
 // NewWAFFixtures constructs WAFFixtures from the canonical demo data.
-func NewWAFFixtures() *WAFFixtures {
+var sharedWAFFixtures = sync.OnceValue(func() *WAFFixtures {
 	return &WAFFixtures{
 		WebACLSummaries: []wafv2types.WebACLSummary{
 			{
@@ -51,4 +52,8 @@ func NewWAFFixtures() *WAFFixtures {
 			},
 		},
 	}
+})
+
+func NewWAFFixtures() *WAFFixtures {
+	return sharedWAFFixtures()
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -177,7 +177,8 @@ func New(profile, region string, opts ...Option) Model {
 	// Load view config synchronously (fast local file read).
 	cfg, cfgErr := config.Load()
 	if cfg == nil {
-		cfg = config.DefaultConfig()
+		// Use the shared read-only default — tui.Model never mutates viewConfig.
+		cfg = config.SharedDefaultConfig()
 	}
 
 	// Create the app-wide context first so it can be passed to AWS client

--- a/tests/unit/bug_report_regressions_test.go
+++ b/tests/unit/bug_report_regressions_test.go
@@ -19,11 +19,10 @@ var defaultEC2RelatedDefs = append([]resource.RelatedDef(nil), resource.GetRelat
 func TestBug_RightColumnFilter_SlashFiltersAndEscapeClears(t *testing.T) {
 	ensureNoColor(t)
 
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: resource.NoopChecker},
 		{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: resource.NoopChecker},
 	})
-	t.Cleanup(func() { resource.UnregisterRelated("ec2") })
 
 	d := makeDetailForFocusTest(t, 140)
 	d = makeExplicitlyVisible(d)
@@ -52,11 +51,10 @@ func TestBug_RightColumnFilter_SlashFiltersAndEscapeClears(t *testing.T) {
 func TestBug_AllZeroRelatedRows_DoNotAllowRightColumnFocus(t *testing.T) {
 	ensureNoColor(t)
 
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: resource.NoopChecker},
 		{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: resource.NoopChecker},
 	})
-	t.Cleanup(func() { resource.UnregisterRelated("ec2") })
 
 	d := makeDetailForFocusTest(t, 140)
 	d = makeExplicitlyVisible(d)
@@ -87,10 +85,9 @@ func TestBug_AllZeroRelatedRows_DoNotAllowRightColumnFocus(t *testing.T) {
 func TestBug_FirstToggleRelated_HidesAutoShownColumn(t *testing.T) {
 	ensureNoColor(t)
 
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: resource.NoopChecker},
 	})
-	t.Cleanup(func() { resource.UnregisterRelated("ec2") })
 
 	d := makeDetailForFocusTest(t, 140)
 	if !strings.Contains(stripAnsi(d.View()), "RELATED") {

--- a/tests/unit/detail_focus_test.go
+++ b/tests/unit/detail_focus_test.go
@@ -113,11 +113,10 @@ func TestDetail_TabSwitchesFocus(t *testing.T) {
 	noopChecker := func(_ context.Context, _ any, _ resource.Resource, _ resource.ResourceCache) resource.RelatedCheckResult {
 		return resource.RelatedCheckResult{Count: 0}
 	}
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		{TargetType: "vpc", DisplayName: "VPCs", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailForFocusTest(t, 140)
 
@@ -153,10 +152,9 @@ func TestDetail_TabTogglesFocusOff(t *testing.T) {
 	noopChecker := func(_ context.Context, _ any, _ resource.Resource, _ resource.ResourceCache) resource.RelatedCheckResult {
 		return resource.RelatedCheckResult{Count: 0}
 	}
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailForFocusTest(t, 140)
 
@@ -201,7 +199,7 @@ func TestDetail_TabTogglesFocusOff(t *testing.T) {
 
 func TestDetail_TabWithoutRightCol_IsNoop(t *testing.T) {
 	// No RelatedDefs needed — at width=80 right col is never shown regardless.
-	resource.UnregisterRelated("ec2")
+	unregisterEC2Related(t)
 
 	d := makeDetailForFocusTest(t, 80)
 	viewBefore := d.View()
@@ -220,7 +218,7 @@ func TestDetail_TabWithoutRightCol_IsNoop(t *testing.T) {
 // TestDetail_TabWithoutRightCol_NoPanicOnNarrowTerminal verifies no panic at
 // extreme narrow width (40 columns).
 func TestDetail_TabWithoutRightCol_NoPanicOnNarrowTerminal(t *testing.T) {
-	resource.UnregisterRelated("ec2")
+	unregisterEC2Related(t)
 
 	d := makeDetailForFocusTest(t, 40)
 
@@ -248,11 +246,10 @@ func TestDetail_RightColFocused_EnterEmitsNavigateMsg(t *testing.T) {
 	noopChecker := func(_ context.Context, _ any, _ resource.Resource, _ resource.ResourceCache) resource.RelatedCheckResult {
 		return resource.RelatedCheckResult{Count: 0}
 	}
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		{TargetType: "vpc", DisplayName: "VPCs", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailForFocusTest(t, 140)
 
@@ -308,10 +305,9 @@ func TestDetail_RightColFocused_EnterEmitsNavigateMsg_ExactTargetType(t *testing
 	noopChecker := func(_ context.Context, _ any, _ resource.Resource, _ resource.ResourceCache) resource.RelatedCheckResult {
 		return resource.RelatedCheckResult{Count: 0}
 	}
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "asg", DisplayName: "Auto Scaling Groups", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailForFocusTest(t, 140)
 
@@ -364,10 +360,9 @@ func TestDetail_RightColFocused_EscUnfocuses(t *testing.T) {
 	noopChecker := func(_ context.Context, _ any, _ resource.Resource, _ resource.ResourceCache) resource.RelatedCheckResult {
 		return resource.RelatedCheckResult{Count: 0}
 	}
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailForFocusTest(t, 140)
 
@@ -403,10 +398,9 @@ func TestDetail_RightColFocused_EscDoesNotHidePanel(t *testing.T) {
 	noopChecker := func(_ context.Context, _ any, _ resource.Resource, _ resource.ResourceCache) resource.RelatedCheckResult {
 		return resource.RelatedCheckResult{Count: 0}
 	}
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailForFocusTest(t, 140)
 
@@ -433,7 +427,7 @@ func TestDetail_RightColFocused_EscDoesNotHidePanel(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDetail_Tab_NoRelatedDefs_IsNoop(t *testing.T) {
-	resource.UnregisterRelated("ec2")
+	unregisterEC2Related(t)
 
 	d := makeDetailForFocusTest(t, 140)
 	viewBefore := d.View()
@@ -465,10 +459,9 @@ func TestDetail_FocusSequence_TabTabRestores(t *testing.T) {
 	noopChecker := func(_ context.Context, _ any, _ resource.Resource, _ resource.ResourceCache) resource.RelatedCheckResult {
 		return resource.RelatedCheckResult{Count: 0}
 	}
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailForFocusTest(t, 140)
 	if !strings.Contains(d.View(), "RELATED") {

--- a/tests/unit/detail_navigable_test.go
+++ b/tests/unit/detail_navigable_test.go
@@ -84,10 +84,9 @@ func TestDetail_NavigableField_HighlightedInView(t *testing.T) {
 	styles.Reinit()
 	t.Cleanup(func() { styles.Reinit() })
 
-	resource.RegisterNavigableFields("ec2", []resource.NavigableField{
+	replaceEC2NavigableFields(t, []resource.NavigableField{
 		{FieldPath: "VpcId", TargetType: "vpc"},
 	})
-	defer resource.UnregisterNavigableFields("ec2")
 
 	d := makeNavDetail(140, 30)
 
@@ -126,10 +125,9 @@ func TestDetail_NavigableField_HighlightedInView(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDetail_NavigableField_EnterEmitsNavigateMsg(t *testing.T) {
-	resource.RegisterNavigableFields("ec2", []resource.NavigableField{
+	replaceEC2NavigableFields(t, []resource.NavigableField{
 		{FieldPath: "VpcId", TargetType: "vpc"},
 	})
-	defer resource.UnregisterNavigableFields("ec2")
 
 	// Use a narrow-enough width that the right column is NOT auto-shown (< 100).
 	// That prevents rightColAutoShown, so the right column is not focused and
@@ -165,8 +163,11 @@ func TestDetail_NavigableField_EnterEmitsNavigateMsg(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDetail_NonNavigableField_EnterIsNoop(t *testing.T) {
-	// Deliberately do NOT register navigable fields for "ec2".
-	// VpcId is present in the config but has no navigable registration.
+	// Deliberately strip ec2 navigable fields for this test — production
+	// init() registers some by default, so the assertion only holds when
+	// the registry is explicitly cleared (and restored on cleanup).
+	unregisterEC2NavigableFields(t)
+
 	d := makeNavDetail(80, 30)
 
 	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
@@ -185,11 +186,10 @@ func TestDetail_NonNavigableField_EnterIsNoop(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestIsFieldNavigable_MatchFound(t *testing.T) {
-	resource.RegisterNavigableFields("ec2", []resource.NavigableField{
+	replaceEC2NavigableFields(t, []resource.NavigableField{
 		{FieldPath: "VpcId", TargetType: "vpc"},
 		{FieldPath: "SubnetId", TargetType: "subnet"},
 	})
-	defer resource.UnregisterNavigableFields("ec2")
 
 	f := resource.IsFieldNavigable("ec2", "VpcId")
 	if f == nil {
@@ -201,10 +201,9 @@ func TestIsFieldNavigable_MatchFound(t *testing.T) {
 }
 
 func TestIsFieldNavigable_NoMatch(t *testing.T) {
-	resource.RegisterNavigableFields("ec2", []resource.NavigableField{
+	replaceEC2NavigableFields(t, []resource.NavigableField{
 		{FieldPath: "VpcId", TargetType: "vpc"},
 	})
-	defer resource.UnregisterNavigableFields("ec2")
 
 	f := resource.IsFieldNavigable("ec2", "SubnetId")
 	if f != nil {

--- a/tests/unit/detail_related_test.go
+++ b/tests/unit/detail_related_test.go
@@ -60,10 +60,9 @@ func pressToggleRelated(d views.DetailModel) (views.DetailModel, func() any) {
 // ---------------------------------------------------------------------------
 
 func TestDetail_ToggleRelated_FirstPressHidesAutoShown(t *testing.T) {
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailForToggleTest(t, 140)
 	before := d.View()
@@ -88,10 +87,9 @@ func TestDetail_ToggleRelated_FirstPressHidesAutoShown(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDetail_ToggleRelated_SecondPressShows(t *testing.T) {
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailForToggleTest(t, 140)
 
@@ -125,10 +123,9 @@ func TestDetail_ToggleRelated_SecondPressShows(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDetail_ToggleRelated_NarrowTerminal(t *testing.T) {
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailForToggleTest(t, 80)
 	_, rawCmd := pressToggleRelated(d)
@@ -149,10 +146,9 @@ func TestDetail_ToggleRelated_NarrowTerminal(t *testing.T) {
 func TestDetail_RelatedCheckResult_UpdatesRightCol(t *testing.T) {
 	ensureNoColor(t)
 
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	// SetSize with width=140 and registered defs auto-shows the right column.
 	d := makeDetailForToggleTest(t, 140)
@@ -184,7 +180,7 @@ func TestDetail_RelatedCheckResult_UpdatesRightCol(t *testing.T) {
 
 func TestDetail_ToggleRelated_NoDefsRegistered(t *testing.T) {
 	// Guarantee no defs are registered for "ec2".
-	resource.UnregisterRelated("ec2")
+	unregisterEC2Related(t)
 
 	d := makeDetailForToggleTest(t, 140)
 	_, rawCmd := pressToggleRelated(d)

--- a/tests/unit/detail_rendering_spec007_test.go
+++ b/tests/unit/detail_rendering_spec007_test.go
@@ -84,10 +84,9 @@ func make007NavDetailWithColors(t *testing.T, width, height int) views.DetailMod
 // register007EC2Defs registers one RelatedDef for "ec2" and returns cleanup.
 func register007EC2Defs(t *testing.T) {
 	t.Helper()
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 	})
-	t.Cleanup(func() { resource.UnregisterRelated("ec2") })
 }
 
 // ---------------------------------------------------------------------------
@@ -143,8 +142,7 @@ func TestDetail_007_SeparatorPresent_RightFocused(t *testing.T) {
 // Must continue to pass after fix.
 func TestDetail_007_SeparatorAbsent_NoRightCol(t *testing.T) {
 	// Explicitly ensure no related defs are registered for "ec2".
-	resource.UnregisterRelated("ec2")
-	t.Cleanup(func() { resource.UnregisterRelated("ec2") })
+	unregisterEC2Related(t)
 
 	d := make007EC2Detail(120, 30, nil)
 	view := d.View()
@@ -186,11 +184,8 @@ func TestDetail_007_SubField_RendersKeyAndValue(t *testing.T) {
 	styles.Reinit()
 	t.Cleanup(func() { styles.Reinit() })
 	resource.UnregisterNavigableFields("ec2")
-	resource.UnregisterRelated("ec2")
-	t.Cleanup(func() {
-		resource.UnregisterNavigableFields("ec2")
-		resource.UnregisterRelated("ec2")
-	})
+	defer resource.UnregisterNavigableFields("ec2")
+	unregisterEC2Related(t)
 
 	// Register a multi-line field: Tags as a YAML-like string with sub-entries.
 	// We inject Tags directly into Fields as a multi-line value so ExtractFieldList

--- a/tests/unit/detail_review_fixes_test.go
+++ b/tests/unit/detail_review_fixes_test.go
@@ -211,10 +211,9 @@ func TestDetail_TabOnAutoShownPanel_ThenTabUnfocuses(t *testing.T) {
 // TargetType from the field at index 3 (SubnetId → "subnet"), NOT from index 0.
 func TestDetail_FieldCursorIndependentFromScroll(t *testing.T) {
 	// Register NavigableField for "SubnetId" → "subnet" (path index 2 in 0-based).
-	resource.RegisterNavigableFields("ec2", []resource.NavigableField{
+	replaceEC2NavigableFields(t, []resource.NavigableField{
 		{FieldPath: "SubnetId", TargetType: "subnet"},
 	})
-	defer resource.UnregisterNavigableFields("ec2")
 
 	// Ensure no related defs so right column isn't shown (avoids Tab interactions).
 	unregisterEC2Related(t)
@@ -258,10 +257,9 @@ func TestDetail_FieldCursorIndependentFromScroll(t *testing.T) {
 // Enter should always reference a valid field (no panic, no index out of range).
 func TestDetail_FieldCursorClamps(t *testing.T) {
 	// Register a navigable field so Enter has something to fire on.
-	resource.RegisterNavigableFields("ec2", []resource.NavigableField{
+	replaceEC2NavigableFields(t, []resource.NavigableField{
 		{FieldPath: "InstanceId", TargetType: "ec2"},
 	})
-	defer resource.UnregisterNavigableFields("ec2")
 
 	unregisterEC2Related(t)
 
@@ -305,11 +303,10 @@ func TestDetail_FieldCursorClamps(t *testing.T) {
 // TestDetail_FieldCursorDown_TwoFieldsClamps verifies the two-field boundary.
 // With only 2 fields, pressing j once lands at index 1, pressing again stays at 1.
 func TestDetail_FieldCursorDown_TwoFieldsClamps(t *testing.T) {
-	resource.RegisterNavigableFields("ec2", []resource.NavigableField{
+	replaceEC2NavigableFields(t, []resource.NavigableField{
 		{FieldPath: "InstanceId", TargetType: "ec2"},
 		{FieldPath: "VpcId", TargetType: "vpc"},
 	})
-	defer resource.UnregisterNavigableFields("ec2")
 	unregisterEC2Related(t)
 
 	// 2-field config.
@@ -356,10 +353,9 @@ func TestDetail_FieldCursorDown_TwoFieldsClamps(t *testing.T) {
 // TestDetail_FieldCursorUp_AtZeroStaysZero verifies pressing k at index 0 keeps
 // the cursor at 0 and Enter still fires on the first field.
 func TestDetail_FieldCursorUp_AtZeroStaysZero(t *testing.T) {
-	resource.RegisterNavigableFields("ec2", []resource.NavigableField{
+	replaceEC2NavigableFields(t, []resource.NavigableField{
 		{FieldPath: "InstanceId", TargetType: "ec2"},
 	})
-	defer resource.UnregisterNavigableFields("ec2")
 	unregisterEC2Related(t)
 
 	d := makeDetailNarrow(t)

--- a/tests/unit/detail_review_fixes_test.go
+++ b/tests/unit/detail_review_fixes_test.go
@@ -98,10 +98,18 @@ func pressTabDetail(d views.DetailModel) (views.DetailModel, tea.Cmd) {
 	return d.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 }
 
-// registerEC2Defs registers one RelatedDef for "ec2" and returns a cleanup func.
+// registerEC2Defs registers one RelatedDef for "ec2" and returns a cleanup func
+// that restores the original defs so test order (shuffle) doesn't matter.
 func registerEC2Defs(defs []resource.RelatedDef) func() {
+	orig := resource.GetRelated("ec2")
 	resource.RegisterRelated("ec2", defs)
-	return func() { resource.UnregisterRelated("ec2") }
+	return func() {
+		if orig == nil {
+			resource.UnregisterRelated("ec2")
+		} else {
+			resource.RegisterRelated("ec2", orig)
+		}
+	}
 }
 
 // deliverResult delivers a RelatedCheckResultMsg to the DetailModel.
@@ -209,7 +217,7 @@ func TestDetail_FieldCursorIndependentFromScroll(t *testing.T) {
 	defer resource.UnregisterNavigableFields("ec2")
 
 	// Ensure no related defs so right column isn't shown (avoids Tab interactions).
-	resource.UnregisterRelated("ec2")
+	unregisterEC2Related(t)
 
 	// Width=80, height=5: not all 10 fields visible simultaneously.
 	d := makeDetailNarrow(t)
@@ -255,7 +263,7 @@ func TestDetail_FieldCursorClamps(t *testing.T) {
 	})
 	defer resource.UnregisterNavigableFields("ec2")
 
-	resource.UnregisterRelated("ec2")
+	unregisterEC2Related(t)
 
 	d := makeDetailNarrow(t)
 
@@ -302,7 +310,7 @@ func TestDetail_FieldCursorDown_TwoFieldsClamps(t *testing.T) {
 		{FieldPath: "VpcId", TargetType: "vpc"},
 	})
 	defer resource.UnregisterNavigableFields("ec2")
-	resource.UnregisterRelated("ec2")
+	unregisterEC2Related(t)
 
 	// 2-field config.
 	cfg := &config.ViewsConfig{
@@ -352,7 +360,7 @@ func TestDetail_FieldCursorUp_AtZeroStaysZero(t *testing.T) {
 		{FieldPath: "InstanceId", TargetType: "ec2"},
 	})
 	defer resource.UnregisterNavigableFields("ec2")
-	resource.UnregisterRelated("ec2")
+	unregisterEC2Related(t)
 
 	d := makeDetailNarrow(t)
 

--- a/tests/unit/ec2_stories_rightcol_misc_test.go
+++ b/tests/unit/ec2_stories_rightcol_misc_test.go
@@ -61,7 +61,8 @@ func ec2StoryDetail(t *testing.T, width, height int, withDefs bool) (views.Detai
 			"State":        "running",
 		},
 	}
-	cleanup := func() {}
+	origEC2Defs := resource.GetRelated("ec2")
+	restoreEC2 := func() { resource.RegisterRelated("ec2", origEC2Defs) }
 	if withDefs {
 		resource.RegisterRelated("ec2", []resource.RelatedDef{
 			{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
@@ -69,14 +70,13 @@ func ec2StoryDetail(t *testing.T, width, height int, withDefs bool) (views.Detai
 			{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: noopChecker},
 			{TargetType: "cfn", DisplayName: "CloudFormation Stacks", Checker: noopChecker},
 		})
-		cleanup = func() { resource.UnregisterRelated("ec2") }
 	} else {
-		resource.UnregisterRelated("ec2")
+		resource.RegisterRelated("ec2", nil)
 	}
 	k := keys.Default()
 	d := views.NewDetail(res, "ec2", nil, k)
 	d.SetSize(width, height)
-	return d, cleanup
+	return d, restoreEC2
 }
 
 // ec2StoryDetailWithConfig builds a DetailModel with a ViewsConfig and nav fields.
@@ -101,20 +101,18 @@ func ec2StoryDetailWithConfig(t *testing.T, width, height int, withDefs bool) (v
 	resource.RegisterNavigableFields("ec2", []resource.NavigableField{
 		{FieldPath: "VpcId", TargetType: "vpc"},
 	})
-	cleanup := func() {
-		resource.UnregisterNavigableFields("ec2")
-	}
+	origEC2Defs2 := resource.GetRelated("ec2")
 	if withDefs {
 		resource.RegisterRelated("ec2", []resource.RelatedDef{
 			{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 			{TargetType: "asg", DisplayName: "Auto Scaling Groups", Checker: noopChecker},
 		})
-		cleanup = func() {
-			resource.UnregisterNavigableFields("ec2")
-			resource.UnregisterRelated("ec2")
-		}
 	} else {
-		resource.UnregisterRelated("ec2")
+		resource.RegisterRelated("ec2", nil)
+	}
+	cleanup := func() {
+		resource.UnregisterNavigableFields("ec2")
+		resource.RegisterRelated("ec2", origEC2Defs2)
 	}
 	k := keys.Default()
 	d := views.NewDetail(res, "ec2", cfg, k)
@@ -853,11 +851,10 @@ func TestEC2_051_CopyFromRightCol(t *testing.T) {
 // RelatedCheckStartedMsg to restart background checks.
 func TestEC2_052_CtrlR_Refresh(t *testing.T) {
 	// Ensure EC2 related defs are registered (prior tests may unregister them).
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		{TargetType: "asg", DisplayName: "Auto Scaling Groups", Checker: noopChecker},
 	})
-	t.Cleanup(func() { resource.UnregisterRelated("ec2") })
 
 	m := tui.New("demo", "us-east-1",
 		tui.WithClients(demo.NewServiceClients()),
@@ -1069,6 +1066,7 @@ func TestEC2_056_YAMLViewFullWidth(t *testing.T) {
 // in the detail view scrolls the viewport downward (or advances cursor by ~page).
 // We verify this by checking that View() content changes after PageDown.
 func TestEC2_057_PageDownMovesViewport(t *testing.T) {
+	unregisterEC2Related(t)
 	// Use a resource with many fields so there's content to scroll.
 	res := resource.Resource{
 		ID:   "i-0a1b2c3d4e5f60001",
@@ -1097,7 +1095,6 @@ func TestEC2_057_PageDownMovesViewport(t *testing.T) {
 		},
 	}
 
-	resource.UnregisterRelated("ec2")
 	k := keys.Default()
 	d := views.NewDetail(res, "ec2", nil, k)
 	// Height=8 ensures not all fields visible at once (20 fields > 8 rows).
@@ -1117,6 +1114,7 @@ func TestEC2_057_PageDownMovesViewport(t *testing.T) {
 // TestEC2_057_PageUpMovesViewport verifies that after scrolling down,
 // pressing Ctrl+U (PageUp) changes the viewport content.
 func TestEC2_057_PageUpMovesViewport(t *testing.T) {
+	unregisterEC2Related(t)
 	res := resource.Resource{
 		ID:   "i-0a1b2c3d4e5f60001",
 		Name: "web-prod-01",
@@ -1144,7 +1142,6 @@ func TestEC2_057_PageUpMovesViewport(t *testing.T) {
 		},
 	}
 
-	resource.UnregisterRelated("ec2")
 	k := keys.Default()
 	d := views.NewDetail(res, "ec2", nil, k)
 	d.SetSize(80, 8)

--- a/tests/unit/issue119_scenarios_golden_test.go
+++ b/tests/unit/issue119_scenarios_golden_test.go
@@ -390,7 +390,7 @@ func sortedIssue119Names(m map[string]string) []string {
 func withIssue119EC2Defs(t *testing.T, fn func() string) string {
 	t.Helper()
 	oldDefs := append([]resource.RelatedDef(nil), resource.GetRelated("ec2")...)
-	oldNav := append([]resource.NavigableField(nil), resource.GetNavigableFields("ec2")...)
+	oldNav := append([]resource.NavigableField(nil), resource.GetActiveNavigableFields("ec2")...)
 	resource.RegisterRelated("ec2", []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		{TargetType: "asg", DisplayName: "Auto Scaling Groups", Checker: noopChecker},
@@ -410,7 +410,11 @@ func withIssue119EC2Defs(t *testing.T, fn func() string) string {
 	})
 	defer func() {
 		resource.RegisterRelated("ec2", oldDefs)
-		resource.RegisterNavigableFields("ec2", oldNav)
+		if len(oldNav) == 0 {
+			resource.UnregisterNavigableFields("ec2")
+		} else {
+			resource.RegisterNavigableFields("ec2", oldNav)
+		}
 	}()
 	return fn()
 }

--- a/tests/unit/issue140_scenarios_golden_test.go
+++ b/tests/unit/issue140_scenarios_golden_test.go
@@ -321,7 +321,7 @@ func TestIssue140ScenarioCatalog(t *testing.T) {
 func withScenarioEC2Defs(t *testing.T, fn func() string) string {
 	t.Helper()
 	oldDefs := append([]resource.RelatedDef(nil), resource.GetRelated("ec2")...)
-	oldNav := append([]resource.NavigableField(nil), resource.GetNavigableFields("ec2")...)
+	oldNav := append([]resource.NavigableField(nil), resource.GetActiveNavigableFields("ec2")...)
 	resource.RegisterRelated("ec2", []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		{TargetType: "asg", DisplayName: "Auto Scaling Groups", Checker: noopChecker},
@@ -341,7 +341,11 @@ func withScenarioEC2Defs(t *testing.T, fn func() string) string {
 	})
 	defer func() {
 		resource.RegisterRelated("ec2", oldDefs)
-		resource.RegisterNavigableFields("ec2", oldNav)
+		if len(oldNav) == 0 {
+			resource.UnregisterNavigableFields("ec2")
+		} else {
+			resource.RegisterNavigableFields("ec2", oldNav)
+		}
 	}()
 	return fn()
 }

--- a/tests/unit/issue140_story_render_contract_test.go
+++ b/tests/unit/issue140_story_render_contract_test.go
@@ -262,7 +262,7 @@ func TestIssue140_Story_EC2_029_FilteredAlarmListTitleAndScope(t *testing.T) {
 func withIssue140EC2RelatedDefs(t *testing.T) {
 	t.Helper()
 	oldDefs := append([]resource.RelatedDef(nil), resource.GetRelated("ec2")...)
-	oldNav := append([]resource.NavigableField(nil), resource.GetNavigableFields("ec2")...)
+	oldNav := append([]resource.NavigableField(nil), resource.GetActiveNavigableFields("ec2")...)
 	resource.RegisterRelated("ec2", []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		{TargetType: "asg", DisplayName: "Auto Scaling Groups", Checker: noopChecker},
@@ -282,7 +282,11 @@ func withIssue140EC2RelatedDefs(t *testing.T) {
 	})
 	t.Cleanup(func() {
 		resource.RegisterRelated("ec2", oldDefs)
-		resource.RegisterNavigableFields("ec2", oldNav)
+		if len(oldNav) == 0 {
+			resource.UnregisterNavigableFields("ec2")
+		} else {
+			resource.RegisterNavigableFields("ec2", oldNav)
+		}
 	})
 }
 

--- a/tests/unit/qa_bottom_hints_test.go
+++ b/tests/unit/qa_bottom_hints_test.go
@@ -328,10 +328,9 @@ type testNavDetailEC2 struct {
 }
 
 func TestBottomHints_Detail_NavigableField(t *testing.T) {
-	resource.RegisterNavigableFields("ec2", []resource.NavigableField{
+	replaceEC2NavigableFields(t, []resource.NavigableField{
 		{FieldPath: "VpcId", TargetType: "vpc"},
 	})
-	t.Cleanup(func() { resource.UnregisterNavigableFields("ec2") })
 
 	vpcID := "vpc-test456"
 	res := resource.Resource{

--- a/tests/unit/qa_keymatch_dual_path_test.go
+++ b/tests/unit/qa_keymatch_dual_path_test.go
@@ -334,10 +334,9 @@ func TestQA_DetailKeyMatch_YEmitsYAMLNavigate_BothPaths(t *testing.T) {
 func TestQA_DetailKeyMatch_RTogglesRightCol_BothPaths(t *testing.T) {
 	checkRToggle := func(t *testing.T, rMsg tea.Msg, path string) {
 		t.Helper()
-		resource.RegisterRelated("ec2", []resource.RelatedDef{
+		replaceEC2Related(t, []resource.RelatedDef{
 			{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		})
-		defer resource.UnregisterRelated("ec2")
 
 		d := makeDetailDualPathWideEC2(t)
 
@@ -458,10 +457,9 @@ func TestQA_DetailKeyMatch_EscClearsSearch_BothPaths(t *testing.T) {
 func TestQA_DetailKeyMatch_TabFocusesRightCol_BothPaths(t *testing.T) {
 	checkTabFocus := func(t *testing.T, tabMsg tea.Msg, path string) {
 		t.Helper()
-		resource.RegisterRelated("ec2", []resource.RelatedDef{
+		replaceEC2Related(t, []resource.RelatedDef{
 			{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		})
-		defer resource.UnregisterRelated("ec2")
 
 		d := makeDetailDualPathWideEC2(t)
 
@@ -537,10 +535,9 @@ func TestQA_DetailKeyMatch_WTogglesWrap_BothPaths(t *testing.T) {
 func TestQA_DetailKeyMatch_TabUnfocusesRightCol_BothPaths(t *testing.T) {
 	checkTabUnfocus := func(t *testing.T, tabMsg tea.Msg, path string) {
 		t.Helper()
-		resource.RegisterRelated("ec2", []resource.RelatedDef{
+		replaceEC2Related(t, []resource.RelatedDef{
 			{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		})
-		defer resource.UnregisterRelated("ec2")
 
 		d := makeDetailDualPathWideEC2(t)
 
@@ -580,10 +577,9 @@ func TestQA_DetailKeyMatch_TabUnfocusesRightCol_BothPaths(t *testing.T) {
 func TestQA_DetailKeyMatch_EscUnfocusesRightCol_BothPaths(t *testing.T) {
 	checkEscUnfocus := func(t *testing.T, escMsg tea.Msg, path string) {
 		t.Helper()
-		resource.RegisterRelated("ec2", []resource.RelatedDef{
+		replaceEC2Related(t, []resource.RelatedDef{
 			{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		})
-		defer resource.UnregisterRelated("ec2")
 
 		d := makeDetailDualPathWideEC2(t)
 
@@ -632,7 +628,7 @@ func TestQA_DetailKeyMatch_EscUnfocusesRightCol_BothPaths(t *testing.T) {
 func TestQA_DetailKeyMatch_RightColFocused_JMovesDown_BothPaths(t *testing.T) {
 	setupFocusedRightColTwoActionableRows := func(t *testing.T) views.DetailModel {
 		t.Helper()
-		resource.RegisterRelated("ec2", []resource.RelatedDef{
+		replaceEC2Related(t, []resource.RelatedDef{
 			{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 			{TargetType: "vpc", DisplayName: "VPCs", Checker: noopChecker},
 		})
@@ -662,11 +658,10 @@ func TestQA_DetailKeyMatch_RightColFocused_JMovesDown_BothPaths(t *testing.T) {
 	}
 
 	t.Run("KeyPressMsg", func(t *testing.T) {
-		resource.RegisterRelated("ec2", []resource.RelatedDef{
+		replaceEC2Related(t, []resource.RelatedDef{
 			{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 			{TargetType: "vpc", DisplayName: "VPCs", Checker: noopChecker},
 		})
-		defer resource.UnregisterRelated("ec2")
 
 		d := setupFocusedRightColTwoActionableRows(t)
 		viewBefore := d.View()
@@ -680,11 +675,10 @@ func TestQA_DetailKeyMatch_RightColFocused_JMovesDown_BothPaths(t *testing.T) {
 	})
 
 	t.Run("KeyReleaseMsg", func(t *testing.T) {
-		resource.RegisterRelated("ec2", []resource.RelatedDef{
+		replaceEC2Related(t, []resource.RelatedDef{
 			{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 			{TargetType: "vpc", DisplayName: "VPCs", Checker: noopChecker},
 		})
-		defer resource.UnregisterRelated("ec2")
 
 		d := setupFocusedRightColTwoActionableRows(t)
 		viewBefore := d.View()
@@ -707,7 +701,7 @@ func TestQA_DetailKeyMatch_RightColFocused_JMovesDown_BothPaths(t *testing.T) {
 func TestQA_DetailKeyMatch_RightColFocused_KMovesUp_BothPaths(t *testing.T) {
 	setupFocusedRightColAtSecondRow := func(t *testing.T) views.DetailModel {
 		t.Helper()
-		resource.RegisterRelated("ec2", []resource.RelatedDef{
+		replaceEC2Related(t, []resource.RelatedDef{
 			{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 			{TargetType: "vpc", DisplayName: "VPCs", Checker: noopChecker},
 		})
@@ -739,11 +733,10 @@ func TestQA_DetailKeyMatch_RightColFocused_KMovesUp_BothPaths(t *testing.T) {
 	}
 
 	t.Run("KeyPressMsg", func(t *testing.T) {
-		resource.RegisterRelated("ec2", []resource.RelatedDef{
+		replaceEC2Related(t, []resource.RelatedDef{
 			{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 			{TargetType: "vpc", DisplayName: "VPCs", Checker: noopChecker},
 		})
-		defer resource.UnregisterRelated("ec2")
 
 		d := setupFocusedRightColAtSecondRow(t)
 		viewAtSecond := d.View()
@@ -757,11 +750,10 @@ func TestQA_DetailKeyMatch_RightColFocused_KMovesUp_BothPaths(t *testing.T) {
 	})
 
 	t.Run("KeyReleaseMsg", func(t *testing.T) {
-		resource.RegisterRelated("ec2", []resource.RelatedDef{
+		replaceEC2Related(t, []resource.RelatedDef{
 			{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 			{TargetType: "vpc", DisplayName: "VPCs", Checker: noopChecker},
 		})
-		defer resource.UnregisterRelated("ec2")
 
 		d := setupFocusedRightColAtSecondRow(t)
 		viewAtSecond := d.View()
@@ -786,7 +778,7 @@ func TestQA_DetailKeyMatch_RightColFocused_KMovesUp_BothPaths(t *testing.T) {
 func TestQA_DetailKeyMatch_RightColFocused_SlashActivatesFilter_BothPaths(t *testing.T) {
 	setupFocusedRightColWithResults := func(t *testing.T) views.DetailModel {
 		t.Helper()
-		resource.RegisterRelated("ec2", []resource.RelatedDef{
+		replaceEC2Related(t, []resource.RelatedDef{
 			{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		})
 		d := makeDetailDualPathWideEC2(t)
@@ -826,18 +818,16 @@ func TestQA_DetailKeyMatch_RightColFocused_SlashActivatesFilter_BothPaths(t *tes
 	}
 
 	t.Run("KeyPressMsg", func(t *testing.T) {
-		resource.RegisterRelated("ec2", []resource.RelatedDef{
+		replaceEC2Related(t, []resource.RelatedDef{
 			{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		})
-		defer resource.UnregisterRelated("ec2")
 		checkSlashFilter(t, tea.KeyPressMsg{Code: -1, Text: "/"}, "KeyPressMsg")
 	})
 
 	t.Run("KeyReleaseMsg", func(t *testing.T) {
-		resource.RegisterRelated("ec2", []resource.RelatedDef{
+		replaceEC2Related(t, []resource.RelatedDef{
 			{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		})
-		defer resource.UnregisterRelated("ec2")
 		checkSlashFilter(t, pressKeyRelease("/"), "KeyReleaseMsg")
 	})
 }
@@ -851,7 +841,7 @@ func TestQA_DetailKeyMatch_RightColFocused_SlashActivatesFilter_BothPaths(t *tes
 func TestQA_DetailKeyMatch_RightColFocused_EnterEmitsNavigate_BothPaths(t *testing.T) {
 	setupFocusedRightColActionable := func(t *testing.T) views.DetailModel {
 		t.Helper()
-		resource.RegisterRelated("ec2", []resource.RelatedDef{
+		replaceEC2Related(t, []resource.RelatedDef{
 			{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		})
 		d := makeDetailDualPathWideEC2(t)
@@ -894,18 +884,16 @@ func TestQA_DetailKeyMatch_RightColFocused_EnterEmitsNavigate_BothPaths(t *testi
 	}
 
 	t.Run("KeyPressMsg", func(t *testing.T) {
-		resource.RegisterRelated("ec2", []resource.RelatedDef{
+		replaceEC2Related(t, []resource.RelatedDef{
 			{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		})
-		defer resource.UnregisterRelated("ec2")
 		assertEnterOnRightCol(t, tea.KeyPressMsg{Code: tea.KeyEnter}, "KeyPressMsg")
 	})
 
 	t.Run("KeyReleaseMsg", func(t *testing.T) {
-		resource.RegisterRelated("ec2", []resource.RelatedDef{
+		replaceEC2Related(t, []resource.RelatedDef{
 			{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		})
-		defer resource.UnregisterRelated("ec2")
 		assertEnterOnRightCol(t, pressSpecialKeyRelease(tea.KeyEnter), "KeyReleaseMsg")
 	})
 }
@@ -919,11 +907,10 @@ func TestQA_DetailKeyMatch_RightColFocused_EnterEmitsNavigate_BothPaths(t *testi
 // TestQA_RightCol_UpdateKeyMsg_JMovesDown verifies j via KeyReleaseMsg moves
 // the right column cursor when focused.
 func TestQA_RightCol_UpdateKeyMsg_JMovesDown(t *testing.T) {
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "aaa", DisplayName: "AAA Resources", Checker: noopChecker},
 		{TargetType: "bbb", DisplayName: "BBB Resources", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailDualPathWideEC2(t)
 	if !strings.Contains(d.View(), "RELATED") {
@@ -962,11 +949,10 @@ func TestQA_RightCol_UpdateKeyMsg_JMovesDown(t *testing.T) {
 
 // TestQA_RightCol_UpdateKeyMsg_KMovesUp verifies k via KeyReleaseMsg in the right column.
 func TestQA_RightCol_UpdateKeyMsg_KMovesUp(t *testing.T) {
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "aaa", DisplayName: "AAA Resources", Checker: noopChecker},
 		{TargetType: "bbb", DisplayName: "BBB Resources", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailDualPathWideEC2(t)
 	if !strings.Contains(d.View(), "RELATED") {
@@ -1007,10 +993,9 @@ func TestQA_RightCol_UpdateKeyMsg_KMovesUp(t *testing.T) {
 // TestQA_RightCol_UpdateKeyMsg_SlashActivatesFilter verifies / via KeyReleaseMsg
 // activates the filter in the right column.
 func TestQA_RightCol_UpdateKeyMsg_SlashActivatesFilter(t *testing.T) {
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "aaa", DisplayName: "AAA Resources", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailDualPathWideEC2(t)
 	if !strings.Contains(d.View(), "RELATED") {

--- a/tests/unit/qa_s3_bucket_policy_parser_test.go
+++ b/tests/unit/qa_s3_bucket_policy_parser_test.go
@@ -29,9 +29,13 @@ import (
 // s3FakeClientsWithPolicies returns a ServiceClients whose S3 fake has
 // BucketPolicies overridden with the per-test map. Enables exercising
 // the bucket-policy parser branches without mutating shared fixtures.
+//
+// Builds a fresh, minimal *S3Fixtures rather than reusing the shared
+// sync.OnceValue singleton — mutating that singleton (via the prior
+// `fix := NewS3Fixtures(); fix.BucketPolicies = policies` pattern)
+// poisoned later tests that rely on the production BucketPolicies map.
 func s3FakeClientsWithPolicies(policies map[string]string) *awsclient.ServiceClients {
-	fix := fixtures.NewS3Fixtures()
-	fix.BucketPolicies = policies
+	fix := &fixtures.S3Fixtures{BucketPolicies: policies}
 	return &awsclient.ServiceClients{S3: fakes.NewS3FromFixtures(fix)}
 }
 

--- a/tests/unit/rightcolumn_test.go
+++ b/tests/unit/rightcolumn_test.go
@@ -93,11 +93,10 @@ func sendRelatedResult(d views.DetailModel, msg messages.RelatedCheckResultMsg) 
 // ---------------------------------------------------------------------------
 
 func TestRightColumn_ToggleShowsRelatedHeader(t *testing.T) {
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		{TargetType: "asg", DisplayName: "Auto Scaling Groups", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailForRelatedTest(t, 140)
 	d = showRelatedPanel(d)
@@ -116,11 +115,10 @@ func TestRightColumn_ToggleShowsRelatedHeader(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestRightColumn_ShowsLoadingState(t *testing.T) {
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		{TargetType: "asg", DisplayName: "Auto Scaling Groups", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailForRelatedTest(t, 140)
 	d = showRelatedPanel(d)
@@ -142,11 +140,10 @@ func TestRightColumn_ShowsLoadingState(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestRightColumn_CountUpdatesOnResult(t *testing.T) {
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		{TargetType: "asg", DisplayName: "Auto Scaling Groups", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailForRelatedTest(t, 140)
 	d = showRelatedPanel(d)
@@ -174,10 +171,9 @@ func TestRightColumn_CountUpdatesOnResult(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestRightColumn_ZeroCountDim(t *testing.T) {
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailForRelatedTest(t, 140)
 	d = showRelatedPanel(d)
@@ -205,10 +201,9 @@ func TestRightColumn_ZeroCountDim(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestRightColumn_ErrorShowsDash(t *testing.T) {
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailForRelatedTest(t, 140)
 	d = showRelatedPanel(d)
@@ -237,11 +232,10 @@ func TestRightColumn_ErrorShowsDash(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestRightColumn_ToggleOffHidesPanel(t *testing.T) {
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		{TargetType: "asg", DisplayName: "Auto Scaling Groups", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailForRelatedTest(t, 140)
 	// Toggle ON
@@ -267,11 +261,10 @@ func TestRightColumn_ToggleOffHidesPanel(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestRightColumn_NarrowTerminalIgnoresToggle(t *testing.T) {
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		{TargetType: "asg", DisplayName: "Auto Scaling Groups", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailForRelatedTest(t, 59)
 	viewBefore := d.View()
@@ -292,7 +285,7 @@ func TestRightColumn_NarrowTerminalIgnoresToggle(t *testing.T) {
 
 func TestRightColumn_EmptyDefsShowsHint(t *testing.T) {
 	// Ensure "ec2" has no related defs registered (clean state)
-	resource.UnregisterRelated("ec2")
+	unregisterEC2Related(t)
 
 	d := makeDetailForRelatedTest(t, 140)
 	d = showRelatedPanel(d)
@@ -318,11 +311,10 @@ func TestRightColumn_EmptyDefsShowsHint(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestRightColumn_MultipleResults_EachUpdatesIndependently(t *testing.T) {
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 		{TargetType: "asg", DisplayName: "Auto Scaling Groups", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailForRelatedTest(t, 140)
 	d = showRelatedPanel(d)
@@ -362,10 +354,9 @@ func TestRightColumn_MultipleResults_EachUpdatesIndependently(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestRightColumn_WrongResourceType_ResultIgnored(t *testing.T) {
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailForRelatedTest(t, 140)
 	d = sendToggleRelated(d)
@@ -394,10 +385,9 @@ func TestRightColumn_WrongResourceType_ResultIgnored(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestRightColumn_ToggleDefaultState_OnEntry(t *testing.T) {
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailForRelatedTest(t, 140)
 	view := d.View()
@@ -416,10 +406,9 @@ func TestRightColumn_ToggleDefaultState_OnEntry(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestRightColumn_View_WideTerminalShowsSideBySide(t *testing.T) {
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 	})
-	defer resource.UnregisterRelated("ec2")
 
 	d := makeDetailForRelatedTest(t, 140)
 	d = showRelatedPanel(d)

--- a/tests/unit/testhelpers_demo_harness.go
+++ b/tests/unit/testhelpers_demo_harness.go
@@ -35,6 +35,40 @@ func replaceEC2Related(t *testing.T, defs []resource.RelatedDef) {
 	t.Cleanup(func() { resource.RegisterRelated("ec2", orig) })
 }
 
+// replaceEC2NavigableFields registers navigable fields for "ec2" and restores
+// the prior ACTIVE registry state on cleanup. Snapshots the ACTIVE registry
+// (not the merged one) so an empty active stays empty after the test —
+// otherwise we'd promote production DEFAULT fields into ACTIVE and poison
+// later tests that check active-only navigability.
+func replaceEC2NavigableFields(t *testing.T, fields []resource.NavigableField) {
+	t.Helper()
+	orig := resource.GetActiveNavigableFields("ec2")
+	resource.RegisterNavigableFields("ec2", fields)
+	t.Cleanup(func() {
+		if orig == nil {
+			resource.UnregisterNavigableFields("ec2")
+		} else {
+			resource.RegisterNavigableFields("ec2", orig)
+		}
+	})
+}
+
+// unregisterEC2NavigableFields strips ec2 navigable fields from the ACTIVE
+// registry for the duration of t and restores them on cleanup. Used by tests
+// that need a clean "no active navigable fields" state for ec2.
+func unregisterEC2NavigableFields(t *testing.T) {
+	t.Helper()
+	orig := resource.GetActiveNavigableFields("ec2")
+	resource.UnregisterNavigableFields("ec2")
+	t.Cleanup(func() {
+		if orig == nil {
+			resource.UnregisterNavigableFields("ec2")
+		} else {
+			resource.RegisterNavigableFields("ec2", orig)
+		}
+	})
+}
+
 // newDemoColdCacheApp constructs a tui.Model exactly as cmd/a9s/main.go will
 // after feature 014-demo-transport-mock is fully wired (T036d). It uses
 // demo.NewServiceClients() to supply fake clients and passes them via

--- a/tests/unit/testhelpers_demo_harness.go
+++ b/tests/unit/testhelpers_demo_harness.go
@@ -16,6 +16,25 @@ var noopChecker resource.RelatedChecker = func(_ context.Context, _ any, _ resou
 	return resource.RelatedCheckResult{Count: 0}
 }
 
+// unregisterEC2Related removes ec2 related defs for the duration of t and
+// restores them on cleanup so test order (shuffle) doesn't poison later tests.
+func unregisterEC2Related(t *testing.T) {
+	t.Helper()
+	orig := resource.GetRelated("ec2")
+	resource.UnregisterRelated("ec2")
+	t.Cleanup(func() { resource.RegisterRelated("ec2", orig) })
+}
+
+// replaceEC2Related registers defs for "ec2" and restores the originals on
+// cleanup so tests that temporarily override related defs don't leave the
+// registry poisoned for subsequent tests running in shuffled order.
+func replaceEC2Related(t *testing.T, defs []resource.RelatedDef) {
+	t.Helper()
+	orig := resource.GetRelated("ec2")
+	resource.RegisterRelated("ec2", defs)
+	t.Cleanup(func() { resource.RegisterRelated("ec2", orig) })
+}
+
 // newDemoColdCacheApp constructs a tui.Model exactly as cmd/a9s/main.go will
 // after feature 014-demo-transport-mock is fully wired (T036d). It uses
 // demo.NewServiceClients() to supply fake clients and passes them via

--- a/tests/unit/testhelpers_demo_harness.go
+++ b/tests/unit/testhelpers_demo_harness.go
@@ -35,40 +35,6 @@ func replaceEC2Related(t *testing.T, defs []resource.RelatedDef) {
 	t.Cleanup(func() { resource.RegisterRelated("ec2", orig) })
 }
 
-// replaceEC2NavigableFields registers navigable fields for "ec2" and restores
-// the prior ACTIVE registry state on cleanup. Snapshots the ACTIVE registry
-// (not the merged one) so an empty active stays empty after the test —
-// otherwise we'd promote production DEFAULT fields into ACTIVE and poison
-// later tests that check active-only navigability.
-func replaceEC2NavigableFields(t *testing.T, fields []resource.NavigableField) {
-	t.Helper()
-	orig := resource.GetActiveNavigableFields("ec2")
-	resource.RegisterNavigableFields("ec2", fields)
-	t.Cleanup(func() {
-		if orig == nil {
-			resource.UnregisterNavigableFields("ec2")
-		} else {
-			resource.RegisterNavigableFields("ec2", orig)
-		}
-	})
-}
-
-// unregisterEC2NavigableFields strips ec2 navigable fields from the ACTIVE
-// registry for the duration of t and restores them on cleanup. Used by tests
-// that need a clean "no active navigable fields" state for ec2.
-func unregisterEC2NavigableFields(t *testing.T) {
-	t.Helper()
-	orig := resource.GetActiveNavigableFields("ec2")
-	resource.UnregisterNavigableFields("ec2")
-	t.Cleanup(func() {
-		if orig == nil {
-			resource.UnregisterNavigableFields("ec2")
-		} else {
-			resource.RegisterNavigableFields("ec2", orig)
-		}
-	})
-}
-
 // newDemoColdCacheApp constructs a tui.Model exactly as cmd/a9s/main.go will
 // after feature 014-demo-transport-mock is fully wired (T036d). It uses
 // demo.NewServiceClients() to supply fake clients and passes them via

--- a/tests/unit/testhelpers_noop_checker_test.go
+++ b/tests/unit/testhelpers_noop_checker_test.go
@@ -2,6 +2,7 @@ package unit_test
 
 import (
 	"context"
+	"testing"
 
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
@@ -11,4 +12,23 @@ import (
 // (e.g. to trigger right-column rendering) but doesn't need real data.
 var noopChecker resource.RelatedChecker = func(_ context.Context, _ any, _ resource.Resource, _ resource.ResourceCache) resource.RelatedCheckResult {
 	return resource.RelatedCheckResult{Count: 0}
+}
+
+// unregisterEC2Related removes ec2 related defs for the duration of t and
+// restores them on cleanup so test order (shuffle) doesn't poison later tests.
+func unregisterEC2Related(t *testing.T) {
+	t.Helper()
+	orig := resource.GetRelated("ec2")
+	resource.UnregisterRelated("ec2")
+	t.Cleanup(func() { resource.RegisterRelated("ec2", orig) })
+}
+
+// replaceEC2Related registers defs for "ec2" and restores the originals on
+// cleanup so tests that temporarily override related defs don't leave the
+// registry poisoned for subsequent tests running in shuffled order.
+func replaceEC2Related(t *testing.T, defs []resource.RelatedDef) {
+	t.Helper()
+	orig := resource.GetRelated("ec2")
+	resource.RegisterRelated("ec2", defs)
+	t.Cleanup(func() { resource.RegisterRelated("ec2", orig) })
 }

--- a/tests/unit/testhelpers_noop_checker_test.go
+++ b/tests/unit/testhelpers_noop_checker_test.go
@@ -32,3 +32,37 @@ func replaceEC2Related(t *testing.T, defs []resource.RelatedDef) {
 	resource.RegisterRelated("ec2", defs)
 	t.Cleanup(func() { resource.RegisterRelated("ec2", orig) })
 }
+
+// replaceEC2NavigableFields registers navigable fields for "ec2" and restores
+// the prior ACTIVE registry state on cleanup. Snapshots the ACTIVE registry
+// (not the merged one) so an empty active stays empty after the test —
+// otherwise we'd promote production DEFAULT fields into ACTIVE and poison
+// later tests that check active-only navigability.
+func replaceEC2NavigableFields(t *testing.T, fields []resource.NavigableField) {
+	t.Helper()
+	orig := resource.GetActiveNavigableFields("ec2")
+	resource.RegisterNavigableFields("ec2", fields)
+	t.Cleanup(func() {
+		if orig == nil {
+			resource.UnregisterNavigableFields("ec2")
+		} else {
+			resource.RegisterNavigableFields("ec2", orig)
+		}
+	})
+}
+
+// unregisterEC2NavigableFields strips ec2 navigable fields from the ACTIVE
+// registry for the duration of t and restores them on cleanup. Used by tests
+// that need a clean "no active navigable fields" state for ec2.
+func unregisterEC2NavigableFields(t *testing.T) {
+	t.Helper()
+	orig := resource.GetActiveNavigableFields("ec2")
+	resource.UnregisterNavigableFields("ec2")
+	t.Cleanup(func() {
+		if orig == nil {
+			resource.UnregisterNavigableFields("ec2")
+		} else {
+			resource.RegisterNavigableFields("ec2", orig)
+		}
+	})
+}

--- a/tests/unit/tui_wiring_test.go
+++ b/tests/unit/tui_wiring_test.go
@@ -131,10 +131,9 @@ func TestWiring_CopyInDetailView_UsesActiveFieldValue(t *testing.T) {
 }
 
 func TestWiring_EscapeOnFocusedRightColumn_StaysInDetail(t *testing.T) {
-	resource.RegisterRelated("ec2", []resource.RelatedDef{
+	replaceEC2Related(t, []resource.RelatedDef{
 		{TargetType: "tg", DisplayName: "Target Groups", Checker: noopChecker},
 	})
-	t.Cleanup(func() { resource.UnregisterRelated("ec2") })
 
 	m := newRootSizedModel()
 	res := &resource.Resource{


### PR DESCRIPTION
## Summary

Reduces test-suite memory allocations from **1310MB → 928MB** (−382MB, −29%) and wall-clock time from ~2.35s → ~2.06s (~12.5%) by sharing lazily-built read-only fixtures via `sync.OnceValue`.

- **44 `internal/demo/fixtures/*.go` files**: each `NewXXXFixtures()` function now delegates to a package-level `sync.OnceValue` var, building the fixture struct once per test binary run instead of once per `NewServiceClients()` call (was called 124× per test run at ~920µs each).
- **`internal/config/defaults.go`**: adds `SharedDefaultConfig()` backed by `sync.OnceValue`; `DefaultConfig()` still returns a fresh mutable copy when needed.
- **`internal/tui/app.go`**: `New()` uses `SharedDefaultConfig()` for the no-file fallback — `tui.Model` never mutates `viewConfig`, so the shared pointer is safe. Eliminates ~215MB of redundant allocations (124 × 1.74MB).
- **`internal/resource/types.go`**: `AllResourceTypes()` returns a `sync.OnceValue`-backed shared slice; all 144 call-sites in tests now amortised to one allocation.

### Profiler deltas (alloc_space)

| Hotspot | Before | After | Delta |
|---|---|---|---|
| `config.DefaultConfig` | 218MB (16.7%) | 75MB (8.1%) | −143MB |
| `aws.String` (fixture allocs) | 33MB (2.5%) | not in top 10 | −33MB+ |
| `AllResourceTypes` | 27MB (2.1%) | not in top 10 | −27MB+ |
| **Total** | **1310MB** | **928MB** | **−382MB (−29%)** |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./tests/unit/ -count=1` same pass/fail ratio as baseline (pre-existing `TestBug194_ClientsReadyMsg_CarriesResolvedRegion` failure is unrelated to this PR)
- [ ] `-race -count=10` — no C compiler in dev env; covered by nightly race matrix CI (AS-6)

Closes step 3 of AS-6 (AS-6.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)