### PR TITLE
fix(security): bump Go toolchain 1.26.2 → 1.26.3 (GO-2026-4971, GO-2026-4918)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k2m30/a9s/v3
 
-go 1.26.2
+go 1.26.3
 
 require (
 	charm.land/bubbles/v2 v2.0.0


### PR DESCRIPTION
## Summary

Bumps Go toolchain from `1.26.2` to `1.26.3` to resolve two newly-published Go stdlib CVEs that are failing the `Security` (govulncheck) gate on all open PRs.

## CVEs resolved

| ID | Description | Fixed in |
|---|---|---|
| GO-2026-4971 | `net` — panic on NUL byte in `Dial`/`LookupPort` (Windows) | `net@go1.26.3` |
| GO-2026-4918 | `net/http` — infinite loop on bad HTTP/2 `SETTINGS_MAX_FRAME_SIZE` | `net/http@go1.26.3` |

## Change

One-line edit to `go.mod`:

```diff
-go 1.26.2
+go 1.26.3
```

All CI workflows use `go-version-file: go.mod` so this is the complete fix — no workflow file edits needed.

## Why now

Last green CI on `main` ran 2026-04-28. Both CVEs were published after that date. This is blocking PR #316 (`process/sustainable-development`) from merging — a docs-only PR with all other checks green.

## Test plan

- [x] Single-file, single-line change to `go.mod`
- [ ] `Security` (govulncheck) passes in CI with Go 1.26.3
- [ ] All other checks remain green