### PR TITLE
docs(process): separate Paperclip company agents from Claude Code subagents (AS-45)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Your work will be review by Codex.
 
 ## Process — single source of truth
 
-**Read [`docs/development-process.md`](docs/development-process.md) first.** It defines the 7-stage lifecycle, Definition of Ready, Definition of Done, agent ownership per stage, and the canonical pre-push and pre-release gates. If a rule below conflicts with that document, the document wins until updated.
+**Read [`docs/development-process.md`](docs/development-process.md) first.** It defines the 8-stage lifecycle (Stages 1–8, with Stage 6.5 as an optional post-merge real-AWS gate), Definition of Ready, Definition of Done, agent ownership per stage, and the canonical pre-push and pre-release gates. If a rule below conflicts with that document, the document wins until updated.
 
 Quick reference:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Quick reference:
 - Repository: `k2m30/a9s` — always use this owner/repo for GitHub API calls, issues, and PRs
 
 ## Active Technologies
+
 - Go 1.26+ + Bubble Tea v2.0.2, Lipgloss v2.0.2, Bubbles v2, AWS SDK Go v2 (autoscaling, codeartifact, codebuild, codepipeline, dynamodb, ec2, ecr, ecs, efs, elasticbeanstalk, elbv2, events, iam, kms, lambda, rds, secretsmanager, ses, sesv2, sfn, sns, ssm, eventbridge, backup), yaml.v3, clipboard (020-architecture-refactor)
 - YAML config on disk (`~/.a9s/config.yaml`, `~/.a9s/themes/*.yaml`, `~/.a9s/views/`); YAML cache on disk (`~/.a9s/cache/<profile>--<region>.yaml`); session-scoped in-memory state owned by `internal/session.Session` after Phase 02 (020-architecture-refactor)
 
@@ -97,6 +98,10 @@ specs/           # feature specifications
 - **Message-driven** — views communicate via typed messages, never import each other
 - **Single source of truth** — key bindings in `keys/keys.go`, types in `types.go`, styles in `styles/`, **related-panel contract in `docs/related-resources.md`**
 
+## Skills and Subagents — in-session tooling, **not** Paperclip assignees
+
+> **The two tables below describe Claude Code skills and subagents.** They are tools invoked from within an agent's Claude Code session. **They are not Paperclip company agents.** They have no heartbeats, cannot be assigned issues, and cannot sign off on PRs. The Paperclip roster (CEO, CTO, Architect, Coder, QA, E2ETester, DevOps, CodexReviewer, CodeReviewer) is the only set of names that can own a stage or sign off on a PR — see [`docs/development-process.md`](docs/development-process.md) §"Agents". When this file refers to an "agent" by an `a9s-*` / `tui-*` / `test-coverage-analyzer` id, it means a tool a Paperclip agent invokes — never an issue assignee.
+
 ## Skills
 
 | Skill | Scope | Usage |
@@ -162,7 +167,7 @@ When a single task would require reading 5+ files totaling >500 lines, OR when y
 - ALWAYS test ALL resource types (S3, EC2, RDS, Redis, DocumentDB, EKS, Secrets Manager, VPC, SG, Node Groups, etc), not just one
 - NEVER delete code, tests, or helpers just to make a linter happy. Understand WHY the code exists first. If it's genuinely dead, remove it. If it serves a purpose (scaffolding, crash-verification tests), use a targeted `//nolint` with a reason comment. If a linter rule produces widespread false positives, fix the rule in `.golangci.yml`.
 - NEVER make multiple push-and-check cycles. Get it right locally, push once.
-- BEFORE any push, the canonical gate is **`make ready-to-push`** — see [`docs/development-process.md`](docs/development-process.md) §"Stage 6 — Pre-push Validation" for the gate contents and the `internal/aws/` live-integration sub-rule. Stage 5 reviewer agents (`a9s-consistency-checker`, `test-coverage-analyzer`, `a9s-architect` ≥ M, `a9s-tui-reviewer`, `a9s-security-auditor`, `a9s-docs-reviewer`) must sign off before this gate runs.
+- BEFORE any push, the canonical gate is **`make ready-to-push`** — see [`docs/development-process.md`](docs/development-process.md) §"Stage 6 — Pre-push Validation" for the gate contents and the `internal/aws/` live-integration sub-rule. Stage 5 reviewers (Paperclip agents: **CodeReviewer**, **CodexReviewer**, **Architect** for size ≥ M, **CTO** as final) must sign off before this gate runs. Those reviewers invoke the subagent tools (`a9s-consistency-checker`, `test-coverage-analyzer`, `a9s-tui-reviewer`, `a9s-security-auditor`, `a9s-docs-reviewer`, `tui-ux-auditor`) in-session — see the §"Skills and Subagents" banner below.
 - BEFORE any release, the canonical gate is **`make ready-to-release`** — see [`docs/development-process.md`](docs/development-process.md) §"Stage 7 — Merge & Release" for the manual checklist (`CHANGELOG.md`, `releases/vX.Y.Z.md`, `docs/architecture.md` alignment, busywork audit on tests added/modified in the release).
 - **Exception**: Docs-only changes (`*.md`, `docs/`, `website/`, `specs/`, `.claude/`, `LICENSE`) skip `ready-to-push`; `make mdlint` is required.
 
@@ -183,4 +188,5 @@ When code changes affect any of the following, update the shared source and rege
 - Go version bumped → `docs/shared/install.md`, CONTRIBUTING.md
 
 ## Recent Changes
+
 - 020-architecture-refactor: Added Go 1.26+ + Bubble Tea v2.0.2, Lipgloss v2.0.2, Bubbles v2, AWS SDK Go v2 (autoscaling, codeartifact, codebuild, codepipeline, dynamodb, ec2, ecr, ecs, efs, elasticbeanstalk, elbv2, events, iam, kms, lambda, rds, secretsmanager, ses, sesv2, sfn, sns, ssm, eventbridge, backup), yaml.v3, clipboard

--- a/docs/development-process.md
+++ b/docs/development-process.md
@@ -1,26 +1,57 @@
 # a9s Development Process
 
-This is the **single source of truth** for how work flows through a9s — from request to release. Everyone (CEO, CTO, every agent) follows it. If a rule here conflicts with an ad-hoc instruction, this document wins until it is updated.
+This is the **single source of truth** for how work flows through a9s — from request to release. Everyone (CEO, CTO, every Paperclip agent) follows it. If a rule here conflicts with an ad-hoc instruction, this document wins until it is updated.
 
 It is short on purpose. Process rot starts the moment a doc becomes too long to re-read in five minutes.
 
 ## Goals
 
 1. **Quality is gated, not hoped for.** Each stage has explicit entry and exit criteria. Nothing advances without its gate.
-2. **Roles are explicit.** Each stage names exactly one owning agent. No ambiguity about "who picks this up next".
+2. **Roles are explicit.** Each stage names exactly one owning **Paperclip company agent**. No ambiguity about who picks this up next.
 3. **TDD is non-negotiable.** Tests exist before implementation merges, full stop.
 4. **Failures fail loudly and locally.** CI is verification, not a debugger. The pre-push and pre-release gate suites catch regressions before they reach `main`.
 5. **The process measures itself.** We track DORA-style metrics and run a weekly retro to keep the process alive.
 
+## Two layers — never confused
+
+There are **two distinct layers** in this codebase, and only one of them can be assigned issues or sign off on PRs:
+
+| Layer | Where it lives | Has heartbeats? | Can be assigned a Paperclip issue? | Can sign off on a PR? |
+|---|---|---|---|---|
+| **Paperclip company agent** | The hired roster (this section, below) | Yes | Yes | Yes |
+| **Claude Code subagent** | `.claude/agents/*.md` (`a9s-*`, `tui-*`, `test-coverage-analyzer`) | No | No | No — they are *tools* a Paperclip agent invokes inside its own Claude Code session |
+
+Throughout this document, every stage owner and every reviewer is a **Paperclip agent name** (capitalized, single word). When that agent uses a Claude Code subagent or skill as a tool, it is listed in the "Tools" column — never in the "Owner" or "Reviewer" column.
+
+Concretely: "the Coder agent invokes the `a9s-coder` subagent during Stage 4." Never "`a9s-coder` owns Stage 4."
+
+## Agents — the 9 hired Paperclip roster
+
+This is the ground-truth list. If a stage names anyone else as an owner or reviewer, the doc is wrong.
+
+| Agent | Role | Charter |
+|---|---|---|
+| **CEO** | Strategic direction | Files issues, sets priorities, makes final calls on scope and trade-offs. |
+| **CTO** | Technical direction | Owns this process. Triage, Stage 5 final sign-off, Stage 7 release ownership, Stage 8 retro. Does not write code. |
+| **Architect** | Spec & design | Owns Stage 2. Reviewer at Stage 5 for size ≥ `M`. |
+| **Coder** | Implementation | Owns Stage 4. Writes production code, wires packages, builds fixtures. |
+| **QA** | Test plans & tests | Owns Stage 3. Translates spec to stories, then to failing tests. |
+| **E2ETester** | Real-AWS scenario validation | Owns Stage 6.5 (post-merge real-AWS smoke) and the Stage 7 integration sign-off against a real profile. |
+| **CodeReviewer** | Diff-level code review | Reviewer at Stage 5 (always runs). Local-commit and PR-diff review. |
+| **CodexReviewer** | Independent pair-review | Reviewer at Stage 5 (always runs). Second-opinion review using Codex. |
+| **DevOps** | Consultative only | Provides operational priority input, AWS-practitioner advice, incident-response guidance. **Does not** write code, push branches, or own deploys. Never an implementation owner. |
+
+If a task's deliverable is a PR, branch, fixture, test, doc edit, or release artifact, it is **not** a DevOps task. Route it to Coder (or QA / Architect / CTO as the stage demands).
+
 ## Definitions
 
-### Definition of Ready (DoR) — required before stage 2 begins
+### Definition of Ready (DoR) — required before Stage 2 begins
 
 An issue is Ready when **all** are true:
 
 - One-sentence problem statement.
 - Acceptance criteria written (or pointer to a spec doc / refactor PR spec).
-- Owning agent assigned.
+- Owning Paperclip agent assigned (from the roster above).
 - Sized: `XS` (≤30 LOC, single file) · `S` (≤200 LOC, ≤3 files) · `M` (≤600 LOC) · `L` (≤1500 LOC) · `XL` (split first — see Splitting below).
 - Linked to a goal, refactor phase, or release milestone if applicable.
 
@@ -29,78 +60,82 @@ If any of those is missing, the issue is parked in `todo` and the assignee asks 
 ### Definition of Done (DoD) — required before an issue closes `done`
 
 - Acceptance criteria demonstrably met (test, screenshot, or live run).
-- All Stage 5 (`make ready-to-push`) gates green locally.
-- Stage 4 reviewers signed off (see matrix below).
+- Stage 6 (`make ready-to-push`) gates green locally.
+- Stage 5 reviewers (per matrix below) signed off.
 - Docs sync respected: README is regenerated when `docs/shared/` changes; `CHANGELOG.md` updated for any user-visible change; `docs/architecture.md` aligned for cross-cutting changes.
 - Single-source-of-truth invariants intact (no dual-authoring, no permanent dual API surface).
 - Conventional commit message, `Co-Authored-By: Paperclip <noreply@paperclip.ing>` on every commit.
 
 ### Splitting
 
-`XL` (>1500 LOC, or touches >3 packages, or no clear single owner) is **always** split before work starts. The architect agent owns the split. The 40-PR refactor program is the canonical example of how to size: one mechanical concern per PR, stabilization checkpoints between phases.
+`XL` (>1500 LOC, or touches >3 packages, or no clear single owner) is **always** split before work starts. **Architect** owns the split. The 40-PR refactor program is the canonical example of how to size: one mechanical concern per PR, stabilization checkpoints between phases.
 
-## Lifecycle — 7 stages
+## Lifecycle — 8 stages
 
-Every unit of work goes through these stages. Stages 1, 2, 4, 6 may be **skipped** for trivial bug fixes (`XS`, single file, no behavior change visible to users). Stages 3, 5, 7 never skip.
+Every unit of work goes through these stages. Stages 1, 2, 4, 6, 6.5 may be **skipped** for trivial bug fixes (`XS`, single file, no behavior change visible to users). Stages 3, 5, 6, 7 never skip.
 
 ```text
-1. Intake → 2. Spec → 3. Test Plan → 4. Implementation → 5. Review → 6. Validation → 7. Merge & Release → 8. Retro
+1. Intake → 2. Spec → 3. Tests → 4. Impl → 5. Review → 6. Validate → 6.5 Post-merge AWS → 7. Release → 8. Retro
 ```
 
-### Stage 1 — Intake (CTO)
+### Stage 1 — Intake
 
-- **Owner**: CTO (this agent).
+- **Owner**: **CTO**.
 - **Trigger**: CEO/board files an issue, or a regression is observed.
-- **Action**: Triage type (bug · feature · refactor · ops · docs), set priority, set size, name the owning agent, draft acceptance criteria.
+- **Action**: Triage type (bug · feature · refactor · ops · docs), set priority, set size, name the owning Paperclip agent, draft acceptance criteria.
 - **Exit**: Issue meets DoR.
 - **Anti-pattern**: Self-assigning unassigned work. CTO does not browse the backlog; only acts on what the CEO assigns. Other agents do not pick up backlog without explicit delegation.
 
-### Stage 2 — Spec & Design (Architect)
+### Stage 2 — Spec & Design
 
-- **Owner**: `a9s-architect` (orchestrator only — produces design output, writes nothing into source).
+- **Owner**: **Architect**.
+- **Tools the Architect invokes**: `a9s-resource-spec` skill (writes `docs/resources/<short>.md`), `a9s-architect` subagent (design output only — writes nothing into source).
+- **Optional consult**: **DevOps** for AWS-practitioner priority sanity ("which 10 resources next?", "is CWL more important than Lambda?").
 - **Trigger**: DoR met and size ≥ `M`. Skipped for `XS`/`S` bug fixes.
-- **Action**: Produce a spec doc. Resources use the `a9s-resource-spec` skill (writes `docs/resources/<short>.md`). Refactor PRs reference the per-PR spec in `docs/refactor/`. Features write to `specs/<n>-<feature>.md`.
+- **Action**: Produce a spec doc. Resources use `a9s-resource-spec`. Refactor PRs reference the per-PR spec in `docs/refactor/`. Features write to `specs/<n>-<feature>.md`.
 - **Exit**: Spec doc + CTO sign-off comment on the issue. The spec is the contract; existing implementation is disposable.
 - **Anti-pattern**: Skipping the spec for "obvious" features. If it is so obvious, the spec is one paragraph — write it anyway.
 
-### Stage 3 — Test Plan (QA)
+### Stage 3 — Tests
 
-- **Owner**: `a9s-qa-stories` (writes given/when/then with zero source-code knowledge) → `a9s-qa` (writes failing Go tests).
+- **Owner**: **QA**.
+- **Tools the QA agent invokes**: `a9s-qa-stories` (given/when/then with zero source-code knowledge), `a9s-qa` (failing Go tests), `a9s-related-qa` (related-view scope).
 - **Trigger**: Stage 2 sign-off (or Stage 1 sign-off for `XS`/`S`).
-- **Action**: Translate spec to stories, then to tests. Tests land on the feature branch and **fail as expected**. Architect provides exact file scope; QA rejects tasks without scope.
-- **Exit**: Failing tests committed. The coder's job is to make them pass.
+- **Action**: Translate spec to stories, then to failing Go tests. Tests land on the feature branch and **fail as expected**. Architect provides exact file scope; QA rejects tasks without scope.
+- **Exit**: Failing tests committed. The Coder's job is to make them pass.
 - **Anti-pattern**: "Test along with implementation." That is not TDD. Tests precede implementation in time and in commit history.
 
-### Stage 4 — Implementation (Coder family)
+### Stage 4 — Implementation
 
-- **Owners**:
-  - `a9s-coder` — Go production code only, no tests.
-  - `a9s-integrator` — cross-package wiring (`internal/tui/app.go`, message flow).
-  - `a9s-fixtures` — demo/test fixtures (uses `a9s-create-demo-fixture` skill).
+- **Owner**: **Coder**.
+- **Tools the Coder invokes**: `a9s-coder` (Go production code), `a9s-integrator` (cross-package wiring, `internal/tui/app.go`, message flow), `a9s-fixtures` (demo/test fixtures via `a9s-create-demo-fixture` skill).
 - **Trigger**: Stage 3 tests landed and red.
-- **Action**: Make the failing tests pass. Touch only files in the architect's scope. Coders rebuild the binary (`make build`) after every change.
+- **Action**: Make the failing tests pass. Touch only files in the Architect's scope. Rebuild the binary (`make build`) after every change.
 - **Exit**: Tests pass; `make build && make test && make lint && make gofix && make security` green locally.
-- **Anti-pattern**: Coder writes tests. Coder edits files outside their scope. Coder skips `make gofix`.
+- **Anti-pattern**: Coder writes new tests instead of routing back to QA. Coder edits files outside the Architect's scope. Coder skips `make gofix`.
 
-### Stage 5 — Review (multi-agent, parallel)
+### Stage 5 — Review
 
-These reviewers run **in parallel**. The PR cannot proceed until every applicable reviewer signs off.
+Reviewers run **in parallel**. The PR cannot proceed until every applicable reviewer signs off. Every reviewer in this matrix is a **Paperclip agent**; the "Tools they invoke" column lists the in-session subagents/skills they use during the review.
 
-| Reviewer | Always runs? | Trigger condition |
-|---|---|---|
-| `a9s-tui-reviewer` | Yes (TUI changes) | Any file under `internal/tui/` or any Bubble Tea / Lipgloss usage |
-| `a9s-consistency-checker` | Yes | Always — even docs-only PRs |
-| `test-coverage-analyzer` | Yes | Any code change |
-| `a9s-security-auditor` | Conditional | Any change in `internal/aws/`, dependency updates, write-API-shaped diffs |
-| `a9s-architect` | Yes for size ≥ `M` | Architecture checklist score; target ≥ 8.5 / 10 |
-| `a9s-docs-reviewer` | Conditional | Any change to `docs/`, `README*`, website content |
-| CodeRabbit | Yes | One pass per push (batch fixes into one push) |
-| CTO | Yes | Final sign-off; all above must be green first |
+| Reviewer (Paperclip agent) | Always runs? | Trigger condition | Tools they invoke in-session |
+|---|---|---|---|
+| **CodeReviewer** | Yes | Any code change | `a9s-tui-reviewer` (TUI files), `a9s-consistency-checker`, `test-coverage-analyzer`, `a9s-docs-reviewer` (docs files), `tui-ux-auditor` (UX) |
+| **CodexReviewer** | Yes | Any code change | Codex pair-review pass — independent of CodeReviewer |
+| **Architect** | Yes for size ≥ `M` | Architecture checklist score; target ≥ 8.5 / 10 | `a9s-architect` (design re-read), `a9s-arch-review` skill |
+| **CTO** | Yes | Final sign-off; all above must be green first | `a9s-security-auditor` (when `internal/aws/` or deps changed) |
+| CodeRabbit (external) | Yes | One pass per push (batch fixes into one push) | n/a — external service, not a Paperclip agent |
 
-- **Exit**: All applicable reviewers thumbs-up; CodeRabbit either resolved or `@coderabbitai ignore`d with reason.
+Notes:
+
+- A subagent id appearing in the "Tools" column is a tool the human-side Paperclip reviewer invokes. It does **not** sign off on its own. Sign-off is the Paperclip agent's act.
+- Docs-only PRs still run CodeReviewer (with `a9s-docs-reviewer` and `a9s-consistency-checker`) and CodexReviewer; Architect is skipped if size < `M`; CTO final sign-off still required.
+- **Exit**: All applicable Paperclip reviewers thumbs-up; CodeRabbit either resolved or `@coderabbitai ignore`d with reason.
 - **Anti-pattern**: Multiple push-fix-push cycles to chase reviewers. Get it right locally; push once.
 
 ### Stage 6 — Pre-push Validation (single command)
+
+Run by **whoever pushes** the branch (typically Coder, occasionally CTO for hotfix or doc PRs).
 
 ```bash
 make ready-to-push
@@ -117,7 +152,7 @@ This target is the canonical gate. It MUST pass locally with zero edits before a
 7. `make snapshot` — golden-file render checks.
 8. `make mdlint` — markdown lint across `docs/`, `CLAUDE.md`, `CONTRIBUTING.md`, `CHANGELOG.md`.
 
-For changes that touch `internal/aws/` real-account behavior, additionally run the live integration test against a real AWS profile:
+For changes that touch `internal/aws/` real-account behavior, additionally run the live integration test against a real AWS profile (this is also the entry to Stage 6.5):
 
 ```bash
 A9S_CT_PROFILE=<profile> go test -tags integration ./tests/integration/ \
@@ -131,50 +166,67 @@ A9S_CT_PROFILE=<profile> go test -tags integration ./tests/integration/ \
 
 For pure docs changes (`*.md`, `docs/`, `website/`, `specs/`, `.claude/`, `LICENSE`), `make ready-to-push` is **not** required. `make mdlint` is.
 
+### Stage 6.5 — Post-merge real-AWS validation
+
+- **Owner**: **E2ETester**.
+- **Trigger**: Any merge to `main` that touches `internal/aws/`, fetchers, child views, related-resource pivots, or fixtures. Skipped for pure-docs and pure-tooling changes.
+- **Action**: Run the integration suite against a real AWS profile (`A9S_CT_PROFILE=<profile>`), exercise the changed surface (golden-path: list → detail → child view → related view), and capture pass/fail per scenario. File a P1 incident issue (assignee CTO) if any real-AWS scenario regresses.
+- **Tools the E2ETester invokes**: `a9s-bug-hunt-real-profile` skill, the integration test binaries under `tests/integration/`.
+- **Exit**: All real-AWS scenarios green, or an incident issue exists with the regression scoped and a follow-up Coder issue created.
+- **Anti-pattern**: Treating Stage 6 (`make ready-to-push`) as sufficient for changes that depend on real AWS API behavior.
+
 ### Stage 7 — Merge & Release
 
 - **Merge to `main`**: only with green CI plus Stage 5 sign-offs.
 - **Release path** (when cutting a tagged version):
-  1. `a9s-release-validator` runs the pre-tag checklist (GoReleaser config, multi-arch builds, changelog, CI).
-  2. `CHANGELOG.md` updated with a Keep-a-Changelog entry; `releases/vX.Y.Z.md` written.
-  3. `docs/architecture.md` aligned with the codebase. Outdated architecture docs are a release blocker.
-  4. **Busywork audit**: every test added or modified in the release is reviewed and deleted if it is a tautology, a mock asserting its own input, a struct-shape pin instead of a behavior pin, or duplicate coverage. Coverage earned by busywork is a liability.
-  5. `make integration` (full demo-mode integration) green.
-  6. Tag pushed; GoReleaser publishes; release notes go live.
+  - **Owner**: **CTO**.
+  - **Tools the CTO invokes**: `a9s-release-validator` subagent (pre-tag checklist — GoReleaser config, multi-arch builds, changelog, CI), `release.md` skill.
+  - **E2ETester** runs the full real-AWS pass before the tag is pushed and signs off.
+  - Steps:
+    1. CTO runs `make ready-to-release` (Stage 6 gates + integration). All green.
+    2. `a9s-release-validator` reports the pre-tag checklist; CTO resolves any flag.
+    3. `CHANGELOG.md` updated with a Keep-a-Changelog entry; `releases/vX.Y.Z.md` written.
+    4. `docs/architecture.md` aligned with the codebase. Outdated architecture docs are a release blocker.
+    5. **Busywork audit**: every test added or modified in the release is reviewed and deleted if it is a tautology, a mock asserting its own input, a struct-shape pin instead of a behavior pin, or duplicate coverage. Coverage earned by busywork is a liability.
+    6. E2ETester signs off after a real-AWS pass on the release commit.
+    7. Tag pushed; GoReleaser publishes; release notes go live.
 - **Exit**: Tag exists, artifacts published, `releases/vX.Y.Z.md` committed.
 
 ### Stage 8 — Retro (weekly, ~15 minutes)
 
-Every week, the CTO writes a single-comment retro on the program tracking issue covering:
-
-- DORA snapshot: PRs merged, lead time median, change-failure rate (PRs requiring a follow-up fix), MTTR for any bug landed in `main`.
-- One thing the process did well.
-- One thing the process slipped on, and the **specific** rule change that prevents it next time. Update this document in the same heartbeat; do not "remember to fix it later."
+- **Owner**: **CTO**.
+- Every week, the CTO writes a single-comment retro on the program tracking issue covering:
+  - DORA snapshot: PRs merged, lead time median, change-failure rate (PRs requiring a follow-up fix), MTTR for any bug landed in `main`.
+  - One thing the process did well.
+  - One thing the process slipped on, and the **specific** rule change that prevents it next time. Update this document in the same heartbeat; do not "remember to fix it later."
 
 Retros that produce no rule change are a smell. Either the process is perfect (it isn't) or the retro is performative.
 
 ## Agent Orchestration — who runs when
 
-| Stage | Primary | Helpers | Reviewers |
-|---|---|---|---|
-| 1 Intake | CTO | — | — |
-| 2 Spec | `a9s-architect` | `a9s-devops` (priority sanity) | CTO |
-| 3 Tests | `a9s-qa-stories` → `a9s-qa` | `a9s-related-qa` (related-view scope) | `a9s-architect` |
-| 4 Impl | `a9s-coder` | `a9s-integrator`, `a9s-fixtures` | — |
-| 5 Review | (multiple, parallel) | — | `a9s-tui-reviewer`, `a9s-consistency-checker`, `test-coverage-analyzer`, `a9s-security-auditor`, `a9s-architect`, `a9s-docs-reviewer`, CodeRabbit, CTO |
-| 6 Validate | (any) | — | `make ready-to-push` |
-| 7 Release | `a9s-release-validator` | CTO | CTO |
-| 8 Retro | CTO | — | — |
+Every "Primary" cell holds a **Paperclip agent name**. The "Tools" column lists Claude Code subagents/skills the Primary invokes in-session.
 
-Skill triggers:
+| Stage | Primary (Paperclip) | Helpers (Paperclip) | Reviewers (Paperclip) | Tools invoked in-session |
+|---|---|---|---|---|
+| 1 Intake | CTO | — | — | — |
+| 2 Spec | Architect | DevOps (consultative, optional) | CTO | `a9s-resource-spec`, `a9s-architect` |
+| 3 Tests | QA | — | Architect | `a9s-qa-stories`, `a9s-qa`, `a9s-related-qa` |
+| 4 Impl | Coder | — | — | `a9s-coder`, `a9s-integrator`, `a9s-fixtures` |
+| 5 Review | (parallel reviewers below) | — | CodeReviewer, CodexReviewer, Architect (≥M), CTO (final), CodeRabbit (external) | `a9s-tui-reviewer`, `a9s-consistency-checker`, `test-coverage-analyzer`, `a9s-security-auditor`, `a9s-docs-reviewer`, `tui-ux-auditor`, `a9s-arch-review` |
+| 6 Validate | (whoever pushes — usually Coder) | — | — | `make ready-to-push` |
+| 6.5 Post-merge AWS | E2ETester | — | CTO (incident triage) | `a9s-bug-hunt-real-profile`, `tests/integration/` |
+| 7 Release | CTO | E2ETester (real-AWS sign-off) | CTO | `a9s-release-validator`, `release.md` skill |
+| 8 Retro | CTO | — | — | — |
 
-- New resource type → `a9s-resource-spec` (Stage 2) → `a9s-implement-resource` (Stages 3–4).
-- New child view → `a9s-add-child-view`.
-- New related view → `a9s-add-related-view`.
+Skill triggers (invoked in-session by the owning Paperclip agent above):
+
+- New resource type → `a9s-resource-spec` (Stage 2, Architect) → `a9s-implement-resource` (Stages 3–4, QA + Coder).
+- New child view → `a9s-add-child-view` (Stage 2 Architect scopes; QA implements tests; Coder implements code).
+- New related view → `a9s-add-related-view` (same split).
 - New attention column → `a9s-add-attention-column`.
-- End-to-end issue → `a9s-implement-issue` (orchestrator across stages 2–7).
-- Architecture review → `a9s-arch-review` (Stage 5).
-- Bug from real account → `a9s-bug-hunt-real-profile`.
+- End-to-end issue → `a9s-implement-issue` (Architect orchestrates across stages 2–7).
+- Architecture review → `a9s-arch-review` (Stage 5, Architect).
+- Bug from real account → `a9s-bug-hunt-real-profile` (Stage 6.5, E2ETester).
 
 ## Branching, Commits, PRs
 
@@ -193,17 +245,17 @@ Skill triggers:
 - **P2 (medium)**: edge case, demo-only, cosmetic. Schedule against the next release.
 - **P3 (low)**: nice-to-have. Backlog only; never auto-promoted.
 
-A bug fix follows the same 7-stage lifecycle. The cheap path for `XS` bug fixes is Stages 1 → 3 → 4 → 5 → 6 → 7 (skip 2). Even cheaper paths are not allowed; "I just changed one line" is how regressions hide.
+A bug fix follows the same lifecycle. The cheap path for `XS` bug fixes is Stages 1 → 3 → 4 → 5 → 6 → 7 (skip 2 and 6.5 if the change does not touch real-AWS surface). Even cheaper paths are not allowed; "I just changed one line" is how regressions hide.
 
 ## Incident & Rollback
 
 If a regression lands in `main`:
 
 1. CTO files an incident issue with timestamp, symptoms, suspected commit.
-2. If user-visible and not safely forward-fixable in <60 minutes: revert the offending commit. Reverts are commits; they go through Stage 5 (lightweight review by CTO + one reviewer) and Stage 6.
+2. If user-visible and not safely forward-fixable in <60 minutes: revert the offending commit. Reverts are commits; they go through Stage 5 (lightweight review by CTO + CodeReviewer) and Stage 6.
 3. After mitigation: a written post-incident note in the incident issue covering root cause, blast radius, what gate failed to catch it, what gate change prevents recurrence. The gate change lands the same week.
 
-A regression that the process did not catch is a process bug, not a coder bug.
+A regression that the process did not catch is a process bug, not a coder bug. If the regression was real-AWS-only, the gate change usually lands in Stage 6.5 (E2ETester scope expansion).
 
 ## Metrics (DORA-flavored)
 
@@ -218,13 +270,14 @@ These are not for vanity. They are the input to the weekly retro: any value that
 
 ## Anti-patterns (call them out, fix them)
 
+- **Naming a subagent as a stage owner or reviewer.** Subagents are tools. Owners and reviewers are Paperclip agents from the roster above.
+- **Routing implementation work to DevOps.** DevOps is consultative only. PRs, branches, fixtures, tests, doc edits → Coder (or QA / Architect / CTO per stage).
 - **Reflexive backlog browsing.** Agents act only on explicit assignments.
 - **"Test along with the code."** Tests precede implementation in commit order.
 - **Push-fix-push cycles.** `make ready-to-push` runs locally before any push.
 - **Skipped gates.** A gate skipped is a gate deleted; either run it or remove it from the gate list.
 - **Dual-authoring.** Two sources of truth for the same fact. Always wrong.
 - **Documentation drift.** Docs that contradict code are a release blocker, not a backlog item.
-- **Ad-hoc agent invocation.** If a stage has an owner, that owner runs it; do not freelance.
 - **Heroic merges.** A PR that requires the author to babysit CI is a PR that broke Stage 6.
 
 ## Updating this document

--- a/docs/development-process.md
+++ b/docs/development-process.md
@@ -72,7 +72,7 @@ If any of those is missing, the issue is parked in `todo` and the assignee asks 
 
 ## Lifecycle — 8 stages
 
-Every unit of work goes through these stages. Stages 1, 2, 4, 6, 6.5 may be **skipped** for trivial bug fixes (`XS`, single file, no behavior change visible to users). Stages 3, 5, 6, 7 never skip.
+Every unit of work goes through these stages. Stages 1, 2, 4, 6, 6.5 may be **skipped** for trivial bug fixes (`XS`, single file, no behavior change visible to users). Stages 3, 5, 7 never skip.
 
 ```text
 1. Intake → 2. Spec → 3. Tests → 4. Impl → 5. Review → 6. Validate → 6.5 Post-merge AWS → 7. Release → 8. Retro

--- a/docs/development-process.md
+++ b/docs/development-process.md
@@ -120,8 +120,8 @@ Reviewers run **in parallel**. The PR cannot proceed until every applicable revi
 
 | Reviewer (Paperclip agent) | Always runs? | Trigger condition | Tools they invoke in-session |
 |---|---|---|---|
-| **CodeReviewer** | Yes | Any code change | `a9s-tui-reviewer` (TUI files), `a9s-consistency-checker`, `test-coverage-analyzer`, `a9s-docs-reviewer` (docs files), `tui-ux-auditor` (UX) |
-| **CodexReviewer** | Yes | Any code change | Codex pair-review pass — independent of CodeReviewer |
+| **CodeReviewer** | Yes | Any PR | `a9s-tui-reviewer` (TUI files), `a9s-consistency-checker`, `test-coverage-analyzer`, `a9s-docs-reviewer` (docs files), `tui-ux-auditor` (UX) |
+| **CodexReviewer** | Yes | Any PR | Codex pair-review pass — independent of CodeReviewer |
 | **Architect** | Yes for size ≥ `M` | Architecture checklist score; target ≥ 8.5 / 10 | `a9s-architect` (design re-read), `a9s-arch-review` skill |
 | **CTO** | Yes | Final sign-off; all above must be green first | `a9s-security-auditor` (when `internal/aws/` or deps changed) |
 | CodeRabbit (external) | Yes | One pass per push (batch fixes into one push) | n/a — external service, not a Paperclip agent |


### PR DESCRIPTION
## Summary

Follow-up to PR #316 (already merged). Fixes the conflation flagged in [AS-44](https://github.com/k2m30/a9s/issues) and remediated under [AS-45](https://github.com/k2m30/a9s/issues): the merged `docs/development-process.md` named subagent ids (`a9s-architect`, `a9s-coder`, `a9s-qa`, `a9s-tui-reviewer`, …) as if they were stage owners or PR sign-off authorities. They are not — they are tools the Paperclip company agents invoke inside their own Claude Code sessions.

This PR brings the doc and `CLAUDE.md` into alignment with the actual 9-agent Paperclip roster.

### `docs/development-process.md`

- New "Two layers — never confused" section with the layer-distinction table.
- New "Agents — the 9 hired Paperclip roster" section (CEO, CTO, Architect, Coder, QA, E2ETester, CodeReviewer, CodexReviewer, DevOps).
- Every stage now names a Paperclip agent as owner; subagents/skills appear under "Tools the &lt;Agent&gt; invokes":
  - **Stage 2 Spec** → **Architect** (tools: `a9s-resource-spec`, `a9s-architect`)
  - **Stage 3 Tests** → **QA** (tools: `a9s-qa-stories`, `a9s-qa`, `a9s-related-qa`)
  - **Stage 4 Impl** → **Coder** (tools: `a9s-coder`, `a9s-integrator`, `a9s-fixtures`)
  - **Stage 5 Review** reviewers are **CodeReviewer**, **CodexReviewer**, **Architect** (size ≥ M), **CTO** (final). CodeRabbit is external. Subagent ids are tools, not signers.
  - **Stage 7 Release** → **CTO** (tools: `a9s-release-validator`, `release.md` skill).
- New **Stage 6.5 — post-merge real-AWS validation** owned by **E2ETester** (was unassigned in the workflow).
- **DevOps** placed as consultative-only per AS-43; explicit anti-pattern that PR/branch/fixture/test work is not a DevOps task.
- Agent Orchestration table rewritten: every "Primary" cell is a Paperclip agent; the new "Tools invoked in-session" column lists subagent ids.

### `CLAUDE.md`

- New "Skills and Subagents — in-session tooling, **not** Paperclip assignees" banner immediately above the Skills/Agents tables, so any reader of those tables sees the layer warning first.
- Stage 5 Rules line rewritten: reviewers are Paperclip agents (CodeReviewer, CodexReviewer, Architect for size ≥ M, CTO final); the subagent ids are listed as tools they invoke in-session.
- Two pre-existing MD022 nits fixed so `make mdlint` stays clean on this PR.

## Test plan

- [x] `markdownlint-cli2 "docs/development-process.md" "CLAUDE.md"` — 0 errors.
- [ ] CodeReviewer (Paperclip agent) sign-off — tracked via Paperclip issue thread.
- [ ] CodexReviewer (Paperclip agent) sign-off — tracked via Paperclip issue thread.
- [ ] CodeRabbit pass.

Do **not** merge until both Paperclip reviewers approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)