### PR TITLE
ci: docs-only shim — surface mdlint and stub required Lint/Test/Build (AS-60)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,68 +9,106 @@ on:
       - 'go.sum'
   pull_request:
     branches: [main]
-    paths:
-      - '**/*.go'
-      - 'go.mod'
-      - 'go.sum'
-      - '.golangci.yml'
-      - 'Makefile'
-      - '.github/workflows/ci.yml'
 
 permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect changes
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+      md: ${{ steps.filter.outputs.md }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            go:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - '.golangci.yml'
+              - 'Makefile'
+              - '.github/workflows/ci.yml'
+            md:
+              - '**/*.md'
+
   lint:
     name: Lint
     if: github.event_name == 'pull_request'
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - if: needs.changes.outputs.go == 'true'
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: golangci/golangci-lint-action@v9
+      - if: needs.changes.outputs.go == 'true'
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.11.3
+      - if: needs.changes.outputs.go != 'true'
+        name: Docs-only PR — Lint stub
+        run: echo "No Go-affecting paths changed; Lint stub passing per docs-only CI shim."
 
   test:
     name: Test (${{ matrix.os }})
     if: github.event_name == 'pull_request'
+    needs: changes
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - if: needs.changes.outputs.go == 'true'
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - name: Run tests
+      - if: needs.changes.outputs.go == 'true'
+        name: Run tests
         run: go test ./tests/unit/ -count=1 -timeout 120s -race
+      - if: needs.changes.outputs.go != 'true'
+        name: Docs-only PR — Test stub
+        run: echo "No Go-affecting paths changed; Test stub passing per docs-only CI shim."
 
   build:
     name: Build
     if: github.event_name == 'pull_request'
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - if: needs.changes.outputs.go == 'true'
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - name: Build binary
+      - if: needs.changes.outputs.go == 'true'
+        name: Build binary
         run: go build -trimpath -o a9s ./cmd/a9s/
-      - name: Verify binary
+      - if: needs.changes.outputs.go == 'true'
+        name: Verify binary
         run: ./a9s --version
-      - name: Validate goreleaser config
+      - if: needs.changes.outputs.go == 'true'
+        name: Validate goreleaser config
         uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
           args: check
+      - if: needs.changes.outputs.go != 'true'
+        name: Docs-only PR — Build stub
+        run: echo "No Go-affecting paths changed; Build stub passing per docs-only CI shim."
 
   security:
     name: Security
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && needs.changes.outputs.go == 'true'
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -84,12 +122,26 @@ jobs:
 
   verify-readonly:
     name: Verify Read-Only APIs
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && needs.changes.outputs.go == 'true'
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Check for write API calls
         run: make verify-readonly
+
+  markdown-lint:
+    name: Markdown lint
+    if: github.event_name == 'pull_request' && needs.changes.outputs.md == 'true'
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Run markdownlint-cli2
+        run: npx --yes markdownlint-cli2 "docs/**/*.md" "CLAUDE.md" "CONTRIBUTING.md" "CHANGELOG.md"
 
   coverage:
     name: Coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     outputs:
       go: ${{ steps.filter.outputs.go }}
       md: ${{ steps.filter.outputs.md }}
+      not_docs: ${{ steps.filter.outputs.not_docs }}
     steps:
       - uses: actions/checkout@v6
       - id: filter
@@ -36,6 +37,14 @@ jobs:
               - '.github/workflows/ci.yml'
             md:
               - '**/*.md'
+            not_docs:
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!website/**'
+              - '!specs/**'
+              - '!.claude/**'
+              - '!LICENSE'
 
   lint:
     name: Lint
@@ -132,7 +141,7 @@ jobs:
 
   markdown-lint:
     name: Markdown lint
-    if: github.event_name == 'pull_request' && needs.changes.outputs.md == 'true'
+    if: github.event_name == 'pull_request' && (needs.changes.outputs.not_docs != 'true' || needs.changes.outputs.md == 'true')
     needs: changes
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Adds a docs-only CI shim so docs-only PRs satisfy the `main` branch ruleset (`Lint`, `Test (ubuntu-latest)`, `Build`) without an admin override, and surfaces `markdownlint-cli2` evidence as a status check.

## Approach

Shape A (single-workflow conditionals). Each existing required job (`Lint`, `Test`, `Build`) keeps a single job declaration and dispatches internally on a `changes` detector:

- New `changes` job uses `dorny/paths-filter@v3` to compute `go` and `md` outputs.
- `lint`, `test`, `build` always run on PRs but their real Go steps are gated on `go == 'true'`; otherwise a single stub step echoes a docs-shim notice and exits 0.
- `security` and `verify-readonly` are gated entirely on `go == 'true'` (not in the required ruleset, no shim needed).
- New `markdown-lint` job runs `npx markdownlint-cli2 \"docs/**/*.md\" \"CLAUDE.md\" \"CONTRIBUTING.md\" \"CHANGELOG.md\"` whenever any `*.md` changed, on docs-only and code+docs PRs alike.
- `coverage` (push event) is unchanged.

The single-job-per-context shape avoids any required-check ambiguity: `Lint`, `Test (ubuntu-latest)`, and `Build` are each produced exactly once with no skipped duplicate.

## Path filter for `pull_request`

Previously `ci.yml` only triggered on Go-affecting paths, so docs-only PRs produced none of the required contexts. The path filter is dropped on `pull_request` (always triggers); `push:` keeps its Go-only filter so coverage doesn't fire on every doc commit.

## Behavior matrix

| PR contents | Real Lint/Test/Build | Stub Lint/Test/Build | Security / Verify-RO | Markdown lint |
| --- | --- | --- | --- | --- |
| Docs only (`**/*.md`, `docs/`, etc.) | skipped | success | skipped | runs (if any `*.md` changed) |
| Go only | runs (real) | skipped | runs | skipped |
| Go + docs | runs (real) | skipped | runs | runs |

## Test plan

- [ ] Confirm CI runs on this PR (Go-affecting: `.github/workflows/ci.yml`) and produces real `Lint`, `Test (*)`, `Build`, `Security`, `Verify Read-Only APIs`.
- [ ] After merge: open a trivial docs-only PR (e.g. one-line edit to `CHANGELOG.md`) and confirm:
  - `Lint`, `Test (ubuntu-latest)`, `Build` all report success (stubs).
  - `Markdown lint` runs and reports its result.
  - `mergeable: MERGEABLE` and `mergeStateStatus: CLEAN` (not `BLOCKED`).
- [ ] Verify a Go-affecting PR is not regressed (full matrix runs as before).

## Notes for reviewers

- Pre-existing markdown lint violations on `main` (notably under `docs/refactor/`) will surface as a *failed* `Markdown lint` check on docs PRs until they are cleaned up. That check is **not** in the required ruleset, so it does not block merge — it just surfaces honest evidence per the issue's DoD. Cleaning those is a separate ticket.

Refs: AS-60

🤖 Generated with [Claude Code](https://claude.com/claude-code)