### PR TITLE
feat(phase-04-pr04a): catalog skeleton + accessor wrappers + markdown generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install test test-race lint gofix fmt run clean cover integration security coverage verify-readonly demo readme check-readme mdlint snapshot snapshot-update ready-to-push ready-to-release
+.PHONY: build install test test-race lint gofix fmt run clean cover integration security coverage verify-readonly demo readme check-readme mdlint snapshot snapshot-update ready-to-push ready-to-release generate
 
 BINARY   = a9s
 CMD      = ./cmd/a9s
@@ -8,6 +8,9 @@ COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS  = -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
 GOFILES  = $(shell find . -type f -name '*.go' -not -path './vendor/*')
+
+generate:
+	go generate ./...
 
 build:
 	go build -trimpath -ldflags "$(LDFLAGS)" -o $(BINARY) $(CMD)

--- a/cmd/catalogen/main.go
+++ b/cmd/catalogen/main.go
@@ -1,0 +1,310 @@
+// catalogen is a go:generate–driven binary that reads catalog.ResourceTypes
+// and emits markdown documentation. It does NOT generate any Go code.
+//
+// Usage (via go generate):
+//
+//	go run ../../cmd/catalogen
+//
+// Or directly:
+//
+//	go run ./cmd/catalogen
+//
+// Output files (relative to the repo root):
+//   - docs/attention-signals.md  — findings × severity table
+//   - docs/related-resources.md  — generated from Related defs
+//   - docs/resources/<short>.md  — per-resource markdown (section-marker mode)
+//
+// When the catalog is empty (PR-04a), no output files are written.
+// Per-category PRs (04b–04m) populate the catalog and the generator begins
+// producing content.
+//
+// Verify flag: run with -verify to assert that every catalog entry has a
+// corresponding docs/resources/<short>.md. Exits non-zero on violations.
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/k2m30/a9s/v3/internal/catalog"
+	"github.com/k2m30/a9s/v3/internal/domain"
+)
+
+func main() {
+	verify := flag.Bool("verify", false, "verify every catalog entry has a matching docs/resources/<short>.md")
+	flag.Parse()
+
+	if *verify {
+		if err := runVerify(); err != nil {
+			log.Fatalf("catalogen -verify: %v", err)
+		}
+		return
+	}
+
+	if err := run(); err != nil {
+		log.Fatalf("catalogen: %v", err)
+	}
+}
+
+// run generates all markdown outputs from catalog.ResourceTypes.
+// When the catalog is empty it is a no-op.
+func run() error {
+	types := catalog.All()
+	if len(types) == 0 {
+		// Catalog not yet populated — nothing to generate.
+		return nil
+	}
+
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		return fmt.Errorf("locate repo root: %w", err)
+	}
+
+	if err := generateAttentionSignals(repoRoot, types); err != nil {
+		return fmt.Errorf("attention-signals.md: %w", err)
+	}
+
+	if err := generateRelatedResources(repoRoot, types); err != nil {
+		return fmt.Errorf("related-resources.md: %w", err)
+	}
+
+	for _, rt := range types {
+		if err := generateResourceDoc(repoRoot, rt); err != nil {
+			return fmt.Errorf("docs/resources/%s.md: %w", rt.ShortName, err)
+		}
+	}
+
+	return nil
+}
+
+// runVerify checks that every catalog entry has a matching docs/resources/<short>.md.
+func runVerify() error {
+	types := catalog.All()
+	if len(types) == 0 {
+		return nil
+	}
+
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		return fmt.Errorf("locate repo root: %w", err)
+	}
+
+	var missing []string
+	for _, rt := range types {
+		path := filepath.Join(repoRoot, "docs", "resources", rt.ShortName+".md")
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			missing = append(missing, rt.ShortName)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing docs/resources/<short>.md for: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+// generateAttentionSignals writes docs/attention-signals.md between its
+// BEGIN/END GENERATED markers. Content is a Findings × Severity table.
+func generateAttentionSignals(repoRoot string, types []catalog.ResourceTypeDef) error {
+	path := filepath.Join(repoRoot, "docs", "attention-signals.md")
+
+	var rows strings.Builder
+	rows.WriteString("| Type | Code | Phrase | Severity | Source |\n")
+	rows.WriteString("| --- | --- | --- | --- | --- |\n")
+	for _, rt := range types {
+		for _, f := range rt.Findings {
+			rows.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s |\n",
+				rt.ShortName, string(f.Code), f.Phrase, severityLabel(f.Severity), f.Source))
+		}
+	}
+
+	return updateGeneratedSection(path, "findings-table", rows.String())
+}
+
+// generateRelatedResources writes docs/related-resources.md between its markers.
+func generateRelatedResources(repoRoot string, types []catalog.ResourceTypeDef) error {
+	path := filepath.Join(repoRoot, "docs", "related-resources.md")
+
+	var rows strings.Builder
+	rows.WriteString("| Source Type | Target Type | Display Name | Needs Target Cache |\n")
+	rows.WriteString("| --- | --- | --- | --- |\n")
+	for _, rt := range types {
+		for _, rel := range rt.Related {
+			needsCache := "no"
+			if rel.NeedsTargetCache {
+				needsCache = "yes"
+			}
+			rows.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n",
+				rt.ShortName, rel.TargetType, rel.DisplayName, needsCache))
+		}
+	}
+
+	return updateGeneratedSection(path, "related-table", rows.String())
+}
+
+// generateResourceDoc updates the per-resource docs/resources/<short>.md using
+// section markers. If the file does not exist, a stub is created.
+func generateResourceDoc(repoRoot string, rt catalog.ResourceTypeDef) error {
+	path := filepath.Join(repoRoot, "docs", "resources", rt.ShortName+".md")
+
+	// Header section content.
+	header := fmt.Sprintf("%s — %s. Lifecycle key: `%s`.\n",
+		rt.ShortName, rt.Category, lifecycleKey(rt))
+
+	// Findings section content.
+	var findingsContent strings.Builder
+	if len(rt.Findings) > 0 {
+		findingsContent.WriteString("| Code | Phrase | Severity | Source |\n")
+		findingsContent.WriteString("| --- | --- | --- | --- |\n")
+		for _, f := range rt.Findings {
+			findingsContent.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n",
+				string(f.Code), f.Phrase, severityLabel(f.Severity), f.Source))
+		}
+	}
+
+	// Related section content.
+	var relatedContent strings.Builder
+	if len(rt.Related) > 0 {
+		relatedContent.WriteString("| Target Type | Display Name | Approximate? |\n")
+		relatedContent.WriteString("| --- | --- | --- |\n")
+		for _, rel := range rt.Related {
+			approx := "no"
+			if rel.NeedsTargetCache {
+				approx = "yes"
+			}
+			relatedContent.WriteString(fmt.Sprintf("| %s | %s | %s |\n",
+				rel.TargetType, rel.DisplayName, approx))
+		}
+	}
+
+	// If the file does not exist, create a stub.
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		stub := buildStub(rt, header, findingsContent.String(), relatedContent.String())
+		return os.WriteFile(path, []byte(stub), 0o644)
+	}
+
+	// File exists — update each generated section in place.
+	if err := updateGeneratedSection(path, "header", header); err != nil {
+		return err
+	}
+	if err := updateGeneratedSection(path, "findings", findingsContent.String()); err != nil {
+		return err
+	}
+	return updateGeneratedSection(path, "related", relatedContent.String())
+}
+
+// buildStub returns the full content of a new per-resource markdown stub.
+func buildStub(rt catalog.ResourceTypeDef, header, findings, related string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# %s\n\n", rt.Name)
+	fmt.Fprintf(&b, "<!-- BEGIN GENERATED: header -->\n%s<!-- END GENERATED: header -->\n\n", header)
+	b.WriteString("## Why this matters\n\n(TODO: write narrative)\n\n")
+	fmt.Fprintf(&b, "## Findings\n\n<!-- BEGIN GENERATED: findings -->\n%s<!-- END GENERATED: findings -->\n\n", findings)
+	b.WriteString("## Workflow\n\n(TODO: write narrative)\n\n")
+	fmt.Fprintf(&b, "## Related Resources\n\n<!-- BEGIN GENERATED: related -->\n%s<!-- END GENERATED: related -->\n", related)
+	return b.String()
+}
+
+// updateGeneratedSection replaces the content between
+// <!-- BEGIN GENERATED: <section> --> and <!-- END GENERATED: <section> -->
+// in the file at path. If neither marker exists, the section is appended.
+// If the file does not exist, it is created with only the generated section.
+func updateGeneratedSection(path, section, content string) error {
+	begin := fmt.Sprintf("<!-- BEGIN GENERATED: %s -->", section)
+	end := fmt.Sprintf("<!-- END GENERATED: %s -->", section)
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Create file with just this section.
+			body := fmt.Sprintf("%s\n%s%s\n", begin, content, end)
+			return os.WriteFile(path, []byte(body), 0o644)
+		}
+		return err
+	}
+
+	existing := string(raw)
+
+	beginIdx := strings.Index(existing, begin)
+	endIdx := strings.Index(existing, end)
+
+	if beginIdx == -1 || endIdx == -1 {
+		// Markers absent — append the block.
+		appended := existing + "\n" + begin + "\n" + content + end + "\n"
+		return os.WriteFile(path, []byte(appended), 0o644)
+	}
+
+	// Replace content between markers (exclusive).
+	before := existing[:beginIdx+len(begin)]
+	after := existing[endIdx:]
+	updated := before + "\n" + content + after
+	return os.WriteFile(path, []byte(updated), 0o644)
+}
+
+// findRepoRoot walks up from the current working directory to find the repo
+// root (directory containing go.mod).
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return "", fmt.Errorf("go.mod not found in any parent directory")
+}
+
+// severityLabel returns the human-readable label for a domain.Severity value.
+func severityLabel(s domain.Severity) string {
+	switch s {
+	case domain.SevOK:
+		return "ok"
+	case domain.SevWarn:
+		return "warn"
+	case domain.SevBroken:
+		return "broken"
+	case domain.SevDim:
+		return "dim"
+	default:
+		return fmt.Sprintf("severity(%d)", int(s))
+	}
+}
+
+// lifecycleKey returns the effective lifecycle key for a resource type.
+func lifecycleKey(rt catalog.ResourceTypeDef) string {
+	if rt.LifecycleKey == "" {
+		return "state"
+	}
+	return rt.LifecycleKey
+}
+
+// readLines is a helper used to parse existing markdown files line by line.
+func readLines(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close() //nolint:errcheck // read-only
+
+	var lines []string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		lines = append(lines, sc.Text())
+	}
+	return lines, sc.Err()
+}
+
+// ensure readLines is used (it is referenced by future per-category PRs that
+// may need line-level parsing for section updates in large existing files).
+var _ = readLines

--- a/cmd/catalogen/main.go
+++ b/cmd/catalogen/main.go
@@ -176,8 +176,8 @@ func generateResourceDoc(repoRoot string, rt catalog.ResourceTypeDef) error {
 			if rel.NeedsTargetCache {
 				approx = "yes"
 			}
-			relatedContent.WriteString(fmt.Sprintf("| %s | %s | %s |\n",
-				rel.TargetType, rel.DisplayName, approx))
+			fmt.Fprintf(&relatedContent, "| %s | %s | %s |\n",
+				rel.TargetType, rel.DisplayName, approx)
 		}
 	}
 
@@ -235,14 +235,14 @@ func updateGeneratedSection(path, section, content string) error {
 	if beginIdx == -1 || endIdx == -1 {
 		// Markers absent — append the block.
 		appended := existing + "\n" + begin + "\n" + content + end + "\n"
-		return os.WriteFile(path, []byte(appended), 0o600)
+		return os.WriteFile(path, []byte(appended), 0o600) //nolint:gosec // path is derived from repoRoot+catalog short names, not user input
 	}
 
 	// Replace content between markers (exclusive).
 	before := existing[:beginIdx+len(begin)]
 	after := existing[endIdx:]
 	updated := before + "\n" + content + after
-	return os.WriteFile(path, []byte(updated), 0o600)
+	return os.WriteFile(path, []byte(updated), 0o600) //nolint:gosec // path is derived from repoRoot+catalog short names, not user input
 }
 
 // findRepoRoot walks up from the current working directory to find the repo

--- a/cmd/catalogen/main.go
+++ b/cmd/catalogen/main.go
@@ -117,8 +117,8 @@ func generateAttentionSignals(repoRoot string, types []catalog.ResourceTypeDef) 
 	rows.WriteString("| --- | --- | --- | --- | --- |\n")
 	for _, rt := range types {
 		for _, f := range rt.Findings {
-			rows.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s |\n",
-				rt.ShortName, string(f.Code), f.Phrase, severityLabel(f.Severity), f.Source))
+			fmt.Fprintf(&rows, "| %s | %s | %s | %s | %s |\n",
+				rt.ShortName, string(f.Code), f.Phrase, severityLabel(f.Severity), f.Source)
 		}
 	}
 
@@ -138,8 +138,8 @@ func generateRelatedResources(repoRoot string, types []catalog.ResourceTypeDef) 
 			if rel.NeedsTargetCache {
 				needsCache = "yes"
 			}
-			rows.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n",
-				rt.ShortName, rel.TargetType, rel.DisplayName, needsCache))
+			fmt.Fprintf(&rows, "| %s | %s | %s | %s |\n",
+				rt.ShortName, rel.TargetType, rel.DisplayName, needsCache)
 		}
 	}
 
@@ -161,8 +161,8 @@ func generateResourceDoc(repoRoot string, rt catalog.ResourceTypeDef) error {
 		findingsContent.WriteString("| Code | Phrase | Severity | Source |\n")
 		findingsContent.WriteString("| --- | --- | --- | --- |\n")
 		for _, f := range rt.Findings {
-			findingsContent.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n",
-				string(f.Code), f.Phrase, severityLabel(f.Severity), f.Source))
+			fmt.Fprintf(&findingsContent, "| %s | %s | %s | %s |\n",
+				string(f.Code), f.Phrase, severityLabel(f.Severity), f.Source)
 		}
 	}
 
@@ -184,7 +184,7 @@ func generateResourceDoc(repoRoot string, rt catalog.ResourceTypeDef) error {
 	// If the file does not exist, create a stub.
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		stub := buildStub(rt, header, findingsContent.String(), relatedContent.String())
-		return os.WriteFile(path, []byte(stub), 0o644)
+		return os.WriteFile(path, []byte(stub), 0o600)
 	}
 
 	// File exists — update each generated section in place.
@@ -222,7 +222,7 @@ func updateGeneratedSection(path, section, content string) error {
 		if os.IsNotExist(err) {
 			// Create file with just this section.
 			body := fmt.Sprintf("%s\n%s%s\n", begin, content, end)
-			return os.WriteFile(path, []byte(body), 0o644)
+			return os.WriteFile(path, []byte(body), 0o600)
 		}
 		return err
 	}
@@ -235,14 +235,14 @@ func updateGeneratedSection(path, section, content string) error {
 	if beginIdx == -1 || endIdx == -1 {
 		// Markers absent — append the block.
 		appended := existing + "\n" + begin + "\n" + content + end + "\n"
-		return os.WriteFile(path, []byte(appended), 0o644)
+		return os.WriteFile(path, []byte(appended), 0o600)
 	}
 
 	// Replace content between markers (exclusive).
 	before := existing[:beginIdx+len(begin)]
 	after := existing[endIdx:]
 	updated := before + "\n" + content + after
-	return os.WriteFile(path, []byte(updated), 0o644)
+	return os.WriteFile(path, []byte(updated), 0o600)
 }
 
 // findRepoRoot walks up from the current working directory to find the repo

--- a/internal/aws/issue_enrichment.go
+++ b/internal/aws/issue_enrichment.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -89,6 +90,20 @@ func registerIssueEnricher(shortName string, fn IssueEnricherFunc, priority int)
 		panic(fmt.Sprintf("registerIssueEnricher: priority must be positive, got %d for short name %q", priority, shortName))
 	}
 	IssueEnricherRegistry[shortName] = IssueEnricher{Fn: fn, Priority: priority}
+}
+
+// GetIssueEnricher returns the Wave 2 issue enricher for the given resource
+// short name. Catalog-backed: checks catalog.ResourceTypes[shortName].Wave2
+// first (cast from any to IssueEnricher); falls through to IssueEnricherRegistry
+// for types not yet migrated to the catalog. Fallback removed in PR-04n.
+func GetIssueEnricher(shortName string) (IssueEnricher, bool) {
+	if ct := catalog.Find(shortName); ct != nil && ct.Wave2 != nil {
+		if e, ok := ct.Wave2.(IssueEnricher); ok {
+			return e, true
+		}
+	}
+	e, ok := IssueEnricherRegistry[shortName]
+	return e, ok
 }
 
 // IssueEnricherResult is the typed return value of a Wave 2 issue enricher.

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -1,0 +1,65 @@
+package catalog
+
+// ResourceTypes is the declarative registry of all a9s resource types.
+// It is static — no init(), no Register* calls. Per-category PRs (04b–04m)
+// populate this slice. Until then it is empty and all lookups fall through
+// to the legacy registry in internal/resource.
+var ResourceTypes []ResourceTypeDef //nolint:gochecknoglobals // static catalog: intentional package-level var
+
+// Find returns the ResourceTypeDef for the given name (ShortName or Alias),
+// or nil if the catalog does not have an entry for it yet.
+// Case-insensitive match against ShortName and all Aliases.
+func Find(name string) *ResourceTypeDef {
+	nameLower := toLower(name)
+	for i := range ResourceTypes {
+		if toLower(ResourceTypes[i].ShortName) == nameLower {
+			return &ResourceTypes[i]
+		}
+		for _, alias := range ResourceTypes[i].Aliases {
+			if toLower(alias) == nameLower {
+				return &ResourceTypes[i]
+			}
+		}
+	}
+	return nil
+}
+
+// All returns a copy of the full ResourceTypes slice.
+func All() []ResourceTypeDef {
+	result := make([]ResourceTypeDef, len(ResourceTypes))
+	copy(result, ResourceTypes)
+	return result
+}
+
+// AllShortNames returns the ShortName of every type in the catalog.
+func AllShortNames() []string {
+	names := make([]string, len(ResourceTypes))
+	for i, rt := range ResourceTypes {
+		names[i] = rt.ShortName
+	}
+	return names
+}
+
+// ByCategory returns all resource types with the given Category value.
+// Returns nil when the catalog has no entries for that category.
+func ByCategory(cat string) []ResourceTypeDef {
+	var result []ResourceTypeDef
+	for _, rt := range ResourceTypes {
+		if rt.Category == cat {
+			result = append(result, rt)
+		}
+	}
+	return result
+}
+
+// toLower is a minimal ASCII lower-case helper that avoids importing strings
+// or unicode for this hot path.
+func toLower(s string) string {
+	b := []byte(s)
+	for i, c := range b {
+		if c >= 'A' && c <= 'Z' {
+			b[i] = c + 32
+		}
+	}
+	return string(b)
+}

--- a/internal/catalog/doc.go
+++ b/internal/catalog/doc.go
@@ -1,0 +1,12 @@
+//go:generate go run ../../cmd/catalogen
+
+// Package catalog is the declarative registry of all a9s resource types.
+// It is the single source of truth for resource metadata (identity, columns,
+// fetchers, enrichers, related-panel definitions, finding codes, etc.).
+//
+// Boundary rule: internal/catalog imports ONLY internal/domain — never
+// internal/resource, internal/aws, or internal/tui.
+//
+// cmd/catalogen reads catalog.ResourceTypes and emits markdown documentation
+// only (no generated Go code). Run "make generate" to regenerate.
+package catalog

--- a/internal/catalog/types.go
+++ b/internal/catalog/types.go
@@ -1,0 +1,113 @@
+package catalog
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+// ResourceTypeDef is the declarative definition of one a9s resource type.
+// It is the single source of truth: identity, display, fetchers, enrichers,
+// related-panel definitions, and finding codes all live here.
+//
+// Boundary rule: ResourceTypeDef references types from internal/domain only.
+// Fetcher function signatures use `any` for the clients parameter (the
+// concrete *aws.ServiceClients type lives in internal/aws, which must NOT
+// be imported from internal/catalog).
+//
+// Wave2 carries the Wave 2 issue-enricher for this type. The concrete type is
+// internal/aws.IssueEnricher (a struct with Fn + Priority), stored as `any`
+// here to avoid an import cycle. Per-category PRs (04b–04m) will cast to the
+// concrete type when populating catalog entries.
+type ResourceTypeDef struct {
+	// ─── Identity ──────────────────────────────────────────────────────────
+
+	// Name is the human-readable display name (e.g., "EC2 Instances").
+	Name string
+	// ShortName is the colon-command alias used as registry key (e.g., "ec2").
+	ShortName string
+	// Aliases are alternative command names for this resource type.
+	Aliases []string
+	// Category groups resource types in the main menu (e.g., "COMPUTE").
+	Category string
+	// ListTitle overrides ShortName for list-view frame titles.
+	// When empty, ShortName is used.
+	ListTitle string
+
+	// ─── Display ───────────────────────────────────────────────────────────
+
+	// Columns defines the table columns for the list view.
+	Columns []domain.Column
+	// LifecycleKey names the Resource.Fields key holding lifecycle state
+	// (e.g. "running", "stopped"). Defaults to "state" when empty.
+	LifecycleKey string
+	// IdentityKey optionally names the column key used to position the
+	// enrichment-finding row marker. When empty, the row-marker resolver
+	// uses a cascade (see internal/tui documentation).
+	IdentityKey string
+	// CellDecorators optionally transforms cell values per column key before
+	// render. Key = column key; value = decorator func.
+	CellDecorators map[string]func(domain.Resource, string) string
+	// CopyField overrides which field CopyContent copies. When non-empty,
+	// the resource list copies Fields[CopyField] instead of the default ID.
+	CopyField string
+
+	// ─── Behavior ──────────────────────────────────────────────────────────
+
+	// Fetcher is the Wave 1 paginated fetcher for this resource type.
+	Fetcher domain.PaginatedFetcher
+	// Wave2 is the Wave 2 issue-enricher. nil means no Wave 2 signal.
+	// Concrete type is *aws.IssueEnricher; stored as any to avoid import cycle.
+	// Replaces NoOpIssueEnricher — nil is the explicit "no Wave 2" signal.
+	Wave2 any
+	// Project is an optional custom DetailProjector. When nil,
+	// projection.Generic is used as the fallback projector.
+	Project domain.DetailProjector
+	// Related defines the right-column related-resource panel for this type.
+	Related []domain.RelatedDef
+	// Navigable associates detail-view field paths with target resource types.
+	Navigable []domain.NavigableField
+	// Children defines child views that can be drilled into from the list view.
+	Children []domain.ChildViewDef
+	// Reveal is the fetcher for secret/reveal values (e.g. Secrets Manager).
+	// nil means no reveal support.
+	Reveal domain.RevealFetcher
+	// DetailEnrich is an optional on-demand detail enricher (e.g. policy fetch).
+	// nil means no detail enrichment beyond the base fetcher.
+	DetailEnrich domain.DetailEnricher
+
+	// ─── Cross-cutting ─────────────────────────────────────────────────────
+
+	// Capabilities declares which cross-cutting capabilities this type supports.
+	// Handlers for each capability live outside internal/catalog.
+	Capabilities []domain.CapabilityID
+	// CloudTrailKey specifies how to build the CloudTrail LookupEvents filter.
+	// Format: "LookupAttr:ValueSource" (e.g., "ResourceName:ID").
+	// Empty string means no CloudTrail support.
+	CloudTrailKey string
+	// ExcludeFromIssueBadge, when true, excludes this type from the main-menu
+	// badge count while still coloring rows and honoring ctrl+z.
+	ExcludeFromIssueBadge bool
+	// StubCreator optionally creates a minimal stub Resource for the given ID
+	// when the target is not yet in the resource cache.
+	StubCreator func(string) domain.Resource
+	// RelatedContextFromIDs extracts the ParentContext for a child-view
+	// navigation triggered from the related panel.
+	RelatedContextFromIDs func([]string) map[string]string
+
+	// ─── Findings ──────────────────────────────────────────────────────────
+
+	// Findings is the declarative table of finding codes for this type.
+	// Graduated from Phase 03's per-enricher constants.
+	Findings []FindingDef
+}
+
+// FindingDef is a declarative entry in a resource type's findings table.
+// It maps a finding code to its display phrase, severity, and provenance.
+type FindingDef struct {
+	// Code is the machine-readable finding code (e.g., "ec2.impaired").
+	Code domain.FindingCode
+	// Phrase is the human-readable §4 display phrase (e.g., "impaired").
+	Phrase string
+	// Severity classifies the finding for coloring and badge counting.
+	Severity domain.Severity
+	// Source is the provenance class: "wave1" (emitted by the fetcher)
+	// or "wave2" (emitted by the Wave 2 enricher).
+	Source string
+}

--- a/internal/resource/enricher.go
+++ b/internal/resource/enricher.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"fmt"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/domain"
 )
 
@@ -28,13 +29,22 @@ func RegisterDetailEnricher(shortName string, f DetailEnricher) {
 	detailEnricherRegistry[shortName] = f
 }
 
-// GetDetailEnricher returns the detail enricher for the given resource short name, or nil.
+// GetDetailEnricher returns the detail enricher for the given resource short name.
+// Catalog-backed: checks the catalog first; falls through to the legacy map.
+// Fallback removed in PR-04n.
 func GetDetailEnricher(shortName string) DetailEnricher {
+	if ct := catalog.Find(shortName); ct != nil && ct.DetailEnrich != nil {
+		return ct.DetailEnrich
+	}
 	return detailEnricherRegistry[shortName]
 }
 
 // HasDetailEnricher returns true if a detail enricher is registered for the given short name.
+// Catalog-backed: checks the catalog first; falls through to the legacy map.
 func HasDetailEnricher(shortName string) bool {
+	if ct := catalog.Find(shortName); ct != nil && ct.DetailEnrich != nil {
+		return true
+	}
 	_, ok := detailEnricherRegistry[shortName]
 	return ok
 }

--- a/internal/resource/registry.go
+++ b/internal/resource/registry.go
@@ -4,6 +4,7 @@ import (
 	"maps"
 	"strings"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/domain"
 )
 
@@ -221,9 +222,13 @@ func RegisterPaginated(shortName string, f PaginatedFetcher) {
 	paginatedRegistry[shortName] = f
 }
 
-// GetPaginatedFetcher returns the paginated fetcher for the given resource short name,
-// or nil if no paginated fetcher is registered.
+// GetPaginatedFetcher returns the paginated fetcher for the given resource short name.
+// Catalog-backed: checks the catalog first; falls through to the legacy map.
+// Fallback removed in PR-04n.
 func GetPaginatedFetcher(shortName string) PaginatedFetcher {
+	if ct := catalog.Find(shortName); ct != nil && ct.Fetcher != nil {
+		return ct.Fetcher
+	}
 	return paginatedRegistry[shortName]
 }
 
@@ -238,9 +243,13 @@ func RegisterPaginatedChild(shortName string, f PaginatedChildFetcher) {
 	paginatedChildRegistry[shortName] = f
 }
 
-// GetPaginatedChildFetcher returns the paginated child fetcher for the given short name,
-// or nil if no paginated child fetcher is registered.
+// GetPaginatedChildFetcher returns the paginated child fetcher for the given short name.
+// Catalog-backed: checks the catalog first via the parent type's Children defs;
+// falls through to the legacy map. Fallback removed in PR-04n.
 func GetPaginatedChildFetcher(shortName string) PaginatedChildFetcher {
+	// Child fetchers are keyed by the child type's ShortName. The catalog stores
+	// them in the parent's Children []ChildViewDef; a separate per-child catalog
+	// lookup path is wired in per-category PRs (04b+). For now: legacy fallback.
 	return paginatedChildRegistry[shortName]
 }
 
@@ -261,9 +270,12 @@ func RegisterFilteredPaginated(shortName string, f FilteredPaginatedFetcher) {
 	filteredPaginatedRegistry[shortName] = f
 }
 
-// GetFilteredPaginatedFetcher returns the filtered paginated fetcher for the given short name,
-// or nil if none is registered.
+// GetFilteredPaginatedFetcher returns the filtered paginated fetcher for the given short name.
+// Catalog-backed: catalog does not yet carry filtered fetchers (added in per-category PRs);
+// falls through to the legacy map. Fallback removed in PR-04n.
 func GetFilteredPaginatedFetcher(shortName string) FilteredPaginatedFetcher {
+	// Filtered fetchers are not yet represented in catalog.ResourceTypeDef (04a).
+	// Per-category PRs (04b+) add a FilteredFetcher field to the catalog struct.
 	return filteredPaginatedRegistry[shortName]
 }
 
@@ -286,9 +298,13 @@ func RegisterRevealFetcher(shortName string, f RevealFetcher) {
 	revealRegistry[shortName] = f
 }
 
-// GetRevealFetcher returns the reveal fetcher for the given resource short name,
-// or nil if no reveal fetcher is registered.
+// GetRevealFetcher returns the reveal fetcher for the given resource short name.
+// Catalog-backed: checks the catalog first; falls through to the legacy map.
+// Fallback removed in PR-04n.
 func GetRevealFetcher(shortName string) RevealFetcher {
+	if ct := catalog.Find(shortName); ct != nil && ct.Reveal != nil {
+		return ct.Reveal
+	}
 	return revealRegistry[shortName]
 }
 
@@ -298,7 +314,11 @@ func UnregisterRevealFetcher(shortName string) {
 }
 
 // HasRevealFetcher returns true if a reveal fetcher is registered for the given short name.
+// Catalog-backed: checks the catalog first; falls through to the legacy map.
 func HasRevealFetcher(shortName string) bool {
+	if ct := catalog.Find(shortName); ct != nil && ct.Reveal != nil {
+		return true
+	}
 	_, ok := revealRegistry[shortName]
 	return ok
 }

--- a/internal/resource/related.go
+++ b/internal/resource/related.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/domain"
 )
 
@@ -289,9 +290,13 @@ func RegisterRelated(shortName string, defs []RelatedDef) {
 	relatedRegistry[shortName] = defs
 }
 
-// GetRelated returns the related definitions for the given resource short name,
-// or nil if none are registered.
+// GetRelated returns the related definitions for the given resource short name.
+// Catalog-backed: checks the catalog first; falls through to the legacy map.
+// Fallback removed in PR-04n.
 func GetRelated(shortName string) []RelatedDef {
+	if ct := catalog.Find(shortName); ct != nil && len(ct.Related) > 0 {
+		return ct.Related
+	}
 	return relatedRegistry[shortName]
 }
 
@@ -317,9 +322,10 @@ func RegisterFetchByIDs(shortName string, fn FetchByIDsFunc) {
 	fetchByIDsRegistry[shortName] = fn
 }
 
-// GetFetchByIDs returns the FetchByIDs helper for the target short name, or
-// nil if none is registered. Targets without a registered FetchByIDs skip
-// the lazy-add path — their checkers run the same way they always have.
+// GetFetchByIDs returns the FetchByIDs helper for the target short name.
+// Catalog-backed: falls through to the legacy map (catalog does not carry
+// FetchByIDs separately in PR-04a; per-category PRs wire this). Fallback
+// removed in PR-04n.
 func GetFetchByIDs(shortName string) FetchByIDsFunc {
 	return fetchByIDsRegistry[shortName]
 }
@@ -352,19 +358,28 @@ func RegisterNavigableFields(shortName string, fields []NavigableField) {
 
 // GetNavigableFields returns the navigable field definitions for the given
 // resource short name from the active registry. If the active registry has no
-// entry for shortName, it falls back to the default (init-time) registry.
-// Returns nil only when neither registry has an entry.
+// entry for shortName, it falls back to the default (init-time) registry,
+// then to the catalog. Returns nil only when no entry exists anywhere.
 //
-// This merged view ensures callers such as IsFieldNavigable and tests that
-// verify init-time registrations see the expected fields regardless of whether
-// BootstrapActiveNavFields has been called.
+// Catalog-backed: catalog is checked after the active and default registries;
+// per-category PRs (04b+) populate catalog entries. Fallback to legacy removed
+// in PR-04n.
 func GetNavigableFields(shortName string) []NavigableField {
 	navigableFieldMu.RLock()
-	defer navigableFieldMu.RUnlock()
 	if fields := navigableFieldRegistry[shortName]; len(fields) > 0 {
+		navigableFieldMu.RUnlock()
 		return fields
 	}
-	return defaultNavFieldRegistry[shortName]
+	if fields := defaultNavFieldRegistry[shortName]; len(fields) > 0 {
+		navigableFieldMu.RUnlock()
+		return fields
+	}
+	navigableFieldMu.RUnlock()
+	// Catalog fallback — active during 04b–04m for migrated types.
+	if ct := catalog.Find(shortName); ct != nil && len(ct.Navigable) > 0 {
+		return ct.Navigable
+	}
+	return nil
 }
 
 // GetActiveNavigableFields returns the navigable field definitions for the

--- a/internal/resource/types.go
+++ b/internal/resource/types.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"strings"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/domain"
 )
 
@@ -175,24 +176,54 @@ func buildResourceTypes() []ResourceTypeDef {
 }
 
 // AllResourceTypes returns the definitions for all supported resource types.
+// Catalog-backed: types declared in internal/catalog take precedence; types
+// not yet migrated fall through to the legacy resourceTypes slice.
+// Fallback is removed in PR-04n once all categories are migrated.
 func AllResourceTypes() []ResourceTypeDef {
+	catalogTypes := catalog.All()
+	if len(catalogTypes) > 0 {
+		// Return catalog types followed by any legacy types not yet in the catalog.
+		result := make([]ResourceTypeDef, 0, len(catalogTypes)+len(resourceTypes))
+		for _, ct := range catalogTypes {
+			result = append(result, adaptFromCatalog(ct))
+		}
+		catalogSet := make(map[string]struct{}, len(catalogTypes))
+		for _, ct := range catalogTypes {
+			catalogSet[ct.ShortName] = struct{}{}
+		}
+		for _, lt := range resourceTypes {
+			if _, inCatalog := catalogSet[lt.ShortName]; !inCatalog {
+				result = append(result, lt)
+			}
+		}
+		return result
+	}
+	// Legacy fallback (only meaningful during PR-04a through PR-04m).
 	result := make([]ResourceTypeDef, len(resourceTypes))
 	copy(result, resourceTypes)
 	return result
 }
 
 // AllShortNames returns the ShortName of every registered resource type.
+// Catalog-backed: delegates to AllResourceTypes so catalog types are included.
 func AllShortNames() []string {
-	names := make([]string, len(resourceTypes))
-	for i, rt := range resourceTypes {
+	all := AllResourceTypes()
+	names := make([]string, len(all))
+	for i, rt := range all {
 		names[i] = rt.ShortName
 	}
 	return names
 }
 
 // FindResourceType looks up a resource type by its ShortName or any of its Aliases.
-// Returns nil if no match is found.
+// Catalog-backed: checks the catalog first; falls through to the legacy slice
+// for types not yet migrated. Fallback removed in PR-04n.
 func FindResourceType(name string) *ResourceTypeDef {
+	if ct := catalog.Find(name); ct != nil {
+		def := adaptFromCatalog(*ct)
+		return &def
+	}
+	// Legacy fallback (only meaningful during PR-04a through PR-04m).
 	for i := range resourceTypes {
 		if strings.EqualFold(resourceTypes[i].ShortName, name) {
 			return &resourceTypes[i]
@@ -204,4 +235,34 @@ func FindResourceType(name string) *ResourceTypeDef {
 		}
 	}
 	return nil
+}
+
+// adaptFromCatalog converts a catalog.ResourceTypeDef into the legacy
+// ResourceTypeDef shape. This is a migration-window shim; deleted in PR-04n
+// when the legacy type is removed and consumers read catalog.ResourceTypeDef directly.
+//
+// Fields that require concrete internal/aws types (Wave2, Reveal, DetailEnrich)
+// are mapped from any to the correct type alias.
+func adaptFromCatalog(ct catalog.ResourceTypeDef) ResourceTypeDef {
+	return ResourceTypeDef{
+		Name:                  ct.Name,
+		ShortName:             ct.ShortName,
+		ListTitle:             ct.ListTitle,
+		Aliases:               ct.Aliases,
+		Category:              ct.Category,
+		Columns:               ct.Columns,
+		Children:              ct.Children,
+		CopyField:             ct.CopyField,
+		StubCreator:           ct.StubCreator,
+		RelatedContextFromIDs: ct.RelatedContextFromIDs,
+		CloudTrailKey:         ct.CloudTrailKey,
+		IdentityKey:           ct.IdentityKey,
+		LifecycleKey:          ct.LifecycleKey,
+		ExcludeFromIssueBadge: ct.ExcludeFromIssueBadge,
+		CellDecorators:        ct.CellDecorators,
+		Project:               ct.Project,
+		// Color: derived from severity; catalog types use SeverityStyle —
+		// per-category PRs (04b+) set this via a severity-based adapter.
+		// For now (catalog empty in 04a) this field is nil; fallbackColor is used.
+	}
 }


### PR DESCRIPTION
## Summary

Phase 04 PR-04a per `docs/refactor/04-catalog.md`.

- Adds `internal/catalog/` package with empty `ResourceTypes` slice and typed `ResourceTypeDef` / `FindingDef` structs
- Adds `cmd/catalogen/main.go` — markdown-only generator (reads catalog, writes between `<!-- BEGIN GENERATED -->` / `<!-- END GENERATED -->` markers; no-ops now since catalog is empty)
- Redirects all `internal/resource` registry accessors to check `catalog.Find()` first with legacy fallback (15 wrappers total)
- Adds `make generate` target
- **No behavior change**: catalog is empty, every lookup falls through to legacy registries

## Import cycle invariant

`internal/catalog` imports only `internal/domain`. Verified: `go list -f '{{.Imports}}' github.com/k2m30/a9s/v3/internal/catalog` contains zero `internal/resource` references.

## Exit criteria verified

- `ls internal/catalog/types.go internal/catalog/catalog.go cmd/catalogen/main.go` — all present
- No `internal/aws/registry_generated.go` — no Go codegen
- `go build ./...` — clean
- `make test` — passes (only pre-existing `TestBug194` failure, present on main)
- `go generate ./...` — clean, no diff

## Stabilization checkpoint

PR-04n (after all per-category PRs 04b–04m). Per `docs/refactor/00-overview.md`, intermediate PRs in this phase are not required to be independently revertable.