### PR TITLE
test: parallelize leaf tests in slowest packages (AS-6)

### DIFF
--- a/tests/unit/app_cancellation_test.go
+++ b/tests/unit/app_cancellation_test.go
@@ -39,6 +39,7 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestModel_HasAppContext(t *testing.T) {
+	t.Parallel()
 	m := tui.New("", "")
 	ctx := m.AppContext()
 	if ctx == nil {
@@ -59,6 +60,7 @@ func TestModel_HasAppContext(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestModel_QuitCancelsAppContext(t *testing.T) {
+	t.Parallel()
 	m := tui.New("", "")
 
 	// Capture AppContext before the Update so we can observe the same context object.
@@ -100,6 +102,7 @@ func TestModel_QuitCancelsAppContext(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestFetchersUseContextNotBackground(t *testing.T) {
+	t.Parallel()
 	// Files that MUST NOT contain context.Background() after the refactor.
 	// These are the sites identified in CONCERNS #2/#20.
 	files := []string{
@@ -220,14 +223,17 @@ func (c *cancelObservingIAMClient) ListEntitiesForPolicy(
 }
 
 func TestIAMRelatedChecker_RespectsCancelledContext_PolicyRole(t *testing.T) {
+	t.Parallel()
 	testPolicyCheckerRespectsCancelledContext(t, "role")
 }
 
 func TestIAMRelatedChecker_RespectsCancelledContext_PolicyUser(t *testing.T) {
+	t.Parallel()
 	testPolicyCheckerRespectsCancelledContext(t, "iam-user")
 }
 
 func TestIAMRelatedChecker_RespectsCancelledContext_PolicyGroup(t *testing.T) {
+	t.Parallel()
 	testPolicyCheckerRespectsCancelledContext(t, "iam-group")
 }
 
@@ -289,6 +295,7 @@ func testPolicyCheckerRespectsCancelledContext(t *testing.T, targetType string) 
 // ---------------------------------------------------------------------------
 
 func TestIAMRelatedChecker_RespectsCancelledContext_RolePolicy(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -309,6 +316,7 @@ func TestIAMRelatedChecker_RespectsCancelledContext_RolePolicy(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestIAMRelatedChecker_RespectsCancelledContext_UserGroup(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -321,6 +329,7 @@ func TestIAMRelatedChecker_RespectsCancelledContext_UserGroup(t *testing.T) {
 }
 
 func TestIAMRelatedChecker_RespectsCancelledContext_UserPolicy(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -337,6 +346,7 @@ func TestIAMRelatedChecker_RespectsCancelledContext_UserPolicy(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestIAMRelatedChecker_RespectsCancelledContext_GroupUser(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -349,6 +359,7 @@ func TestIAMRelatedChecker_RespectsCancelledContext_GroupUser(t *testing.T) {
 }
 
 func TestIAMRelatedChecker_RespectsCancelledContext_GroupPolicy(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -368,6 +379,7 @@ func TestIAMRelatedChecker_RespectsCancelledContext_GroupPolicy(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestModel_Cancel_ZeroValue_DoesNotPanic(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r != nil {
 			t.Fatalf("Cancel() on zero-value Model panicked: %v", r)
@@ -385,6 +397,7 @@ func TestModel_Cancel_ZeroValue_DoesNotPanic(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestModel_Cancel_CancelsAppContext(t *testing.T) {
+	t.Parallel()
 	m := tui.New("", "")
 
 	ctx := m.AppContext()

--- a/tests/unit/demo_app_test.go
+++ b/tests/unit/demo_app_test.go
@@ -24,6 +24,7 @@ func demoClientsReadyMsg() messages.ClientsReadyMsg {
 // ---------------------------------------------------------------------------
 
 func TestDemoMode_Init_NoAWSConnection(t *testing.T) {
+	t.Parallel()
 	model := tui.New("demo", "us-east-1",
 		tui.WithClients(demo.NewServiceClients()),
 		tui.WithIsDemo(true),
@@ -52,6 +53,7 @@ func TestDemoMode_Init_NoAWSConnection(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDemoMode_FetchResources_EC2(t *testing.T) {
+	t.Parallel()
 	model := tui.New("demo", "us-east-1",
 		tui.WithClients(demo.NewServiceClients()),
 		tui.WithIsDemo(true),
@@ -92,6 +94,7 @@ func TestDemoMode_FetchResources_EC2(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDemoMode_FetchResources_Unknown(t *testing.T) {
+	t.Parallel()
 	model := tui.New("demo", "us-east-1",
 		tui.WithClients(demo.NewServiceClients()),
 		tui.WithIsDemo(true),
@@ -140,6 +143,7 @@ func TestDemoMode_FetchResources_Unknown(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDemoMode_BlockedCommand_Ctx(t *testing.T) {
+	t.Parallel()
 	model := tui.New("demo", "us-east-1",
 		tui.WithClients(demo.NewServiceClients()),
 		tui.WithIsDemo(true),
@@ -173,6 +177,7 @@ func TestDemoMode_BlockedCommand_Ctx(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDemoMode_BlockedCommand_Region(t *testing.T) {
+	t.Parallel()
 	model := tui.New("demo", "us-east-1",
 		tui.WithClients(demo.NewServiceClients()),
 		tui.WithIsDemo(true),
@@ -206,6 +211,7 @@ func TestDemoMode_BlockedCommand_Region(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDemoMode_RevealWorks(t *testing.T) {
+	t.Parallel()
 	model := tui.New("demo", "us-east-1",
 		tui.WithClients(demo.NewServiceClients()),
 		tui.WithIsDemo(true),
@@ -268,6 +274,7 @@ func TestDemoMode_RevealWorks(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDemoMode_SSMRevealWorks(t *testing.T) {
+	t.Parallel()
 	model := tui.New("demo", "us-east-1",
 		tui.WithClients(demo.NewServiceClients()),
 		tui.WithIsDemo(true),
@@ -327,6 +334,7 @@ func TestDemoMode_SSMRevealWorks(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDemoMode_RefreshReturnsSameData(t *testing.T) {
+	t.Parallel()
 	model := tui.New("demo", "us-east-1",
 		tui.WithClients(demo.NewServiceClients()),
 		tui.WithIsDemo(true),
@@ -375,6 +383,7 @@ func TestDemoMode_RefreshReturnsSameData(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestNonDemoMode_Unchanged(t *testing.T) {
+	t.Parallel()
 	model := tui.New("", "")
 	cmd := model.Init()
 	if cmd == nil {

--- a/tests/unit/demo_cold_cache_ctevents_test.go
+++ b/tests/unit/demo_cold_cache_ctevents_test.go
@@ -29,6 +29,7 @@ import (
 // TestDemoColdCacheCtEvents_ListPopulates verifies that ct-events list view
 // populates from the demo transport on a cold cache.
 func TestDemoColdCacheCtEvents_ListPopulates(t *testing.T) {
+	t.Parallel()
 	m := newDemoColdCacheApp(t)
 
 	*m, _ = rootApplyMsg(*m, tea.WindowSizeMsg{Width: 120, Height: 40})
@@ -77,6 +78,7 @@ func TestDemoColdCacheCtEvents_ListPopulates(t *testing.T) {
 // opening CT event detail dispatches the real checker path (not a demo shortcut)
 // and that at least one checker returns a non-error result (Count >= 0).
 func TestDemoColdCacheCtEvents_DetailRelatedChecksRunLivePath(t *testing.T) {
+	t.Parallel()
 	m := newDemoColdCacheApp(t)
 
 	*m, _ = rootApplyMsg(*m, tea.WindowSizeMsg{Width: 120, Height: 40})
@@ -254,6 +256,7 @@ func TestDemoColdCacheCtEvents_DetailRelatedChecksRunLivePath(t *testing.T) {
 // RelatedCheckResultMsg values (not nil messages or panics), which only holds
 // if the live checker path is active.
 func TestDemoColdCacheCtEvents_NoDemoShortcut(t *testing.T) {
+	t.Parallel()
 	m := newDemoColdCacheApp(t)
 
 	*m, _ = rootApplyMsg(*m, tea.WindowSizeMsg{Width: 120, Height: 40})
@@ -317,6 +320,7 @@ func TestDemoColdCacheCtEvents_NoDemoShortcut(t *testing.T) {
 // This test is intentionally a no-op placeholder so the T012b requirement is
 // visible in the test suite.
 func TestDemoColdCacheACM_HasLiveFetcher(t *testing.T) {
+	t.Parallel()
 	// T012b: ACM has a live fetcher (FetchACMCertificates in internal/aws/acm.go).
 	// Typed-fake implementation tracked in T028. No skip needed.
 	t.Log("T012b: ACM live fetcher confirmed — migration to typed fake tracked under T028")

--- a/tests/unit/demo_cold_cache_ec2_test.go
+++ b/tests/unit/demo_cold_cache_ec2_test.go
@@ -81,7 +81,6 @@ func TestDemoColdCacheEC2_ListPopulates(t *testing.T) {
 //
 // Expected to FAIL initially because EC2Fake methods panic (T013 not yet done).
 func TestDemoColdCacheEC2_DetailRelatedPanels(t *testing.T) {
-	t.Parallel()
 	m := newDemoColdCacheApp(t)
 
 	*m, _ = rootApplyMsg(*m, tea.WindowSizeMsg{Width: 120, Height: 40})

--- a/tests/unit/demo_cold_cache_ec2_test.go
+++ b/tests/unit/demo_cold_cache_ec2_test.go
@@ -19,6 +19,7 @@ import (
 // that method is still a stub ("not yet implemented"). The coder's task (T013) is
 // to implement the fake and provide fixture data — at that point this test passes.
 func TestDemoColdCacheEC2_ListPopulates(t *testing.T) {
+	t.Parallel()
 	m := newDemoColdCacheApp(t)
 
 	// Size the model so View() renders.
@@ -80,6 +81,7 @@ func TestDemoColdCacheEC2_ListPopulates(t *testing.T) {
 //
 // Expected to FAIL initially because EC2Fake methods panic (T013 not yet done).
 func TestDemoColdCacheEC2_DetailRelatedPanels(t *testing.T) {
+	t.Parallel()
 	m := newDemoColdCacheApp(t)
 
 	*m, _ = rootApplyMsg(*m, tea.WindowSizeMsg{Width: 120, Height: 40})

--- a/tests/unit/demo_cold_cache_nested_children_test.go
+++ b/tests/unit/demo_cold_cache_nested_children_test.go
@@ -153,6 +153,7 @@ func enterChildExpectError(t *testing.T, m *tui.Model, childType string, parentC
 // TestDemoColdCacheNestedChildren_LogsChain verifies the three-level chain
 // logs → log_streams → log_events from a cold cache.
 func TestDemoColdCacheNestedChildren_LogsChain(t *testing.T) {
+	t.Parallel()
 	m := setupDemoApp(t)
 
 	// Level 0: load log groups.
@@ -195,6 +196,7 @@ func TestDemoColdCacheNestedChildren_LogsChain(t *testing.T) {
 // rule 4 for the log_streams child: an unknown log group name must surface an
 // error (ResourceNotFoundException), not an empty list.
 func TestDemoColdCacheNestedChildren_LogsChain_UnknownParent(t *testing.T) {
+	t.Parallel()
 	m := setupDemoApp(t)
 
 	// Ensure clients are wired but no real list navigation needed.
@@ -211,6 +213,7 @@ func TestDemoColdCacheNestedChildren_LogsChain_UnknownParent(t *testing.T) {
 // TestDemoColdCacheNestedChildren_LambdaChain verifies the three-level chain
 // lambda → lambda_invocations → lambda_invocation_logs from a cold cache.
 func TestDemoColdCacheNestedChildren_LambdaChain(t *testing.T) {
+	t.Parallel()
 	m := setupDemoApp(t)
 
 	// Level 0: load lambda functions.
@@ -262,6 +265,7 @@ func TestDemoColdCacheNestedChildren_LambdaChain(t *testing.T) {
 // rule 4 for lambda_invocations: an unknown function name must produce an SDK
 // error (or empty with error — not silent empty).
 func TestDemoColdCacheNestedChildren_LambdaChain_UnknownParent(t *testing.T) {
+	t.Parallel()
 	m := setupDemoApp(t)
 
 	enterChildExpectError(t, m, "lambda_invocations",
@@ -280,6 +284,7 @@ func TestDemoColdCacheNestedChildren_LambdaChain_UnknownParent(t *testing.T) {
 // TestDemoColdCacheNestedChildren_SFNChain verifies the three-level chain
 // sfn → sfn_executions → sfn_execution_history from a cold cache.
 func TestDemoColdCacheNestedChildren_SFNChain(t *testing.T) {
+	t.Parallel()
 	m := setupDemoApp(t)
 
 	// Level 0: load state machines.
@@ -332,6 +337,7 @@ func TestDemoColdCacheNestedChildren_SFNChain(t *testing.T) {
 // TestDemoColdCacheNestedChildren_SFNChain_UnknownParent verifies contract
 // rule 4 for sfn_executions: an unknown state machine ARN must surface an error.
 func TestDemoColdCacheNestedChildren_SFNChain_UnknownParent(t *testing.T) {
+	t.Parallel()
 	m := setupDemoApp(t)
 
 	enterChildExpectError(t, m, "sfn_executions",
@@ -350,6 +356,7 @@ func TestDemoColdCacheNestedChildren_SFNChain_UnknownParent(t *testing.T) {
 // TestDemoColdCacheNestedChildren_CBChain verifies the three-level chain
 // cb → cb_builds → cb_build_logs from a cold cache.
 func TestDemoColdCacheNestedChildren_CBChain(t *testing.T) {
+	t.Parallel()
 	m := setupDemoApp(t)
 
 	// Level 0: load CodeBuild projects.
@@ -397,6 +404,7 @@ func TestDemoColdCacheNestedChildren_CBChain(t *testing.T) {
 // TestDemoColdCacheNestedChildren_CBChain_UnknownParent verifies contract
 // rule 4 for cb_builds: an unknown project name must surface an error.
 func TestDemoColdCacheNestedChildren_CBChain_UnknownParent(t *testing.T) {
+	t.Parallel()
 	m := setupDemoApp(t)
 
 	enterChildExpectError(t, m, "cb_builds",
@@ -412,6 +420,7 @@ func TestDemoColdCacheNestedChildren_CBChain_UnknownParent(t *testing.T) {
 // TestDemoColdCacheNestedChildren_ELBChain verifies the three-level chain
 // elb → elb_listeners → elb_listener_rules from a cold cache.
 func TestDemoColdCacheNestedChildren_ELBChain(t *testing.T) {
+	t.Parallel()
 	m := setupDemoApp(t)
 
 	// Level 0: load load balancers.
@@ -454,6 +463,7 @@ func TestDemoColdCacheNestedChildren_ELBChain(t *testing.T) {
 // TestDemoColdCacheNestedChildren_ELBChain_UnknownParent verifies contract
 // rule 4 for elb_listeners: an unknown LB ARN must surface an error.
 func TestDemoColdCacheNestedChildren_ELBChain_UnknownParent(t *testing.T) {
+	t.Parallel()
 	m := setupDemoApp(t)
 
 	enterChildExpectError(t, m, "elb_listeners",

--- a/tests/unit/demo_cold_cache_s3_test.go
+++ b/tests/unit/demo_cold_cache_s3_test.go
@@ -23,6 +23,7 @@ import (
 // TestDemoColdCacheS3_ListPopulates verifies that navigating to the S3 resource
 // list with a cold cache produces at least one bucket from the demo transport.
 func TestDemoColdCacheS3_ListPopulates(t *testing.T) {
+	t.Parallel()
 	m := newDemoColdCacheApp(t)
 
 	*m, _ = rootApplyMsg(*m, tea.WindowSizeMsg{Width: 120, Height: 40})
@@ -75,6 +76,7 @@ func TestDemoColdCacheS3_ListPopulates(t *testing.T) {
 // injection requires a live program loop. The message mirrors what ResourceList
 // emits when Enter is pressed on a bucket row.
 func TestDemoColdCacheS3_ObjectsChildView(t *testing.T) {
+	t.Parallel()
 	m := newDemoColdCacheApp(t)
 
 	*m, _ = rootApplyMsg(*m, tea.WindowSizeMsg{Width: 120, Height: 40})
@@ -153,6 +155,7 @@ func TestDemoColdCacheS3_ObjectsChildView(t *testing.T) {
 // fetching s3_objects for a bucket that does not exist in the fixture must
 // produce an error, not an empty list.
 func TestDemoColdCacheS3_UnknownBucketReturnsError(t *testing.T) {
+	t.Parallel()
 	m := newDemoColdCacheApp(t)
 
 	*m, _ = rootApplyMsg(*m, tea.WindowSizeMsg{Width: 120, Height: 40})

--- a/tests/unit/qa_fetch_test.go
+++ b/tests/unit/qa_fetch_test.go
@@ -718,6 +718,7 @@ func TestQA_FetchResources_NilClients(t *testing.T) {
 
 	for _, rt := range resource.AllShortNames() {
 		t.Run(rt, func(t *testing.T) {
+			t.Parallel()
 			_, cmd := rootApplyMsg(m, messages.NavigateMsg{
 				Target:       messages.TargetResourceList,
 				ResourceType: rt,


### PR DESCRIPTION
## Summary

Parallelize leaf tests in the slowest `tests/unit` packages by adding `t.Parallel()` to test functions that have no shared mutable state. Pure test-only change: **+42 / -0** across **7 files**, no production code touched, no assertions weakened, no tests skipped or removed.

Tracks [AS-6](AS-6) (parallelize tests) and unblocks [AS-26](AS-26) (parallelization gate). Stage 5 review was completed on the reshape issue [AS-47](AS-47) — see approvals from CodeReviewer ([comment 94227c2c](https://github.com/k2m30/a9s/issues)) and CodexReviewer ([comment 83e2c397](https://github.com/k2m30/a9s/issues)) plus CTO final sign-off ([comment 21be008a](https://github.com/k2m30/a9s/issues)). Three commits preserved for reviewer-traceable SHAs; merge with default merge commit (do not squash) to keep history.

## Commits

### 1. `68b4dec` — `test: parallelize NilClients subtests (AS-6)`

`tests/unit/qa_fetch_test.go` (1 file)

`t.Parallel()` is added inside the `t.Run` closure in `TestQA_FetchResources_NilClients` only — NOT at the outer test level. The outer test writes `tui.Version` (shared global) so cannot be parallelised at the top level. Subtests are pure leaf: they read the pre-built `m` model value (BubbleTea Update returns a new model) and call no global-mutating helpers.

Per-package wall-time (`tests/unit`, `-shuffle=on`, `-count=1`):

- before: 11.333s
- after:  1.808s / 1.820s (two shuffle iterations, all pass)

### 2. `3437afa` — `test: parallelize cold-cache demo tests (AS-6)`

Files (4):

- `tests/unit/demo_cold_cache_ec2_test.go`
- `tests/unit/demo_cold_cache_s3_test.go`
- `tests/unit/demo_cold_cache_ctevents_test.go`
- `tests/unit/demo_cold_cache_nested_children_test.go`

`t.Parallel()` at the top of each top-level test function. All tests call `newDemoColdCacheApp(t)` or `setupDemoApp(t)` which construct an independent model per test — no shared mutable state, no `tui.Version` writes, no `t.Setenv`, no global side effects.

Per-package wall-time:

- before: 11.333s
- after:  1.864s / 1.823s (3 shuffle iterations, all pass)

### 3. `c6364e1` — `test: parallelize demo-app and IAM cancellation tests (AS-6)`

Files (2):

- `tests/unit/demo_app_test.go`
- `tests/unit/app_cancellation_test.go`

`t.Parallel()` at top of each top-level test function. `demo_app_test.go`: each test constructs an independent `tui.Model` via `tui.New()` — no shared state, no `tui.Version` writes. `app_cancellation_test.go`: IAM cancellation tests each create their own mock client and model. `testPolicyCheckerRespectsCancelledContext` is a helper (not a `Test` func) and inherits `t` from the calling test — left non-parallel correctly.

Per-package wall-time:

- before (baseline): 12.675s
- after run 1: 1.862s
- after run 2: 1.911s (3 shuffle iterations, all pass)

## Verification

- `git merge-tree --write-tree origin/main test/parallelize-as26` produces a clean tree (no conflicts).
- Diff vs `origin/main` merge-base: +42 / -0 across 7 files (pure `t.Parallel()` insertions).
- Three shuffle iterations of `tests/unit` per cohort, all green; speedup ~6x per package.
- Go 1.26 — no `tt := tt` capture needed (loop-variable capture fixed since Go 1.22).

## Test plan

- [x] Local `go test -shuffle=on -count=1` on `tests/unit` (3 iterations, all pass)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>
