### PR TITLE
fix(ci): fix two pre-existing test failures on main

### DIFF
--- a/internal/tui/app_fetchers.go
+++ b/internal/tui/app_fetchers.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -275,32 +276,63 @@ func (m *Model) fetchRevealValue(resourceType, resourceID string) tea.Cmd {
 func (m *Model) connectAWS(profile, region string, gen int) tea.Cmd {
 	ctx := m.appCtx
 	return func() tea.Msg {
+		configPath := awsclient.DefaultConfigPath()
+		bestRegion := region
+
 		// First attempt: let SDK resolve region from env vars + config file.
 		cfg, err := awsclient.NewAWSSessionContext(ctx, profile, region)
+		// Read region from cfg even on error, then fall back to env vars — the SDK
+		// may not populate cfg.Region when profile loading fails.
+		if cfg.Region != "" {
+			bestRegion = cfg.Region
+		} else if r := os.Getenv("AWS_REGION"); r != "" {
+			bestRegion = r
+		} else if r := os.Getenv("AWS_DEFAULT_REGION"); r != "" {
+			bestRegion = r
+		}
 		if err != nil {
-			// If SDK fails due to missing region and we didn't provide one,
-			// fall back to config-file / us-east-1 (issue #82 safety net).
-			if region == "" && isMissingRegionError(err) {
-				configPath := awsclient.DefaultConfigPath()
-				fallbackRegion := awsclient.GetDefaultRegion(configPath, profile)
-				cfg, err = awsclient.NewAWSSessionContext(ctx, profile, fallbackRegion)
+			// If SDK failed due to missing region and env vars didn't help,
+			// retry with config-file / us-east-1 (issue #82 safety net).
+			if region == "" && bestRegion == "" && isMissingRegionError(err) {
+				fallback := awsclient.GetDefaultRegion(configPath, profile)
+				cfg2, err2 := awsclient.NewAWSSessionContext(ctx, profile, fallback)
+				if cfg2.Region != "" {
+					bestRegion = cfg2.Region
+				} else {
+					bestRegion = fallback
+				}
+				if err2 == nil {
+					clients := awsclient.CreateServiceClients(cfg2)
+					return messages.ClientsReadyMsg{Clients: clients, Region: bestRegion, Gen: gen}
+				}
+				err = err2
 			}
-			if err != nil {
-				return messages.ClientsReadyMsg{Err: err, Gen: gen}
+			// Last resort: ensure Region is non-empty for the error return.
+			if bestRegion == "" {
+				bestRegion = awsclient.GetDefaultRegion(configPath, profile)
 			}
+			return messages.ClientsReadyMsg{Err: err, Region: bestRegion, Gen: gen}
 		}
 		// SDK may succeed but leave Region empty (no env var, no config file).
 		// Retry with config-file / us-east-1 so API calls don't fail later.
 		if cfg.Region == "" && region == "" {
-			configPath := awsclient.DefaultConfigPath()
-			fallbackRegion := awsclient.GetDefaultRegion(configPath, profile)
-			cfg, err = awsclient.NewAWSSessionContext(ctx, profile, fallbackRegion)
-			if err != nil {
-				return messages.ClientsReadyMsg{Err: err, Gen: gen}
+			fallback := awsclient.GetDefaultRegion(configPath, profile)
+			cfg2, err2 := awsclient.NewAWSSessionContext(ctx, profile, fallback)
+			if err2 != nil {
+				if bestRegion == "" {
+					bestRegion = fallback
+				}
+				return messages.ClientsReadyMsg{Err: err2, Region: bestRegion, Gen: gen}
 			}
+			if cfg2.Region != "" {
+				bestRegion = cfg2.Region
+			} else {
+				bestRegion = fallback
+			}
+			cfg = cfg2
 		}
 		clients := awsclient.CreateServiceClients(cfg)
-		return messages.ClientsReadyMsg{Clients: clients, Region: cfg.Region, Gen: gen}
+		return messages.ClientsReadyMsg{Clients: clients, Region: bestRegion, Gen: gen}
 	}
 }
 

--- a/tests/unit/qa_detail_layout_test.go
+++ b/tests/unit/qa_detail_layout_test.go
@@ -102,12 +102,19 @@ func TestDetailLayout_SectionHeadersAlignedWithScalars(t *testing.T) {
 			Code: new(int32(16)),
 		},
 	}
-	cfg, err := config.LoadFromDirs([]string{filepath.Join("..", "..", ".a9s", "views")})
-	if err != nil {
-		t.Fatalf("views dir not loadable: %v", err)
-	}
-	if cfg == nil {
-		t.Fatalf(".a9s/views/ directory not found or returned nil config")
+	// Build a minimal view config that maps "InstanceId" as a scalar and
+	// "State" (the whole nested struct) as a section, producing both a scalar
+	// line and a section-header line. Using the real EC2 view config would map
+	// State to the scalar State.Name and produce no section header.
+	cfg := &config.ViewsConfig{
+		Views: map[string]config.ViewDef{
+			"ec2": {
+				Detail: []config.DetailField{
+					{Path: "InstanceId"},
+					{Path: "State"},
+				},
+			},
+		},
 	}
 	res := resource.Resource{
 		ID:        "i-test123",
@@ -132,6 +139,13 @@ func TestDetailLayout_SectionHeadersAlignedWithScalars(t *testing.T) {
 	foundSubField := false
 
 	for line := range strings.SplitSeq(plain, "\n") {
+		// The detail view renders a two-column layout: left panel │ right panel.
+		// Trim everything from the │ separator onward so we inspect only the
+		// left (field) column's indentation and content.
+		if idx := strings.Index(line, "│"); idx >= 0 {
+			line = line[:idx]
+		}
+		line = strings.TrimRight(line, " ")
 		if strings.TrimSpace(line) == "" {
 			continue
 		}


### PR DESCRIPTION
## Summary

- **TestDetailLayout_SectionHeadersAlignedWithScalars**: The test was loading the EC2 view config from disk, which maps `State` to the scalar `State.Name` — this prevents section headers from being generated. Fixed by using a programmatic `ViewsConfig` that maps `State` as the full nested struct. Also added `│` stripping to handle the two-column layout that appears in test output.
- **TestBug194_ClientsReadyMsg_CarriesResolvedRegion** / **TestBug194_ConnectAWS_Respects*EnvVar**: `connectAWS` wasn't populating `Region` in error-path returns. Fixed by reading `cfg.Region` after every SDK call (even on error), then falling back to `AWS_REGION`/`AWS_DEFAULT_REGION` env vars when the SDK doesn't populate `cfg.Region` due to profile loading failure, and using `GetDefaultRegion` (us-east-1) only as a last resort.

These failures exist on `main` and cause CI to fail on all three open PRs (#315, #322, #323).

## Test plan

- [x] `go test ./tests/unit/ -count=1` passes locally (all tests green)
- [x] `go build ./...` passes
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)