### PR TITLE
docs(process): add Stage 6 test-suite wall budget (AS-83)

### DIFF
--- a/docs/development-process.md
+++ b/docs/development-process.md
@@ -152,6 +152,18 @@ This target is the canonical gate. It MUST pass locally with zero edits before a
 7. `make snapshot` — golden-file render checks.
 8. `make mdlint` — markdown lint across `docs/`, `CLAUDE.md`, `CONTRIBUTING.md`, `CHANGELOG.md`.
 
+#### Test suite wall budget
+
+`make test` (non-race) MUST complete in ≤ **5 minutes** wall on standard CI hardware (the AS-6 baseline). If a change pushes the suite past that, the author must do one of:
+
+- (a) add `t.Parallel()` + row capture to the new tests;
+- (b) split the package into a sub-package (suggested boundary: any single package whose aggregate test wall exceeds 60 s, per the AS-24 finding);
+- (c) attach a `go test -json` profile + a written plan to the PR description and request CTO sign-off as part of Stage 5.
+
+Parallelization and shared-fixture techniques are tracked under AS-26 and AS-27; the profile baseline lives in AS-24.
+
+Enforcement is manual until measurement infrastructure exists — there is no CI gate failing the build at the 5-minute mark yet. Until that gate lands, the author is responsible for catching budget regressions during Stage 6.
+
 For changes that touch `internal/aws/` real-account behavior, additionally run the live integration test against a real AWS profile (this is also the entry to Stage 6.5):
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a new **Test suite wall budget** subsection to `docs/development-process.md` §"Stage 6 — Pre-push Validation" capping non-race `make test` at ≤ **5 minutes** wall on standard CI hardware (the AS-6 baseline), so AS-6 (suite > 10 min) cannot recur silently as the suite grows.

The new subsection sits immediately after the `make ready-to-push` step list and before the `internal/aws/` live-integration sub-rule.

## What changed

- Three concrete remediation paths when a change pushes the suite past 5 minutes: `t.Parallel()` + row capture, sub-package split (60 s/package boundary per AS-24), or a `go test -json` profile + plan with CTO sign-off as part of Stage 5.
- Cross-references AS-24 (profile baseline) and AS-26/AS-27 (parallelization & shared-fixture techniques) by issue id, per the AC.
- Notes explicitly that enforcement is manual until measurement infrastructure exists — no CI gate yet, no Makefile edits.

## Out of scope

- No CI gate enforcing the budget (manual until measurement infra exists).
- No `Makefile` changes.
- No `docs/shared/` impact — README and other generated docs unaffected.

## Verification

- `markdownlint-cli2 docs/development-process.md` → 0 errors.
- Pre-existing `MD036` errors in `docs/refactor/05-boundary.md` are unrelated to this change (they trace to a separate AS-36 in-flight branch).
- Process-only doc change; no code paths affected.

## Stage 5

Per the size matrix this is XS, so reviewers are CodeReviewer + CodexReviewer; CTO will file the review issues. Architect review is skipped (size < M).

Source: AS-6 Stage 8 retro. Closes AS-83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)