### PR TITLE
ci(mdlint): exclude docs/refactor/** until phase-03 stabilizes (AS-85)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,10 @@ jobs:
         with:
           node-version: '22'
       - name: Run markdownlint-cli2
-        run: npx --yes markdownlint-cli2 "docs/**/*.md" "CLAUDE.md" "CONTRIBUTING.md" "CHANGELOG.md"
+        # TODO(AS-36): drop the docs/refactor/** exclusion once phase-03 lands
+        # and refactor-doc churn stops. Excluding here keeps unrelated doc PRs
+        # from being gated by in-flight refactor-doc lint regressions (see AS-85).
+        run: npx --yes markdownlint-cli2 "docs/**/*.md" "!docs/refactor/**" "CLAUDE.md" "CONTRIBUTING.md" "CHANGELOG.md"
 
   coverage:
     name: Coverage

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,11 @@ integration:
 security:
 	govulncheck ./...
 
+# TODO(AS-36): drop the docs/refactor/** exclusion once phase-03 lands and
+# refactor-doc churn stops. Excluding here keeps unrelated doc PRs from being
+# gated by in-flight refactor-doc lint regressions (see AS-85).
 mdlint:
-	markdownlint-cli2 "docs/**/*.md" "CLAUDE.md" "CONTRIBUTING.md" "CHANGELOG.md"
+	markdownlint-cli2 "docs/**/*.md" "!docs/refactor/**" "CLAUDE.md" "CONTRIBUTING.md" "CHANGELOG.md"
 
 coverage:
 	go test ./internal/... ./tests/... -coverpkg=./internal/... -coverprofile=coverage.out -covermode=atomic


### PR DESCRIPTION
## Summary

Adds `!docs/refactor/**` as a negative glob to the `markdownlint-cli2` invocation in both `.github/workflows/ci.yml` and the `Makefile` `mdlint` target.

This unblocks unrelated doc PRs (e.g. [AS-83](/AS/issues/AS-83) / #331) from being gated by in-flight refactor-doc lint churn under `docs/refactor/` — the trigger for [AS-85](/AS/issues/AS-85). The exclusion is temporary; a `TODO(AS-36)` marker in both places asks for the exclusion to be removed when phase-03 lands and refactor-doc lint cleanliness is re-imposed.

## Why option (a) — the workflow glob exclusion

[AS-85](/AS/issues/AS-85) gave three options:

- **(a) Add `docs/refactor/**` to the markdownlint-cli2 ignores.** Smallest viable diff (2 files, 6 net lines), keeps the existing `.markdownlint.yaml` rule config untouched, and is easy to revert with a single line per file when phase-03 stabilizes (the TODO(AS-36) marker tracks that). The issue explicitly endorses this as acceptable temporarily.
- (b) Run `markdownlint-cli2 --fix` on `docs/refactor/*.md`. PR #330 already cleaned the current refactor docs, but this approach causes ongoing content churn during in-flight refactor work and competes with [AS-23](/AS/issues/AS-23) / [AS-35](/AS/issues/AS-35) / [AS-36](/AS/issues/AS-36).
- (c) Scope the CI lint to changed `*.md` files only via `tj-actions/changed-files`. Most architecturally correct but a much larger workflow change for what is meant to be a temporary phase-03 mitigation.

Picked (a) per the size matrix (XS/S) and per the issue author's explicit recommendation.

## Verification (acceptance criterion 4)

To confirm the workflow does not silently mask future regressions in non-refactor docs, I introduced a deliberate MD036 violation in two locations and ran the new lint command locally; both probes were removed before opening this PR.

```text
# Probe 1: docs/_probe/README.md with MD036 (non-refactor location)
$ markdownlint-cli2 "docs/**/*.md" "!docs/refactor/**" "CLAUDE.md" "CONTRIBUTING.md" "CHANGELOG.md"
Linting: 269 file(s)
Summary: 1 error(s)
docs/_probe/README.md:3 error MD036/no-emphasis-as-heading
=> CI WOULD FAIL (good)

# Probe 2: docs/refactor/_probe.md with the same MD036 (excluded location)
$ markdownlint-cli2 "docs/**/*.md" "!docs/refactor/**" "CLAUDE.md" "CONTRIBUTING.md" "CHANGELOG.md"
Linting: 268 file(s)
Summary: 0 error(s)
=> CI WOULD PASS (matches the intentional exclusion)
```

So the exclusion targets exactly `docs/refactor/**` and nothing else.

## Related

- Closes [AS-85](/AS/issues/AS-85).
- Unblocks [AS-83](/AS/issues/AS-83) / #331; once this lands, AS-83 rebases its branch and resumes Stage 5.
- TODO(AS-36) — drop the exclusion when phase-03 lands.

## Test plan

- [ ] CI `Markdown lint` job passes on this PR (touches `**/*.md` filter via the workflow change).
- [ ] CI `Markdown lint` job passes on [AS-83](/AS/issues/AS-83) PR #331 once it rebases.
- [ ] `make mdlint` runs locally with the new globs and reports 0 errors against the current tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)