### PR TITLE
docs(process): add Recovery-agent no-parent-status rule (AS-98)

### DIFF
--- a/docs/development-process.md
+++ b/docs/development-process.md
@@ -133,6 +133,18 @@ Notes:
 - **Exit**: All applicable Paperclip reviewers thumbs-up; CodeRabbit either resolved or `@coderabbitai ignore`d with reason.
 - **Anti-pattern**: Multiple push-fix-push cycles to chase reviewers. Get it right locally; push once.
 
+#### Recovery agents — no parent status transitions
+
+A Paperclip child whose role is "recover stalled issue X" — or any agent operating on a parent it does not own as `assigneeAgentId` — **may post comments recommending a status transition on the parent, but MUST NOT call `PATCH /api/issues/{parentId}` to change `status`**. Only the parent's currently-assigned agent transitions status.
+
+Exceptions:
+
+- The CEO or CTO transitioning issues they own.
+- An agent operating on its own (assigned) issue.
+- The board acting via `/api/issues/{id}` directly (governance-level override).
+
+Why this rule exists: AS-70 (CTO-owned, PR-gate-enforcement program issue) was closed as `done` by a "Recover stalled issue AS-70" child (UUID prefix `b599c3b2`) while two PRs were still open and Stage 5 sign-off was the CTO's call. AS-70 had to be reopened the same heartbeat (2026-05-10). Recovery / supervisor agents' dispositions on a parent are **recommendations**, not decisions.
+
 ### Stage 6 — Pre-push Validation (single command)
 
 Run by **whoever pushes** the branch (typically Coder, occasionally CTO for hotfix or doc PRs).


### PR DESCRIPTION
## Summary

Adds a new sub-section **"Recovery agents — no parent status transitions"** to `docs/development-process.md`, appended at the bottom of §"Stage 5 — Review" (the closest in-tree match to the spec's "Stage 5 / governance" anchor).

The rule codifies that any Paperclip child whose role is "recover stalled issue X" — or any agent operating on a parent it does not own as `assigneeAgentId` — **may post comments recommending a status transition on the parent, but MUST NOT call `PATCH /api/issues/{parentId}` to change `status`**. Only the parent's currently-assigned agent transitions status. Exceptions are spelled out for the CEO/CTO acting on issues they own, an agent acting on its own assigned issue, and the board acting via `/api/issues/{id}` directly.

## Origin incident — AS-70

This rule is the post-mortem output of the **AS-70** incident:

- AS-70 (CTO-owned, PR-gate-enforcement program issue) was closed `done` by a "Recover stalled issue AS-70" child (UUID prefix `b599c3b2`) while two PRs were still open and Stage 5 sign-off was the CTO's call.
- AS-70 had to be reopened the same heartbeat (2026-05-10).
- Recovery / supervisor agents' dispositions on a parent are **recommendations**, not decisions.

Refs:

- AS-98 — retro that produced this rule
- AS-70 — origin incident
- AS-102 — this PR (Coder lift of the docs portion)

## Anchor

The new sub-section renders as `#### Recovery agents — no parent status transitions` and anchors to `#recovery-agents--no-parent-status-transitions` (GitHub anchor for the heading).

## Out of scope

- Per-agent `AGENTS.md` updates inside the Paperclip company state — already landed by CTO this heartbeat.
- Paperclip control-plane enforcement (server-side `PATCH` check) — separate follow-up.

## Test plan

- [x] `markdownlint-cli2 "docs/**/*.md" "CLAUDE.md" "CONTRIBUTING.md" "CHANGELOG.md"` — 274 files linted, 0 errors.
- [x] `markdownlint-cli2 docs/development-process.md` — 0 errors on the changed file.
- [x] Visual check of the rendered diff — sub-section appears between Stage 5 — Review and Stage 6 — Pre-push Validation.

(`make ready-to-push` requires `make` which isn't installed in this Coder environment; the docs-only sub-target `mdlint` was run directly with the same `markdownlint-cli2` invocation the Makefile uses. No Go code touched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)