### PR TITLE
docs(process): require Stage 5 verdict cross-post + add ops runbook (AS-117)

### DIFF
--- a/docs/development-process.md
+++ b/docs/development-process.md
@@ -130,8 +130,22 @@ Notes:
 
 - A subagent id appearing in the "Tools" column is a tool the human-side Paperclip reviewer invokes. It does **not** sign off on its own. Sign-off is the Paperclip agent's act.
 - Docs-only PRs still run CodeReviewer (with `a9s-docs-reviewer` and `a9s-consistency-checker`) and CodexReviewer; Architect is skipped if size < `M`; CTO final sign-off still required.
-- **Exit**: All applicable Paperclip reviewers thumbs-up; CodeRabbit either resolved or `@coderabbitai ignore`d with reason.
+- **Verdict cross-post (CodeReviewer + CodexReviewer, mandatory).** Both reviewers MUST cross-post their final verdict (APPROVED / NEEDS CHANGES / REJECTED) as a `gh pr comment` on the GitHub PR thread, in addition to whatever they post on the Paperclip review-issue thread. The Stage 5 audit rule presumes a human-side reviewer can read verdicts on the PR itself; a verdict that lives only inside Paperclip violates that contract. The PR-thread comment must repeat the verdict label, the gate findings (with `file:line` citations), and the next owner — i.e. it is the same content as the Paperclip-thread post, not a "see Paperclip" pointer. CodeRabbit comments still do not count as Stage 5. Example invocation:
+
+  ```bash
+  gh pr comment <n> --repo k2m30/a9s --body "$(cat <<'EOF'
+  CodexReviewer Stage 5 verdict: NEEDS CHANGES
+  - [GATE] path/to/file.go:42 — finding + required fix
+  - Ruling: rule cited
+  Next owner: Coder
+  EOF
+  )"
+  ```
+
+  The cross-post is part of the Stage 5 deliverable; the PR-Gate audit treats the absence of a cross-post the same as the absence of a verdict — a missing cross-post means the PR stays `stage5-pending` for that reviewer regardless of what the Paperclip thread says.
+- **Exit**: All applicable Paperclip reviewers thumbs-up (Paperclip-thread verdict **and** GitHub PR cross-post present for CodeReviewer + CodexReviewer); CodeRabbit either resolved or `@coderabbitai ignore`d with reason.
 - **Anti-pattern**: Multiple push-fix-push cycles to chase reviewers. Get it right locally; push once.
+- **Anti-pattern**: Posting a Stage 5 verdict only on the Paperclip thread. The PR is the human-readable record of who signed off on what; an audit reading only the GitHub PR cannot reconstruct Stage 5 unless the cross-post is present.
 
 #### Recovery agents — no parent status transitions
 
@@ -270,6 +284,12 @@ Skill triggers (invoked in-session by the owning Paperclip agent above):
 - **P3 (low)**: nice-to-have. Backlog only; never auto-promoted.
 
 A bug fix follows the same lifecycle. The cheap path for `XS` bug fixes is Stages 1 → 3 → 4 → 5 → 6 → 7 (skip 2 and 6.5 if the change does not touch real-AWS surface). Even cheaper paths are not allowed; "I just changed one line" is how regressions hide.
+
+## Operations runbook (platform-layer incidents)
+
+Software incidents go through Stage 6.5 / "Incident & Rollback" below. **Platform-layer incidents** — agents stuck in `error`, recovery primitives, bearer-scoped operations — live in `docs/runbook.md`. Read that file first when something is wrong with an agent's lifecycle (not its code).
+
+The runbook is the single home for the CEO-bearer `error → idle` recovery primitive (`PATCH /api/agents/{id}` with `{"status":"idle"}`) and the constraints around it. Future on-call decisions should consult `docs/runbook.md`, not the originating incident issue body.
 
 ## Incident & Rollback
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,42 @@
+# a9s Operations Runbook
+
+This is the runbook for **operational incidents that fall outside the standard Stage 5 / Stage 6 / Stage 6.5 review-and-validation pipeline**. It is the single place to look first when something is wrong with the agent fleet or the Paperclip platform layer that hosts a9s' agents — not when something is wrong with a9s' code.
+
+For software incidents (regressions in `main`, P0/P1 bugs, real-AWS regressions), see `docs/development-process.md` § "Incident & Rollback" and § "Stage 6.5".
+
+## Agent recovery — `error → idle`
+
+If a Paperclip agent on the a9s roster is stuck in `error` state and is not progressing through its standard heartbeat lifecycle, the operative recovery primitive is:
+
+```
+PATCH /api/agents/{id}
+{ "status": "idle" }
+```
+
+### Constraints (do not violate)
+
+- **CEO bearer token only.** Lower-trust bearers cannot transition agent state. The CTO bearer is **not** sufficient. If the CEO is unavailable, escalate; do not attempt with another bearer.
+- **Only valid for the `error → idle` transition.** Do not use this endpoint for `paused → idle`, `running → idle`, `terminated → idle`, or any other transition. Those go through their own dedicated endpoints.
+- **All other agent transitions go through dedicated endpoints**:
+  - `POST /api/agents/{id}/pause` — running → paused
+  - `POST /api/agents/{id}/resume` — paused → running
+  - `POST /api/agents/{id}/terminate` — any → terminated
+- **Do not** invent ad-hoc transitions through `PATCH /api/agents/{id}`. The `error → idle` carve-out is the one documented exception; everything else uses the dedicated endpoint or files an incident.
+
+### When to use it
+
+Use this primitive when:
+
+1. An agent is stuck in `error` after a heartbeat that hit a non-recoverable adapter exception (model API rejection, malformed tool call, etc.).
+2. The agent's pending issues are time-sensitive (assigned PR review, release-blocking work) and waiting for a natural recovery is not acceptable.
+3. The board / CEO has confirmed the underlying cause has been addressed (or determined that the cause was transient and unlikely to recur this heartbeat).
+
+If the underlying cause is unknown, **do not unstick the agent**. Diagnose first; an agent that is unstuck without root-cause analysis will re-enter `error` on its next wake and burn budget repeatedly.
+
+### Audit trail
+
+Every use of this primitive is logged at the platform layer. The originating CEO bearer is recorded against the transition. Do not paper-over the diagnosis: file or update the incident issue with the timestamp of the recovery, the symptom, the suspected cause, and the gate change (if any) that prevents recurrence — same rule as `docs/development-process.md` § "Incident & Rollback".
+
+### History
+
+Captured here from AS-115 (2026-05-10) so future on-call decisions do not require reading the issue body. Filed by [AS-117](https://github.com/k2m30/a9s/issues) per CEO direction. Any future addition to this constraint set lands as a single PR that updates this section in the same change.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -39,4 +39,4 @@ Every use of this primitive is logged at the platform layer. The originating CEO
 
 ### History
 
-Captured here from AS-115 (2026-05-10) so future on-call decisions do not require reading the issue body. Filed by [AS-117](https://github.com/k2m30/a9s/issues) per CEO direction. Any future addition to this constraint set lands as a single PR that updates this section in the same change.
+Captured here from AS-115 (2026-05-10, Paperclip-internal) so future on-call decisions do not require reading the issue body. Filed by AS-117 (Paperclip-internal) per CEO direction. Any future addition to this constraint set lands as a single PR that updates this section in the same change.


### PR DESCRIPTION
## Summary

Closes the two process gaps surfaced by the CEO disposition on AS-115 / AS-117:

- **Stage 5 verdict cross-post is now mandatory.** `docs/development-process.md` Stage 5 notes now require CodeReviewer + CodexReviewer to cross-post their final verdict (APPROVED / NEEDS CHANGES / REJECTED) to the GitHub PR thread via `gh pr comment`, in addition to the Paperclip review-issue thread. The PR-Gate audit treats a missing cross-post the same as a missing verdict.
- **Operations runbook added.** New `docs/runbook.md` captures the CEO-bearer agent-recovery primitive (`PATCH /api/agents/{id}` `{\"status\":\"idle\"}`) — operative **only** for `error → idle`. All other transitions go through `pause` / `resume` / `terminate`. Sourced from AS-115 so future on-call doesn't have to read the original incident body.
- `development-process.md` gains a short pointer to the runbook so on-call agents land in the right doc.

CodeReviewer + CodexReviewer agent-instruction `AGENTS.md` files (outside this repo, in the Paperclip company-instructions tree) are updated in the same change to mirror the new cross-post deliverable, including the safety carve-out for the GitHub PR cross-post.

## Acceptance criteria — AS-117

- [x] AC1 — `docs/development-process.md` Stage 5 explicitly requires reviewers to cross-post the final verdict to the GitHub PR thread.
- [x] AC2 — CodeReviewer's and CodexReviewer's instruction `AGENTS.md` require the GitHub PR cross-post as part of the Stage 5 verdict deliverable, with an example `gh pr comment` invocation. (Edited directly in the Paperclip company-instructions tree, outside this repo.)
- [x] AC3 — `docs/runbook.md` captures the CEO-bearer `PATCH /api/agents/{id}` `error → idle` recovery primitive and constraints.
- [x] AC4 — Retroactive CodexReviewer NEEDS CHANGES verdict cross-post on PR #334 was already posted (https://github.com/k2m30/a9s/pull/334#issuecomment-4414774436).

## Test plan

- [x] `markdownlint-cli2 docs/development-process.md docs/runbook.md` clean.
- [ ] Stage 5 reviewers land their verdicts on this PR thread (this is the first PR exercising the new cross-post rule).

## Out of scope

- Any platform-side automation of the cross-post.
- Re-running Stage 5 on PR #334.
- Changes to upstream Paperclip platform code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)