### PR TITLE
feat(phase-03-pr03e): databases — fetchers emit canonical Findings (v2)

### DIFF
--- a/internal/aws/dbc.go
+++ b/internal/aws/dbc.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/docdb"
 	docdbtypes "github.com/aws/aws-sdk-go-v2/service/docdb/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -206,17 +207,22 @@ func FetchDocDBClustersPage(ctx context.Context, api DocDBDescribeDBClustersAPI,
 			backupRetentionPeriod = fmt.Sprintf("%d", *cluster.BackupRetentionPeriod)
 		}
 
-		computedStatus, computedIssues := computeDBCStatusAndIssues(cluster)
+		findings := computeDBCStatusAndIssues(cluster)
+		statusPhrase := ""
+		if len(findings) > 0 {
+			statusPhrase = findings[0].Phrase
+			if len(findings) > 1 {
+				statusPhrase = fmt.Sprintf("%s (+%d)", statusPhrase, len(findings)-1)
+			}
+		}
 
 		r := resource.Resource{
-			ID:     clusterID,
-			Name:   clusterID,
-			Status: computedStatus,
-			Issues: computedIssues,
+			ID:   clusterID,
+			Name: clusterID,
 			Fields: map[string]string{
 				"cluster_id":              clusterID,
 				"engine_version":          engineVersion,
-				"status":                  computedStatus,
+				"status":                  statusPhrase,
 				"instances":               instances,
 				"endpoint":                endpoint,
 				"arn":                     aws.ToString(cluster.DBClusterArn),
@@ -226,6 +232,7 @@ func FetchDocDBClustersPage(ctx context.Context, api DocDBDescribeDBClustersAPI,
 				"storage_encrypted":       storageEncrypted,
 				"backup_retention_period": backupRetentionPeriod,
 			},
+			Findings:  findings,
 			RawStruct: cluster,
 		}
 
@@ -255,14 +262,6 @@ func FetchDocDBClustersPage(ctx context.Context, api DocDBDescribeDBClustersAPI,
 	}, nil
 }
 
-// brokenDBCStatusPhrase maps DocumentDB cluster statuses that represent hard failures
-// to their display phrases per spec §4.
-var brokenDBCStatusPhrase = map[string]string{
-	"failed":                              "failed: cluster operation",
-	"inaccessible-encryption-credentials": "encryption key unreachable",
-	"incompatible-parameters":             "parameter group incompatible",
-}
-
 // transitionalDBCStatusSet contains DocumentDB cluster statuses that indicate a
 // transitional (Warning) state. These show a ": in progress" suffix.
 var transitionalDBCStatusSet = map[string]struct{}{
@@ -282,54 +281,51 @@ func countWriters(members []docdbtypes.DBClusterMember) int {
 	return n
 }
 
-// computeDBCStatusAndIssues returns the top S4 phrase (with `(+N)` suffix when
-// multiple warnings stack) AND the full ordered list of every active issue phrase.
-// The second return feeds Resource.Issues so the detail view can render all
-// active warnings individually (spec rule 7). Broken / transitional / healthy
-// states each produce at most one phrase.
-func computeDBCStatusAndIssues(cluster docdbtypes.DBCluster) (string, []string) {
+// computeDBCStatusAndIssues returns the ordered Wave-1 findings for a DocumentDB cluster.
+// Returns nil for healthy clusters. Broken / transitional / healthy states each produce
+// at most one finding per severity bucket; warning states may stack multiple findings.
+func computeDBCStatusAndIssues(cluster docdbtypes.DBCluster) []domain.Finding {
 	status := aws.ToString(cluster.Status)
 
-	// Broken statuses — first match wins; no warning stacking.
-	if phrase, ok := brokenDBCStatusPhrase[status]; ok {
-		return phrase, []string{phrase}
+	// Broken statuses — map to specific codes.
+	switch status {
+	case "failed":
+		return []domain.Finding{{Code: CodeDBCFailed, Phrase: "failed: cluster operation", Severity: domain.SevBroken, Source: "wave1"}}
+	case "inaccessible-encryption-credentials":
+		return []domain.Finding{{Code: CodeDBCEncryptionKeyUnreachable, Phrase: "encryption key unreachable", Severity: domain.SevBroken, Source: "wave1"}}
+	case "incompatible-parameters":
+		return []domain.Finding{{Code: CodeDBCIncompatibleParameters, Phrase: "parameter group incompatible", Severity: domain.SevBroken, Source: "wave1"}}
 	}
 
 	// No writer on an available cluster — reads only (Broken; beats warnings).
 	if status == "available" && countWriters(cluster.DBClusterMembers) == 0 {
-		const phrase = "no writer: reads only"
-		return phrase, []string{phrase}
+		return []domain.Finding{{Code: CodeDBCNoWriter, Phrase: "no writer: reads only", Severity: domain.SevBroken, Source: "wave1"}}
 	}
 
 	// Transitional statuses.
 	if _, ok := transitionalDBCStatusSet[status]; ok {
 		phrase := status + ": in progress"
-		return phrase, []string{phrase}
+		return []domain.Finding{{Code: CodeDBCTransitional, Phrase: phrase, Severity: domain.SevWarn, Source: "wave1"}}
 	}
 
 	// Healthy available — collect Wave-1 warnings in spec §4 table order.
 	if status == "available" {
-		var warnings []string
-		// §4 order: delete-protection off, not encrypted at rest, no automated backups.
+		var findings []domain.Finding
 		if cluster.DeletionProtection != nil && !*cluster.DeletionProtection {
-			warnings = append(warnings, "delete-protection off")
+			findings = append(findings, domain.Finding{Code: CodeDBCDeletionProtectionOff, Phrase: "delete-protection off", Severity: domain.SevWarn, Source: "wave1"})
 		}
 		if cluster.StorageEncrypted != nil && !*cluster.StorageEncrypted {
-			warnings = append(warnings, "not encrypted at rest")
+			findings = append(findings, domain.Finding{Code: CodeDBCNotEncryptedAtRest, Phrase: "not encrypted at rest", Severity: domain.SevWarn, Source: "wave1"})
 		}
 		if cluster.BackupRetentionPeriod != nil && *cluster.BackupRetentionPeriod == 0 {
-			warnings = append(warnings, "no automated backups")
+			findings = append(findings, domain.Finding{Code: CodeDBCNoAutomatedBackups, Phrase: "no automated backups", Severity: domain.SevWarn, Source: "wave1"})
 		}
-		switch len(warnings) {
-		case 0:
-			return "", nil
-		case 1:
-			return warnings[0], warnings
-		default:
-			return fmt.Sprintf("%s (+%d)", warnings[0], len(warnings)-1), warnings
-		}
+		return findings
 	}
 
-	// Unknown status — bare keyword passthrough (future-proof for new AWS statuses).
-	return status, []string{status}
+	// Unknown status — pass through as transitional.
+	if status != "" {
+		return []domain.Finding{{Code: CodeDBCTransitional, Phrase: status, Severity: domain.SevWarn, Source: "wave1"}}
+	}
+	return nil
 }

--- a/internal/aws/dbc_codes.go
+++ b/internal/aws/dbc_codes.go
@@ -1,0 +1,19 @@
+package aws
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+const (
+	CodeDBCFailed                   domain.FindingCode = "dbc.broken.failed"
+	CodeDBCEncryptionKeyUnreachable domain.FindingCode = "dbc.broken.encryption_key_unreachable"
+	CodeDBCIncompatibleParameters   domain.FindingCode = "dbc.broken.incompatible_parameters"
+	CodeDBCNoWriter                 domain.FindingCode = "dbc.broken.no_writer"
+	CodeDBCTransitional             domain.FindingCode = "dbc.warn.transitional"
+	CodeDBCDeletionProtectionOff    domain.FindingCode = "dbc.warn.deletion_protection_off"
+	CodeDBCNotEncryptedAtRest       domain.FindingCode = "dbc.warn.not_encrypted_at_rest"
+	CodeDBCNoAutomatedBackups       domain.FindingCode = "dbc.warn.no_automated_backups"
+
+	CodeDBCSnapFailed       domain.FindingCode = "dbc-snap.broken.failed"
+	CodeDBCSnapIncompatible domain.FindingCode = "dbc-snap.broken.incompatible"
+	CodeDBCSnapCreating     domain.FindingCode = "dbc-snap.warn.creating"
+	CodeDBCSnapManualUnused domain.FindingCode = "dbc-snap.warn.manual_unused"
+)

--- a/internal/aws/dbc_issue_enrichment.go
+++ b/internal/aws/dbc_issue_enrichment.go
@@ -46,7 +46,9 @@ func EnrichDBCMaintenance(ctx context.Context, clients *ServiceClients, resource
 	for _, r := range resources {
 		if r.ID != "" {
 			probeIDs = append(probeIDs, r.ID)
-			statusByID[r.ID] = r.Status
+			// r.Status is empty; the fetcher writes the display
+			// phrase to Fields["status"] instead.
+			statusByID[r.ID] = r.Fields["status"]
 		}
 	}
 

--- a/internal/aws/dbc_rds.go
+++ b/internal/aws/dbc_rds.go
@@ -10,17 +10,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
-
-// brokenRDSDBCStatusPhrase maps Aurora / Multi-AZ cluster statuses that represent
-// hard failures to their display phrases per spec §4.
-// Mirrors brokenDBCStatusPhrase for the RDS-side cluster type.
-var brokenRDSDBCStatusPhrase = map[string]string{
-	"failed":                              "failed: cluster operation",
-	"inaccessible-encryption-credentials": "encryption key unreachable",
-	"incompatible-parameters":             "parameter group incompatible",
-}
 
 // transitionalRDSDBCStatusSet contains Aurora / Multi-AZ cluster statuses that
 // indicate a transitional (Warning) state.
@@ -43,54 +35,52 @@ func countRDSWriters(members []rdstypes.DBClusterMember) int {
 	return n
 }
 
-// computeRDSDBClusterStatusAndIssues returns the §4 phrase and the full ordered
-// list of every active issue phrase for an RDS-side (Aurora / Multi-AZ) DB cluster.
-// Algorithm mirrors computeDBCStatusAndIssues.
-func computeRDSDBClusterStatusAndIssues(cluster rdstypes.DBCluster) (string, []string) {
+// computeRDSDBClusterStatusAndIssues returns the ordered Wave-1 findings for an
+// RDS-side (Aurora / Multi-AZ) DB cluster. Algorithm mirrors computeDBCStatusAndIssues.
+func computeRDSDBClusterStatusAndIssues(cluster rdstypes.DBCluster) []domain.Finding {
 	status := aws.ToString(cluster.Status)
 
-	// Broken statuses — first match wins; no warning stacking.
-	if phrase, ok := brokenRDSDBCStatusPhrase[status]; ok {
-		return phrase, []string{phrase}
+	// Broken statuses — map to specific codes.
+	switch status {
+	case "failed":
+		return []domain.Finding{{Code: CodeDBCFailed, Phrase: "failed: cluster operation", Severity: domain.SevBroken, Source: "wave1"}}
+	case "inaccessible-encryption-credentials":
+		return []domain.Finding{{Code: CodeDBCEncryptionKeyUnreachable, Phrase: "encryption key unreachable", Severity: domain.SevBroken, Source: "wave1"}}
+	case "incompatible-parameters":
+		return []domain.Finding{{Code: CodeDBCIncompatibleParameters, Phrase: "parameter group incompatible", Severity: domain.SevBroken, Source: "wave1"}}
 	}
 
 	// No writer on an available cluster — reads only (Broken; beats warnings).
 	if status == "available" && countRDSWriters(cluster.DBClusterMembers) == 0 {
-		const phrase = "no writer: reads only"
-		return phrase, []string{phrase}
+		return []domain.Finding{{Code: CodeDBCNoWriter, Phrase: "no writer: reads only", Severity: domain.SevBroken, Source: "wave1"}}
 	}
 
 	// Transitional statuses.
 	if _, ok := transitionalRDSDBCStatusSet[status]; ok {
 		phrase := status + ": in progress"
-		return phrase, []string{phrase}
+		return []domain.Finding{{Code: CodeDBCTransitional, Phrase: phrase, Severity: domain.SevWarn, Source: "wave1"}}
 	}
 
 	// Healthy available — collect Wave-1 warnings in spec §4 table order.
 	if status == "available" {
-		var warnings []string
-		// §4 order: delete-protection off, not encrypted at rest, no automated backups.
+		var findings []domain.Finding
 		if cluster.DeletionProtection != nil && !*cluster.DeletionProtection {
-			warnings = append(warnings, "delete-protection off")
+			findings = append(findings, domain.Finding{Code: CodeDBCDeletionProtectionOff, Phrase: "delete-protection off", Severity: domain.SevWarn, Source: "wave1"})
 		}
 		if cluster.StorageEncrypted != nil && !*cluster.StorageEncrypted {
-			warnings = append(warnings, "not encrypted at rest")
+			findings = append(findings, domain.Finding{Code: CodeDBCNotEncryptedAtRest, Phrase: "not encrypted at rest", Severity: domain.SevWarn, Source: "wave1"})
 		}
 		if cluster.BackupRetentionPeriod != nil && *cluster.BackupRetentionPeriod == 0 {
-			warnings = append(warnings, "no automated backups")
+			findings = append(findings, domain.Finding{Code: CodeDBCNoAutomatedBackups, Phrase: "no automated backups", Severity: domain.SevWarn, Source: "wave1"})
 		}
-		switch len(warnings) {
-		case 0:
-			return "", nil
-		case 1:
-			return warnings[0], warnings
-		default:
-			return fmt.Sprintf("%s (+%d)", warnings[0], len(warnings)-1), warnings
-		}
+		return findings
 	}
 
-	// Unknown status — bare keyword passthrough (future-proof for new AWS statuses).
-	return status, []string{status}
+	// Unknown status — pass through as transitional.
+	if status != "" {
+		return []domain.Finding{{Code: CodeDBCTransitional, Phrase: status, Severity: domain.SevWarn, Source: "wave1"}}
+	}
+	return nil
 }
 
 // FetchRDSDBClustersPage fetches a single page of Aurora + Multi-AZ DB clusters
@@ -171,17 +161,22 @@ func FetchRDSDBClustersPage(ctx context.Context, api RDSDescribeDBClustersAPI, c
 			backupRetentionPeriod = fmt.Sprintf("%d", *cluster.BackupRetentionPeriod)
 		}
 
-		computedStatus, computedIssues := computeRDSDBClusterStatusAndIssues(cluster)
+		findings := computeRDSDBClusterStatusAndIssues(cluster)
+		statusPhrase := ""
+		if len(findings) > 0 {
+			statusPhrase = findings[0].Phrase
+			if len(findings) > 1 {
+				statusPhrase = fmt.Sprintf("%s (+%d)", statusPhrase, len(findings)-1)
+			}
+		}
 
 		r := resource.Resource{
-			ID:     clusterID,
-			Name:   clusterID,
-			Status: computedStatus,
-			Issues: computedIssues,
+			ID:   clusterID,
+			Name: clusterID,
 			Fields: map[string]string{
 				"cluster_id":              clusterID,
 				"engine_version":          engineVersion,
-				"status":                  computedStatus,
+				"status":                  statusPhrase,
 				"instances":               instances,
 				"endpoint":                endpoint,
 				"arn":                     aws.ToString(cluster.DBClusterArn),
@@ -191,6 +186,7 @@ func FetchRDSDBClustersPage(ctx context.Context, api RDSDescribeDBClustersAPI, c
 				"storage_encrypted":       storageEncrypted,
 				"backup_retention_period": backupRetentionPeriod,
 			},
+			Findings:  findings,
 			RawStruct: cluster,
 		}
 

--- a/internal/aws/dbc_snap.go
+++ b/internal/aws/dbc_snap.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/docdb"
 	docdbtypes "github.com/aws/aws-sdk-go-v2/service/docdb/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -111,10 +112,8 @@ func init() {
 	})
 }
 
-// ComputeDBCSnapStatusAndIssues computes the §4 status phrase and ordered
-// issues slice for a DocDB / Aurora cluster snapshot. Returns ("", nil) for a
-// healthy (available) snapshot. The top phrase becomes Resource.Status; the
-// full slice becomes Resource.Issues.
+// computeDBCSnapFindings computes the ordered Wave-1 findings for a
+// DocDB / Aurora cluster snapshot. Returns nil for a healthy (available) snapshot.
 //
 // §0.1 / §3.1 precedence ladder (Broken > Warning, table order within severity):
 //  1. Broken: Status == "failed" → phrase "failed"
@@ -126,39 +125,58 @@ func init() {
 //     Gate: SnapshotType == "manual" AND SnapshotCreateTime != nil AND age > 365.
 //
 // Cross-ref signals (orphan, past-retention) are added by the Wave-1 issue
-// enricher (ComputeDBCSnapStatusAndIssues) via FieldUpdates, never here.
-func ComputeDBCSnapStatusAndIssues(snap docdbtypes.DBClusterSnapshot) (string, []string) {
+// enricher via FieldUpdates, never here.
+func computeDBCSnapFindings(snap docdbtypes.DBClusterSnapshot) []domain.Finding {
 	rawStatus := ""
 	if snap.Status != nil {
 		rawStatus = *snap.Status
 	}
 
-	var issues []string
-
 	// Broken checks first (severity wins).
 	if rawStatus == "failed" {
-		issues = append(issues, "failed")
-		return buildStatusFromIssues(issues), issues
+		return []domain.Finding{{Code: CodeDBCSnapFailed, Phrase: "failed", Severity: domain.SevBroken, Source: "wave1"}}
 	}
 	if strings.HasPrefix(rawStatus, "incompatible-") {
-		issues = append(issues, rawStatus)
-		return buildStatusFromIssues(issues), issues
+		return []domain.Finding{{Code: CodeDBCSnapIncompatible, Phrase: rawStatus, Severity: domain.SevBroken, Source: "wave1"}}
 	}
+
+	var findings []domain.Finding
 
 	// Warning: creating (transitional). DBClusterSnapshot has no PercentProgress.
 	if rawStatus == "creating" {
-		issues = append(issues, "creating")
+		findings = append(findings, domain.Finding{Code: CodeDBCSnapCreating, Phrase: "creating", Severity: domain.SevWarn, Source: "wave1"})
 	}
 
 	// Warning: manual snapshot unused for > 365 days.
 	if snap.SnapshotType != nil && *snap.SnapshotType == "manual" && snap.SnapshotCreateTime != nil {
 		ageD := int(time.Since(*snap.SnapshotCreateTime).Hours() / 24)
 		if ageD > 365 {
-			issues = append(issues, fmt.Sprintf("manual, unused %dd", ageD))
+			findings = append(findings, domain.Finding{Code: CodeDBCSnapManualUnused, Phrase: fmt.Sprintf("manual, unused %dd", ageD), Severity: domain.SevWarn, Source: "wave1"})
 		}
 	}
 
-	return buildStatusFromIssues(issues), issues
+	return findings
+}
+
+// ComputeDBCSnapStatusAndIssues exists solely so tests in package unit can
+// exercise computeDBCSnapFindings without importing internal/aws as a package.
+// The status phrase carries the (+N) suffix to match what
+// FetchDocDBClusterSnapshotsPage writes to Fields["status"]. No production
+// code calls this — production paths use computeDBCSnapFindings directly.
+func ComputeDBCSnapStatusAndIssues(snap docdbtypes.DBClusterSnapshot) (string, []string) {
+	findings := computeDBCSnapFindings(snap)
+	if len(findings) == 0 {
+		return "", nil
+	}
+	phrases := make([]string, len(findings))
+	for i, f := range findings {
+		phrases[i] = f.Phrase
+	}
+	statusPhrase := phrases[0]
+	if len(phrases) > 1 {
+		statusPhrase = fmt.Sprintf("%s (+%d)", statusPhrase, len(phrases)-1)
+	}
+	return statusPhrase, phrases
 }
 
 // FetchDocDBClusterSnapshots calls the DocumentDB DescribeDBClusterSnapshots API and converts the
@@ -211,11 +229,16 @@ func FetchDocDBClusterSnapshotsPage(ctx context.Context, api DocDBDescribeDBClus
 
 		// Per spec §4 (docs/resources/dbc-snap.md), Status is the §4 phrase, not
 		// raw AWS state. Healthy snapshots render BLANK. Wave-1 fetcher-local
-		// signals (failed, incompatible-*, creating, manual-unused) are computed
-		// by ComputeDBCSnapStatusAndIssues and stored in Issues. Cross-ref signals
-		// (orphan, past-retention) come from enrichDBCSnapCrossRef and overwrite
-		// via FieldUpdates / merge with computeMergedStatus.
-		computedStatus, allIssues := ComputeDBCSnapStatusAndIssues(snapshot)
+		// signals (failed, incompatible-*, creating, manual-unused) are emitted
+		// as Findings by computeDBCSnapFindings.
+		findings := computeDBCSnapFindings(snapshot)
+		statusPhrase := ""
+		if len(findings) > 0 {
+			statusPhrase = findings[0].Phrase
+			if len(findings) > 1 {
+				statusPhrase = fmt.Sprintf("%s (+%d)", statusPhrase, len(findings)-1)
+			}
+		}
 
 		engine := ""
 		if snapshot.Engine != nil {
@@ -243,20 +266,19 @@ func FetchDocDBClusterSnapshotsPage(ctx context.Context, api DocDBDescribeDBClus
 		}
 
 		r := resource.Resource{
-			ID:     snapshotID,
-			Name:   snapshotID,
-			Status: computedStatus,
-			Issues: allIssues,
+			ID:   snapshotID,
+			Name: snapshotID,
 			Fields: map[string]string{
 				"snapshot_id":          snapshotID,
 				"cluster_id":           clusterID,
-				"status":               computedStatus,
+				"status":               statusPhrase,
 				"engine":               engine,
 				"snapshot_type":        snapshotType,
 				"snapshot_create_time": snapshotCreateTime,
 				"storage_type":         storageType,
 				"storage_encrypted":    storageEncrypted,
 			},
+			Findings:  findings,
 			RawStruct: snapshot,
 		}
 

--- a/internal/aws/dbc_snap_rds.go
+++ b/internal/aws/dbc_snap_rds.go
@@ -11,50 +11,70 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-// ComputeRDSDBClusterSnapshotStatusAndIssues computes the §4 status phrase and
-// ordered issues slice for an Aurora / Multi-AZ DB cluster snapshot fetched via
-// the RDS SDK. Returns ("", nil) for a healthy (available) snapshot.
+// computeRDSDBClusterSnapshotFindings computes the ordered Wave-1 findings
+// for an Aurora / Multi-AZ DB cluster snapshot fetched via the RDS SDK.
+// Returns nil for a healthy (available) snapshot.
 //
-// Algorithm mirrors ComputeDBCSnapStatusAndIssues — same §4 precedence ladder:
+// Algorithm mirrors computeDBCSnapFindings — same §4 precedence ladder:
 //  1. Broken: Status == "failed" → phrase "failed"
 //  2. Broken: strings.HasPrefix(Status, "incompatible-") → phrase verbatim
 //  3. Warning: Status == "creating" → phrase "creating"
 //  4. Warning: manual snapshot older than 365d → "manual, unused <N>d"
-func ComputeRDSDBClusterSnapshotStatusAndIssues(snap rdstypes.DBClusterSnapshot) (string, []string) {
+func computeRDSDBClusterSnapshotFindings(snap rdstypes.DBClusterSnapshot) []domain.Finding {
 	rawStatus := ""
 	if snap.Status != nil {
 		rawStatus = *snap.Status
 	}
 
-	var issues []string
-
 	// Broken checks first (severity wins).
 	if rawStatus == "failed" {
-		issues = append(issues, "failed")
-		return buildStatusFromIssues(issues), issues
+		return []domain.Finding{{Code: CodeDBCSnapFailed, Phrase: "failed", Severity: domain.SevBroken, Source: "wave1"}}
 	}
 	if strings.HasPrefix(rawStatus, "incompatible-") {
-		issues = append(issues, rawStatus)
-		return buildStatusFromIssues(issues), issues
+		return []domain.Finding{{Code: CodeDBCSnapIncompatible, Phrase: rawStatus, Severity: domain.SevBroken, Source: "wave1"}}
 	}
+
+	var findings []domain.Finding
 
 	// Warning: creating (transitional). DBClusterSnapshot has no PercentProgress.
 	if rawStatus == "creating" {
-		issues = append(issues, "creating")
+		findings = append(findings, domain.Finding{Code: CodeDBCSnapCreating, Phrase: "creating", Severity: domain.SevWarn, Source: "wave1"})
 	}
 
 	// Warning: manual snapshot unused for > 365 days.
 	if snap.SnapshotType != nil && *snap.SnapshotType == "manual" && snap.SnapshotCreateTime != nil {
 		ageD := int(time.Since(*snap.SnapshotCreateTime).Hours() / 24)
 		if ageD > 365 {
-			issues = append(issues, fmt.Sprintf("manual, unused %dd", ageD))
+			findings = append(findings, domain.Finding{Code: CodeDBCSnapManualUnused, Phrase: fmt.Sprintf("manual, unused %dd", ageD), Severity: domain.SevWarn, Source: "wave1"})
 		}
 	}
 
-	return buildStatusFromIssues(issues), issues
+	return findings
+}
+
+// ComputeRDSDBClusterSnapshotStatusAndIssues exists solely so tests in package
+// unit can exercise computeRDSDBClusterSnapshotFindings. The status phrase
+// carries the (+N) suffix to match what FetchRDSDBClusterSnapshotsPage writes
+// to Fields["status"]. No production code calls this — production paths use
+// computeRDSDBClusterSnapshotFindings directly.
+func ComputeRDSDBClusterSnapshotStatusAndIssues(snap rdstypes.DBClusterSnapshot) (string, []string) {
+	findings := computeRDSDBClusterSnapshotFindings(snap)
+	if len(findings) == 0 {
+		return "", nil
+	}
+	phrases := make([]string, len(findings))
+	for i, f := range findings {
+		phrases[i] = f.Phrase
+	}
+	statusPhrase := phrases[0]
+	if len(phrases) > 1 {
+		statusPhrase = fmt.Sprintf("%s (+%d)", statusPhrase, len(phrases)-1)
+	}
+	return statusPhrase, phrases
 }
 
 // FetchRDSDBClusterSnapshotsPage fetches a single page of Aurora + Multi-AZ DB
@@ -92,7 +112,14 @@ func FetchRDSDBClusterSnapshotsPage(ctx context.Context, api RDSDescribeDBCluste
 			clusterID = *snapshot.DBClusterIdentifier
 		}
 
-		computedStatus, allIssues := ComputeRDSDBClusterSnapshotStatusAndIssues(snapshot)
+		findings := computeRDSDBClusterSnapshotFindings(snapshot)
+		statusPhrase := ""
+		if len(findings) > 0 {
+			statusPhrase = findings[0].Phrase
+			if len(findings) > 1 {
+				statusPhrase = fmt.Sprintf("%s (+%d)", statusPhrase, len(findings)-1)
+			}
+		}
 
 		engine := ""
 		if snapshot.Engine != nil {
@@ -120,20 +147,19 @@ func FetchRDSDBClusterSnapshotsPage(ctx context.Context, api RDSDescribeDBCluste
 		}
 
 		r := resource.Resource{
-			ID:     snapshotID,
-			Name:   snapshotID,
-			Status: computedStatus,
-			Issues: allIssues,
+			ID:   snapshotID,
+			Name: snapshotID,
 			Fields: map[string]string{
 				"snapshot_id":          snapshotID,
 				"cluster_id":           clusterID,
-				"status":               computedStatus,
+				"status":               statusPhrase,
 				"engine":               engine,
 				"snapshot_type":        snapshotType,
 				"snapshot_create_time": snapshotCreateTime,
 				"storage_type":         storageType,
 				"storage_encrypted":    storageEncrypted,
 			},
+			Findings:  findings,
 			RawStruct: snapshot,
 		}
 

--- a/internal/aws/dbi_issue_enrichment.go
+++ b/internal/aws/dbi_issue_enrichment.go
@@ -60,7 +60,9 @@ func EnrichDBIMaintenance(ctx context.Context, clients *ServiceClients, resource
 	for _, r := range resources {
 		if r.ID != "" {
 			probeIDs = append(probeIDs, r.ID)
-			statusByID[r.ID] = r.Status
+			// r.Status is empty; the fetcher writes the display
+			// phrase to Fields["status"] instead.
+			statusByID[r.ID] = r.Fields["status"]
 		}
 	}
 

--- a/internal/aws/dbi_snap.go
+++ b/internal/aws/dbi_snap.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -44,9 +45,8 @@ func init() {
 	})
 }
 
-// ComputeDBISnapStatusAndIssues computes the §4 status phrase and ordered issues
-// slice for an RDS snapshot. Returns ("", nil) for a healthy (available + encrypted)
-// snapshot. The top phrase is used as Resource.Status; the full slice as Resource.Issues.
+// ComputeDBISnapStatusAndIssues computes the ordered Wave-1 findings for an RDS snapshot.
+// Returns nil for a healthy (available + encrypted) snapshot.
 //
 // §0.1 precedence ladder (Broken > Warning, table order within severity):
 //  1. Broken: failed
@@ -56,23 +56,21 @@ func init() {
 //
 // Cross-ref signals (orphan, past-retention) are added by the Wave-1 issue enricher
 // which has access to the sibling dbi cache.
-func ComputeDBISnapStatusAndIssues(snap rdstypes.DBSnapshot) (string, []string) {
+func ComputeDBISnapStatusAndIssues(snap rdstypes.DBSnapshot) []domain.Finding {
 	rawStatus := ""
 	if snap.Status != nil {
 		rawStatus = *snap.Status
 	}
 
-	var issues []string
-
 	// Broken checks first (severity wins).
 	if rawStatus == "failed" {
-		issues = append(issues, "failed")
-		return buildStatusFromIssues(issues), issues
+		return []domain.Finding{{Code: CodeDBISnapFailed, Phrase: "failed", Severity: domain.SevBroken, Source: "wave1"}}
 	}
 	if strings.HasPrefix(rawStatus, "incompatible-") {
-		issues = append(issues, rawStatus)
-		return buildStatusFromIssues(issues), issues
+		return []domain.Finding{{Code: CodeDBISnapIncompatible, Phrase: rawStatus, Severity: domain.SevBroken, Source: "wave1"}}
 	}
+
+	var findings []domain.Finding
 
 	// Warning: creating (transitional).
 	if rawStatus == "creating" {
@@ -81,20 +79,20 @@ func ComputeDBISnapStatusAndIssues(snap rdstypes.DBSnapshot) (string, []string) 
 			pct = *snap.PercentProgress
 		}
 		phrase := fmt.Sprintf("creating: %d%%", pct)
-		issues = append(issues, phrase)
+		findings = append(findings, domain.Finding{Code: CodeDBISnapCreating, Phrase: phrase, Severity: domain.SevWarn, Source: "wave1"})
 		// Unencrypted can also apply during creating.
 		if isSnapUnencrypted(snap) {
-			issues = append(issues, "unencrypted")
+			findings = append(findings, domain.Finding{Code: CodeDBISnapUnencrypted, Phrase: "unencrypted", Severity: domain.SevWarn, Source: "wave1"})
 		}
-		return buildStatusFromIssues(issues), issues
+		return findings
 	}
 
 	// Warning: unencrypted (only for available/other non-broken states).
 	if isSnapUnencrypted(snap) {
-		issues = append(issues, "unencrypted")
+		findings = append(findings, domain.Finding{Code: CodeDBISnapUnencrypted, Phrase: "unencrypted", Severity: domain.SevWarn, Source: "wave1"})
 	}
 
-	return buildStatusFromIssues(issues), issues
+	return findings
 }
 
 // isSnapUnencrypted returns true when the snapshot's Encrypted field is
@@ -102,18 +100,6 @@ func ComputeDBISnapStatusAndIssues(snap rdstypes.DBSnapshot) (string, []string) 
 // Per spec §4: the unencrypted signal fires on Encrypted == false only.
 func isSnapUnencrypted(snap rdstypes.DBSnapshot) bool {
 	return snap.Encrypted != nil && !*snap.Encrypted
-}
-
-// buildStatusFromIssues returns the top phrase with a (+N) suffix when there
-// are multiple issues, or empty string when there are none.
-func buildStatusFromIssues(issues []string) string {
-	if len(issues) == 0 {
-		return ""
-	}
-	if len(issues) == 1 {
-		return issues[0]
-	}
-	return resource.BumpFindingSuffix(issues[0])
 }
 
 // FetchDBISnapshots calls the RDS DescribeDBSnapshots API and converts the
@@ -192,26 +178,31 @@ func FetchDBISnapshotsPage(ctx context.Context, api RDSDescribeDBSnapshotsAPI, c
 			encryptedStr = "false"
 		}
 
-		// Compute §4 status phrase and ordered issues slice per §0.1 precedence ladder.
-		// computedStatus is empty for healthy (available+encrypted) snapshots.
-		// r.Status stores the §4 phrase (consistent with all other resource types).
-		computedStatus, allIssues := ComputeDBISnapStatusAndIssues(snap)
+		// Compute Wave-1 findings per §0.1 precedence ladder.
+		// The first finding's Phrase drives Fields["status"] for display.
+		findings := ComputeDBISnapStatusAndIssues(snap)
+		statusPhrase := ""
+		if len(findings) > 0 {
+			statusPhrase = findings[0].Phrase
+			if len(findings) > 1 {
+				statusPhrase = fmt.Sprintf("%s (+%d)", statusPhrase, len(findings)-1)
+			}
+		}
 
 		r := resource.Resource{
-			ID:     snapshotID,
-			Name:   snapshotID,
-			Status: computedStatus,
-			Issues: allIssues,
+			ID:   snapshotID,
+			Name: snapshotID,
 			Fields: map[string]string{
 				"snapshot_id":   snapshotID,
 				"db_instance":   dbInstance,
-				"status":        computedStatus,
+				"status":        statusPhrase,
 				"encrypted":     encryptedStr,
 				"engine":        engine,
 				"snapshot_type": snapshotType,
 				"created":       created,
 				"arn":           snapARN,
 			},
+			Findings:  findings,
 			RawStruct: snap,
 		}
 

--- a/internal/aws/ddb.go
+++ b/internal/aws/ddb.go
@@ -8,31 +8,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
-
-// ddbTableStatusPhrase maps a DynamoDB TableStatus enum to the §4 list phrase.
-// Returns "" for ACTIVE (Healthy silence) and a lowercase phrase for all other states.
-func ddbTableStatusPhrase(ts ddbtypes.TableStatus) string {
-	switch ts {
-	case ddbtypes.TableStatusActive:
-		return ""
-	case ddbtypes.TableStatusCreating:
-		return "creating"
-	case ddbtypes.TableStatusUpdating:
-		return "updating"
-	case ddbtypes.TableStatusDeleting:
-		return "deleting"
-	case ddbtypes.TableStatusArchiving:
-		return "archiving"
-	case ddbtypes.TableStatusInaccessibleEncryptionCredentials:
-		return "kms key inaccessible"
-	case ddbtypes.TableStatusArchived:
-		return "archived: kms key lost"
-	default:
-		return ""
-	}
-}
 
 func init() {
 	resource.RegisterFieldKeys("ddb", []string{"table_name", "status", "item_count", "size_bytes", "billing_mode"})
@@ -59,6 +37,29 @@ func init() {
 	resource.RegisterDefaultNavFields("ddb", []resource.NavigableField{
 		{FieldPath: "SSEDescription.KMSMasterKeyArn", TargetType: "kms"},
 	})
+}
+
+// computeDDBFindings returns the ordered Wave-1 findings for a DynamoDB table.
+// Returns nil for ACTIVE (healthy) tables.
+func computeDDBFindings(ts ddbtypes.TableStatus) []domain.Finding {
+	switch ts {
+	case ddbtypes.TableStatusActive:
+		return nil
+	case ddbtypes.TableStatusCreating:
+		return []domain.Finding{{Code: CodeDDBCreating, Phrase: "creating", Severity: domain.SevWarn, Source: "wave1"}}
+	case ddbtypes.TableStatusUpdating:
+		return []domain.Finding{{Code: CodeDDBUpdating, Phrase: "updating", Severity: domain.SevWarn, Source: "wave1"}}
+	case ddbtypes.TableStatusDeleting:
+		return []domain.Finding{{Code: CodeDDBDeleting, Phrase: "deleting", Severity: domain.SevWarn, Source: "wave1"}}
+	case ddbtypes.TableStatusArchiving:
+		return []domain.Finding{{Code: CodeDDBArchiving, Phrase: "archiving", Severity: domain.SevWarn, Source: "wave1"}}
+	case ddbtypes.TableStatusInaccessibleEncryptionCredentials:
+		return []domain.Finding{{Code: CodeDDBKMSKeyInaccessible, Phrase: "kms key inaccessible", Severity: domain.SevBroken, Source: "wave1"}}
+	case ddbtypes.TableStatusArchived:
+		return []domain.Finding{{Code: CodeDDBArchivedKMSLost, Phrase: "archived: kms key lost", Severity: domain.SevBroken, Source: "wave1"}}
+	default:
+		return nil
+	}
 }
 
 // FetchDynamoDBTables calls the DynamoDB ListTables/DescribeTable APIs and
@@ -123,7 +124,14 @@ func FetchDynamoDBTablesPage(ctx context.Context, listAPI DDBListTablesAPI, desc
 			name = *table.TableName
 		}
 
-		phrase := ddbTableStatusPhrase(table.TableStatus)
+		findings := computeDDBFindings(table.TableStatus)
+		statusPhrase := ""
+		if len(findings) > 0 {
+			statusPhrase = findings[0].Phrase
+			if len(findings) > 1 {
+				statusPhrase = fmt.Sprintf("%s (+%d)", statusPhrase, len(findings)-1)
+			}
+		}
 
 		itemCount := ""
 		if table.ItemCount != nil {
@@ -145,24 +153,18 @@ func FetchDynamoDBTablesPage(ctx context.Context, listAPI DDBListTablesAPI, desc
 			arn = *table.TableArn
 		}
 
-		var issues []string
-		if phrase != "" {
-			issues = []string{phrase}
-		}
-
 		r := resource.Resource{
-			ID:     name,
-			Name:   name,
-			Status: phrase,
-			Issues: issues,
+			ID:   name,
+			Name: name,
 			Fields: map[string]string{
 				"table_name":   name,
-				"status":       phrase,
+				"status":       statusPhrase,
 				"item_count":   itemCount,
 				"size_bytes":   sizeBytes,
 				"billing_mode": billingMode,
 				"arn":          arn,
 			},
+			Findings:  findings,
 			RawStruct: table,
 		}
 

--- a/internal/aws/ddb_codes.go
+++ b/internal/aws/ddb_codes.go
@@ -1,0 +1,12 @@
+package aws
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+const (
+	CodeDDBKMSKeyInaccessible domain.FindingCode = "ddb.broken.kms_key_inaccessible"
+	CodeDDBArchivedKMSLost    domain.FindingCode = "ddb.broken.archived_kms_lost"
+	CodeDDBCreating           domain.FindingCode = "ddb.warn.creating"
+	CodeDDBUpdating           domain.FindingCode = "ddb.warn.updating"
+	CodeDDBDeleting           domain.FindingCode = "ddb.warn.deleting"
+	CodeDDBArchiving          domain.FindingCode = "ddb.warn.archiving"
+)

--- a/internal/aws/efs.go
+++ b/internal/aws/efs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/efs"
 	efstypes "github.com/aws/aws-sdk-go-v2/service/efs/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -42,48 +43,42 @@ func FetchEFSFileSystems(ctx context.Context, api EFSDescribeFileSystemsAPI) ([]
 	return all, nil
 }
 
-// efsW1Signals returns the active Wave-1 issue phrases for this filesystem in
-// §4 precedence order: Broken signals first (error, no mount targets), then
+// efsW1Findings returns the active Wave-1 findings for this filesystem in
+// precedence order: Broken signals first (error, no mount targets), then
 // Warning signals (creating, updating, deleting).
 //
-// The first phrase is the "top" displayed in the Status column (plus (+N-1)
-// suffix when more than one phrase is active). All phrases are appended to
-// Resource.Issues so the detail view can render every signal individually.
-func efsW1Signals(lcs efstypes.LifeCycleState, numMT int32) []string {
-	// §4 precedence order (severity first, then table order within severity):
-	//   Broken: "error", "no mount targets"
-	//   Warning: "creating", "updating", "deleting"
-	var phrases []string
+// The first finding's Phrase is displayed in the Status column. All findings
+// are stored in Resource.Findings so the detail view can render every signal.
+func efsW1Findings(lcs efstypes.LifeCycleState, numMT int32) []domain.Finding {
+	var findings []domain.Finding
 
 	switch lcs {
 	case efstypes.LifeCycleStateError:
-		phrases = append(phrases, "error")
+		findings = append(findings, domain.Finding{Code: CodeEFSError, Phrase: "error", Severity: domain.SevBroken, Source: "wave1"})
 	case efstypes.LifeCycleStateCreating:
-		phrases = append(phrases, "creating")
+		findings = append(findings, domain.Finding{Code: CodeEFSCreating, Phrase: "creating", Severity: domain.SevWarn, Source: "wave1"})
 	case efstypes.LifeCycleStateUpdating:
-		phrases = append(phrases, "updating")
+		findings = append(findings, domain.Finding{Code: CodeEFSUpdating, Phrase: "updating", Severity: domain.SevWarn, Source: "wave1"})
 	case efstypes.LifeCycleStateDeleting:
-		phrases = append(phrases, "deleting")
-	// "available" and "deleted" produce no W1 phrase.
+		findings = append(findings, domain.Finding{Code: CodeEFSDeleting, Phrase: "deleting", Severity: domain.SevWarn, Source: "wave1"})
+		// "available" and "deleted" produce no Wave-1 phrase.
 	}
 
 	// "no mount targets" applies only while the filesystem exists. A deleted
 	// filesystem intrinsically has no mount targets — surfacing that as a
-	// broken-severity finding is noise (spec §4: "deleted" produces no W1
-	// phrase, and the absence of mount targets is a consequence of deletion,
-	// not an independent signal).
+	// broken-severity finding is noise.
 	if numMT == 0 && lcs != efstypes.LifeCycleStateDeleted {
-		// Insert "no mount targets" before Warning phrases (it is Broken-severity).
-		// If "error" is already present, append after it. Otherwise prepend.
-		if len(phrases) > 0 && phrases[0] == "error" {
-			phrases = append([]string{phrases[0], "no mount targets"}, phrases[1:]...)
+		noMT := domain.Finding{Code: CodeEFSNoMountTargets, Phrase: "no mount targets", Severity: domain.SevBroken, Source: "wave1"}
+		if len(findings) > 0 && findings[0].Code == CodeEFSError {
+			// "error" is Broken, insert "no mount targets" after it.
+			findings = append([]domain.Finding{findings[0], noMT}, findings[1:]...)
 		} else {
-			// "no mount targets" is Broken, so it precedes any Warning phrase.
-			phrases = append([]string{"no mount targets"}, phrases...)
+			// "no mount targets" is Broken, so it precedes any Warning finding.
+			findings = append([]domain.Finding{noMT}, findings...)
 		}
 	}
 
-	return phrases
+	return findings
 }
 
 // FetchEFSFileSystemsPage fetches a single page of EFS file systems.
@@ -125,41 +120,28 @@ func FetchEFSFileSystemsPage(ctx context.Context, api EFSDescribeFileSystemsAPI,
 
 		mountTargets := fmt.Sprintf("%d", fs.NumberOfMountTargets)
 
-		// Compute Wave-1 signals in §4 precedence order.
-		signals := efsW1Signals(fs.LifeCycleState, fs.NumberOfMountTargets)
-
-		// Derive Status (S4) and Issues from active signals.
-		var status string
-		var issues []string
-
-		switch len(signals) {
-		case 0:
-			// Healthy — blank S4.
-			status = ""
-			issues = nil
-		case 1:
-			status = signals[0]
-			issues = signals
-		default:
-			// Multiple W1 signals: top phrase + "(+N-1)" suffix where N-1 = len-1.
-			status = fmt.Sprintf("%s (+%d)", signals[0], len(signals)-1)
-			issues = signals
+		findings := efsW1Findings(fs.LifeCycleState, fs.NumberOfMountTargets)
+		statusPhrase := ""
+		if len(findings) > 0 {
+			statusPhrase = findings[0].Phrase
+			if len(findings) > 1 {
+				statusPhrase = fmt.Sprintf("%s (+%d)", statusPhrase, len(findings)-1)
+			}
 		}
 
 		r := resource.Resource{
-			ID:     fsID,
-			Name:   name,
-			Status: status,
-			Issues: issues,
+			ID:   fsID,
+			Name: name,
 			Fields: map[string]string{
 				"file_system_id":   fsID,
 				"name":             name,
-				"status":           status,
+				"status":           statusPhrase,
 				"performance_mode": performanceMode,
 				"throughput_mode":  throughputMode,
 				"encrypted":        encrypted,
 				"mount_targets":    mountTargets,
 			},
+			Findings:  findings,
 			RawStruct: fs,
 		}
 

--- a/internal/aws/efs_codes.go
+++ b/internal/aws/efs_codes.go
@@ -1,0 +1,11 @@
+package aws
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+const (
+	CodeEFSError          domain.FindingCode = "efs.broken.error"
+	CodeEFSNoMountTargets domain.FindingCode = "efs.broken.no_mount_targets"
+	CodeEFSCreating       domain.FindingCode = "efs.warn.creating"
+	CodeEFSUpdating       domain.FindingCode = "efs.warn.updating"
+	CodeEFSDeleting       domain.FindingCode = "efs.warn.deleting"
+)

--- a/internal/aws/efs_issue_enrichment.go
+++ b/internal/aws/efs_issue_enrichment.go
@@ -125,16 +125,16 @@ func EnrichEFSMountTargets(ctx context.Context, clients *ServiceClients, resourc
 		}
 		findings[fsID] = finding
 
-		// FieldUpdates: the Wave-2 phrase becomes the top, the Wave-1 phrases
-		// carried in r.Issues become the hidden count N. Deriving N from
-		// len(r.Issues) keeps the enricher idempotent — re-running against
-		// already-merged FieldUpdates["status"] never double-bumps the suffix,
-		// because Issues is fetcher-owned and stable across enrichment runs.
+		// FieldUpdates: the Wave-2 phrase becomes the top, the Wave-1 findings
+		// become the hidden count N. derive N from r.Findings
+		// (was len(r.Issues)). Findings is fetcher-owned and stable across
+		// enrichment runs, so re-running against already-merged FieldUpdates
+		// never double-bumps.
 		var newStatus string
-		if len(r.Issues) == 0 {
+		if len(r.Findings) == 0 {
 			newStatus = "mount target down"
 		} else {
-			newStatus = fmt.Sprintf("mount target down (+%d)", len(r.Issues))
+			newStatus = fmt.Sprintf("mount target down (+%d)", len(r.Findings))
 		}
 		fu := map[string]string{"status": newStatus}
 		fieldUpdates[fsID] = fu

--- a/internal/aws/kinesis.go
+++ b/internal/aws/kinesis.go
@@ -6,12 +6,14 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
+	kinesistypes "github.com/aws/aws-sdk-go-v2/service/kinesis/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
-	resource.RegisterFieldKeys("kinesis", []string{"stream_name", "status", "stream_mode", "creation_time"})
+	resource.RegisterFieldKeys("kinesis", []string{"stream_name", "status", "stream_status", "stream_mode", "creation_time"})
 
 	resource.RegisterPaginated("kinesis", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
 		c, ok := clients.(*ServiceClients)
@@ -20,6 +22,23 @@ func init() {
 		}
 		return FetchKinesisStreamsPage(ctx, c.Kinesis, continuationToken)
 	})
+}
+
+// computeKinesisFindings returns the Wave-1 findings for a Kinesis stream status.
+// Returns nil for ACTIVE (healthy) streams.
+func computeKinesisFindings(status kinesistypes.StreamStatus) []domain.Finding {
+	switch status {
+	case kinesistypes.StreamStatusActive:
+		return nil
+	case kinesistypes.StreamStatusCreating:
+		return []domain.Finding{{Code: CodeKinesisCreating, Phrase: "creating", Severity: domain.SevWarn, Source: "wave1"}}
+	case kinesistypes.StreamStatusUpdating:
+		return []domain.Finding{{Code: CodeKinesisUpdating, Phrase: "updating", Severity: domain.SevWarn, Source: "wave1"}}
+	case kinesistypes.StreamStatusDeleting:
+		return []domain.Finding{{Code: CodeKinesisDeleting, Phrase: "deleting", Severity: domain.SevWarn, Source: "wave1"}}
+	default:
+		return nil
+	}
 }
 
 // FetchKinesisStreams calls the Kinesis ListStreams API and converts the
@@ -81,17 +100,27 @@ func FetchKinesisStreamsPage(ctx context.Context, api KinesisListStreamsAPI, con
 			streamMode = string(stream.StreamModeDetails.StreamMode)
 		}
 
+		findings := computeKinesisFindings(stream.StreamStatus)
+		statusPhrase := ""
+		if len(findings) > 0 {
+			statusPhrase = findings[0].Phrase
+			if len(findings) > 1 {
+				statusPhrase = fmt.Sprintf("%s (+%d)", statusPhrase, len(findings)-1)
+			}
+		}
+
 		r := resource.Resource{
-			ID:     streamName,
-			Name:   streamName,
-			Status: status,
+			ID:   streamName,
+			Name: streamName,
 			Fields: map[string]string{
 				"stream_name":   streamName,
-				"status":        status,
+				"status":        statusPhrase,
+				"stream_status": status,
 				"stream_arn":    streamARN,
 				"creation_time": creationTime,
 				"stream_mode":   streamMode,
 			},
+			Findings:  findings,
 			RawStruct: stream,
 		}
 

--- a/internal/aws/kinesis_codes.go
+++ b/internal/aws/kinesis_codes.go
@@ -1,0 +1,9 @@
+package aws
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+const (
+	CodeKinesisCreating domain.FindingCode = "kinesis.warn.creating"
+	CodeKinesisUpdating domain.FindingCode = "kinesis.warn.updating"
+	CodeKinesisDeleting domain.FindingCode = "kinesis.warn.deleting"
+)

--- a/internal/aws/msk.go
+++ b/internal/aws/msk.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kafka"
+	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -20,6 +22,31 @@ func init() {
 		}
 		return FetchMSKClustersPage(ctx, c.MSK, continuationToken)
 	})
+}
+
+// computeMSKFindings returns the Wave-1 findings for an MSK cluster state.
+// Returns nil for ACTIVE (healthy) clusters.
+func computeMSKFindings(state kafkatypes.ClusterState) []domain.Finding {
+	switch state {
+	case kafkatypes.ClusterStateActive:
+		return nil
+	case kafkatypes.ClusterStateCreating:
+		return []domain.Finding{{Code: CodeMSKCreating, Phrase: "creating", Severity: domain.SevWarn, Source: "wave1"}}
+	case kafkatypes.ClusterStateUpdating:
+		return []domain.Finding{{Code: CodeMSKUpdating, Phrase: "updating", Severity: domain.SevWarn, Source: "wave1"}}
+	case kafkatypes.ClusterStateMaintenance:
+		return []domain.Finding{{Code: CodeMSKMaintenance, Phrase: "maintenance", Severity: domain.SevWarn, Source: "wave1"}}
+	case kafkatypes.ClusterStateRebootingBroker:
+		return []domain.Finding{{Code: CodeMSKRebootingBroker, Phrase: "rebooting broker", Severity: domain.SevWarn, Source: "wave1"}}
+	case kafkatypes.ClusterStateHealing:
+		return []domain.Finding{{Code: CodeMSKHealing, Phrase: "healing", Severity: domain.SevWarn, Source: "wave1"}}
+	case kafkatypes.ClusterStateDeleting:
+		return []domain.Finding{{Code: CodeMSKDeleting, Phrase: "deleting", Severity: domain.SevWarn, Source: "wave1"}}
+	case kafkatypes.ClusterStateFailed:
+		return []domain.Finding{{Code: CodeMSKFailed, Phrase: "failed", Severity: domain.SevBroken, Source: "wave1"}}
+	default:
+		return nil
+	}
 }
 
 // FetchMSKClusters calls the MSK ListClustersV2 API and returns a slice of
@@ -76,17 +103,27 @@ func FetchMSKClustersPage(ctx context.Context, api MSKListClustersV2API, continu
 			clusterARN = *cluster.ClusterArn
 		}
 
+		findings := computeMSKFindings(cluster.State)
+		statusPhrase := ""
+		if len(findings) > 0 {
+			statusPhrase = findings[0].Phrase
+			if len(findings) > 1 {
+				statusPhrase = fmt.Sprintf("%s (+%d)", statusPhrase, len(findings)-1)
+			}
+		}
+
 		r := resource.Resource{
-			ID:     clusterName,
-			Name:   clusterName,
-			Status: state,
+			ID:   clusterName,
+			Name: clusterName,
 			Fields: map[string]string{
 				"cluster_name": clusterName,
 				"cluster_arn":  clusterARN,
 				"cluster_type": clusterType,
 				"state":        state,
+				"status":       statusPhrase,
 				"version":      version,
 			},
+			Findings:  findings,
 			RawStruct: cluster,
 		}
 

--- a/internal/aws/msk_codes.go
+++ b/internal/aws/msk_codes.go
@@ -1,0 +1,13 @@
+package aws
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+const (
+	CodeMSKCreating        domain.FindingCode = "msk.warn.creating"
+	CodeMSKUpdating        domain.FindingCode = "msk.warn.updating"
+	CodeMSKMaintenance     domain.FindingCode = "msk.warn.maintenance"
+	CodeMSKRebootingBroker domain.FindingCode = "msk.warn.rebooting_broker"
+	CodeMSKHealing         domain.FindingCode = "msk.warn.healing"
+	CodeMSKDeleting        domain.FindingCode = "msk.warn.deleting"
+	CodeMSKFailed          domain.FindingCode = "msk.broken.failed"
+)

--- a/internal/aws/opensearch.go
+++ b/internal/aws/opensearch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/opensearch"
 	opensearchtypes "github.com/aws/aws-sdk-go-v2/service/opensearch/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -36,86 +37,87 @@ func init() {
 	})
 }
 
-// computeOpenSearchStatusAndIssues classifies a DomainStatus against the 5 spec signals
-// and returns the top Status phrase (with optional (+N) suffix) and the Issues slice
-// (hard-state phrases only). now is injected so tests can use a fixed instant.
+// computeOpenSearchFindings classifies a DomainStatus against the 5 spec signals
+// and returns ordered Wave-1 findings. now is injected so tests can use a fixed instant.
 //
 // Signal precedence (top-first):
 //  1. Deleted → "deleting: removal in progress" (Dim / hard-state)
 //  2. DomainProcessingStatus=="Isolated" → "isolated: quarantined by AWS" (Broken / hard-state)
 //  3. Processing || UpgradeProcessing → "processing: config change in flight" (Warning / hard-state)
-//  4. UpdateAvailable && AutomatedUpdateDate in the past → "software update forced soon" (! background)
-//  5. EncryptionAtRestOptions.Enabled==false → "encryption at rest off" (~ background)
-//
-// Hard-state phrases go into Issues; background-check phrases do NOT.
-// topPhrase is "" when all signals are absent (Healthy silence — rule 1).
-func computeOpenSearchStatusAndIssues(domain opensearchtypes.DomainStatus, now time.Time) (topPhrase string, issues []string) {
-	const (
-		phraseDeleting   = "deleting: removal in progress"
-		phraseIsolated   = "isolated: quarantined by AWS"
-		phraseProcessing = "processing: config change in flight"
-		phraseUpdateSoon = "software update forced soon"
-		phraseEncOff     = "encryption at rest off"
-	)
-
+//  4. UpdateAvailable && AutomatedUpdateDate in the past → "software update forced soon" (Warning / background)
+//  5. EncryptionAtRestOptions.Enabled==false → "encryption at rest off" (Warning / background)
+func computeOpenSearchFindings(dom opensearchtypes.DomainStatus, now time.Time) []domain.Finding {
 	// Classify each signal.
-	isDeleted := domain.Deleted != nil && *domain.Deleted
-	isIsolated := domain.DomainProcessingStatus == opensearchtypes.DomainProcessingStatusTypeIsolated
-	isProcessing := (domain.Processing != nil && *domain.Processing) ||
-		(domain.UpgradeProcessing != nil && *domain.UpgradeProcessing)
+	isDeleted := dom.Deleted != nil && *dom.Deleted
+	isIsolated := dom.DomainProcessingStatus == opensearchtypes.DomainProcessingStatusTypeIsolated
+	isProcessing := (dom.Processing != nil && *dom.Processing) ||
+		(dom.UpgradeProcessing != nil && *dom.UpgradeProcessing)
 
-	isUpdateForcedSoon := domain.ServiceSoftwareOptions != nil &&
-		domain.ServiceSoftwareOptions.UpdateAvailable != nil &&
-		*domain.ServiceSoftwareOptions.UpdateAvailable &&
-		domain.ServiceSoftwareOptions.AutomatedUpdateDate != nil &&
-		domain.ServiceSoftwareOptions.AutomatedUpdateDate.Before(now)
+	isUpdateForcedSoon := dom.ServiceSoftwareOptions != nil &&
+		dom.ServiceSoftwareOptions.UpdateAvailable != nil &&
+		*dom.ServiceSoftwareOptions.UpdateAvailable &&
+		dom.ServiceSoftwareOptions.AutomatedUpdateDate != nil &&
+		dom.ServiceSoftwareOptions.AutomatedUpdateDate.Before(now)
 
-	isEncOff := domain.EncryptionAtRestOptions != nil &&
-		domain.EncryptionAtRestOptions.Enabled != nil &&
-		!*domain.EncryptionAtRestOptions.Enabled
+	isEncOff := dom.EncryptionAtRestOptions != nil &&
+		dom.EncryptionAtRestOptions.Enabled != nil &&
+		!*dom.EncryptionAtRestOptions.Enabled
 
-	// Build ordered phrase list (precedence order).
-	var phrases []string
-	var hardPhrases []string
+	var findings []domain.Finding
 
 	if isDeleted {
-		phrases = append(phrases, phraseDeleting)
-		hardPhrases = append(hardPhrases, phraseDeleting)
+		findings = append(findings, domain.Finding{Code: CodeOpenSearchDeleting, Phrase: "deleting: removal in progress", Severity: domain.SevDim, Source: "wave1"})
 	}
 	if isIsolated {
-		phrases = append(phrases, phraseIsolated)
-		hardPhrases = append(hardPhrases, phraseIsolated)
+		findings = append(findings, domain.Finding{Code: CodeOpenSearchIsolated, Phrase: "isolated: quarantined by AWS", Severity: domain.SevBroken, Source: "wave1"})
 	}
 	if isProcessing {
-		phrases = append(phrases, phraseProcessing)
-		hardPhrases = append(hardPhrases, phraseProcessing)
+		findings = append(findings, domain.Finding{Code: CodeOpenSearchProcessing, Phrase: "processing: config change in flight", Severity: domain.SevWarn, Source: "wave1"})
+	}
+	// Background-check signals (UpdateForcedSoon, EncOff) are owned by the
+	// EnrichOpenSearchDomains Wave 2 enricher — emitting them as wave1 here
+	// would double-render in the detail view and incorrectly drive Color.
+	// They appear in Fields["status"] as display phrases via the suffix below.
+	_ = isUpdateForcedSoon
+	_ = isEncOff
+
+	return findings
+}
+
+// computeOpenSearchDisplayPhrases mirrors computeOpenSearchFindings but returns
+// the full ordered phrase list including background-check signals (used to
+// build Fields["status"] with (+N) suffix).
+func computeOpenSearchDisplayPhrases(dom opensearchtypes.DomainStatus, now time.Time) []string {
+	isDeleted := dom.Deleted != nil && *dom.Deleted
+	isIsolated := dom.DomainProcessingStatus == opensearchtypes.DomainProcessingStatusTypeIsolated
+	isProcessing := (dom.Processing != nil && *dom.Processing) ||
+		(dom.UpgradeProcessing != nil && *dom.UpgradeProcessing)
+	isUpdateForcedSoon := dom.ServiceSoftwareOptions != nil &&
+		dom.ServiceSoftwareOptions.UpdateAvailable != nil &&
+		*dom.ServiceSoftwareOptions.UpdateAvailable &&
+		dom.ServiceSoftwareOptions.AutomatedUpdateDate != nil &&
+		dom.ServiceSoftwareOptions.AutomatedUpdateDate.Before(now)
+	isEncOff := dom.EncryptionAtRestOptions != nil &&
+		dom.EncryptionAtRestOptions.Enabled != nil &&
+		!*dom.EncryptionAtRestOptions.Enabled
+
+	var phrases []string
+	if isDeleted {
+		phrases = append(phrases, "deleting: removal in progress")
+	}
+	if isIsolated {
+		phrases = append(phrases, "isolated: quarantined by AWS")
+	}
+	if isProcessing {
+		phrases = append(phrases, "processing: config change in flight")
 	}
 	if isUpdateForcedSoon {
-		phrases = append(phrases, phraseUpdateSoon)
-		// background-check: NOT added to hardPhrases
+		phrases = append(phrases, "software update forced soon")
 	}
 	if isEncOff {
-		phrases = append(phrases, phraseEncOff)
-		// background-check: NOT added to hardPhrases
+		phrases = append(phrases, "encryption at rest off")
 	}
-
-	if len(phrases) == 0 {
-		return "", nil
-	}
-
-	top := phrases[0]
-	hidden := len(phrases) - 1
-	if hidden > 0 {
-		top = fmt.Sprintf("%s (+%d)", top, hidden)
-	}
-
-	// Issues carries only hard-state phrases (no suffix — raw phrase per signal).
-	var issueList []string
-	if len(hardPhrases) > 0 {
-		issueList = hardPhrases
-	}
-
-	return top, issueList
+	return phrases
 }
 
 // FetchOpenSearchDomains performs a two-step fetch:
@@ -167,52 +169,52 @@ func FetchOpenSearchDomainsAt(
 
 	var resources []resource.Resource
 
-	for _, domain := range descOutput.DomainStatusList {
+	for _, dom := range descOutput.DomainStatusList {
 		domainName := ""
-		if domain.DomainName != nil {
-			domainName = *domain.DomainName
+		if dom.DomainName != nil {
+			domainName = *dom.DomainName
 		}
 
 		engineVersion := ""
-		if domain.EngineVersion != nil {
-			engineVersion = *domain.EngineVersion
+		if dom.EngineVersion != nil {
+			engineVersion = *dom.EngineVersion
 		}
 
 		endpoint := ""
-		if domain.Endpoint != nil {
-			endpoint = *domain.Endpoint
+		if dom.Endpoint != nil {
+			endpoint = *dom.Endpoint
 		}
 
 		instanceType := ""
 		instanceCount := ""
-		if domain.ClusterConfig != nil {
-			instanceType = string(domain.ClusterConfig.InstanceType)
-			if domain.ClusterConfig.InstanceCount != nil {
-				instanceCount = fmt.Sprintf("%d", *domain.ClusterConfig.InstanceCount)
+		if dom.ClusterConfig != nil {
+			instanceType = string(dom.ClusterConfig.InstanceType)
+			if dom.ClusterConfig.InstanceCount != nil {
+				instanceCount = fmt.Sprintf("%d", *dom.ClusterConfig.InstanceCount)
 			}
 		}
 
 		// --- Signal flags ---
 		deleted := "false"
-		if domain.Deleted != nil && *domain.Deleted {
+		if dom.Deleted != nil && *dom.Deleted {
 			deleted = "true"
 		}
 
 		processing := "false"
-		if domain.Processing != nil && *domain.Processing {
+		if dom.Processing != nil && *dom.Processing {
 			processing = "true"
 		}
 
 		upgradeProcessing := "false"
-		if domain.UpgradeProcessing != nil && *domain.UpgradeProcessing {
+		if dom.UpgradeProcessing != nil && *dom.UpgradeProcessing {
 			upgradeProcessing = "true"
 		}
 
 		// DomainProcessingStatus: always emit at least "Active" so the Color func's
 		// Isolated branch is deterministic even when the AWS field is zero-value.
 		processingStatus := "Active"
-		if domain.DomainProcessingStatus != "" {
-			processingStatus = string(domain.DomainProcessingStatus)
+		if dom.DomainProcessingStatus != "" {
+			processingStatus = string(dom.DomainProcessingStatus)
 		}
 
 		// Software update forced soon: UpdateAvailable AND AutomatedUpdateDate in the past.
@@ -220,8 +222,8 @@ func FetchOpenSearchDomainsAt(
 		updateDate := ""
 		currentVersion := ""
 		newVersion := ""
-		if domain.ServiceSoftwareOptions != nil {
-			sso := domain.ServiceSoftwareOptions
+		if dom.ServiceSoftwareOptions != nil {
+			sso := dom.ServiceSoftwareOptions
 			if sso.UpdateAvailable != nil && *sso.UpdateAvailable &&
 				sso.AutomatedUpdateDate != nil &&
 				sso.AutomatedUpdateDate.Before(now) {
@@ -240,20 +242,28 @@ func FetchOpenSearchDomainsAt(
 
 		// Encryption at rest: non-nil pointer with value false.
 		encEnabled := "true"
-		if domain.EncryptionAtRestOptions != nil &&
-			domain.EncryptionAtRestOptions.Enabled != nil &&
-			!*domain.EncryptionAtRestOptions.Enabled {
+		if dom.EncryptionAtRestOptions != nil &&
+			dom.EncryptionAtRestOptions.Enabled != nil &&
+			!*dom.EncryptionAtRestOptions.Enabled {
 			encEnabled = "false"
 		}
 
-		// Classify status and issues using the shared classifier (injectable now).
-		statusPhrase, issues := computeOpenSearchStatusAndIssues(domain, now)
+		findings := computeOpenSearchFindings(dom, now)
+		// Display phrase covers background-check signals (UpdateForcedSoon,
+		// EncOff) that are deliberately not in Findings — those are Wave 2
+		// territory but still surface in the Status column for visibility.
+		displayPhrases := computeOpenSearchDisplayPhrases(dom, now)
+		statusPhrase := ""
+		if len(displayPhrases) > 0 {
+			statusPhrase = displayPhrases[0]
+			if len(displayPhrases) > 1 {
+				statusPhrase = fmt.Sprintf("%s (+%d)", statusPhrase, len(displayPhrases)-1)
+			}
+		}
 
 		r := resource.Resource{
-			ID:     domainName,
-			Name:   domainName,
-			Status: statusPhrase,
-			Issues: issues,
+			ID:   domainName,
+			Name: domainName,
 			Fields: map[string]string{
 				"domain_name":                       domainName,
 				"engine_version":                    engineVersion,
@@ -271,7 +281,8 @@ func FetchOpenSearchDomainsAt(
 				"current_version":                   currentVersion,
 				"new_version":                       newVersion,
 			},
-			RawStruct: domain,
+			Findings:  findings,
+			RawStruct: dom,
 		}
 
 		resources = append(resources, r)

--- a/internal/aws/opensearch_codes.go
+++ b/internal/aws/opensearch_codes.go
@@ -1,0 +1,11 @@
+package aws
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+const (
+	CodeOpenSearchDeleting             domain.FindingCode = "opensearch.dim.deleting"
+	CodeOpenSearchIsolated             domain.FindingCode = "opensearch.broken.isolated"
+	CodeOpenSearchProcessing           domain.FindingCode = "opensearch.warn.processing"
+	CodeOpenSearchSoftwareUpdateForced domain.FindingCode = "opensearch.warn.software_update_forced"
+	CodeOpenSearchEncryptionAtRestOff  domain.FindingCode = "opensearch.warn.encryption_at_rest_off"
+)

--- a/internal/aws/rds.go
+++ b/internal/aws/rds.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -141,18 +142,23 @@ func FetchRDSInstancesPage(ctx context.Context, api RDSDescribeDBInstancesAPI, c
 			backupRetentionPeriod = fmt.Sprintf("%d", *db.BackupRetentionPeriod)
 		}
 
-		computedStatus, computedIssues := computeDBIStatusAndIssues(db)
+		findings := computeDBIStatusAndIssues(db)
+		statusPhrase := ""
+		if len(findings) > 0 {
+			statusPhrase = findings[0].Phrase
+			if len(findings) > 1 {
+				statusPhrase = fmt.Sprintf("%s (+%d)", statusPhrase, len(findings)-1)
+			}
+		}
 
 		r := resource.Resource{
-			ID:     dbIdentifier,
-			Name:   dbIdentifier,
-			Status: computedStatus,
-			Issues: computedIssues,
+			ID:   dbIdentifier,
+			Name: dbIdentifier,
 			Fields: map[string]string{
 				"db_identifier":           dbIdentifier,
 				"engine":                  engine,
 				"engine_version":          engineVersion,
-				"status":                  computedStatus,
+				"status":                  statusPhrase,
 				"class":                   class,
 				"endpoint":                endpoint,
 				"multi_az":                multiAZ,
@@ -162,6 +168,7 @@ func FetchRDSInstancesPage(ctx context.Context, api RDSDescribeDBInstancesAPI, c
 				"deletion_protection":     deletionProtection,
 				"backup_retention_period": backupRetentionPeriod,
 			},
+			Findings:  findings,
 			RawStruct: db,
 		}
 
@@ -191,73 +198,86 @@ func FetchRDSInstancesPage(ctx context.Context, api RDSDescribeDBInstancesAPI, c
 	}, nil
 }
 
-// brokenStatusPhrase maps RDS instance statuses that represent hard failures to
-// their display phrases. "inaccessible-encryption-credentials" is remapped per spec §4.
-var brokenStatusPhrase = map[string]string{
-	"failed":                              "failed",
-	"storage-full":                        "storage-full",
-	"incompatible-network":                "incompatible-network",
-	"incompatible-option-group":           "incompatible-option-group",
-	"incompatible-parameters":             "incompatible-parameters",
-	"incompatible-restore":                "incompatible-restore",
-	"restore-error":                       "restore-error",
-	"inaccessible-encryption-credentials": "encryption key unavailable",
-}
-
 // transitionalStatusSet contains RDS instance statuses that indicate a
 // transitional (Warning) state. These show a pending modification key suffix when applicable.
+//
+// "stopped" is intentionally classified Warn (not Broken) — it is admin
+// action, not failure, mirroring EC2 stopped semantics. previously mapped
+// stopped→Broken via a structural Color arm; that arm is now dead because
+// Findings drive Color. The shift is intentional.
 var transitionalStatusSet = map[string]struct{}{
 	"creating": {}, "modifying": {}, "backing-up": {}, "rebooting": {},
 	"renaming": {}, "resetting-master-credentials": {}, "starting": {},
-	"stopping": {}, "upgrading": {}, "maintenance": {},
+	"stopping": {}, "stopped": {}, "upgrading": {}, "maintenance": {},
 	"configuring-enhanced-monitoring": {}, "configuring-iam-database-auth": {},
 	"configuring-log-exports": {}, "converting-to-vpc": {}, "moving-to-vpc": {},
 	"storage-optimization": {},
 }
 
-// computeDBIStatusAndIssues returns the top S4 phrase (with `(+N)` suffix when
-// multiple warnings stack) AND the full ordered list of every active issue
-// phrase. The second return feeds Resource.Issues so the detail view can
-// render all active warnings individually (spec rule 7: "every finding
-// individually visible"). Broken / transitional / healthy states each produce
-// at most one phrase.
-func computeDBIStatusAndIssues(db rdstypes.DBInstance) (string, []string) {
+// computeDBIStatusAndIssues returns the ordered Wave-1 findings for a DB instance.
+// Returns nil for healthy instances. Broken / transitional / healthy states each
+// produce at most one finding; warning states may stack multiple findings.
+func computeDBIStatusAndIssues(db rdstypes.DBInstance) []domain.Finding {
 	status := aws.ToString(db.DBInstanceStatus)
-	if phrase, ok := brokenStatusPhrase[status]; ok {
-		return phrase, []string{phrase}
+
+	// Broken statuses — map to specific codes.
+	var brokenCode domain.FindingCode
+	var brokenPhrase string
+	switch status {
+	case "failed":
+		brokenCode, brokenPhrase = CodeDBIFailed, "failed"
+	case "storage-full":
+		brokenCode, brokenPhrase = CodeDBIStorageFull, "storage-full"
+	case "incompatible-network":
+		brokenCode, brokenPhrase = CodeDBIIncompatibleNetwork, "incompatible-network"
+	case "incompatible-option-group":
+		brokenCode, brokenPhrase = CodeDBIIncompatibleOptionGroup, "incompatible-option-group"
+	case "incompatible-parameters":
+		brokenCode, brokenPhrase = CodeDBIIncompatibleParameters, "incompatible-parameters"
+	case "incompatible-restore":
+		brokenCode, brokenPhrase = CodeDBIIncompatibleRestore, "incompatible-restore"
+	case "restore-error":
+		brokenCode, brokenPhrase = CodeDBIRestoreError, "restore-error"
+	case "inaccessible-encryption-credentials":
+		brokenCode, brokenPhrase = CodeDBIEncryptionKeyUnavailable, "encryption key unavailable"
 	}
+	if brokenCode != "" {
+		return []domain.Finding{{Code: brokenCode, Phrase: brokenPhrase, Severity: domain.SevBroken, Source: "wave1"}}
+	}
+
+	// Transitional statuses.
 	if _, ok := transitionalStatusSet[status]; ok {
 		key := firstNonEmptyPendingModifiedValueKey(db.PendingModifiedValues)
-		if key == "" {
-			return status, []string{status}
+		phrase := status
+		if key != "" {
+			phrase = status + ": " + key
 		}
-		phrase := status + ": " + key
-		return phrase, []string{phrase}
+		return []domain.Finding{{Code: CodeDBITransitional, Phrase: phrase, Severity: domain.SevWarn, Source: "wave1"}}
 	}
+
+	// Available: collect Wave-1 warnings.
 	if status == "available" {
-		var warnings []string
+		var findings []domain.Finding
 		if db.BackupRetentionPeriod != nil && *db.BackupRetentionPeriod == 0 {
-			warnings = append(warnings, "no automated backups")
+			findings = append(findings, domain.Finding{Code: CodeDBINoAutomatedBackups, Phrase: "no automated backups", Severity: domain.SevWarn, Source: "wave1"})
 		}
 		if db.PubliclyAccessible != nil && *db.PubliclyAccessible {
-			warnings = append(warnings, "publicly accessible")
+			findings = append(findings, domain.Finding{Code: CodeDBIPubliclyAccessible, Phrase: "publicly accessible", Severity: domain.SevWarn, Source: "wave1"})
 		}
 		if db.StorageEncrypted != nil && !*db.StorageEncrypted {
-			warnings = append(warnings, "unencrypted storage")
+			findings = append(findings, domain.Finding{Code: CodeDBIUnencryptedStorage, Phrase: "unencrypted storage", Severity: domain.SevWarn, Source: "wave1"})
 		}
 		if db.DeletionProtection != nil && !*db.DeletionProtection {
-			warnings = append(warnings, "deletion protection off")
+			findings = append(findings, domain.Finding{Code: CodeDBIDeletionProtectionOff, Phrase: "deletion protection off", Severity: domain.SevWarn, Source: "wave1"})
 		}
-		switch len(warnings) {
-		case 0:
-			return "", nil
-		case 1:
-			return warnings[0], warnings
-		default:
-			return fmt.Sprintf("%s (+%d)", warnings[0], len(warnings)-1), warnings
-		}
+		return findings
 	}
-	return status, []string{status} // unknown status — pass through
+
+	// Unknown status — pass through as transitional.
+	if status != "" {
+		return []domain.Finding{{Code: CodeDBITransitional, Phrase: status, Severity: domain.SevWarn, Source: "wave1"}}
+	}
+	return nil
 }
 
 // firstNonEmptyPendingModifiedValueKey inspects PendingModifiedValues fields in spec-defined order

--- a/internal/aws/rds_codes.go
+++ b/internal/aws/rds_codes.go
@@ -1,0 +1,24 @@
+package aws
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+const (
+	CodeDBIFailed                   domain.FindingCode = "dbi.broken.failed"
+	CodeDBIStorageFull              domain.FindingCode = "dbi.broken.storage_full"
+	CodeDBIIncompatibleNetwork      domain.FindingCode = "dbi.broken.incompatible_network"
+	CodeDBIIncompatibleOptionGroup  domain.FindingCode = "dbi.broken.incompatible_option_group"
+	CodeDBIIncompatibleParameters   domain.FindingCode = "dbi.broken.incompatible_parameters"
+	CodeDBIIncompatibleRestore      domain.FindingCode = "dbi.broken.incompatible_restore"
+	CodeDBIRestoreError             domain.FindingCode = "dbi.broken.restore_error"
+	CodeDBIEncryptionKeyUnavailable domain.FindingCode = "dbi.broken.encryption_key_unavailable"
+	CodeDBITransitional             domain.FindingCode = "dbi.warn.transitional"
+	CodeDBINoAutomatedBackups       domain.FindingCode = "dbi.warn.no_automated_backups"
+	CodeDBIPubliclyAccessible       domain.FindingCode = "dbi.warn.publicly_accessible"
+	CodeDBIUnencryptedStorage       domain.FindingCode = "dbi.warn.unencrypted_storage"
+	CodeDBIDeletionProtectionOff    domain.FindingCode = "dbi.warn.deletion_protection_off"
+
+	CodeDBISnapFailed       domain.FindingCode = "dbi-snap.broken.failed"
+	CodeDBISnapIncompatible domain.FindingCode = "dbi-snap.broken.incompatible"
+	CodeDBISnapCreating     domain.FindingCode = "dbi-snap.warn.creating"
+	CodeDBISnapUnencrypted  domain.FindingCode = "dbi-snap.warn.unencrypted"
+)

--- a/internal/aws/redis.go
+++ b/internal/aws/redis.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	elasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -25,9 +26,9 @@ func init() {
 	})
 }
 
-// computeShardIssues returns one §4 phrase per non-available NodeGroup on a
+// computeShardIssues returns one phrase per non-available NodeGroup on a
 // multi-shard (cluster-mode-enabled) replication group, ordered alphabetically
-// by phrase so rule-7 precedence is stable. Returns nil when the RG has ≤1
+// by phrase so rule-7 precedence is stable. Returns nil when the RG has <=1
 // NodeGroup — single-shard RGs use the RG-level phrase instead.
 func computeShardIssues(nodeGroups []elasticachetypes.NodeGroup) []string {
 	if len(nodeGroups) <= 1 {
@@ -49,13 +50,13 @@ func computeShardIssues(nodeGroups []elasticachetypes.NodeGroup) []string {
 	return out
 }
 
-// rgTransientPhrase maps a transient RG-level status to its §4 list phrase.
+// rgTransientPhrase maps a transient RG-level status to its list phrase.
 func rgTransientPhrase(state string) string {
 	switch state {
 	case "modifying":
-		return "modifying \u2014 config change"
+		return "modifying — config change"
 	case "snapshotting":
-		return "snapshotting \u2014 backup running"
+		return "snapshotting — backup running"
 	}
 	return ""
 }
@@ -99,7 +100,7 @@ func FetchRedisPage(ctx context.Context, api ElastiCacheDescribeReplicationGroup
 	var resources []resource.Resource
 
 	for _, rg := range output.ReplicationGroups {
-		// Engine filter (spec §3.1, P2-1): skip any RG whose engine is not "redis".
+		// Engine filter: skip any RG whose engine is not "redis".
 		// DescribeReplicationGroups returns all ElastiCache engines (redis, valkey,
 		// memcached) through the same API; this fetcher is redis-only.
 		if rg.Engine == nil || !strings.EqualFold(aws.ToString(rg.Engine), "redis") {
@@ -135,8 +136,14 @@ func FetchRedisPage(ctx context.Context, api ElastiCacheDescribeReplicationGroup
 		multiAZ := rg.MultiAZ == elasticachetypes.MultiAZStatusEnabled
 		autoFailover := rg.AutomaticFailover == elasticachetypes.AutomaticFailoverStatusEnabled
 
-		issues := computeRedisIssues(status, multiAZ, autoFailover, rg.NodeGroups)
-		statusPhrase := redisStatusPhrase(issues)
+		findings := computeRedisFindings(status, multiAZ, autoFailover, rg.NodeGroups)
+		statusPhrase := ""
+		if len(findings) > 0 {
+			statusPhrase = findings[0].Phrase
+			if len(findings) > 1 {
+				statusPhrase = fmt.Sprintf("%s (+%d)", statusPhrase, len(findings)-1)
+			}
+		}
 
 		r := resource.Resource{
 			ID:   rgID,
@@ -149,7 +156,7 @@ func FetchRedisPage(ctx context.Context, api ElastiCacheDescribeReplicationGroup
 				"status":     statusPhrase,
 				"arn":        arn,
 			},
-			Issues:    issues,
+			Findings:  findings,
 			RawStruct: rg,
 		}
 
@@ -179,61 +186,48 @@ func FetchRedisPage(ctx context.Context, api ElastiCacheDescribeReplicationGroup
 	}, nil
 }
 
-// computeRedisIssues derives the ordered §4 issues slice for a ReplicationGroup.
-// Wave 1 signals only — spec §3.2 has no Wave 2 signals for redis.
-//
-// Precedence: Broken first, then Warnings alphabetically (per impl-plan §5).
-// The em-dash character (—) is used literally in all phrases.
+// computeRedisFindings derives the ordered Wave-1 findings slice for a ReplicationGroup.
+// Precedence: Broken first, then Warnings alphabetically.
 // For multi-shard RGs (len(nodeGroups) > 1) in modifying/snapshotting state,
-// per-shard phrases are emitted instead of the RG-level phrase.
-func computeRedisIssues(status string, multiAZ bool, autoFailover bool, nodeGroups []elasticachetypes.NodeGroup) []string {
-	var broken []string
-	var warnings []string
+// per-shard findings are emitted instead of the RG-level finding.
+func computeRedisFindings(status string, multiAZ bool, autoFailover bool, nodeGroups []elasticachetypes.NodeGroup) []domain.Finding {
+	var broken []domain.Finding
+	var warnings []domain.Finding
 
 	switch status {
 	case "available":
 		// Healthy — no state issue.
 	case "creating":
-		warnings = append(warnings, "creating \u2014 new group")
+		warnings = append(warnings, domain.Finding{Code: CodeRedisCreating, Phrase: "creating — new group", Severity: domain.SevWarn, Source: "wave1"})
 	case "deleting":
-		warnings = append(warnings, "deleting \u2014 teardown")
+		warnings = append(warnings, domain.Finding{Code: CodeRedisDeleting, Phrase: "deleting — teardown", Severity: domain.SevWarn, Source: "wave1"})
 	case "create-failed":
-		broken = append(broken, "create failed \u2014 see events")
+		broken = append(broken, domain.Finding{Code: CodeRedisCreateFailed, Phrase: "create failed — see events", Severity: domain.SevBroken, Source: "wave1"})
 	case "modifying", "snapshotting":
 		shardIssues := computeShardIssues(nodeGroups)
 		if len(shardIssues) > 0 {
-			// Multi-shard with at least one non-available shard: use shard-level phrases.
-			warnings = append(warnings, shardIssues...)
+			// Multi-shard with at least one non-available shard: use shard-level findings.
+			for _, p := range shardIssues {
+				warnings = append(warnings, domain.Finding{Code: CodeRedisShardIssue, Phrase: p, Severity: domain.SevWarn, Source: "wave1"})
+			}
 		} else {
-			// Single-shard OR all shards available (transient RG-level state):
-			// fall back to the RG-level phrase.
+			// Single-shard OR all shards available: fall back to the RG-level phrase.
 			if p := rgTransientPhrase(status); p != "" {
-				warnings = append(warnings, p)
+				code := CodeRedisModifying
+				if status == "snapshotting" {
+					code = CodeRedisSnapshotting
+				}
+				warnings = append(warnings, domain.Finding{Code: code, Phrase: p, Severity: domain.SevWarn, Source: "wave1"})
 			}
 		}
 	}
 
 	if multiAZ && !autoFailover {
-		warnings = append(warnings, "multi-AZ without auto-failover")
+		warnings = append(warnings, domain.Finding{Code: CodeRedisMultiAZWithoutAutoFailover, Phrase: "multi-AZ without auto-failover", Severity: domain.SevWarn, Source: "wave1"})
 	}
 
-	// Sort warnings alphabetically (per impl-plan §5 precedence).
-	sort.Strings(warnings)
+	// Sort warnings alphabetically (broken always first by construction).
+	sort.Slice(warnings, func(i, j int) bool { return warnings[i].Phrase < warnings[j].Phrase })
 
-	// Broken first, then sorted warnings.
 	return append(broken, warnings...)
-}
-
-// redisStatusPhrase converts an issues slice to the S4 status column string.
-// Empty slice → "" (Healthy silence per spec §4).
-// Single issue → the phrase verbatim.
-// Multiple issues → top phrase + " (+N)" suffix per universal rule 7.
-func redisStatusPhrase(issues []string) string {
-	if len(issues) == 0 {
-		return ""
-	}
-	if len(issues) == 1 {
-		return issues[0]
-	}
-	return fmt.Sprintf("%s (+%d)", issues[0], len(issues)-1)
 }

--- a/internal/aws/redis_codes.go
+++ b/internal/aws/redis_codes.go
@@ -1,0 +1,13 @@
+package aws
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+const (
+	CodeRedisCreateFailed               domain.FindingCode = "redis.broken.create_failed"
+	CodeRedisCreating                   domain.FindingCode = "redis.warn.creating"
+	CodeRedisDeleting                   domain.FindingCode = "redis.warn.deleting"
+	CodeRedisModifying                  domain.FindingCode = "redis.warn.modifying"
+	CodeRedisSnapshotting               domain.FindingCode = "redis.warn.snapshotting"
+	CodeRedisShardIssue                 domain.FindingCode = "redis.warn.shard_issue"
+	CodeRedisMultiAZWithoutAutoFailover domain.FindingCode = "redis.warn.multiaz_without_auto_failover"
+)

--- a/internal/aws/redshift.go
+++ b/internal/aws/redshift.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -118,16 +119,21 @@ func FetchRedshiftClustersPage(ctx context.Context, api RedshiftDescribeClusters
 			clusterAvailabilityStatus = *cluster.ClusterAvailabilityStatus
 		}
 
-		derivedStatus, issues := computeRedshiftStatusAndIssues(cluster)
+		findings := computeRedshiftFindings(cluster)
+		statusPhrase := ""
+		if len(findings) > 0 {
+			statusPhrase = findings[0].Phrase
+			if len(findings) > 1 {
+				statusPhrase = fmt.Sprintf("%s (+%d)", statusPhrase, len(findings)-1)
+			}
+		}
 
 		r := resource.Resource{
-			ID:     clusterID,
-			Name:   clusterID,
-			Status: derivedStatus,
-			Issues: issues,
+			ID:   clusterID,
+			Name: clusterID,
 			Fields: map[string]string{
 				"cluster_id":                  clusterID,
-				"status":                      derivedStatus,
+				"status":                      statusPhrase,
 				"cluster_status":              clusterStatus,
 				"node_type":                   nodeType,
 				"num_nodes":                   numNodes,
@@ -139,6 +145,7 @@ func FetchRedshiftClustersPage(ctx context.Context, api RedshiftDescribeClusters
 				"encrypted":                   encrypted,
 				"cluster_availability_status": clusterAvailabilityStatus,
 			},
+			Findings:  findings,
 			RawStruct: cluster,
 		}
 
@@ -168,12 +175,10 @@ func FetchRedshiftClustersPage(ctx context.Context, api RedshiftDescribeClusters
 	}, nil
 }
 
-// computeRedshiftStatusAndIssues returns the top S4 phrase (with `(+N)` suffix
-// when multiple warnings stack) AND the full ordered list of every active issue
-// phrase. Mirrors computeDBIStatusAndIssues from rds.go but uses Redshift signals
-// per spec §3.1 and §4. Broken / transitional / healthy states each produce at
-// most one phrase; configuration-warning states stack per rule 7.
-func computeRedshiftStatusAndIssues(cluster redshifttypes.Cluster) (string, []string) {
+// computeRedshiftFindings returns the ordered Wave-1 findings for a Redshift cluster.
+// Broken / transitional / healthy states each produce at most one finding;
+// configuration-warning states may stack multiple findings.
+func computeRedshiftFindings(cluster redshifttypes.Cluster) []domain.Finding {
 	clusterStatus := ""
 	if cluster.ClusterStatus != nil {
 		clusterStatus = *cluster.ClusterStatus
@@ -187,91 +192,77 @@ func computeRedshiftStatusAndIssues(cluster redshifttypes.Cluster) (string, []st
 	// Step 1: Broken bucket — ClusterStatus-driven (highest severity, beats availability).
 	switch clusterStatus {
 	case "incompatible-hsm":
-		phrase := "broken: incompatible-hsm"
-		return phrase, []string{phrase}
+		return []domain.Finding{{Code: CodeRedshiftIncompatibleHSM, Phrase: "broken: incompatible-hsm", Severity: domain.SevBroken, Source: "wave1"}}
 	case "incompatible-network":
-		phrase := "broken: incompatible-network"
-		return phrase, []string{phrase}
+		return []domain.Finding{{Code: CodeRedshiftIncompatibleNetwork, Phrase: "broken: incompatible-network", Severity: domain.SevBroken, Source: "wave1"}}
 	case "incompatible-parameters":
-		phrase := "broken: incompatible-parameters"
-		return phrase, []string{phrase}
+		return []domain.Finding{{Code: CodeRedshiftIncompatibleParameters, Phrase: "broken: incompatible-parameters", Severity: domain.SevBroken, Source: "wave1"}}
 	case "incompatible-restore":
-		phrase := "broken: incompatible-restore"
-		return phrase, []string{phrase}
+		return []domain.Finding{{Code: CodeRedshiftIncompatibleRestore, Phrase: "broken: incompatible-restore", Severity: domain.SevBroken, Source: "wave1"}}
 	case "hardware-failure":
-		phrase := "broken: hardware-failure"
-		return phrase, []string{phrase}
+		return []domain.Finding{{Code: CodeRedshiftHardwareFailure, Phrase: "broken: hardware-failure", Severity: domain.SevBroken, Source: "wave1"}}
 	case "storage-full":
-		phrase := "broken: storage-full"
-		return phrase, []string{phrase}
+		return []domain.Finding{{Code: CodeRedshiftStorageFull, Phrase: "broken: storage-full", Severity: domain.SevBroken, Source: "wave1"}}
 	}
 
 	// Step 1b: Broken bucket — ClusterAvailabilityStatus-driven.
 	switch clusterAvailStatus {
 	case "Unavailable":
-		return "unavailable", []string{"unavailable"}
+		return []domain.Finding{{Code: CodeRedshiftUnavailable, Phrase: "unavailable", Severity: domain.SevBroken, Source: "wave1"}}
 	case "Failed":
-		return "failed", []string{"failed"}
+		return []domain.Finding{{Code: CodeRedshiftFailed, Phrase: "failed", Severity: domain.SevBroken, Source: "wave1"}}
 	}
 
 	// Step 2: Transitional bucket (Warning, ClusterStatus-driven) — return immediately.
 	switch clusterStatus {
 	case "creating":
-		return "creating", []string{"creating"}
+		return []domain.Finding{{Code: CodeRedshiftCreating, Phrase: "creating", Severity: domain.SevWarn, Source: "wave1"}}
 	case "modifying":
-		return "modifying", []string{"modifying"}
+		return []domain.Finding{{Code: CodeRedshiftModifying, Phrase: "modifying", Severity: domain.SevWarn, Source: "wave1"}}
 	case "resizing":
-		return "resizing", []string{"resizing"}
+		return []domain.Finding{{Code: CodeRedshiftResizing, Phrase: "resizing", Severity: domain.SevWarn, Source: "wave1"}}
 	case "rebooting":
-		return "rebooting", []string{"rebooting"}
+		return []domain.Finding{{Code: CodeRedshiftRebooting, Phrase: "rebooting", Severity: domain.SevWarn, Source: "wave1"}}
 	case "renaming":
-		return "renaming", []string{"renaming"}
+		return []domain.Finding{{Code: CodeRedshiftRenaming, Phrase: "renaming", Severity: domain.SevWarn, Source: "wave1"}}
 	case "deleting":
-		return "deleting", []string{"deleting"}
+		return []domain.Finding{{Code: CodeRedshiftDeleting, Phrase: "deleting", Severity: domain.SevWarn, Source: "wave1"}}
 	}
 
 	// Steps 3–5: Warning bucket — collect all active warnings and stack them.
-	var warnings []string
+	var warnings []domain.Finding
 
 	// Step 3: ClusterAvailabilityStatus warnings (first in precedence).
 	switch clusterAvailStatus {
 	case "Maintenance":
-		warnings = append(warnings, "maintenance")
+		warnings = append(warnings, domain.Finding{Code: CodeRedshiftMaintenance, Phrase: "maintenance", Severity: domain.SevWarn, Source: "wave1"})
 	case "Modifying":
-		warnings = append(warnings, "modifying")
+		warnings = append(warnings, domain.Finding{Code: CodeRedshiftAvailabilityModifying, Phrase: "modifying", Severity: domain.SevWarn, Source: "wave1"})
 	}
 
-	// Step 4: Configuration / maintenance warnings (in §4 precedence order).
+	// Step 4: Configuration / maintenance warnings (in precedence order).
 
 	// 4.1: PendingModifiedValues non-nil and at least one sub-field non-empty.
 	if hasPendingRedshiftModifiedValues(cluster.PendingModifiedValues) {
-		warnings = append(warnings, "pending change queued")
+		warnings = append(warnings, domain.Finding{Code: CodeRedshiftPendingChange, Phrase: "pending change queued", Severity: domain.SevWarn, Source: "wave1"})
 	}
 
 	// 4.2: DeferredMaintenanceWindows with active window (now ∈ [start, end]).
 	if hasActiveDeferredMaintenanceWindow(cluster.DeferredMaintenanceWindows, time.Now().UTC()) {
-		warnings = append(warnings, "maintenance deferred")
+		warnings = append(warnings, domain.Finding{Code: CodeRedshiftMaintenanceDeferred, Phrase: "maintenance deferred", Severity: domain.SevWarn, Source: "wave1"})
 	}
 
 	// 4.3: PubliclyAccessible == true.
 	if cluster.PubliclyAccessible != nil && *cluster.PubliclyAccessible {
-		warnings = append(warnings, "publicly accessible")
+		warnings = append(warnings, domain.Finding{Code: CodeRedshiftPubliclyAccessible, Phrase: "publicly accessible", Severity: domain.SevWarn, Source: "wave1"})
 	}
 
 	// 4.4: Encrypted == false.
 	if cluster.Encrypted != nil && !*cluster.Encrypted {
-		warnings = append(warnings, "unencrypted at rest")
+		warnings = append(warnings, domain.Finding{Code: CodeRedshiftUnencryptedAtRest, Phrase: "unencrypted at rest", Severity: domain.SevWarn, Source: "wave1"})
 	}
 
-	// Step 5: Combine.
-	switch len(warnings) {
-	case 0:
-		return "", nil
-	case 1:
-		return warnings[0], warnings
-	default:
-		return fmt.Sprintf("%s (+%d)", warnings[0], len(warnings)-1), warnings
-	}
+	return warnings
 }
 
 // hasPendingRedshiftModifiedValues returns true when PendingModifiedValues is

--- a/internal/aws/redshift_codes.go
+++ b/internal/aws/redshift_codes.go
@@ -1,0 +1,26 @@
+package aws
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+const (
+	CodeRedshiftIncompatibleHSM        domain.FindingCode = "redshift.broken.incompatible_hsm"
+	CodeRedshiftIncompatibleNetwork    domain.FindingCode = "redshift.broken.incompatible_network"
+	CodeRedshiftIncompatibleParameters domain.FindingCode = "redshift.broken.incompatible_parameters"
+	CodeRedshiftIncompatibleRestore    domain.FindingCode = "redshift.broken.incompatible_restore"
+	CodeRedshiftHardwareFailure        domain.FindingCode = "redshift.broken.hardware_failure"
+	CodeRedshiftStorageFull            domain.FindingCode = "redshift.broken.storage_full"
+	CodeRedshiftUnavailable            domain.FindingCode = "redshift.broken.unavailable"
+	CodeRedshiftFailed                 domain.FindingCode = "redshift.broken.failed"
+	CodeRedshiftCreating               domain.FindingCode = "redshift.warn.creating"
+	CodeRedshiftModifying              domain.FindingCode = "redshift.warn.modifying"
+	CodeRedshiftResizing               domain.FindingCode = "redshift.warn.resizing"
+	CodeRedshiftRebooting              domain.FindingCode = "redshift.warn.rebooting"
+	CodeRedshiftRenaming               domain.FindingCode = "redshift.warn.renaming"
+	CodeRedshiftDeleting               domain.FindingCode = "redshift.warn.deleting"
+	CodeRedshiftMaintenance            domain.FindingCode = "redshift.warn.maintenance"
+	CodeRedshiftAvailabilityModifying  domain.FindingCode = "redshift.warn.availability_modifying"
+	CodeRedshiftPendingChange          domain.FindingCode = "redshift.warn.pending_change"
+	CodeRedshiftMaintenanceDeferred    domain.FindingCode = "redshift.warn.maintenance_deferred"
+	CodeRedshiftPubliclyAccessible     domain.FindingCode = "redshift.warn.publicly_accessible"
+	CodeRedshiftUnencryptedAtRest      domain.FindingCode = "redshift.warn.unencrypted_at_rest"
+)

--- a/internal/catalog/types_databases.go
+++ b/internal/catalog/types_databases.go
@@ -8,6 +8,9 @@ import (
 )
 
 func colorDBI(r domain.Resource) domain.Color {
+	if c, ok := colorFromWave1(r); ok {
+		return c
+	}
 	status := r.Fields["status"]
 	stripped := stripFindingSuffix(status)
 	switch stripped {
@@ -66,6 +69,9 @@ func colorDBI(r domain.Resource) domain.Color {
 func colorS3(_ domain.Resource) domain.Color { return domain.ColorHealthy }
 
 func colorRedis(r domain.Resource) domain.Color {
+	if c, ok := colorFromWave1(r); ok {
+		return c
+	}
 	phrase := stripFindingSuffix(r.Fields["status"])
 	if phrase == "deleted" {
 		return domain.ColorDim
@@ -89,6 +95,9 @@ func colorRedis(r domain.Resource) domain.Color {
 }
 
 func colorDBC(r domain.Resource) domain.Color {
+	if c, ok := colorFromWave1(r); ok {
+		return c
+	}
 	phrase := stripFindingSuffix(r.Fields["status"])
 	switch phrase {
 	case "":
@@ -112,6 +121,9 @@ func colorDBC(r domain.Resource) domain.Color {
 }
 
 func colorDDB(r domain.Resource) domain.Color {
+	if c, ok := colorFromWave1(r); ok {
+		return c
+	}
 	phrase := stripFindingSuffix(r.Fields["status"])
 	switch phrase {
 	case "":
@@ -127,6 +139,9 @@ func colorDDB(r domain.Resource) domain.Color {
 }
 
 func colorOpenSearch(r domain.Resource) domain.Color {
+	if c, ok := colorFromWave1(r); ok {
+		return c
+	}
 	if r.Fields["deleted"] == "true" {
 		return domain.ColorDim
 	}
@@ -147,6 +162,9 @@ func colorOpenSearch(r domain.Resource) domain.Color {
 }
 
 func colorRedshift(r domain.Resource) domain.Color {
+	if c, ok := colorFromWave1(r); ok {
+		return c
+	}
 	phrase := stripFindingSuffix(r.Fields["status"])
 	if phrase == "" {
 		phrase = stripFindingSuffix(r.Status)
@@ -202,6 +220,9 @@ func colorRedshift(r domain.Resource) domain.Color {
 }
 
 func colorEFS(r domain.Resource) domain.Color {
+	if c, ok := colorFromWave1(r); ok {
+		return c
+	}
 	status := r.Fields["status"]
 	if status == "" {
 		status = r.Status
@@ -220,6 +241,9 @@ func colorEFS(r domain.Resource) domain.Color {
 }
 
 func colorDBISnap(r domain.Resource) domain.Color {
+	if c, ok := colorFromWave1(r); ok {
+		return c
+	}
 	phrase := stripFindingSuffix(r.Fields["status"])
 	if phrase == "failed" {
 		return domain.ColorBroken
@@ -237,6 +261,9 @@ func colorDBISnap(r domain.Resource) domain.Color {
 }
 
 func colorDBCSnap(r domain.Resource) domain.Color {
+	if c, ok := colorFromWave1(r); ok {
+		return c
+	}
 	phrase := stripFindingSuffix(r.Fields["status"])
 	if phrase == "failed" {
 		return domain.ColorBroken

--- a/internal/catalog/types_messaging.go
+++ b/internal/catalog/types_messaging.go
@@ -32,6 +32,9 @@ func colorEBRule(r domain.Resource) domain.Color {
 }
 
 func colorKinesis(r domain.Resource) domain.Color {
+	if c, ok := colorFromWave1(r); ok {
+		return c
+	}
 	switch r.Fields["stream_status"] {
 	case "ACTIVE":
 		return domain.ColorHealthy
@@ -48,6 +51,9 @@ func colorKinesis(r domain.Resource) domain.Color {
 }
 
 func colorMSK(r domain.Resource) domain.Color {
+	if c, ok := colorFromWave1(r); ok {
+		return c
+	}
 	switch r.Fields["state"] {
 	case "ACTIVE":
 		return domain.ColorHealthy

--- a/internal/tui/views/table_render.go
+++ b/internal/tui/views/table_render.go
@@ -333,20 +333,30 @@ func (m ResourceListModel) extractCellValue(c listCol, r resource.Resource) stri
 	if c.key == "@id" {
 		return r.ID
 	}
-	// PR-03a-views: status/lifecycle column reads Findings first, then
-	// Fields[LifecycleKey] as fallback — never r.Status or the raw key value.
-	// The status column is identified by c.key == "status" (conventional) or
-	// c.key == td.LifecycleKey when an explicit lifecycle key is set.
+	// PR-03a-views: status/lifecycle column resolution:
+	//  1. Findings[0].Phrase + (+N) suffix — canonical phrase from migrated
+	//     fetchers. Findings take priority so Wave-2 enrichers that write
+	//     FieldUpdates["status"] do not shadow the fetcher-emitted phrase.
+	//  2. Fields[c.key] (Wave-2 enriched value written via FieldUpdates, or
+	//     legacy fetchers that still populate Fields["status"] directly).
+	//  3. Fields[LifecycleKey] — final structural fallback for legacy paths.
 	lifecycleKey := lifecycleColumnKey(m.typeDef)
 	isStatusCol := c.key == "status" || c.key == lifecycleKey
 	if isStatusCol {
 		if len(r.Findings) > 0 {
-			return r.Findings[0].Phrase
+			phrase := r.Findings[0].Phrase
+			if len(r.Findings) > 1 {
+				phrase = fmt.Sprintf("%s (+%d)", phrase, len(r.Findings)-1)
+			}
+			return phrase
+		}
+		if v, ok := r.Fields[c.key]; ok && v != "" {
+			return v
 		}
 		if v := r.Fields[lifecycleKey]; v != "" {
 			return v
 		}
-		// Fall through to normal extraction if neither Findings nor LifecycleKey value is set.
+		// Fall through to normal extraction if none of the above produced a value.
 	}
 	// Fields map (key-based columns) takes priority over raw struct fields.
 	// This ensures Wave-2 enriched values always win over struct literals,

--- a/tests/unit/aws_dbc_test.go
+++ b/tests/unit/aws_dbc_test.go
@@ -1,19 +1,19 @@
 package unit
 
 // aws_dbc_test.go — fetcher tests for the dbc (DocumentDB cluster) resource type.
-//
-// Tests exercise FetchDocDBClusters and FetchDocDBClustersPage, verifying:
-//   - All required Fields are populated with correct values.
-//   - CIS flags (cis_flags) are computed correctly from StorageEncrypted,
-//     BackupRetentionPeriod, and DeletionProtection.
-//   - has_writer / writer_count are set correctly for various member configs.
-//   - Pagination: Marker is threaded correctly; IsTruncated is set when present.
-//   - Error propagation returns a wrapped error.
-//   - Empty API response returns empty Resources slice (not nil).
+// // Tests exercise FetchDocDBClusters and FetchDocDBClustersPage, verifying:
+// - All required Fields are populated with correct values.
+// - CIS flags (cis_flags) are computed correctly from StorageEncrypted,
+// BackupRetentionPeriod, and DeletionProtection.
+// - has_writer / writer_count are set correctly for various member configs.
+// - Pagination: Marker is threaded correctly; IsTruncated is set when present.
+// - Error propagation returns a wrapped error.
+// - Empty API response returns empty Resources slice (not nil).
 
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -105,12 +105,16 @@ func TestFetchDocDBClusters_FieldMapping(t *testing.T) {
 	if r.Name != "prod-docdb-01" {
 		t.Errorf("Name = %q, want %q", r.Name, "prod-docdb-01")
 	}
-	// Healthy clusters render a blank Status phrase per spec §4 (silence is the UX).
+	// Status is always "" (phrases moved to Findings + Fields["status"]).
 	if r.Status != "" {
-		t.Errorf("Status = %q, want blank (healthy silence)", r.Status)
+		t.Errorf("Status = %q, want blank", r.Status)
 	}
-	if len(r.Issues) != 0 {
-		t.Errorf("Issues = %v, want empty slice for healthy cluster", r.Issues)
+	if len(r.Findings) != 0 {
+		phrases := make([]string, len(r.Findings))
+		for i, f := range r.Findings {
+			phrases[i] = f.Phrase
+		}
+		t.Errorf("Findings = %v, want empty slice for healthy cluster", phrases)
 	}
 
 	// Required field keys. cis_flags is intentionally absent (jargon column removed).
@@ -570,18 +574,14 @@ func buildDocDBCluster(id string) docdbtypes.DBCluster {
 
 // TestDbc_Pagination_MultiPage_Success drives the registered "dbc" paginated
 // fetcher through the full DocDB→RDS token-prefix transition and verifies:
-//
-//   - tick 1 (token=""): fetches DocDB page 1 (has more); no RDS call yet.
-//     Result: DocDB page 1 rows, NextToken="docdb:d1", IsTruncated=true.
-//
-//   - tick 2 (token="docdb:d1"): fetches DocDB page 2 (last DocDB page),
-//     then immediately fetches RDS page 1 (has more). Result: DocDB page 2
-//     rows + RDS page 1 rows concatenated, NextToken="rds:r1", IsTruncated=true.
-//
-//   - tick 3 (token="rds:r1"): fetches RDS page 2 (last page, no Marker).
-//     Result: RDS page 2 rows only, NextToken="", IsTruncated=false.
-//
-// This is a regression pin for Issue 5: verifies that the token-prefix logic
+// // - tick 1 (token=""): fetches DocDB page 1 (has more); no RDS call yet.
+// Result: DocDB page 1 rows, NextToken="docdb:d1", IsTruncated=true.
+// // - tick 2 (token="docdb:d1"): fetches DocDB page 2 (last DocDB page),
+// then immediately fetches RDS page 1 (has more). Result: DocDB page 2
+// rows + RDS page 1 rows concatenated, NextToken="rds:r1", IsTruncated=true.
+// // - tick 3 (token="rds:r1"): fetches RDS page 2 (last page, no Marker).
+// Result: RDS page 2 rows only, NextToken="", IsTruncated=false.
+// // This is a regression pin for Issue 5: verifies that the token-prefix logic
 // in dbc.go correctly sequences DocDB and RDS pages and that the combined
 // result assembles correctly without losing rows.
 func TestDbc_Pagination_MultiPage_Success(t *testing.T) {
@@ -709,9 +709,10 @@ func TestDbc_Pagination_MultiPage_Success(t *testing.T) {
 	}
 }
 
-// TestComputeRDSDBClusterStatusAndIssues validates computeRDSDBClusterStatusAndIssues
+// TestComputeRDSDBClusterStatusAndFindings validates computeRDSDBClusterStatusAndIssues
 // (unexported) via FetchRDSDBClustersPage — 11 cases mirroring the docdb table.
-func TestComputeRDSDBClusterStatusAndIssues(t *testing.T) {
+// assertions migrated from Status/Issues to Fields["status"]/Findings.
+func TestComputeRDSDBClusterStatusAndFindings(t *testing.T) {
 	boolPtr := func(b bool) *bool { return &b }
 	int32Ptr := func(i int32) *int32 { return &i }
 	writer := rdstypes.DBClusterMember{IsClusterWriter: boolPtr(true)}
@@ -719,8 +720,8 @@ func TestComputeRDSDBClusterStatusAndIssues(t *testing.T) {
 	cases := []struct {
 		name        string
 		cluster     rdstypes.DBCluster
-		wantStatus  string
-		wantIssues  []string
+		wantPhrase  string   // expected Fields["status"] display phrase
+		wantFindings []string // expected Findings phrases in order
 	}{
 		{
 			name: "healthy_available_writer",
@@ -732,8 +733,8 @@ func TestComputeRDSDBClusterStatusAndIssues(t *testing.T) {
 				StorageEncrypted:      boolPtr(true),
 				BackupRetentionPeriod: int32Ptr(7),
 			},
-			wantStatus: "",
-			wantIssues: nil,
+			wantPhrase:  "",
+			wantFindings: nil,
 		},
 		{
 			name: "available_zero_writers",
@@ -745,8 +746,8 @@ func TestComputeRDSDBClusterStatusAndIssues(t *testing.T) {
 				StorageEncrypted:      boolPtr(true),
 				BackupRetentionPeriod: int32Ptr(7),
 			},
-			wantStatus: "no writer: reads only",
-			wantIssues: []string{"no writer: reads only"},
+			wantPhrase:  "no writer: reads only",
+			wantFindings: []string{"no writer: reads only"},
 		},
 		{
 			name: "available_deletion_protection_false",
@@ -758,8 +759,8 @@ func TestComputeRDSDBClusterStatusAndIssues(t *testing.T) {
 				StorageEncrypted:      boolPtr(true),
 				BackupRetentionPeriod: int32Ptr(7),
 			},
-			wantStatus: "delete-protection off",
-			wantIssues: []string{"delete-protection off"},
+			wantPhrase:  "delete-protection off",
+			wantFindings: []string{"delete-protection off"},
 		},
 		{
 			name: "available_storage_not_encrypted",
@@ -771,8 +772,8 @@ func TestComputeRDSDBClusterStatusAndIssues(t *testing.T) {
 				StorageEncrypted:      boolPtr(false),
 				BackupRetentionPeriod: int32Ptr(7),
 			},
-			wantStatus: "not encrypted at rest",
-			wantIssues: []string{"not encrypted at rest"},
+			wantPhrase:  "not encrypted at rest",
+			wantFindings: []string{"not encrypted at rest"},
 		},
 		{
 			name: "available_backup_retention_zero",
@@ -784,8 +785,8 @@ func TestComputeRDSDBClusterStatusAndIssues(t *testing.T) {
 				StorageEncrypted:      boolPtr(true),
 				BackupRetentionPeriod: int32Ptr(0),
 			},
-			wantStatus: "no automated backups",
-			wantIssues: []string{"no automated backups"},
+			wantPhrase:  "no automated backups",
+			wantFindings: []string{"no automated backups"},
 		},
 		{
 			name: "available_all_three_warnings",
@@ -797,8 +798,8 @@ func TestComputeRDSDBClusterStatusAndIssues(t *testing.T) {
 				StorageEncrypted:      boolPtr(false),
 				BackupRetentionPeriod: int32Ptr(0),
 			},
-			wantStatus: "delete-protection off (+2)",
-			wantIssues: []string{"delete-protection off", "not encrypted at rest", "no automated backups"},
+			wantPhrase:  "delete-protection off (+2)",
+			wantFindings: []string{"delete-protection off", "not encrypted at rest", "no automated backups"},
 		},
 		{
 			name: "failed_status",
@@ -807,8 +808,8 @@ func TestComputeRDSDBClusterStatusAndIssues(t *testing.T) {
 				Status:              aws.String("failed"),
 				DBClusterMembers:    []rdstypes.DBClusterMember{writer},
 			},
-			wantStatus: "failed: cluster operation",
-			wantIssues: []string{"failed: cluster operation"},
+			wantPhrase:  "failed: cluster operation",
+			wantFindings: []string{"failed: cluster operation"},
 		},
 		{
 			name: "inaccessible_encryption_credentials",
@@ -817,8 +818,8 @@ func TestComputeRDSDBClusterStatusAndIssues(t *testing.T) {
 				Status:              aws.String("inaccessible-encryption-credentials"),
 				DBClusterMembers:    []rdstypes.DBClusterMember{writer},
 			},
-			wantStatus: "encryption key unreachable",
-			wantIssues: []string{"encryption key unreachable"},
+			wantPhrase:  "encryption key unreachable",
+			wantFindings: []string{"encryption key unreachable"},
 		},
 		{
 			name: "incompatible_parameters",
@@ -827,8 +828,8 @@ func TestComputeRDSDBClusterStatusAndIssues(t *testing.T) {
 				Status:              aws.String("incompatible-parameters"),
 				DBClusterMembers:    []rdstypes.DBClusterMember{writer},
 			},
-			wantStatus: "parameter group incompatible",
-			wantIssues: []string{"parameter group incompatible"},
+			wantPhrase:  "parameter group incompatible",
+			wantFindings: []string{"parameter group incompatible"},
 		},
 		{
 			name: "modifying_transitional",
@@ -837,8 +838,8 @@ func TestComputeRDSDBClusterStatusAndIssues(t *testing.T) {
 				Status:              aws.String("modifying"),
 				DBClusterMembers:    []rdstypes.DBClusterMember{writer},
 			},
-			wantStatus: "modifying: in progress",
-			wantIssues: []string{"modifying: in progress"},
+			wantPhrase:  "modifying: in progress",
+			wantFindings: []string{"modifying: in progress"},
 		},
 		{
 			name: "unknown_status_passthrough",
@@ -847,8 +848,8 @@ func TestComputeRDSDBClusterStatusAndIssues(t *testing.T) {
 				Status:              aws.String("cross-region-copying"),
 				DBClusterMembers:    []rdstypes.DBClusterMember{writer},
 			},
-			wantStatus: "cross-region-copying",
-			wantIssues: []string{"cross-region-copying"},
+			wantPhrase:  "cross-region-copying",
+			wantFindings: []string{"cross-region-copying"},
 		},
 	}
 
@@ -862,17 +863,27 @@ func TestComputeRDSDBClusterStatusAndIssues(t *testing.T) {
 				t.Fatalf("expected 1 resource, got %d", len(result.Resources))
 			}
 			r := result.Resources[0]
-			if r.Status != tc.wantStatus {
-				t.Errorf("Status = %q, want %q", r.Status, tc.wantStatus)
+			// Status must always be "".
+			if r.Status != "" {
+				t.Errorf("Status = %q, want %q", r.Status, "")
 			}
-			if len(r.Issues) != len(tc.wantIssues) {
-				t.Errorf("Issues = %v, want %v", r.Issues, tc.wantIssues)
-			} else {
-				for i, want := range tc.wantIssues {
-					if r.Issues[i] != want {
-						t.Errorf("Issues[%d] = %q, want %q", i, r.Issues[i], want)
-					}
-				}
+			if r.Fields["status"] != tc.wantPhrase {
+				t.Errorf("Fields[status] = %q, want %q", r.Fields["status"], tc.wantPhrase)
+			}
+			// Compare finding phrases.
+			gotPhrases := make([]string, len(r.Findings))
+			for i, f := range r.Findings {
+				gotPhrases[i] = f.Phrase
+			}
+			wantFindings := tc.wantFindings
+			if len(wantFindings) == 0 {
+				wantFindings = nil
+			}
+			if len(gotPhrases) == 0 {
+				gotPhrases = nil
+			}
+			if !reflect.DeepEqual(gotPhrases, wantFindings) {
+				t.Errorf("Findings phrases = %v, want %v", gotPhrases, wantFindings)
 			}
 		})
 	}

--- a/tests/unit/aws_dbi_snap_test.go
+++ b/tests/unit/aws_dbi_snap_test.go
@@ -1,13 +1,13 @@
 package unit
 
 // aws_rds_snap_test.go — Fetcher tests for dbi-snap resource type.
-//
-// Spec: docs/resources/dbi-snap.md §3.1 + §4 + impl-plan §1.1/§1.4.
+// // Spec: docs/resources/dbi-snap.md §3.1 + §4 + impl-plan §1.1/§1.4.
 // Tests call FetchDBISnapshotsPage via a strict mock, asserting:
-//   - Resource.Status = §4 phrase for each signal (healthy = "").
-//   - Resource.Issues = ordered slice per §0.1 precedence ladder.
-//   - Fields["arn"] populated for the backup-pivot (per §3.1 gap fix).
-//   - Adversarial rows (nil ID, nil Status, nil SnapshotCreateTime) do not panic.
+// - Resource.Status = "".
+// - Resource.Fields["status"] = §4 phrase for each signal (healthy = "").
+// - Resource.Findings = ordered slice per §0.1 precedence ladder (source: "wave1").
+// - Fields["arn"] populated for the backup-pivot (per §3.1 gap fix).
+// - Adversarial rows (nil ID, nil Status, nil SnapshotCreateTime) do not panic.
 
 import (
 	"context"
@@ -23,6 +23,7 @@ import (
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/demo/fixtures"
+	"github.com/k2m30/a9s/v3/internal/domain"
 )
 
 // ---------------------------------------------------------------------------
@@ -48,6 +49,7 @@ func snapOutput(snaps ...rdstypes.DBSnapshot) *rds.DescribeDBSnapshotsOutput {
 }
 
 // fetchSnap fetches a page from a single-page mock holding the provided snapshots.
+// resourceRow.status is populated from r.Fields["status"] (not r.Status).
 func fetchSnap(t *testing.T, snaps ...rdstypes.DBSnapshot) []resourceRow {
 	t.Helper()
 	mock := &mockDescribeDBSnapshots{output: snapOutput(snaps...)}
@@ -57,18 +59,24 @@ func fetchSnap(t *testing.T, snaps ...rdstypes.DBSnapshot) []resourceRow {
 	}
 	rows := make([]resourceRow, len(result.Resources))
 	for i, r := range result.Resources {
-		rows[i] = resourceRow{status: r.Status, issues: r.Issues, fields: r.Fields, id: r.ID}
+		rows[i] = resourceRow{
+			status:   r.Fields["status"],
+			findings: r.Findings,
+			fields:   r.Fields,
+			id:       r.ID,
+		}
 	}
 	return rows
 }
 
 // resourceRow captures the fields we assert on — avoids depending on the
 // full resource.Resource struct layout in tests.
+// status is now r.Fields["status"]; issues replaced by findings.
 type resourceRow struct {
-	id     string
-	status string
-	issues []string
-	fields map[string]string
+	id       string
+	status   string
+	findings []domain.Finding
+	fields   map[string]string
 }
 
 // ---------------------------------------------------------------------------
@@ -92,8 +100,12 @@ func TestDBISnap_Fetcher_HealthyAvailable_BlankS4(t *testing.T) {
 	if r.status != "" {
 		t.Errorf("Status = %q, want empty (healthy silence)", r.status)
 	}
-	if len(r.issues) != 0 {
-		t.Errorf("Issues = %v, want empty for healthy row", r.issues)
+	if len(r.findings) != 0 {
+		phrases := make([]string, len(r.findings))
+		for i, f := range r.findings {
+			phrases[i] = f.Phrase
+		}
+		t.Errorf("Findings = %v, want empty for healthy row", phrases)
 	}
 }
 
@@ -114,8 +126,12 @@ func TestDBISnap_Fetcher_Creating_CarriesPercent(t *testing.T) {
 	if r.status != "creating: 42%" {
 		t.Errorf("Status = %q, want %q", r.status, "creating: 42%")
 	}
-	if len(r.issues) != 1 || r.issues[0] != "creating: 42%" {
-		t.Errorf("Issues = %v, want [creating: 42%%]", r.issues)
+	if len(r.findings) != 1 || r.findings[0].Phrase != "creating: 42%" {
+		phrases := make([]string, len(r.findings))
+		for i, f := range r.findings {
+			phrases[i] = f.Phrase
+		}
+		t.Errorf("Findings = %v, want [creating: 42%%]", phrases)
 	}
 }
 
@@ -136,8 +152,12 @@ func TestDBISnap_Fetcher_Failed_BareKeyword(t *testing.T) {
 	if r.status != "failed" {
 		t.Errorf("Status = %q, want %q", r.status, "failed")
 	}
-	if len(r.issues) != 1 || r.issues[0] != "failed" {
-		t.Errorf("Issues = %v, want [failed]", r.issues)
+	if len(r.findings) != 1 || r.findings[0].Phrase != "failed" {
+		phrases := make([]string, len(r.findings))
+		for i, f := range r.findings {
+			phrases[i] = f.Phrase
+		}
+		t.Errorf("Findings = %v, want [failed]", phrases)
 	}
 }
 
@@ -160,8 +180,12 @@ func TestDBISnap_Fetcher_IncompatibleKeywordPreserved(t *testing.T) {
 			if r.status != status {
 				t.Errorf("Status = %q, want %q (keyword must be preserved verbatim)", r.status, status)
 			}
-			if len(r.issues) != 1 || r.issues[0] != status {
-				t.Errorf("Issues = %v, want [%s]", r.issues, status)
+			if len(r.findings) != 1 || r.findings[0].Phrase != status {
+				phrases := make([]string, len(r.findings))
+				for i, f := range r.findings {
+					phrases[i] = f.Phrase
+				}
+				t.Errorf("Findings = %v, want [%s]", phrases, status)
 			}
 		})
 	}
@@ -184,8 +208,12 @@ func TestDBISnap_Fetcher_Unencrypted(t *testing.T) {
 	if r.status != "unencrypted" {
 		t.Errorf("Status = %q, want %q", r.status, "unencrypted")
 	}
-	if len(r.issues) != 1 || r.issues[0] != "unencrypted" {
-		t.Errorf("Issues = %v, want [unencrypted]", r.issues)
+	if len(r.findings) != 1 || r.findings[0].Phrase != "unencrypted" {
+		phrases := make([]string, len(r.findings))
+		for i, f := range r.findings {
+			phrases[i] = f.Phrase
+		}
+		t.Errorf("Findings = %v, want [unencrypted]", phrases)
 	}
 }
 
@@ -207,8 +235,12 @@ func TestDBISnap_Fetcher_SeverityBrokenBeatsWarning(t *testing.T) {
 	if r.status != "failed" {
 		t.Errorf("Status = %q, want %q (Broken wins; unencrypted suppressed when Status=failed)", r.status, "failed")
 	}
-	if len(r.issues) != 1 || r.issues[0] != "failed" {
-		t.Errorf("Issues = %v, want [failed] (Broken suppresses Warning in same row)", r.issues)
+	if len(r.findings) != 1 || r.findings[0].Phrase != "failed" {
+		phrases := make([]string, len(r.findings))
+		for i, f := range r.findings {
+			phrases[i] = f.Phrase
+		}
+		t.Errorf("Findings = %v, want [failed] (Broken suppresses Warning in same row)", phrases)
 	}
 }
 
@@ -231,19 +263,19 @@ func TestDBISnap_Fetcher_PopulatesARNField(t *testing.T) {
 	}
 }
 
-// TestDBISnap_Fetcher_IssuesPopulatedInPrecedenceOrder verifies (U7f) that
-// Resource.Issues is ordered per §0.1 for each signal case:
-//   - Healthy → empty
-//   - failed → ["failed"]
-//   - incompatible-restore → ["incompatible-restore"]
-//   - creating → ["creating: 60%"]
-//   - unencrypted → ["unencrypted"]
-func TestDBISnap_Fetcher_IssuesPopulatedInPrecedenceOrder(t *testing.T) {
+// TestDBISnap_Fetcher_FindingsPopulatedInPrecedenceOrder verifies (U7f) that
+// Resource.Findings is ordered per §0.1 for each signal case ():
+// - Healthy → empty
+// - failed → ["failed"]
+// - incompatible-restore → ["incompatible-restore"]
+// - creating → ["creating: 60%"]
+// - unencrypted → ["unencrypted"]
+func TestDBISnap_Fetcher_FindingsPopulatedInPrecedenceOrder(t *testing.T) {
 	cases := []struct {
-		name        string
-		snap        rdstypes.DBSnapshot
-		wantStatus  string
-		wantIssues  []string
+		name         string
+		snap         rdstypes.DBSnapshot
+		wantPhrase   string
+		wantFindings []string
 	}{
 		{
 			name: "healthy_empty",
@@ -253,8 +285,8 @@ func TestDBISnap_Fetcher_IssuesPopulatedInPrecedenceOrder(t *testing.T) {
 				Encrypted:            aws.Bool(true),
 				PercentProgress:      aws.Int32(100),
 			},
-			wantStatus: "",
-			wantIssues: nil,
+			wantPhrase:   "",
+			wantFindings: nil,
 		},
 		{
 			name: "failed_single",
@@ -264,8 +296,8 @@ func TestDBISnap_Fetcher_IssuesPopulatedInPrecedenceOrder(t *testing.T) {
 				Encrypted:            aws.Bool(true),
 				PercentProgress:      aws.Int32(0),
 			},
-			wantStatus: "failed",
-			wantIssues: []string{"failed"},
+			wantPhrase:   "failed",
+			wantFindings: []string{"failed"},
 		},
 		{
 			name: "incompatible_restore",
@@ -275,8 +307,8 @@ func TestDBISnap_Fetcher_IssuesPopulatedInPrecedenceOrder(t *testing.T) {
 				Encrypted:            aws.Bool(true),
 				PercentProgress:      aws.Int32(0),
 			},
-			wantStatus: "incompatible-restore",
-			wantIssues: []string{"incompatible-restore"},
+			wantPhrase:   "incompatible-restore",
+			wantFindings: []string{"incompatible-restore"},
 		},
 		{
 			name: "creating_60pct",
@@ -286,8 +318,8 @@ func TestDBISnap_Fetcher_IssuesPopulatedInPrecedenceOrder(t *testing.T) {
 				Encrypted:            aws.Bool(true),
 				PercentProgress:      aws.Int32(60),
 			},
-			wantStatus: "creating: 60%",
-			wantIssues: []string{"creating: 60%"},
+			wantPhrase:   "creating: 60%",
+			wantFindings: []string{"creating: 60%"},
 		},
 		{
 			name: "unencrypted",
@@ -297,8 +329,8 @@ func TestDBISnap_Fetcher_IssuesPopulatedInPrecedenceOrder(t *testing.T) {
 				Encrypted:            aws.Bool(false),
 				PercentProgress:      aws.Int32(100),
 			},
-			wantStatus: "unencrypted",
-			wantIssues: []string{"unencrypted"},
+			wantPhrase:   "unencrypted",
+			wantFindings: []string{"unencrypted"},
 		},
 	}
 
@@ -309,15 +341,26 @@ func TestDBISnap_Fetcher_IssuesPopulatedInPrecedenceOrder(t *testing.T) {
 				t.Fatalf("expected 1 row, got %d", len(rows))
 			}
 			r := rows[0]
-			if r.status != tc.wantStatus {
-				t.Errorf("Status = %q, want %q", r.status, tc.wantStatus)
+			if r.status != tc.wantPhrase {
+				t.Errorf("Fields[status] = %q, want %q", r.status, tc.wantPhrase)
 			}
-			if len(r.issues) != len(tc.wantIssues) {
-				t.Errorf("Issues length = %d, want %d; got %v", len(r.issues), len(tc.wantIssues), r.issues)
+			gotPhrases := make([]string, len(r.findings))
+			for i, f := range r.findings {
+				gotPhrases[i] = f.Phrase
+			}
+			if len(gotPhrases) == 0 {
+				gotPhrases = nil
+			}
+			wantF := tc.wantFindings
+			if len(wantF) == 0 {
+				wantF = nil
+			}
+			if len(gotPhrases) != len(wantF) {
+				t.Errorf("Findings length = %d, want %d; got %v", len(gotPhrases), len(wantF), gotPhrases)
 			} else {
-				for i, want := range tc.wantIssues {
-					if r.issues[i] != want {
-						t.Errorf("Issues[%d] = %q, want %q", i, r.issues[i], want)
+				for i, want := range wantF {
+					if gotPhrases[i] != want {
+						t.Errorf("Findings[%d].Phrase = %q, want %q", i, gotPhrases[i], want)
 					}
 				}
 			}
@@ -354,15 +397,19 @@ func TestDBISnap_Fetcher_MultiW1_TopPlusSuffix(t *testing.T) {
 	if !strings.Contains(r.status, "(+1)") {
 		t.Errorf("Status = %q, want (+1) suffix (multi-W1 indicator)", r.status)
 	}
-	// Issues: creating phrase first, then unencrypted.
-	if len(r.issues) < 2 {
-		t.Errorf("Issues = %v, want at least 2 (creating + unencrypted)", r.issues)
-	} else {
-		if !strings.HasPrefix(r.issues[0], "creating: 15%") {
-			t.Errorf("Issues[0] = %q, want creating phrase first (§0.1 precedence)", r.issues[0])
+	// Findings: creating phrase first, then unencrypted.
+	if len(r.findings) < 2 {
+		phrases := make([]string, len(r.findings))
+		for i, f := range r.findings {
+			phrases[i] = f.Phrase
 		}
-		if r.issues[1] != "unencrypted" {
-			t.Errorf("Issues[1] = %q, want %q", r.issues[1], "unencrypted")
+		t.Errorf("Findings = %v, want at least 2 (creating + unencrypted)", phrases)
+	} else {
+		if !strings.HasPrefix(r.findings[0].Phrase, "creating: 15%") {
+			t.Errorf("Findings[0].Phrase = %q, want creating phrase first (§0.1 precedence)", r.findings[0].Phrase)
+		}
+		if r.findings[1].Phrase != "unencrypted" {
+			t.Errorf("Findings[1].Phrase = %q, want %q", r.findings[1].Phrase, "unencrypted")
 		}
 	}
 }
@@ -459,8 +506,7 @@ func TestDBISnap_Fetcher_AllFixtures_NoError(t *testing.T) {
 // under internal/aws and asserts that every direct RDS/Backup API call appears
 // inside a RetryOnThrottle closure. Per universal rule U13, callers must never
 // call AWS APIs directly from enricher or fetcher bodies outside throttle wraps.
-//
-// Scan strategy: any line that calls api.Describe*/api.Get*/api.List*/api.Lookup*
+// // Scan strategy: any line that calls api.Describe*/api.Get*/api.List*/api.Lookup*
 // directly (not as the argument to RetryOnThrottle) is a violation.
 func TestDBISnap_StaticAudit_AllSDKCallsThrottleWrapped(t *testing.T) {
 	root := findRepoFile(t, "internal/aws")

--- a/tests/unit/aws_dbi_test.go
+++ b/tests/unit/aws_dbi_test.go
@@ -1,14 +1,14 @@
 package unit
 
 // aws_dbi_test.go — fetcher behavior tests for RDS DB Instances.
-//
-// Tests drive FetchRDSInstancesPage with a mock RDS client and assert
-// that Resource.Status follows spec §4 precedence exactly:
-//   - Healthy available row → blank Status (silence).
-//   - Transitional statuses → bare keyword or "keyword: PendingModifiedValues key".
-//   - Broken statuses → exact keyword (with inaccessible-encryption-credentials remapped).
-//   - Config warnings on available → first-wins precedence phrase.
-//   - cis_flags field must NOT be present (no jargon columns).
+// // Tests drive FetchRDSInstancesPage with a mock RDS client and assert
+// that Resource.Findings and Resource.Fields follow spec §4 precedence ():
+// - Resource.Status is always "".
+// - Healthy available row → blank Fields["status"], nil Findings (silence).
+// - Transitional statuses → Fields["status"] = bare keyword or "keyword: PendingModifiedValues key".
+// - Broken statuses → Findings with exact keyword (inaccessible-encryption-credentials remapped).
+// - Config warnings on available → Findings in first-wins precedence order.
+// - cis_flags field must NOT be present (no jargon columns).
 
 import (
 	"context"
@@ -21,6 +21,7 @@ import (
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/demo/fixtures"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -58,8 +59,9 @@ func findDBI(t *testing.T, id string) rdstypes.DBInstance {
 	return rdstypes.DBInstance{}
 }
 
-// fetchSingle calls FetchRDSInstancesPage with one instance and returns the resulting Resource.
-func fetchSingle(t *testing.T, inst rdstypes.DBInstance) (status string, fields map[string]string) {
+// fetchSingle calls FetchRDSInstancesPage with one instance and returns
+// status (always "" ), fields, and findings.
+func fetchSingle(t *testing.T, inst rdstypes.DBInstance) (status string, fields map[string]string, findings []domain.Finding) {
 	t.Helper()
 	mock := &mockRDSPageClient{instances: []rdstypes.DBInstance{inst}}
 	result, err := awsclient.FetchRDSInstancesPage(context.Background(), mock, "")
@@ -70,7 +72,7 @@ func fetchSingle(t *testing.T, inst rdstypes.DBInstance) (status string, fields 
 		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
 	}
 	r := result.Resources[0]
-	return r.Status, r.Fields
+	return r.Status, r.Fields, r.Findings
 }
 
 // ---------------------------------------------------------------------------
@@ -81,18 +83,21 @@ func fetchSingle(t *testing.T, inst rdstypes.DBInstance) (status string, fields 
 // "available" instance produces an empty Status (spec §4: healthy rows render blank S4).
 func TestDBI_Fetch_AvailableHealthy_StatusBlank(t *testing.T) {
 	inst := findDBI(t, fixtures.ProdDbiID)
-	status, fields := fetchSingle(t, inst)
+	status, fields, findings := fetchSingle(t, inst)
 
 	if status != "" {
-		t.Errorf("Status = %q, want %q (healthy silence)", status, "")
+		t.Errorf("Status = %q, want %q", status, "")
 	}
 	for _, banned := range []string{"OK", "available", "ACTIVE", "running", "healthy", "-"} {
-		if status == banned {
-			t.Errorf("banned Status value %q — healthy rows must render blank", banned)
+		if fields["status"] == banned {
+			t.Errorf("banned Fields[status] value %q — healthy rows must render blank", banned)
 		}
 	}
 	if fields["status"] != "" {
-		t.Errorf("Fields[status] = %q, want %q", fields["status"], "")
+		t.Errorf("Fields[status] = %q, want %q (healthy silence)", fields["status"], "")
+	}
+	if len(findings) != 0 {
+		t.Errorf("Findings = %v, want nil/empty for healthy row", findings)
 	}
 }
 
@@ -105,11 +110,14 @@ func TestDBI_Fetch_AvailableHealthy_StatusBlank(t *testing.T) {
 // "modifying: DBInstanceClass" per spec §4.
 func TestDBI_Fetch_Modifying_WithPendingClassChange(t *testing.T) {
 	inst := findDBI(t, fixtures.StagingDbiModifyingID)
-	status, _ := fetchSingle(t, inst)
+	status, fields, _ := fetchSingle(t, inst)
 
 	want := "modifying: DBInstanceClass"
-	if status != want {
-		t.Errorf("Status = %q, want %q", status, want)
+	if status != "" {
+		t.Errorf("Status = %q, want %q", status, "")
+	}
+	if fields["status"] != want {
+		t.Errorf("Fields[status] = %q, want %q", fields["status"], want)
 	}
 }
 
@@ -117,10 +125,13 @@ func TestDBI_Fetch_Modifying_WithPendingClassChange(t *testing.T) {
 // all-empty PendingModifiedValues renders bare "rebooting".
 func TestDBI_Fetch_Rebooting_NoPending(t *testing.T) {
 	inst := findDBI(t, fixtures.StagingDbiRebootingID)
-	status, _ := fetchSingle(t, inst)
+	status, fields, _ := fetchSingle(t, inst)
 
-	if status != "rebooting" {
-		t.Errorf("Status = %q, want %q", status, "rebooting")
+	if status != "" {
+		t.Errorf("Status = %q, want %q", status, "")
+	}
+	if fields["status"] != "rebooting" {
+		t.Errorf("Fields[status] = %q, want %q", fields["status"], "rebooting")
 	}
 }
 
@@ -146,9 +157,12 @@ func TestDBI_Fetch_TransitionalKeywords_AllBare(t *testing.T) {
 				StorageEncrypted:     aws.Bool(true),
 				DeletionProtection:   aws.Bool(true),
 			}
-			status, _ := fetchSingle(t, inst)
-			if status != kw {
-				t.Errorf("Status = %q, want bare keyword %q", status, kw)
+			status, fields, _ := fetchSingle(t, inst)
+			if status != "" {
+				t.Errorf("Status = %q, want %q", status, "")
+			}
+			if fields["status"] != kw {
+				t.Errorf("Fields[status] = %q, want bare keyword %q", fields["status"], kw)
 			}
 		})
 	}
@@ -186,9 +200,12 @@ func TestDBI_Fetch_BrokenStatuses(t *testing.T) {
 				StorageEncrypted:     aws.Bool(true),
 				DeletionProtection:   aws.Bool(true),
 			}
-			status, _ := fetchSingle(t, inst)
-			if status != tc.want {
-				t.Errorf("Status = %q, want %q", status, tc.want)
+			status, fields, _ := fetchSingle(t, inst)
+			if status != "" {
+				t.Errorf("Status = %q, want %q", status, "")
+			}
+			if fields["status"] != tc.want {
+				t.Errorf("Fields[status] = %q, want %q", fields["status"], tc.want)
 			}
 		})
 	}
@@ -199,11 +216,14 @@ func TestDBI_Fetch_BrokenStatuses(t *testing.T) {
 // "encryption key unavailable" (spec §4 remap table).
 func TestDBI_Fetch_InaccessibleEncryptionCredentials_Remap(t *testing.T) {
 	inst := findDBI(t, fixtures.BrokenDbiEncryptionLockedID)
-	status, _ := fetchSingle(t, inst)
+	status, fields, _ := fetchSingle(t, inst)
 
 	want := "encryption key unavailable"
-	if status != want {
-		t.Errorf("Status = %q, want %q", status, want)
+	if status != "" {
+		t.Errorf("Status = %q, want %q", status, "")
+	}
+	if fields["status"] != want {
+		t.Errorf("Fields[status] = %q, want %q", fields["status"], want)
 	}
 }
 
@@ -219,10 +239,13 @@ func TestDBI_Fetch_BrokenPrecedenceOverConfigWarnings(t *testing.T) {
 		StorageEncrypted:     aws.Bool(false),  // would trigger "unencrypted storage"
 		DeletionProtection:   aws.Bool(false),  // would trigger "deletion protection off"
 	}
-	status, _ := fetchSingle(t, inst)
+	status, fields, _ := fetchSingle(t, inst)
 
-	if status != "storage-full" {
-		t.Errorf("Status = %q, want %q (broken beats config warnings)", status, "storage-full")
+	if status != "" {
+		t.Errorf("Status = %q, want %q", status, "")
+	}
+	if fields["status"] != "storage-full" {
+		t.Errorf("Fields[status] = %q, want %q (broken beats config warnings)", fields["status"], "storage-full")
 	}
 }
 
@@ -234,10 +257,13 @@ func TestDBI_Fetch_BrokenPrecedenceOverConfigWarnings(t *testing.T) {
 // "no automated backups" on an otherwise-healthy available instance.
 func TestDBI_Fetch_NoAutomatedBackups(t *testing.T) {
 	inst := findDBI(t, fixtures.WarnDbiNoBackupsID)
-	status, _ := fetchSingle(t, inst)
+	status, fields, _ := fetchSingle(t, inst)
 
-	if status != "no automated backups" {
-		t.Errorf("Status = %q, want %q", status, "no automated backups")
+	if status != "" {
+		t.Errorf("Status = %q, want %q", status, "")
+	}
+	if fields["status"] != "no automated backups" {
+		t.Errorf("Fields[status] = %q, want %q", fields["status"], "no automated backups")
 	}
 }
 
@@ -245,10 +271,13 @@ func TestDBI_Fetch_NoAutomatedBackups(t *testing.T) {
 // healthy available instance produces "publicly accessible".
 func TestDBI_Fetch_PubliclyAccessible(t *testing.T) {
 	inst := findDBI(t, fixtures.WarnDbiPublicID)
-	status, _ := fetchSingle(t, inst)
+	status, fields, _ := fetchSingle(t, inst)
 
-	if status != "publicly accessible" {
-		t.Errorf("Status = %q, want %q", status, "publicly accessible")
+	if status != "" {
+		t.Errorf("Status = %q, want %q", status, "")
+	}
+	if fields["status"] != "publicly accessible" {
+		t.Errorf("Fields[status] = %q, want %q", fields["status"], "publicly accessible")
 	}
 }
 
@@ -256,10 +285,13 @@ func TestDBI_Fetch_PubliclyAccessible(t *testing.T) {
 // healthy available instance produces "unencrypted storage".
 func TestDBI_Fetch_UnencryptedStorage(t *testing.T) {
 	inst := findDBI(t, fixtures.WarnDbiUnencryptedID)
-	status, _ := fetchSingle(t, inst)
+	status, fields, _ := fetchSingle(t, inst)
 
-	if status != "unencrypted storage" {
-		t.Errorf("Status = %q, want %q", status, "unencrypted storage")
+	if status != "" {
+		t.Errorf("Status = %q, want %q", status, "")
+	}
+	if fields["status"] != "unencrypted storage" {
+		t.Errorf("Fields[status] = %q, want %q", fields["status"], "unencrypted storage")
 	}
 }
 
@@ -267,10 +299,13 @@ func TestDBI_Fetch_UnencryptedStorage(t *testing.T) {
 // healthy available instance produces "deletion protection off".
 func TestDBI_Fetch_DeletionProtectionOff(t *testing.T) {
 	inst := findDBI(t, fixtures.WarnDbiUnprotectedID)
-	status, _ := fetchSingle(t, inst)
+	status, fields, _ := fetchSingle(t, inst)
 
-	if status != "deletion protection off" {
-		t.Errorf("Status = %q, want %q", status, "deletion protection off")
+	if status != "" {
+		t.Errorf("Status = %q, want %q", status, "")
+	}
+	if fields["status"] != "deletion protection off" {
+		t.Errorf("Fields[status] = %q, want %q", fields["status"], "deletion protection off")
 	}
 }
 
@@ -287,11 +322,14 @@ func TestDBI_Fetch_WarningPrecedence(t *testing.T) {
 		StorageEncrypted:      aws.Bool(false),
 		DeletionProtection:    aws.Bool(false),
 	}
-	status, _ := fetchSingle(t, inst)
+	status, fields, _ := fetchSingle(t, inst)
 
+	if status != "" {
+		t.Errorf("Status = %q, want %q", status, "")
+	}
 	// All 4 warnings → top phrase wins + "(+3)" for the 3 hidden warnings.
-	if status != "no automated backups (+3)" {
-		t.Errorf("Status = %q, want %q (backups > public > unencrypted > no-protection, +3 suffix)", status, "no automated backups (+3)")
+	if fields["status"] != "no automated backups (+3)" {
+		t.Errorf("Fields[status] = %q, want %q (backups > public > unencrypted > no-protection, +3 suffix)", fields["status"], "no automated backups (+3)")
 	}
 }
 
@@ -308,11 +346,14 @@ func TestDBI_Fetch_WarningPrecedence(t *testing.T) {
 // phrase followed by "(+2)" — one hidden finding per extra warning.
 func TestDBI_Fetch_MultiW1Warnings_SuffixThree(t *testing.T) {
 	inst := findDBI(t, fixtures.WarnDbiMultiID)
-	status, _ := fetchSingle(t, inst)
+	status, fields, _ := fetchSingle(t, inst)
 
 	want := "no automated backups (+2)"
-	if status != want {
-		t.Errorf("Status = %q, want %q (3 warnings: backups+public+unencrypted, deletion-protection=true)", status, want)
+	if status != "" {
+		t.Errorf("Status = %q, want %q", status, "")
+	}
+	if fields["status"] != want {
+		t.Errorf("Fields[status] = %q, want %q (3 warnings: backups+public+unencrypted, deletion-protection=true)", fields["status"], want)
 	}
 }
 
@@ -328,11 +369,14 @@ func TestDBI_Fetch_MultiW1Warnings_SuffixFour(t *testing.T) {
 		StorageEncrypted:      aws.Bool(false), // warning 3: unencrypted storage
 		DeletionProtection:    aws.Bool(false), // warning 4: deletion protection off
 	}
-	status, _ := fetchSingle(t, inst)
+	status, fields, _ := fetchSingle(t, inst)
 
 	want := "no automated backups (+3)"
-	if status != want {
-		t.Errorf("Status = %q, want %q (all 4 warnings stacked)", status, want)
+	if status != "" {
+		t.Errorf("Status = %q, want %q", status, "")
+	}
+	if fields["status"] != want {
+		t.Errorf("Fields[status] = %q, want %q (all 4 warnings stacked)", fields["status"], want)
 	}
 }
 
@@ -350,11 +394,14 @@ func TestDBI_Fetch_MultiW1Warnings_PrecedenceOrder(t *testing.T) {
 		StorageEncrypted:      aws.Bool(true),  // OK
 		DeletionProtection:    aws.Bool(false), // warning 2: deletion protection off
 	}
-	status, _ := fetchSingle(t, inst)
+	status, fields, _ := fetchSingle(t, inst)
 
 	want := "publicly accessible (+1)"
-	if status != want {
-		t.Errorf("Status = %q, want %q (public beats deletion-protection per §4 precedence)", status, want)
+	if status != "" {
+		t.Errorf("Status = %q, want %q", status, "")
+	}
+	if fields["status"] != want {
+		t.Errorf("Fields[status] = %q, want %q (public beats deletion-protection per §4 precedence)", fields["status"], want)
 	}
 }
 
@@ -363,11 +410,14 @@ func TestDBI_Fetch_MultiW1Warnings_PrecedenceOrder(t *testing.T) {
 // when N >= 2 warnings are present.
 func TestDBI_Fetch_SingleW1Warning_NoSuffix_Regression(t *testing.T) {
 	inst := findDBI(t, fixtures.WarnDbiPublicID)
-	status, _ := fetchSingle(t, inst)
+	status, fields, _ := fetchSingle(t, inst)
 
 	want := "publicly accessible"
-	if status != want {
-		t.Errorf("Status = %q, want %q (single warning must not have suffix)", status, want)
+	if status != "" {
+		t.Errorf("Status = %q, want %q", status, "")
+	}
+	if fields["status"] != want {
+		t.Errorf("Fields[status] = %q, want %q (single warning must not have suffix)", fields["status"], want)
 	}
 }
 
@@ -375,10 +425,13 @@ func TestDBI_Fetch_SingleW1Warning_NoSuffix_Regression(t *testing.T) {
 // produces an empty Status — no suffix, no phrase.
 func TestDBI_Fetch_HealthyInstance_NoSuffix(t *testing.T) {
 	inst := findDBI(t, fixtures.ProdDbiID)
-	status, _ := fetchSingle(t, inst)
+	status, fields, _ := fetchSingle(t, inst)
 
 	if status != "" {
-		t.Errorf("Status = %q, want %q (healthy instance must produce blank status)", status, "")
+		t.Errorf("Status = %q, want %q", status, "")
+	}
+	if fields["status"] != "" {
+		t.Errorf("Fields[status] = %q, want %q (healthy instance must produce blank)", fields["status"], "")
 	}
 }
 
@@ -390,7 +443,7 @@ func TestDBI_Fetch_HealthyInstance_NoSuffix(t *testing.T) {
 // in the fetcher output — spec §3.1 forbids jargon columns.
 func TestDBI_Fetch_NoCISFlagsField(t *testing.T) {
 	inst := findDBI(t, fixtures.ProdDbiID)
-	_, fields := fetchSingle(t, inst)
+	_, fields, _ := fetchSingle(t, inst)
 
 	if val, ok := fields["cis_flags"]; ok && val != "" {
 		t.Errorf("Fields[cis_flags] = %q — jargon field must not appear in output (spec §3.1)", val)
@@ -416,23 +469,27 @@ func fetchSingleResource(t *testing.T, inst rdstypes.DBInstance) resource.Resour
 }
 
 // ---------------------------------------------------------------------------
-// Resource.Issues population — spec rule 7 (S5): "every finding individually visible"
+// Resource.Findings population — spec rule 7 (S5): "every finding individually visible"
 // ---------------------------------------------------------------------------
 
-// TestDBI_Fetch_IssuesPopulated_Healthy verifies that a fully-healthy available
-// instance produces nil or empty Issues (no warnings to surface in S5).
-func TestDBI_Fetch_IssuesPopulated_Healthy(t *testing.T) {
+// TestDBI_Fetch_FindingsPopulated_Healthy verifies that a fully-healthy available
+// instance produces nil or empty Findings (no warnings to surface in S5).
+func TestDBI_Fetch_FindingsPopulated_Healthy(t *testing.T) {
 	inst := findDBI(t, fixtures.ProdDbiID)
 	r := fetchSingleResource(t, inst)
 
-	if len(r.Issues) != 0 {
-		t.Errorf("Issues = %v, want nil or empty for healthy row", r.Issues)
+	if len(r.Findings) != 0 {
+		phrases := make([]string, len(r.Findings))
+		for i, f := range r.Findings {
+			phrases[i] = f.Phrase
+		}
+		t.Errorf("Findings = %v, want nil or empty for healthy row", phrases)
 	}
 }
 
-// TestDBI_Fetch_IssuesPopulated_SingleWarning verifies that each single-warning
-// fixture populates Resource.Issues with exactly one entry matching the §4 phrase.
-func TestDBI_Fetch_IssuesPopulated_SingleWarning(t *testing.T) {
+// TestDBI_Fetch_FindingsPopulated_SingleWarning verifies that each single-warning
+// fixture populates Resource.Findings with exactly one entry matching the §4 phrase.
+func TestDBI_Fetch_FindingsPopulated_SingleWarning(t *testing.T) {
 	cases := []struct{ id, want string }{
 		{fixtures.WarnDbiNoBackupsID, "no automated backups"},
 		{fixtures.WarnDbiPublicID, "publicly accessible"},
@@ -445,43 +502,54 @@ func TestDBI_Fetch_IssuesPopulated_SingleWarning(t *testing.T) {
 			inst := findDBI(t, tc.id)
 			r := fetchSingleResource(t, inst)
 
-			if len(r.Issues) != 1 {
-				t.Errorf("Issues length = %d, want 1; Issues = %v", len(r.Issues), r.Issues)
+			if len(r.Findings) != 1 {
+				phrases := make([]string, len(r.Findings))
+				for i, f := range r.Findings {
+					phrases[i] = f.Phrase
+				}
+				t.Errorf("Findings length = %d, want 1; Findings = %v", len(r.Findings), phrases)
 				return
 			}
-			if r.Issues[0] != tc.want {
-				t.Errorf("Issues[0] = %q, want %q", r.Issues[0], tc.want)
+			if r.Findings[0].Phrase != tc.want {
+				t.Errorf("Findings[0].Phrase = %q, want %q", r.Findings[0].Phrase, tc.want)
+			}
+			if r.Findings[0].Source != "wave1" {
+				t.Errorf("Findings[0].Source = %q, want %q", r.Findings[0].Source, "wave1")
 			}
 		})
 	}
 }
 
-// TestDBI_Fetch_IssuesPopulated_MultiWarning verifies that warn-dbi-multi
+// TestDBI_Fetch_FindingsPopulated_MultiWarning verifies that warn-dbi-multi
 // (3 Wave-1 warnings: no-backups + public + unencrypted, deletion-protection=true)
-// produces Issues with length 3 in §4 precedence order.
-func TestDBI_Fetch_IssuesPopulated_MultiWarning(t *testing.T) {
+// produces Findings with length 3 in §4 precedence order.
+func TestDBI_Fetch_FindingsPopulated_MultiWarning(t *testing.T) {
 	inst := findDBI(t, fixtures.WarnDbiMultiID)
 	r := fetchSingleResource(t, inst)
 
-	wantIssues := []string{
+	wantPhrases := []string{
 		"no automated backups",
 		"publicly accessible",
 		"unencrypted storage",
 	}
 
-	if len(r.Issues) != len(wantIssues) {
-		t.Fatalf("Issues length = %d, want %d; Issues = %v", len(r.Issues), len(wantIssues), r.Issues)
+	if len(r.Findings) != len(wantPhrases) {
+		phrases := make([]string, len(r.Findings))
+		for i, f := range r.Findings {
+			phrases[i] = f.Phrase
+		}
+		t.Fatalf("Findings length = %d, want %d; Findings = %v", len(r.Findings), len(wantPhrases), phrases)
 	}
-	for i, want := range wantIssues {
-		if r.Issues[i] != want {
-			t.Errorf("Issues[%d] = %q, want %q (§4 precedence violated)", i, r.Issues[i], want)
+	for i, want := range wantPhrases {
+		if r.Findings[i].Phrase != want {
+			t.Errorf("Findings[%d].Phrase = %q, want %q (§4 precedence violated)", i, r.Findings[i].Phrase, want)
 		}
 	}
 }
 
-// TestDBI_Fetch_IssuesPopulated_AllFourWarnings verifies that an inline fixture
-// with all 4 Wave-1 warnings produces Issues of length 4 in §4 precedence order.
-func TestDBI_Fetch_IssuesPopulated_AllFourWarnings(t *testing.T) {
+// TestDBI_Fetch_FindingsPopulated_AllFourWarnings verifies that an inline fixture
+// with all 4 Wave-1 warnings produces Findings of length 4 in §4 precedence order.
+func TestDBI_Fetch_FindingsPopulated_AllFourWarnings(t *testing.T) {
 	inst := rdstypes.DBInstance{
 		DBInstanceIdentifier:  aws.String("inline-all-four-warnings"),
 		DBInstanceArn:         aws.String("arn:aws:rds:us-east-1:123456789012:db:inline-all-four-warnings"),
@@ -493,37 +561,44 @@ func TestDBI_Fetch_IssuesPopulated_AllFourWarnings(t *testing.T) {
 	}
 	r := fetchSingleResource(t, inst)
 
-	wantIssues := []string{
+	wantPhrases := []string{
 		"no automated backups",
 		"publicly accessible",
 		"unencrypted storage",
 		"deletion protection off",
 	}
 
-	if len(r.Issues) != len(wantIssues) {
-		t.Fatalf("Issues length = %d, want %d; Issues = %v", len(r.Issues), len(wantIssues), r.Issues)
+	if len(r.Findings) != len(wantPhrases) {
+		phrases := make([]string, len(r.Findings))
+		for i, f := range r.Findings {
+			phrases[i] = f.Phrase
+		}
+		t.Fatalf("Findings length = %d, want %d; Findings = %v", len(r.Findings), len(wantPhrases), phrases)
 	}
-	for i, want := range wantIssues {
-		if r.Issues[i] != want {
-			t.Errorf("Issues[%d] = %q, want %q (§4 precedence violated)", i, r.Issues[i], want)
+	for i, want := range wantPhrases {
+		if r.Findings[i].Phrase != want {
+			t.Errorf("Findings[%d].Phrase = %q, want %q (§4 precedence violated)", i, r.Findings[i].Phrase, want)
 		}
 	}
 }
 
-// TestDBI_Fetch_IssuesPopulated_Broken verifies broken-status fixtures:
-// Issues carries the single broken phrase (not config warnings, which are blocked
+// TestDBI_Fetch_FindingsPopulated_Broken verifies broken-status fixtures:
+// Findings carries the single broken phrase (not config warnings, which are blocked
 // by the broken-first precedence in §4).
-func TestDBI_Fetch_IssuesPopulated_Broken(t *testing.T) {
+func TestDBI_Fetch_FindingsPopulated_Broken(t *testing.T) {
 	t.Run("storage-full", func(t *testing.T) {
 		inst := findDBI(t, fixtures.BrokenDbiStorageFullID)
 		r := fetchSingleResource(t, inst)
 
-		wantIssues := []string{"storage-full"}
-		if len(r.Issues) != 1 {
-			t.Fatalf("Issues length = %d, want 1; Issues = %v", len(r.Issues), r.Issues)
+		if len(r.Findings) != 1 {
+			phrases := make([]string, len(r.Findings))
+			for i, f := range r.Findings {
+				phrases[i] = f.Phrase
+			}
+			t.Fatalf("Findings length = %d, want 1; Findings = %v", len(r.Findings), phrases)
 		}
-		if r.Issues[0] != wantIssues[0] {
-			t.Errorf("Issues[0] = %q, want %q", r.Issues[0], wantIssues[0])
+		if r.Findings[0].Phrase != "storage-full" {
+			t.Errorf("Findings[0].Phrase = %q, want %q", r.Findings[0].Phrase, "storage-full")
 		}
 	})
 
@@ -531,29 +606,35 @@ func TestDBI_Fetch_IssuesPopulated_Broken(t *testing.T) {
 		inst := findDBI(t, fixtures.BrokenDbiEncryptionLockedID)
 		r := fetchSingleResource(t, inst)
 
-		wantIssues := []string{"encryption key unavailable"}
-		if len(r.Issues) != 1 {
-			t.Fatalf("Issues length = %d, want 1; Issues = %v", len(r.Issues), r.Issues)
+		if len(r.Findings) != 1 {
+			phrases := make([]string, len(r.Findings))
+			for i, f := range r.Findings {
+				phrases[i] = f.Phrase
+			}
+			t.Fatalf("Findings length = %d, want 1; Findings = %v", len(r.Findings), phrases)
 		}
-		if r.Issues[0] != wantIssues[0] {
-			t.Errorf("Issues[0] = %q, want %q (broken remap must appear in Issues)", r.Issues[0], wantIssues[0])
+		if r.Findings[0].Phrase != "encryption key unavailable" {
+			t.Errorf("Findings[0].Phrase = %q, want %q (broken remap must appear in Findings)", r.Findings[0].Phrase, "encryption key unavailable")
 		}
 	})
 }
 
-// TestDBI_Fetch_IssuesPopulated_Transitional verifies transitional-status fixtures:
-// Issues carries the single transitional phrase (with pending key suffix when present).
-func TestDBI_Fetch_IssuesPopulated_Transitional(t *testing.T) {
+// TestDBI_Fetch_FindingsPopulated_Transitional verifies transitional-status fixtures:
+// Findings carries the single transitional phrase (with pending key suffix when present).
+func TestDBI_Fetch_FindingsPopulated_Transitional(t *testing.T) {
 	t.Run("modifying-with-pending-class", func(t *testing.T) {
 		inst := findDBI(t, fixtures.StagingDbiModifyingID)
 		r := fetchSingleResource(t, inst)
 
-		wantIssues := []string{"modifying: DBInstanceClass"}
-		if len(r.Issues) != 1 {
-			t.Fatalf("Issues length = %d, want 1; Issues = %v", len(r.Issues), r.Issues)
+		if len(r.Findings) != 1 {
+			phrases := make([]string, len(r.Findings))
+			for i, f := range r.Findings {
+				phrases[i] = f.Phrase
+			}
+			t.Fatalf("Findings length = %d, want 1; Findings = %v", len(r.Findings), phrases)
 		}
-		if r.Issues[0] != wantIssues[0] {
-			t.Errorf("Issues[0] = %q, want %q", r.Issues[0], wantIssues[0])
+		if r.Findings[0].Phrase != "modifying: DBInstanceClass" {
+			t.Errorf("Findings[0].Phrase = %q, want %q", r.Findings[0].Phrase, "modifying: DBInstanceClass")
 		}
 	})
 
@@ -561,12 +642,15 @@ func TestDBI_Fetch_IssuesPopulated_Transitional(t *testing.T) {
 		inst := findDBI(t, fixtures.StagingDbiRebootingID)
 		r := fetchSingleResource(t, inst)
 
-		wantIssues := []string{"rebooting"}
-		if len(r.Issues) != 1 {
-			t.Fatalf("Issues length = %d, want 1; Issues = %v", len(r.Issues), r.Issues)
+		if len(r.Findings) != 1 {
+			phrases := make([]string, len(r.Findings))
+			for i, f := range r.Findings {
+				phrases[i] = f.Phrase
+			}
+			t.Fatalf("Findings length = %d, want 1; Findings = %v", len(r.Findings), phrases)
 		}
-		if r.Issues[0] != wantIssues[0] {
-			t.Errorf("Issues[0] = %q, want %q", r.Issues[0], wantIssues[0])
+		if r.Findings[0].Phrase != "rebooting" {
+			t.Errorf("Findings[0].Phrase = %q, want %q", r.Findings[0].Phrase, "rebooting")
 		}
 	})
 }
@@ -625,23 +709,22 @@ func TestDBI_Fetch_DetailFieldsPopulated(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Resource.Issues per-fixture audit — complete coverage across all named fixtures
+// Resource.Findings per-fixture audit — complete coverage across all named fixtures
 // ---------------------------------------------------------------------------
 
-// TestDBI_Fetch_IssuesPopulated_EveryFixture is a table-driven audit that verifies
-// Resource.Issues is exactly correct for every named DBI fixture. Nil expected
-// issues means the fixture is Healthy and must produce an empty slice (spec §4:
-// Healthy silence). Non-nil expected issues must match in exact §4 precedence order.
-//
-// Uses reflect.DeepEqual for slice equality — catches both missing phrases and
+// TestDBI_Fetch_FindingsPopulated_EveryFixture is a table-driven audit that verifies
+// Resource.Findings phrases are exactly correct for every named DBI fixture. Nil expected
+// phrases means the fixture is Healthy and must produce empty Findings (spec §4:
+// Healthy silence). Non-nil expected phrases must match in exact §4 precedence order.
+// // Uses reflect.DeepEqual for slice equality — catches both missing phrases and
 // ordering bugs that the existing per-fixture spot-checks would miss.
-func TestDBI_Fetch_IssuesPopulated_EveryFixture(t *testing.T) {
-	type issueCase struct {
-		id     string
-		issues []string // nil = expect nil or empty Issues
+func TestDBI_Fetch_FindingsPopulated_EveryFixture(t *testing.T) {
+	type findingCase struct {
+		id      string
+		phrases []string // nil = expect nil or empty Findings
 	}
-	cases := []issueCase{
-		// Healthy rows — must produce nil/empty Issues.
+	cases := []findingCase{
+		// Healthy rows — must produce nil/empty Findings.
 		{fixtures.ProdDbiID, nil},
 		{fixtures.ProdDbiAuroraID, nil},
 		// Transitional (Wave-1, single phrase).
@@ -657,9 +740,9 @@ func TestDBI_Fetch_IssuesPopulated_EveryFixture(t *testing.T) {
 		{fixtures.WarnDbiUnprotectedID, []string{"deletion protection off"}},
 		// Multi Config Warnings.
 		{fixtures.WarnDbiMultiID, []string{"no automated backups", "publicly accessible", "unencrypted storage"}},
-		// Wave-1 warning + Wave-2 maintenance — Issues carries Wave-1 phrases only.
+		// Wave-1 warning + Wave-2 maintenance — Findings carries Wave-1 phrases only.
 		{fixtures.WarnDbiPublicMaintID, []string{"publicly accessible"}},
-		// Wave-2 only on Healthy row — Issues must be nil/empty (Wave-2 is not in Issues).
+		// Wave-2 only on Healthy row — Findings must be nil/empty (Wave-2 is not in Findings).
 		{fixtures.MaintDbiScheduledID, nil},
 		// Legacy fixture with all 4 Wave-1 warnings — sourced from full RDS pool.
 		{"db-public-no-encryption", []string{"no automated backups", "publicly accessible", "unencrypted storage", "deletion protection off"}},
@@ -677,18 +760,21 @@ func TestDBI_Fetch_IssuesPopulated_EveryFixture(t *testing.T) {
 			}
 			r := fetchSingleResource(t, inst)
 
-			// Normalise: nil and empty slice are both "no issues".
-			got := r.Issues
+			// Extract phrases from Findings for comparison.
+			got := make([]string, len(r.Findings))
+			for i, f := range r.Findings {
+				got[i] = f.Phrase
+			}
 			if len(got) == 0 {
 				got = nil
 			}
-			want := tc.issues
+			want := tc.phrases
 			if len(want) == 0 {
 				want = nil
 			}
 
 			if !reflect.DeepEqual(got, want) {
-				t.Fatalf("%s: Issues = %v, want %v", tc.id, r.Issues, tc.issues)
+				t.Fatalf("%s: Findings phrases = %v, want %v", tc.id, got, tc.phrases)
 			}
 		})
 	}

--- a/tests/unit/aws_ddb_test.go
+++ b/tests/unit/aws_ddb_test.go
@@ -71,7 +71,10 @@ func (s *ddbDescribeStub) DescribeTable(_ context.Context, in *dynamodb.Describe
 // ---------------------------------------------------------------------------
 
 // fetchDDBSingle wires a single TableDescription through FetchDynamoDBTablesPage
-// and returns the resulting Resource (status, issues, fields).
+// and returns (status, issues, fields) derived from the new Findings-based contract:
+//   - status  is r.Fields["status"]   (fetcher writes phrase here; r.Status is always "")
+//   - issues  is a []string of r.Findings[i].Phrase (same phrases, different carrier)
+//   - fields  is r.Fields
 func fetchDDBSingle(t *testing.T, table *ddbtypes.TableDescription) (status string, issues []string, fields map[string]string) {
 	t.Helper()
 	if table.TableName == nil {
@@ -89,7 +92,12 @@ func fetchDDBSingle(t *testing.T, table *ddbtypes.TableDescription) (status stri
 		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
 	}
 	r := result.Resources[0]
-	return r.Status, r.Issues, r.Fields
+	// Derive issues from Findings so existing assertions stay intact.
+	phrases := make([]string, 0, len(r.Findings))
+	for _, f := range r.Findings {
+		phrases = append(phrases, f.Phrase)
+	}
+	return r.Fields["status"], phrases, r.Fields
 }
 
 // findDDBTable returns the TableDescription with the given name from the fixture.

--- a/tests/unit/aws_efs_issue_enrichment_test.go
+++ b/tests/unit/aws_efs_issue_enrichment_test.go
@@ -21,6 +21,7 @@ import (
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/demo/fixtures"
+	"github.com/k2m30/a9s/v3/internal/domain"
 )
 
 // Shared helper efsMTFakeFromFixtures lives in helpers_efs_test.go.
@@ -144,9 +145,11 @@ func TestEnrichEFSMountTargets_W1WarningPlusW2Bumps(t *testing.T) {
 	clients := &awsclient.ServiceClients{EFS: fake}
 
 	// Resource represents the fetcher output for this W1-Warning fixture.
+	// enricher reads len(r.Findings) for the (+N) count.
 	res := efsResources(fsID)
-	res[0].Status = "updating"
-	res[0].Issues = []string{"updating"}
+	res[0].Findings = []domain.Finding{
+		{Code: awsclient.CodeEFSUpdating, Phrase: "updating", Severity: domain.SevWarn, Source: "wave1"},
+	}
 
 	result, err := awsclient.EnrichEFSMountTargets(context.Background(), clients, res, nil)
 	if err != nil {

--- a/tests/unit/aws_efs_test.go
+++ b/tests/unit/aws_efs_test.go
@@ -78,8 +78,8 @@ func TestFetchEFSFileSystems_HealthyBaseline_Silence(t *testing.T) {
 	if statusField := r.Fields["status"]; statusField != "" {
 		t.Errorf("Fields[\"status\"] = %q, want %q (healthy rows must have blank status field)", statusField, "")
 	}
-	if len(r.Issues) != 0 {
-		t.Errorf("Issues = %v, want nil/empty (healthy rows have no Wave-1 issues)", r.Issues)
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings = %v, want nil/empty (healthy rows have no Wave-1 findings)", r.Findings)
 	}
 }
 
@@ -102,11 +102,11 @@ func TestFetchEFSFileSystems_Creating_Warning(t *testing.T) {
 		t.Fatalf("fixture %q not found in fetcher output", fsID)
 	}
 
-	if r.Status != "creating" {
-		t.Errorf("Status = %q, want %q", r.Status, "creating")
+	if r.Fields["status"] != "creating" {
+		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], "creating")
 	}
-	if len(r.Issues) != 1 || r.Issues[0] != "creating" {
-		t.Errorf("Issues = %v, want [creating]", r.Issues)
+	if len(r.Findings) != 1 || r.Findings[0].Phrase != "creating" {
+		t.Errorf("Findings = %v, want one finding with Phrase %q", r.Findings, "creating")
 	}
 }
 
@@ -129,11 +129,11 @@ func TestFetchEFSFileSystems_Updating_Warning(t *testing.T) {
 		t.Fatalf("fixture %q not found in fetcher output", fsID)
 	}
 
-	if r.Status != "updating" {
-		t.Errorf("Status = %q, want %q", r.Status, "updating")
+	if r.Fields["status"] != "updating" {
+		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], "updating")
 	}
-	if len(r.Issues) != 1 || r.Issues[0] != "updating" {
-		t.Errorf("Issues = %v, want [updating]", r.Issues)
+	if len(r.Findings) != 1 || r.Findings[0].Phrase != "updating" {
+		t.Errorf("Findings = %v, want one finding with Phrase %q", r.Findings, "updating")
 	}
 }
 
@@ -156,11 +156,11 @@ func TestFetchEFSFileSystems_Deleting_Warning(t *testing.T) {
 		t.Fatalf("fixture %q not found in fetcher output", fsID)
 	}
 
-	if r.Status != "deleting" {
-		t.Errorf("Status = %q, want %q", r.Status, "deleting")
+	if r.Fields["status"] != "deleting" {
+		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], "deleting")
 	}
-	if len(r.Issues) != 1 || r.Issues[0] != "deleting" {
-		t.Errorf("Issues = %v, want [deleting]", r.Issues)
+	if len(r.Findings) != 1 || r.Findings[0].Phrase != "deleting" {
+		t.Errorf("Findings = %v, want one finding with Phrase %q", r.Findings, "deleting")
 	}
 }
 
@@ -183,11 +183,11 @@ func TestFetchEFSFileSystems_Error_Broken(t *testing.T) {
 		t.Fatalf("fixture %q not found in fetcher output", fsID)
 	}
 
-	if r.Status != "error" {
-		t.Errorf("Status = %q, want %q", r.Status, "error")
+	if r.Fields["status"] != "error" {
+		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], "error")
 	}
-	if len(r.Issues) != 1 || r.Issues[0] != "error" {
-		t.Errorf("Issues = %v, want [error]", r.Issues)
+	if len(r.Findings) != 1 || r.Findings[0].Phrase != "error" {
+		t.Errorf("Findings = %v, want one finding with Phrase %q", r.Findings, "error")
 	}
 }
 
@@ -211,11 +211,11 @@ func TestFetchEFSFileSystems_NoMountTargets_Broken(t *testing.T) {
 		t.Fatalf("fixture %q not found in fetcher output", fsID)
 	}
 
-	if r.Status != "no mount targets" {
-		t.Errorf("Status = %q, want %q", r.Status, "no mount targets")
+	if r.Fields["status"] != "no mount targets" {
+		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], "no mount targets")
 	}
-	if len(r.Issues) != 1 || r.Issues[0] != "no mount targets" {
-		t.Errorf("Issues = %v, want [no mount targets]", r.Issues)
+	if len(r.Findings) != 1 || r.Findings[0].Phrase != "no mount targets" {
+		t.Errorf("Findings = %v, want one finding with Phrase %q", r.Findings, "no mount targets")
 	}
 }
 
@@ -244,19 +244,19 @@ func TestFetchEFSFileSystems_MultiW1_NomountsPlusDeleting(t *testing.T) {
 	}
 
 	wantStatus := "no mount targets (+1)"
-	if r.Status != wantStatus {
-		t.Errorf("Status = %q, want %q (Broken wins over Warning; hidden count +1)", r.Status, wantStatus)
+	if r.Status != "" {
+		t.Errorf("Status = %q, want %q (fetcher must not write Status)", r.Status, "")
 	}
 	if statusField := r.Fields["status"]; statusField != wantStatus {
-		t.Errorf("Fields[\"status\"] = %q, want %q", statusField, wantStatus)
+		t.Errorf("Fields[\"status\"] = %q, want %q (top phrase + (+N) suffix)", statusField, wantStatus)
 	}
-	wantIssues := []string{"no mount targets", "deleting"}
-	if len(r.Issues) != len(wantIssues) {
-		t.Errorf("Issues = %v, want %v", r.Issues, wantIssues)
+	wantPhrases := []string{"no mount targets", "deleting"}
+	if len(r.Findings) != len(wantPhrases) {
+		t.Errorf("Findings = %v, want %d findings", r.Findings, len(wantPhrases))
 	} else {
-		for i, want := range wantIssues {
-			if r.Issues[i] != want {
-				t.Errorf("Issues[%d] = %q, want %q", i, r.Issues[i], want)
+		for i, want := range wantPhrases {
+			if r.Findings[i].Phrase != want {
+				t.Errorf("Findings[%d].Phrase = %q, want %q", i, r.Findings[i].Phrase, want)
 			}
 		}
 	}
@@ -340,18 +340,18 @@ func TestFetchEFSFileSystems_PopulatesResourceIssues(t *testing.T) {
 				t.Fatalf("fixture %q not found in fetcher output (got IDs: %v)", tc.fsID, sortedKeys(byID))
 			}
 			if tc.wantIssues == nil {
-				if len(r.Issues) != 0 {
-					t.Errorf("Issues = %v, want nil/empty", r.Issues)
+				if len(r.Findings) != 0 {
+					t.Errorf("Findings = %v, want nil/empty", r.Findings)
 				}
 				return
 			}
-			if len(r.Issues) != len(tc.wantIssues) {
-				t.Errorf("Issues = %v, want %v", r.Issues, tc.wantIssues)
+			if len(r.Findings) != len(tc.wantIssues) {
+				t.Errorf("Findings len = %d, want %d; Findings = %v, want phrases %v", len(r.Findings), len(tc.wantIssues), r.Findings, tc.wantIssues)
 				return
 			}
 			for i, want := range tc.wantIssues {
-				if r.Issues[i] != want {
-					t.Errorf("Issues[%d] = %q, want %q", i, r.Issues[i], want)
+				if r.Findings[i].Phrase != want {
+					t.Errorf("Findings[%d].Phrase = %q, want %q", i, r.Findings[i].Phrase, want)
 				}
 			}
 		})
@@ -547,10 +547,10 @@ func TestFetchEFSFileSystems_W1Updating_IsolatesFromMTState(t *testing.T) {
 	}
 
 	// Phase 1 contract: lifecycle-state signal only.
-	if r.Status != "updating" {
-		t.Errorf("Status = %q, want %q (W1 signal only; MT state is W2)", r.Status, "updating")
+	if r.Fields["status"] != "updating" {
+		t.Errorf("Fields[\"status\"] = %q, want %q (W1 signal only; MT state is W2)", r.Fields["status"], "updating")
 	}
-	if len(r.Issues) != 1 || r.Issues[0] != "updating" {
-		t.Errorf("Issues = %v, want [updating]", r.Issues)
+	if len(r.Findings) != 1 || r.Findings[0].Phrase != "updating" {
+		t.Errorf("Findings = %v, want one finding with Phrase %q", r.Findings, "updating")
 	}
 }

--- a/tests/unit/aws_opensearch_test.go
+++ b/tests/unit/aws_opensearch_test.go
@@ -8,7 +8,6 @@ package unit
 
 import (
 	"context"
-	"reflect"
 	"testing"
 	"time"
 
@@ -165,11 +164,15 @@ func TestOpenSearch_Fetch_DeletedDim(t *testing.T) {
 	r := resources[0]
 
 	const wantPhrase = "deleting: removal in progress"
-	if r.Status != wantPhrase {
-		t.Errorf("Status = %q, want %q", r.Status, wantPhrase)
+	// Fetcher does not write Resource.Status — it is always "".
+	if r.Status != "" {
+		t.Errorf("Status = %q, want %q (fetcher must not write Status)", r.Status, "")
 	}
-	if !reflect.DeepEqual(r.Issues, []string{wantPhrase}) {
-		t.Errorf("Issues = %v, want [%q] (U7f deep-equals)", r.Issues, wantPhrase)
+	if r.Fields["status"] != wantPhrase {
+		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], wantPhrase)
+	}
+	if len(r.Findings) != 1 || r.Findings[0].Phrase != wantPhrase {
+		t.Errorf("Findings = %v, want one finding with Phrase %q", r.Findings, wantPhrase)
 	}
 	if r.Fields["deleted"] != "true" {
 		t.Errorf("Fields[\"deleted\"] = %q, want %q", r.Fields["deleted"], "true")
@@ -202,11 +205,15 @@ func TestOpenSearch_Fetch_IsolatedBroken(t *testing.T) {
 	r := resources[0]
 
 	const wantPhrase = "isolated: quarantined by AWS"
-	if r.Status != wantPhrase {
-		t.Errorf("Status = %q, want %q", r.Status, wantPhrase)
+	// Fetcher does not write Resource.Status — it is always "".
+	if r.Status != "" {
+		t.Errorf("Status = %q, want %q (fetcher must not write Status)", r.Status, "")
 	}
-	if !reflect.DeepEqual(r.Issues, []string{wantPhrase}) {
-		t.Errorf("Issues = %v, want [%q] (U7f deep-equals)", r.Issues, wantPhrase)
+	if r.Fields["status"] != wantPhrase {
+		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], wantPhrase)
+	}
+	if len(r.Findings) != 1 || r.Findings[0].Phrase != wantPhrase {
+		t.Errorf("Findings = %v, want one finding with Phrase %q", r.Findings, wantPhrase)
 	}
 	if r.Fields["domain_processing_status"] != "Isolated" {
 		t.Errorf("Fields[\"domain_processing_status\"] = %q, want %q", r.Fields["domain_processing_status"], "Isolated")
@@ -240,11 +247,15 @@ func TestOpenSearch_Fetch_ProcessingWarning(t *testing.T) {
 	r := resources[0]
 
 	const wantPhrase = "processing: config change in flight"
-	if r.Status != wantPhrase {
-		t.Errorf("Status = %q, want %q", r.Status, wantPhrase)
+	// Fetcher does not write Resource.Status — it is always "".
+	if r.Status != "" {
+		t.Errorf("Status = %q, want %q (fetcher must not write Status)", r.Status, "")
 	}
-	if !reflect.DeepEqual(r.Issues, []string{wantPhrase}) {
-		t.Errorf("Issues = %v, want [%q] (U7f deep-equals)", r.Issues, wantPhrase)
+	if r.Fields["status"] != wantPhrase {
+		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], wantPhrase)
+	}
+	if len(r.Findings) != 1 || r.Findings[0].Phrase != wantPhrase {
+		t.Errorf("Findings = %v, want one finding with Phrase %q", r.Findings, wantPhrase)
 	}
 	if r.Fields["processing"] != "true" {
 		t.Errorf("Fields[\"processing\"] = %q, want %q", r.Fields["processing"], "true")
@@ -278,11 +289,15 @@ func TestOpenSearch_Fetch_UpgradeProcessingWarning(t *testing.T) {
 	r := resources[0]
 
 	const wantPhrase = "processing: config change in flight"
-	if r.Status != wantPhrase {
-		t.Errorf("Status = %q, want %q", r.Status, wantPhrase)
+	// Fetcher does not write Resource.Status — it is always "".
+	if r.Status != "" {
+		t.Errorf("Status = %q, want %q (fetcher must not write Status)", r.Status, "")
 	}
-	if !reflect.DeepEqual(r.Issues, []string{wantPhrase}) {
-		t.Errorf("Issues = %v, want [%q] (U7f deep-equals)", r.Issues, wantPhrase)
+	if r.Fields["status"] != wantPhrase {
+		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], wantPhrase)
+	}
+	if len(r.Findings) != 1 || r.Findings[0].Phrase != wantPhrase {
+		t.Errorf("Findings = %v, want one finding with Phrase %q", r.Findings, wantPhrase)
 	}
 	if r.Fields["upgrade_processing"] != "true" {
 		t.Errorf("Fields[\"upgrade_processing\"] = %q, want %q", r.Fields["upgrade_processing"], "true")
@@ -323,11 +338,17 @@ func TestOpenSearch_Fetch_UpdateAvailableHealthyBang(t *testing.T) {
 	}
 	r := resources[0]
 
-	if r.Status != "software update forced soon" {
-		t.Errorf("Status = %q, want %q", r.Status, "software update forced soon")
+	// Fetcher does not write Resource.Status — it is always "".
+	if r.Status != "" {
+		t.Errorf("Status = %q, want %q (fetcher must not write Status)", r.Status, "")
 	}
-	if len(r.Issues) != 0 {
-		t.Errorf("Issues = %v, want nil (background-check → Finding, not Issues)", r.Issues)
+	if r.Fields["status"] != "software update forced soon" {
+		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], "software update forced soon")
+	}
+	// UpdateForcedSoon is a background-check signal owned by the Wave 2
+	// enricher — it appears in Fields["status"] for display but not in Findings.
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings = %v, want none (UpdateForcedSoon is enricher territory, not wave1)", r.Findings)
 	}
 	if r.Fields["service_software_update_available"] != "true" {
 		t.Errorf("Fields[\"service_software_update_available\"] = %q, want %q", r.Fields["service_software_update_available"], "true")
@@ -400,11 +421,17 @@ func TestOpenSearch_Fetch_EncryptionOffHealthyTilde(t *testing.T) {
 	}
 	r := resources[0]
 
-	if r.Status != "encryption at rest off" {
-		t.Errorf("Status = %q, want %q", r.Status, "encryption at rest off")
+	// Fetcher does not write Resource.Status — it is always "".
+	if r.Status != "" {
+		t.Errorf("Status = %q, want %q (fetcher must not write Status)", r.Status, "")
 	}
-	if len(r.Issues) != 0 {
-		t.Errorf("Issues = %v, want nil (background signal → Finding, not Issues)", r.Issues)
+	if r.Fields["status"] != "encryption at rest off" {
+		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], "encryption at rest off")
+	}
+	// EncryptionOff is a background-check signal owned by the Wave 2 enricher —
+	// it appears in Fields["status"] for display but not in Findings.
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings = %v, want none (EncryptionOff is enricher territory, not wave1)", r.Findings)
 	}
 	if r.Fields["encryption_at_rest_enabled"] != "false" {
 		t.Errorf("Fields[\"encryption_at_rest_enabled\"] = %q, want %q", r.Fields["encryption_at_rest_enabled"], "false")
@@ -445,11 +472,17 @@ func TestOpenSearch_Fetch_MultiW2UpdatePlusEncryptionSuffix(t *testing.T) {
 	}
 	r := resources[0]
 
-	if r.Status != "software update forced soon (+1)" {
-		t.Errorf("Status = %q, want %q (! beats ~; hidden = 1)", r.Status, "software update forced soon (+1)")
+	// Fetcher does not write Resource.Status — it is always "".
+	if r.Status != "" {
+		t.Errorf("Status = %q, want %q (fetcher must not write Status)", r.Status, "")
 	}
-	if len(r.Issues) != 0 {
-		t.Errorf("Issues = %v, want nil (no hard-state; findings go in EnrichmentFinding)", r.Issues)
+	// Display column carries both background-check signals with (+N) suffix.
+	if r.Fields["status"] != "software update forced soon (+1)" {
+		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], "software update forced soon (+1)")
+	}
+	// Both signals are background-checks owned by Wave 2 — neither in Findings.
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings = %v, want none (background-checks are enricher territory)", r.Findings)
 	}
 }
 
@@ -485,11 +518,20 @@ func TestOpenSearch_Fetch_HardStatePlusBackgroundSuffix(t *testing.T) {
 	}
 	r := resources[0]
 
-	if r.Status != "processing: config change in flight (+1)" {
-		t.Errorf("Status = %q, want %q", r.Status, "processing: config change in flight (+1)")
+	// Fetcher does not write Resource.Status — it is always "".
+	if r.Status != "" {
+		t.Errorf("Status = %q, want %q (fetcher must not write Status)", r.Status, "")
 	}
-	if !reflect.DeepEqual(r.Issues, []string{"processing: config change in flight"}) {
-		t.Errorf("Issues = %v, want [\"processing: config change in flight\"] (hard-state in Issues only)", r.Issues)
+	// Display: processing (hard-state) + software update (background) → suffix (+1).
+	if r.Fields["status"] != "processing: config change in flight (+1)" {
+		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], "processing: config change in flight (+1)")
+	}
+	// Only the hard-state (processing) is in Findings; UpdateForcedSoon is enricher territory.
+	if len(r.Findings) != 1 {
+		t.Errorf("Findings len = %d, want 1 (only processing); Findings = %v", len(r.Findings), r.Findings)
+	}
+	if len(r.Findings) > 0 && r.Findings[0].Phrase != "processing: config change in flight" {
+		t.Errorf("Findings[0].Phrase = %q, want %q", r.Findings[0].Phrase, "processing: config change in flight")
 	}
 }
 
@@ -521,11 +563,20 @@ func TestOpenSearch_Fetch_IsolatedPlusEncryptionOff(t *testing.T) {
 	}
 	r := resources[0]
 
-	if r.Status != "isolated: quarantined by AWS (+1)" {
-		t.Errorf("Status = %q, want %q", r.Status, "isolated: quarantined by AWS (+1)")
+	// Fetcher does not write Resource.Status — it is always "".
+	if r.Status != "" {
+		t.Errorf("Status = %q, want %q (fetcher must not write Status)", r.Status, "")
 	}
-	if !reflect.DeepEqual(r.Issues, []string{"isolated: quarantined by AWS"}) {
-		t.Errorf("Issues = %v, want [\"isolated: quarantined by AWS\"]", r.Issues)
+	// Display: isolated (hard-state) + encryption-off (background) → suffix (+1).
+	if r.Fields["status"] != "isolated: quarantined by AWS (+1)" {
+		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], "isolated: quarantined by AWS (+1)")
+	}
+	// Only the hard-state (isolated) is in Findings; EncryptionOff is enricher territory.
+	if len(r.Findings) != 1 {
+		t.Errorf("Findings len = %d, want 1 (only isolated); Findings = %v", len(r.Findings), r.Findings)
+	}
+	if len(r.Findings) > 0 && r.Findings[0].Phrase != "isolated: quarantined by AWS" {
+		t.Errorf("Findings[0].Phrase = %q, want %q", r.Findings[0].Phrase, "isolated: quarantined by AWS")
 	}
 }
 
@@ -564,11 +615,20 @@ func TestOpenSearch_Fetch_DeletedPlusBackgroundBackgroundSuppressed(t *testing.T
 	}
 	r := resources[0]
 
-	if r.Status != "deleting: removal in progress (+2)" {
-		t.Errorf("Status = %q, want %q", r.Status, "deleting: removal in progress (+2)")
+	// Fetcher does not write Resource.Status — it is always "".
+	if r.Status != "" {
+		t.Errorf("Status = %q, want %q (fetcher must not write Status)", r.Status, "")
 	}
-	if !reflect.DeepEqual(r.Issues, []string{"deleting: removal in progress"}) {
-		t.Errorf("Issues = %v, want [\"deleting: removal in progress\"]", r.Issues)
+	// Display: deleted (hard-state) + 2 background-checks → suffix (+2).
+	if r.Fields["status"] != "deleting: removal in progress (+2)" {
+		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], "deleting: removal in progress (+2)")
+	}
+	// Only the hard-state (deleting, SevDim) is in Findings; background-checks are enricher territory.
+	if len(r.Findings) != 1 {
+		t.Errorf("Findings len = %d, want 1 (only deleting); Findings = %v", len(r.Findings), r.Findings)
+	}
+	if len(r.Findings) > 0 && r.Findings[0].Phrase != "deleting: removal in progress" {
+		t.Errorf("Findings[0].Phrase = %q, want %q", r.Findings[0].Phrase, "deleting: removal in progress")
 	}
 }
 
@@ -604,10 +664,10 @@ func TestOpenSearch_Fetch_Wave3ClusterHealthIsOutOfScope(t *testing.T) {
 			t.Errorf("Fields[%q] = %q should not exist — Wave 3 CloudWatch metrics are out of scope", key, val)
 		}
 	}
-	// Verify no cluster_health issue is raised.
-	for _, issue := range r.Issues {
-		if issue == "cluster_health" || issue == "cluster health red" {
-			t.Errorf("Issues contains %q — Wave 3 signals must not surface in fetcher", issue)
+	// Verify no cluster_health finding is raised.
+	for _, f := range r.Findings {
+		if f.Phrase == "cluster_health" || f.Phrase == "cluster health red" {
+			t.Errorf("Findings contains %q — Wave 3 signals must not surface in fetcher", f.Phrase)
 		}
 	}
 }

--- a/tests/unit/aws_redis_test.go
+++ b/tests/unit/aws_redis_test.go
@@ -90,8 +90,8 @@ func TestRedis_Fetch_HealthyAvailable(t *testing.T) {
 	if r.Fields["status"] != "" {
 		t.Errorf("Fields[\"status\"] = %q, want %q (Healthy silence)", r.Fields["status"], "")
 	}
-	if len(r.Issues) != 0 {
-		t.Errorf("Issues = %v, want empty (Healthy)", r.Issues)
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings = %v, want empty (Healthy)", r.Findings)
 	}
 }
 
@@ -118,8 +118,8 @@ func TestRedis_Fetch_StatusCreating(t *testing.T) {
 	if r.Fields["status"] != wantPhrase {
 		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], wantPhrase)
 	}
-	if len(r.Issues) != 1 || r.Issues[0] != wantPhrase {
-		t.Errorf("Issues = %v, want [%q]", r.Issues, wantPhrase)
+	if len(r.Findings) != 1 || r.Findings[0].Phrase != wantPhrase {
+		t.Errorf("Findings = %v, want one finding with Phrase %q", r.Findings, wantPhrase)
 	}
 }
 
@@ -146,8 +146,8 @@ func TestRedis_Fetch_StatusModifying(t *testing.T) {
 	if r.Fields["status"] != wantPhrase {
 		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], wantPhrase)
 	}
-	if len(r.Issues) != 1 || r.Issues[0] != wantPhrase {
-		t.Errorf("Issues = %v, want [%q]", r.Issues, wantPhrase)
+	if len(r.Findings) != 1 || r.Findings[0].Phrase != wantPhrase {
+		t.Errorf("Findings = %v, want one finding with Phrase %q", r.Findings, wantPhrase)
 	}
 }
 
@@ -174,8 +174,8 @@ func TestRedis_Fetch_StatusSnapshotting(t *testing.T) {
 	if r.Fields["status"] != wantPhrase {
 		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], wantPhrase)
 	}
-	if len(r.Issues) != 1 || r.Issues[0] != wantPhrase {
-		t.Errorf("Issues = %v, want [%q]", r.Issues, wantPhrase)
+	if len(r.Findings) != 1 || r.Findings[0].Phrase != wantPhrase {
+		t.Errorf("Findings = %v, want one finding with Phrase %q", r.Findings, wantPhrase)
 	}
 }
 
@@ -202,8 +202,8 @@ func TestRedis_Fetch_StatusDeleting(t *testing.T) {
 	if r.Fields["status"] != wantPhrase {
 		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], wantPhrase)
 	}
-	if len(r.Issues) != 1 || r.Issues[0] != wantPhrase {
-		t.Errorf("Issues = %v, want [%q]", r.Issues, wantPhrase)
+	if len(r.Findings) != 1 || r.Findings[0].Phrase != wantPhrase {
+		t.Errorf("Findings = %v, want one finding with Phrase %q", r.Findings, wantPhrase)
 	}
 }
 
@@ -230,8 +230,8 @@ func TestRedis_Fetch_StatusCreateFailed(t *testing.T) {
 	if r.Fields["status"] != wantPhrase {
 		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], wantPhrase)
 	}
-	if len(r.Issues) != 1 || r.Issues[0] != wantPhrase {
-		t.Errorf("Issues = %v, want [%q]", r.Issues, wantPhrase)
+	if len(r.Findings) != 1 || r.Findings[0].Phrase != wantPhrase {
+		t.Errorf("Findings = %v, want one finding with Phrase %q", r.Findings, wantPhrase)
 	}
 }
 
@@ -258,8 +258,8 @@ func TestRedis_Fetch_MultiAZWithoutFailover(t *testing.T) {
 	if r.Fields["status"] != wantPhrase {
 		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], wantPhrase)
 	}
-	if len(r.Issues) != 1 || r.Issues[0] != wantPhrase {
-		t.Errorf("Issues = %v, want [%q]", r.Issues, wantPhrase)
+	if len(r.Findings) != 1 || r.Findings[0].Phrase != wantPhrase {
+		t.Errorf("Findings = %v, want one finding with Phrase %q", r.Findings, wantPhrase)
 	}
 }
 
@@ -285,8 +285,8 @@ func TestRedis_Fetch_MultiAZDisabled_NoFinding(t *testing.T) {
 	if r.Fields["status"] != "" {
 		t.Errorf("Fields[\"status\"] = %q, want %q (single-AZ groups do not trigger the signal)", r.Fields["status"], "")
 	}
-	if len(r.Issues) != 0 {
-		t.Errorf("Issues = %v, want empty (no signal for single-AZ)", r.Issues)
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings = %v, want empty (no signal for single-AZ)", r.Findings)
 	}
 }
 
@@ -313,16 +313,16 @@ func TestRedis_Fetch_MultiW1_ModifyingPlusNoFailover(t *testing.T) {
 	if r.Fields["status"] != wantStatus {
 		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], wantStatus)
 	}
-	if len(r.Issues) != 2 {
-		t.Fatalf("Issues len = %d, want 2; Issues = %v", len(r.Issues), r.Issues)
+	if len(r.Findings) != 2 {
+		t.Fatalf("Findings len = %d, want 2; Findings = %v", len(r.Findings), r.Findings)
 	}
-	// Issues must be in §4 precedence order: alphabetical among warnings.
+	// Findings must be in §4 precedence order: alphabetical among warnings.
 	// "modifying — config change" < "multi-AZ without auto-failover" alphabetically.
-	if r.Issues[0] != "modifying \u2014 config change" {
-		t.Errorf("Issues[0] = %q, want %q", r.Issues[0], "modifying \u2014 config change")
+	if r.Findings[0].Phrase != "modifying \u2014 config change" {
+		t.Errorf("Findings[0].Phrase = %q, want %q", r.Findings[0].Phrase, "modifying \u2014 config change")
 	}
-	if r.Issues[1] != "multi-AZ without auto-failover" {
-		t.Errorf("Issues[1] = %q, want %q", r.Issues[1], "multi-AZ without auto-failover")
+	if r.Findings[1].Phrase != "multi-AZ without auto-failover" {
+		t.Errorf("Findings[1].Phrase = %q, want %q", r.Findings[1].Phrase, "multi-AZ without auto-failover")
 	}
 }
 
@@ -550,8 +550,8 @@ func TestRedis_Fetch_SingleShardModifying_UsesRGPhrase(t *testing.T) {
 	if r.Fields["status"] != wantPhrase {
 		t.Errorf("Fields[\"status\"] = %q, want %q (single-shard preserves RG phrase)", r.Fields["status"], wantPhrase)
 	}
-	if len(r.Issues) != 1 || r.Issues[0] != wantPhrase {
-		t.Errorf("Issues = %v, want [%q]", r.Issues, wantPhrase)
+	if len(r.Findings) != 1 || r.Findings[0].Phrase != wantPhrase {
+		t.Errorf("Findings = %v, want [%q]", r.Findings, wantPhrase)
 	}
 }
 
@@ -582,8 +582,8 @@ func TestRedis_Fetch_MultiShard_OneShardModifying(t *testing.T) {
 	if r.Fields["status"] != wantPhrase {
 		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], wantPhrase)
 	}
-	if len(r.Issues) != 1 || r.Issues[0] != wantPhrase {
-		t.Errorf("Issues = %v, want [%q]", r.Issues, wantPhrase)
+	if len(r.Findings) != 1 || r.Findings[0].Phrase != wantPhrase {
+		t.Errorf("Findings = %v, want [%q]", r.Findings, wantPhrase)
 	}
 }
 
@@ -616,15 +616,15 @@ func TestRedis_Fetch_MultiShard_TwoShardsTransitioning(t *testing.T) {
 	if r.Fields["status"] != wantStatus {
 		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], wantStatus)
 	}
-	if len(r.Issues) != 2 {
-		t.Fatalf("Issues len = %d, want 2; Issues = %v", len(r.Issues), r.Issues)
+	if len(r.Findings) != 2 {
+		t.Fatalf("Findings len = %d, want 2; Findings = %v", len(r.Findings), r.Findings)
 	}
 	// Alphabetical by phrase: "shard 0001: modifying" < "shard 0002: snapshotting".
-	if r.Issues[0] != "shard 0001: modifying" {
-		t.Errorf("Issues[0] = %q, want %q", r.Issues[0], "shard 0001: modifying")
+	if r.Findings[0].Phrase != "shard 0001: modifying" {
+		t.Errorf("Findings[0].Phrase = %q, want %q", r.Findings[0].Phrase, "shard 0001: modifying")
 	}
-	if r.Issues[1] != "shard 0002: snapshotting" {
-		t.Errorf("Issues[1] = %q, want %q", r.Issues[1], "shard 0002: snapshotting")
+	if r.Findings[1].Phrase != "shard 0002: snapshotting" {
+		t.Errorf("Findings[1].Phrase = %q, want %q", r.Findings[1].Phrase, "shard 0002: snapshotting")
 	}
 }
 
@@ -657,8 +657,8 @@ func TestRedis_Fetch_MultiShard_AllShardAvailableButRGModifying(t *testing.T) {
 	if r.Fields["status"] != wantPhrase {
 		t.Errorf("Fields[\"status\"] = %q, want %q (fallback to RG phrase when no shard is transitioning)", r.Fields["status"], wantPhrase)
 	}
-	if len(r.Issues) != 1 || r.Issues[0] != wantPhrase {
-		t.Errorf("Issues = %v, want [%q]", r.Issues, wantPhrase)
+	if len(r.Findings) != 1 || r.Findings[0].Phrase != wantPhrase {
+		t.Errorf("Findings = %v, want [%q]", r.Findings, wantPhrase)
 	}
 }
 
@@ -693,13 +693,13 @@ func TestRedis_Fetch_MultiShard_ShardPlusMultiAZNoFailover(t *testing.T) {
 	if r.Fields["status"] != wantStatus {
 		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], wantStatus)
 	}
-	if len(r.Issues) != 2 {
-		t.Fatalf("Issues len = %d, want 2; Issues = %v", len(r.Issues), r.Issues)
+	if len(r.Findings) != 2 {
+		t.Fatalf("Findings len = %d, want 2; Findings = %v", len(r.Findings), r.Findings)
 	}
-	if r.Issues[0] != "multi-AZ without auto-failover" {
-		t.Errorf("Issues[0] = %q, want %q", r.Issues[0], "multi-AZ without auto-failover")
+	if r.Findings[0].Phrase != "multi-AZ without auto-failover" {
+		t.Errorf("Findings[0].Phrase = %q, want %q", r.Findings[0].Phrase, "multi-AZ without auto-failover")
 	}
-	if r.Issues[1] != "shard 0001: modifying" {
-		t.Errorf("Issues[1] = %q, want %q", r.Issues[1], "shard 0001: modifying")
+	if r.Findings[1].Phrase != "shard 0001: modifying" {
+		t.Errorf("Findings[1].Phrase = %q, want %q", r.Findings[1].Phrase, "shard 0001: modifying")
 	}
 }

--- a/tests/unit/aws_redshift_test.go
+++ b/tests/unit/aws_redshift_test.go
@@ -1,20 +1,13 @@
 // aws_redshift_test.go — Unit tests for the Redshift fetcher.
-//
-// Tests assert on the contract surface of FetchRedshiftClustersPage:
-//   - Resource.Status  (§4 phrase, optionally suffixed with "(+N)")
-//   - Resource.Issues  (slice of §4 phrases in §4 precedence order)
-//   - Resource.Fields["status"]          (mirrors Resource.Status)
-//   - Resource.Fields["cluster_status"]  (raw ClusterStatus value — read by Color func)
-//
-// Wave 1 signals only (Wave 2 = None per spec).
+// // Tests assert on the contract surface of FetchRedshiftClustersPage:
+// - Resource.Status  always ""
+// - Resource.Findings (slice of domain.Finding in §4 precedence order, Source="wave1")
+// - Resource.Fields["status"]          (§4 display phrase — drives list-view color)
+// - Resource.Fields["cluster_status"]  (raw ClusterStatus value — read by Color func)
+// // Wave 1 signals only (Wave 2 = None per spec).
 // Anti-tests verify no CloudWatch-derived phrases surface (§3.3 out of scope).
 // Severity-precedence tests verify Broken beats Warning (U8).
-// Multi-finding tests verify rule-7 "(+N)" suffix and Issues ordering.
-//
-// Phase 6a fixture source: internal/demo/fixtures.NewRedshiftFixtures().
-// Phase 7 coder output is not yet complete; all signal tests are expected to
-// FAIL against the current redshift.go until phase 7 delivers the rewritten
-// fetcher. See "Expected failures" section in the task handoff notes.
+// Multi-finding tests verify rule-7 "(+N)" suffix and Findings ordering.
 package unit
 
 import (
@@ -29,6 +22,7 @@ import (
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/demo/fixtures"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -69,35 +63,60 @@ func fetchSingleCluster(t *testing.T, cluster redshifttypes.Cluster) resource.Re
 	return result.Resources[0]
 }
 
-// assertStatus asserts Resource.Status and Resource.Fields["status"].
-func assertStatus(t *testing.T, r resource.Resource, want string) {
+// assertStatus asserts Resource.Status is always empty () and
+// Resource.Fields["status"] carries the display phrase.
+func assertStatus(t *testing.T, r resource.Resource, wantPhrase string) {
 	t.Helper()
-	if r.Status != want {
-		t.Errorf("Resource.Status = %q, want %q", r.Status, want)
+	if r.Status != "" {
+		t.Errorf("Resource.Status = %q, want %q", r.Status, "")
 	}
-	if r.Fields["status"] != want {
-		t.Errorf("Resource.Fields[\"status\"] = %q, want %q", r.Fields["status"], want)
+	if r.Fields["status"] != wantPhrase {
+		t.Errorf("Resource.Fields[\"status\"] = %q, want %q", r.Fields["status"], wantPhrase)
 	}
 }
 
-// assertIssues asserts Resource.Issues deep-equals want (nil vs empty-slice
-// treated identically when want is nil).
-func assertIssues(t *testing.T, r resource.Resource, want []string) {
+// assertFindings asserts Resource.Findings matches the expected phrase list.
+// Each element of wantPhrases must match the corresponding Finding.Phrase in
+// Findings order. Nil/empty wantPhrases means healthy — no findings expected.
+func assertFindings(t *testing.T, r resource.Resource, wantPhrases []string) {
 	t.Helper()
-	if want == nil {
-		if len(r.Issues) != 0 {
-			t.Errorf("Resource.Issues = %v, want nil/empty", r.Issues)
+	if len(wantPhrases) == 0 {
+		if len(r.Findings) != 0 {
+			phrases := make([]string, len(r.Findings))
+			for i, f := range r.Findings {
+				phrases[i] = f.Phrase
+			}
+			t.Errorf("Resource.Findings = %v, want nil/empty (healthy)", phrases)
 		}
 		return
 	}
-	if len(r.Issues) != len(want) {
-		t.Errorf("Resource.Issues = %v (len=%d), want %v (len=%d)", r.Issues, len(r.Issues), want, len(want))
+	if len(r.Findings) != len(wantPhrases) {
+		phrases := make([]string, len(r.Findings))
+		for i, f := range r.Findings {
+			phrases[i] = f.Phrase
+		}
+		t.Errorf("Resource.Findings len=%d (%v), want len=%d (%v)", len(r.Findings), phrases, len(wantPhrases), wantPhrases)
 		return
 	}
-	for i, w := range want {
-		if r.Issues[i] != w {
-			t.Errorf("Resource.Issues[%d] = %q, want %q", i, r.Issues[i], w)
+	for i, want := range wantPhrases {
+		if r.Findings[i].Phrase != want {
+			t.Errorf("Resource.Findings[%d].Phrase = %q, want %q", i, r.Findings[i].Phrase, want)
 		}
+		if r.Findings[i].Source != "wave1" {
+			t.Errorf("Resource.Findings[%d].Source = %q, want %q", i, r.Findings[i].Source, "wave1")
+		}
+	}
+}
+
+// assertFindingCode asserts that Findings[i].Code matches the expected code.
+func assertFindingCode(t *testing.T, r resource.Resource, i int, want domain.FindingCode) {
+	t.Helper()
+	if i >= len(r.Findings) {
+		t.Errorf("Findings[%d] out of range (len=%d)", i, len(r.Findings))
+		return
+	}
+	if r.Findings[i].Code != want {
+		t.Errorf("Findings[%d].Code = %q, want %q", i, r.Findings[i].Code, want)
 	}
 }
 
@@ -125,7 +144,7 @@ func TestRedshift_Fetch_HealthyHasEmptyIssues(t *testing.T) {
 		t.Run(id, func(t *testing.T) {
 			r := fetchSingleCluster(t, redshiftFixtureByID(t, id))
 			assertStatus(t, r, "")
-			assertIssues(t, r, nil)
+			assertFindings(t, r, nil)
 			assertClusterStatusField(t, r, "available")
 		})
 	}
@@ -136,7 +155,7 @@ func TestRedshift_Fetch_HealthyHasEmptyIssues(t *testing.T) {
 func TestRedshift_Fetch_Healthy_Silent(t *testing.T) {
 	r := fetchSingleCluster(t, redshiftFixtureByID(t, fixtures.AcmeWarehouseID))
 	assertStatus(t, r, "")
-	assertIssues(t, r, nil)
+	assertFindings(t, r, nil)
 	assertClusterStatusField(t, r, "available")
 	// No jargon in status field
 	for _, bad := range []string{"OK", "ACTIVE", "available", "healthy", "-", "Available"} {
@@ -155,7 +174,7 @@ func TestRedshift_Fetch_Healthy_Silent(t *testing.T) {
 func TestRedshift_Fetch_Transitional_Resizing(t *testing.T) {
 	r := fetchSingleCluster(t, redshiftFixtureByID(t, fixtures.RedshiftResizingID))
 	assertStatus(t, r, "resizing")
-	assertIssues(t, r, []string{"resizing"})
+	assertFindings(t, r, []string{"resizing"})
 	assertClusterStatusField(t, r, "resizing")
 }
 
@@ -163,7 +182,7 @@ func TestRedshift_Fetch_Transitional_Resizing(t *testing.T) {
 func TestRedshift_Fetch_Transitional_Rebooting(t *testing.T) {
 	r := fetchSingleCluster(t, redshiftFixtureByID(t, fixtures.RedshiftRebootingID))
 	assertStatus(t, r, "rebooting")
-	assertIssues(t, r, []string{"rebooting"})
+	assertFindings(t, r, []string{"rebooting"})
 	assertClusterStatusField(t, r, "rebooting")
 }
 
@@ -175,7 +194,7 @@ func TestRedshift_Fetch_Transitional_Rebooting(t *testing.T) {
 func TestRedshift_Fetch_Broken_IncompatibleNetwork(t *testing.T) {
 	r := fetchSingleCluster(t, redshiftFixtureByID(t, fixtures.RedshiftIncompatibleNetworkID))
 	assertStatus(t, r, "broken: incompatible-network")
-	assertIssues(t, r, []string{"broken: incompatible-network"})
+	assertFindings(t, r, []string{"broken: incompatible-network"})
 	assertClusterStatusField(t, r, "incompatible-network")
 }
 
@@ -183,7 +202,7 @@ func TestRedshift_Fetch_Broken_IncompatibleNetwork(t *testing.T) {
 func TestRedshift_Fetch_Broken_HardwareFailure(t *testing.T) {
 	r := fetchSingleCluster(t, redshiftFixtureByID(t, fixtures.RedshiftHardwareFailureID))
 	assertStatus(t, r, "broken: hardware-failure")
-	assertIssues(t, r, []string{"broken: hardware-failure"})
+	assertFindings(t, r, []string{"broken: hardware-failure"})
 	assertClusterStatusField(t, r, "hardware-failure")
 }
 
@@ -191,7 +210,7 @@ func TestRedshift_Fetch_Broken_HardwareFailure(t *testing.T) {
 func TestRedshift_Fetch_Broken_StorageFull(t *testing.T) {
 	r := fetchSingleCluster(t, redshiftFixtureByID(t, fixtures.RedshiftStorageFullID))
 	assertStatus(t, r, "broken: storage-full")
-	assertIssues(t, r, []string{"broken: storage-full"})
+	assertFindings(t, r, []string{"broken: storage-full"})
 	assertClusterStatusField(t, r, "storage-full")
 }
 
@@ -203,7 +222,7 @@ func TestRedshift_Fetch_Broken_StorageFull(t *testing.T) {
 func TestRedshift_Fetch_Availability_Unavailable(t *testing.T) {
 	r := fetchSingleCluster(t, redshiftFixtureByID(t, fixtures.RedshiftAvailUnavailableID))
 	assertStatus(t, r, "unavailable")
-	assertIssues(t, r, []string{"unavailable"})
+	assertFindings(t, r, []string{"unavailable"})
 	assertClusterStatusField(t, r, "available")
 }
 
@@ -211,7 +230,7 @@ func TestRedshift_Fetch_Availability_Unavailable(t *testing.T) {
 func TestRedshift_Fetch_Availability_Failed(t *testing.T) {
 	r := fetchSingleCluster(t, redshiftFixtureByID(t, fixtures.RedshiftAvailFailedID))
 	assertStatus(t, r, "failed")
-	assertIssues(t, r, []string{"failed"})
+	assertFindings(t, r, []string{"failed"})
 	assertClusterStatusField(t, r, "available")
 }
 
@@ -223,7 +242,7 @@ func TestRedshift_Fetch_Availability_Failed(t *testing.T) {
 func TestRedshift_Fetch_Availability_Maintenance(t *testing.T) {
 	r := fetchSingleCluster(t, redshiftFixtureByID(t, fixtures.RedshiftAvailMaintenanceID))
 	assertStatus(t, r, "maintenance")
-	assertIssues(t, r, []string{"maintenance"})
+	assertFindings(t, r, []string{"maintenance"})
 	assertClusterStatusField(t, r, "available")
 }
 
@@ -231,7 +250,7 @@ func TestRedshift_Fetch_Availability_Maintenance(t *testing.T) {
 func TestRedshift_Fetch_Availability_Modifying(t *testing.T) {
 	r := fetchSingleCluster(t, redshiftFixtureByID(t, fixtures.RedshiftAvailModifyingID))
 	assertStatus(t, r, "modifying")
-	assertIssues(t, r, []string{"modifying"})
+	assertFindings(t, r, []string{"modifying"})
 	assertClusterStatusField(t, r, "available")
 }
 
@@ -243,7 +262,7 @@ func TestRedshift_Fetch_Availability_Modifying(t *testing.T) {
 func TestRedshift_Fetch_PendingChange(t *testing.T) {
 	r := fetchSingleCluster(t, redshiftFixtureByID(t, fixtures.RedshiftPendingChangeID))
 	assertStatus(t, r, "pending change queued")
-	assertIssues(t, r, []string{"pending change queued"})
+	assertFindings(t, r, []string{"pending change queued"})
 	assertClusterStatusField(t, r, "available")
 }
 
@@ -251,7 +270,7 @@ func TestRedshift_Fetch_PendingChange(t *testing.T) {
 func TestRedshift_Fetch_MaintenanceDeferred_Active(t *testing.T) {
 	r := fetchSingleCluster(t, redshiftFixtureByID(t, fixtures.RedshiftMaintenanceDeferredID))
 	assertStatus(t, r, "maintenance deferred")
-	assertIssues(t, r, []string{"maintenance deferred"})
+	assertFindings(t, r, []string{"maintenance deferred"})
 	assertClusterStatusField(t, r, "available")
 }
 
@@ -260,7 +279,7 @@ func TestRedshift_Fetch_MaintenanceDeferred_Active(t *testing.T) {
 func TestRedshift_Fetch_MaintenanceDeferred_Expired(t *testing.T) {
 	r := fetchSingleCluster(t, redshiftFixtureByID(t, fixtures.RedshiftMaintenanceDeferredExpiredID))
 	assertStatus(t, r, "")
-	assertIssues(t, r, nil)
+	assertFindings(t, r, nil)
 	assertClusterStatusField(t, r, "available")
 }
 
@@ -272,7 +291,7 @@ func TestRedshift_Fetch_MaintenanceDeferred_Expired(t *testing.T) {
 func TestRedshift_Fetch_PubliclyAccessible(t *testing.T) {
 	r := fetchSingleCluster(t, redshiftFixtureByID(t, fixtures.RedshiftPubliclyAccessibleID))
 	assertStatus(t, r, "publicly accessible")
-	assertIssues(t, r, []string{"publicly accessible"})
+	assertFindings(t, r, []string{"publicly accessible"})
 	assertClusterStatusField(t, r, "available")
 }
 
@@ -280,7 +299,7 @@ func TestRedshift_Fetch_PubliclyAccessible(t *testing.T) {
 func TestRedshift_Fetch_Unencrypted(t *testing.T) {
 	r := fetchSingleCluster(t, redshiftFixtureByID(t, fixtures.RedshiftUnencryptedID))
 	assertStatus(t, r, "unencrypted at rest")
-	assertIssues(t, r, []string{"unencrypted at rest"})
+	assertFindings(t, r, []string{"unencrypted at rest"})
 	assertClusterStatusField(t, r, "available")
 }
 
@@ -294,7 +313,7 @@ func TestRedshift_Fetch_Unencrypted(t *testing.T) {
 func TestRedshift_Fetch_MultiW1_PendingPlusPublicPlusUnencrypted(t *testing.T) {
 	r := fetchSingleCluster(t, redshiftFixtureByID(t, fixtures.WarnRedshiftMultiID))
 	assertStatus(t, r, "pending change queued (+2)")
-	assertIssues(t, r, []string{
+	assertFindings(t, r, []string{
 		"pending change queued",
 		"publicly accessible",
 		"unencrypted at rest",
@@ -306,7 +325,7 @@ func TestRedshift_Fetch_MultiW1_PendingPlusPublicPlusUnencrypted(t *testing.T) {
 func TestRedshift_Fetch_MultiW1_Two_Warnings_Suffix_Plus_1(t *testing.T) {
 	r := fetchSingleCluster(t, redshiftFixtureByID(t, fixtures.WarnRedshiftTwoID))
 	assertStatus(t, r, "publicly accessible (+1)")
-	assertIssues(t, r, []string{
+	assertFindings(t, r, []string{
 		"publicly accessible",
 		"unencrypted at rest",
 	})
@@ -322,12 +341,12 @@ func TestRedshift_Fetch_MultiW1_Two_Warnings_Suffix_Plus_1(t *testing.T) {
 func TestRedshift_Fetch_Broken_ClusterStatus_Beats_Availability_Modifying(t *testing.T) {
 	r := fetchSingleCluster(t, redshiftFixtureByID(t, fixtures.RedshiftBrokenWithWarningHiddenID))
 	assertStatus(t, r, "broken: storage-full")
-	assertIssues(t, r, []string{"broken: storage-full"})
+	assertFindings(t, r, []string{"broken: storage-full"})
 	assertClusterStatusField(t, r, "storage-full")
-	// The Issues slice must NOT contain any Warning phrases.
-	for _, issue := range r.Issues {
-		if strings.Contains(issue, "publicly") || strings.Contains(issue, "unencrypted") || strings.Contains(issue, "modifying") {
-			t.Errorf("Issues contains warning phrase %q when Broken should suppress all Warnings", issue)
+	// The Findings slice must NOT contain any Warning phrases.
+	for _, f := range r.Findings {
+		if strings.Contains(f.Phrase, "publicly") || strings.Contains(f.Phrase, "unencrypted") || strings.Contains(f.Phrase, "modifying") {
+			t.Errorf("Findings contains warning phrase %q when Broken should suppress all Warnings", f.Phrase)
 		}
 	}
 }
@@ -338,11 +357,11 @@ func TestRedshift_Fetch_Broken_ClusterStatus_Beats_Availability_Modifying(t *tes
 func TestRedshift_Fetch_Broken_Availability_Beats_Warning_PubliclyAccessible(t *testing.T) {
 	r := fetchSingleCluster(t, redshiftFixtureByID(t, fixtures.RedshiftAvailUnavailableWithWarningHiddenID))
 	assertStatus(t, r, "unavailable")
-	assertIssues(t, r, []string{"unavailable"})
-	// No Warning phrases in Issues.
-	for _, issue := range r.Issues {
-		if strings.Contains(issue, "publicly") || strings.Contains(issue, "unencrypted") {
-			t.Errorf("Issues contains warning phrase %q when Broken should suppress all Warnings", issue)
+	assertFindings(t, r, []string{"unavailable"})
+	// No Warning phrases in Findings.
+	for _, f := range r.Findings {
+		if strings.Contains(f.Phrase, "publicly") || strings.Contains(f.Phrase, "unencrypted") {
+			t.Errorf("Findings contains warning phrase %q when Broken should suppress all Warnings", f.Phrase)
 		}
 	}
 }
@@ -362,13 +381,13 @@ func TestRedshift_Fetch_IgnoresCloudWatchPercentageDiskSpaceUsed(t *testing.T) {
 			id = *cluster.ClusterIdentifier
 		}
 		forbidden := []string{"PercentageDiskSpaceUsed", "disk_space", "disk space", "percentage disk"}
-		for _, f := range forbidden {
-			if strings.Contains(strings.ToLower(r.Status), strings.ToLower(f)) {
-				t.Errorf("cluster %s: Status contains CloudWatch phrase %q (out of scope)", id, f)
+		for _, forbiddenPhrase := range forbidden {
+			if strings.Contains(strings.ToLower(r.Fields["status"]), strings.ToLower(forbiddenPhrase)) {
+				t.Errorf("cluster %s: Fields[status] contains CloudWatch phrase %q (out of scope)", id, forbiddenPhrase)
 			}
-			for _, issue := range r.Issues {
-				if strings.Contains(strings.ToLower(issue), strings.ToLower(f)) {
-					t.Errorf("cluster %s: Issues contains CloudWatch phrase %q (out of scope)", id, f)
+			for _, finding := range r.Findings {
+				if strings.Contains(strings.ToLower(finding.Phrase), strings.ToLower(forbiddenPhrase)) {
+					t.Errorf("cluster %s: Findings contains CloudWatch phrase %q (out of scope)", id, forbiddenPhrase)
 				}
 			}
 		}
@@ -387,12 +406,12 @@ func TestRedshift_Fetch_IgnoresCloudWatchHealthStatus(t *testing.T) {
 		// "health" as a substring would catch HealthStatus, HealthState, etc.
 		// Note: "unhealthy" is also out of scope; none of these come from CW.
 		for _, phrase := range []string{"HealthStatus", "health_status"} {
-			if strings.Contains(r.Status, phrase) {
-				t.Errorf("cluster %s: Status contains CloudWatch phrase %q (out of scope)", id, phrase)
+			if strings.Contains(r.Fields["status"], phrase) {
+				t.Errorf("cluster %s: Fields[status] contains CloudWatch phrase %q (out of scope)", id, phrase)
 			}
-			for _, issue := range r.Issues {
-				if strings.Contains(issue, phrase) {
-					t.Errorf("cluster %s: Issues contains CloudWatch phrase %q (out of scope)", id, phrase)
+			for _, finding := range r.Findings {
+				if strings.Contains(finding.Phrase, phrase) {
+					t.Errorf("cluster %s: Findings contains CloudWatch phrase %q (out of scope)", id, phrase)
 				}
 			}
 		}

--- a/tests/unit/aws_review_pins_test.go
+++ b/tests/unit/aws_review_pins_test.go
@@ -14,6 +14,7 @@ import (
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/demo/fixtures"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -97,10 +98,11 @@ func TestEnrichEFSMountTargets_Idempotent(t *testing.T) {
 	fake := efsMTFakeFromFixtures()
 	clients := &awsclient.ServiceClients{EFS: fake}
 
-	// Fetcher output: W1 Warning "updating", Issues carries the single phrase.
+	// Fetcher output: W1 Warning "updating" lives in Findings .
 	res := efsResources(fsID)
-	res[0].Status = "updating"
-	res[0].Issues = []string{"updating"}
+	res[0].Findings = []domain.Finding{
+		{Code: awsclient.CodeEFSUpdating, Phrase: "updating", Severity: domain.SevWarn, Source: "wave1"},
+	}
 
 	r1, err := awsclient.EnrichEFSMountTargets(context.Background(), clients, res, nil)
 	if err != nil {
@@ -113,9 +115,8 @@ func TestEnrichEFSMountTargets_Idempotent(t *testing.T) {
 	}
 
 	// Simulate merge of FieldUpdates into Fields (what the pipeline does),
-	// then re-run. Issues is fetcher-owned and stays = ["updating"].
+	// then re-run. Findings is fetcher-owned and stays unchanged.
 	res[0].Fields["status"] = r1.FieldUpdates[fsID]["status"]
-	res[0].Status = r1.FieldUpdates[fsID]["status"]
 
 	r2, err := awsclient.EnrichEFSMountTargets(context.Background(), clients, res, nil)
 	if err != nil {

--- a/tests/unit/phase03_databases_pr03e_test.go
+++ b/tests/unit/phase03_databases_pr03e_test.go
@@ -1,0 +1,1521 @@
+package unit_test
+
+// phase03_databases_pr03e_test.go — PR-03e migration contract tests for the
+// 12 database resource types (dbi, dbi-snap, dbc, dbc-snap, s3, redis,
+// opensearch, ddb, redshift, msk, efs, kinesis).
+//
+// Post-migration invariants:
+//   - Fetcher writes Resource.Status == "" (no more Status writes)
+//   - Fetcher writes Resource.Issues == nil (no more Issues writes)
+//   - Fetcher writes Resource.Findings with Source:"wave1" for each non-healthy signal
+//   - Healthy resources have len(Resource.Findings) == 0
+//   - Fields["status"] (or Fields["state"]) preserved for the display column
+//
+// These tests FAIL on RED (before coder migrates the fetchers). They pass GREEN
+// once the coder delivers Findings-emitting implementations.
+//
+// Pattern reference: tests/unit/phase03_networking_pr03d_test.go
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ddksdk "github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	efssdk "github.com/aws/aws-sdk-go-v2/service/efs"
+	efstypes "github.com/aws/aws-sdk-go-v2/service/efs/types"
+	elasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
+	elasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	kafkasdk "github.com/aws/aws-sdk-go-v2/service/kafka"
+	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+	kinesissdk "github.com/aws/aws-sdk-go-v2/service/kinesis"
+	kinesistypes "github.com/aws/aws-sdk-go-v2/service/kinesis/types"
+	opensearchsdk "github.com/aws/aws-sdk-go-v2/service/opensearch"
+	ostypes "github.com/aws/aws-sdk-go-v2/service/opensearch/types"
+	rdssdk "github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	redshiftsdk "github.com/aws/aws-sdk-go-v2/service/redshift"
+	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
+	s3sdk "github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+
+	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
+	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// =============================================================================
+// DBI (RDS DB Instance)
+// =============================================================================
+
+// TestPR03e_DBIFetcher_HealthyEmitsNoFinding asserts that a healthy "available"
+// RDS DB instance produces Status=="", no Findings, and Fields["status"]=="".
+func TestPR03e_DBIFetcher_HealthyEmitsNoFinding(t *testing.T) {
+	mock := &pr03eRDSMock{
+		instances: []rdstypes.DBInstance{
+			{
+				DBInstanceIdentifier:  aws.String("prod-dbi-healthy"),
+				DBInstanceArn:         aws.String("arn:aws:rds:us-east-1:000000000000:db:prod-dbi-healthy"),
+				DBInstanceStatus:      aws.String("available"),
+				BackupRetentionPeriod: aws.Int32(7),
+				PubliclyAccessible:    aws.Bool(false),
+				StorageEncrypted:      aws.Bool(true),
+				DeletionProtection:    aws.Bool(true),
+			},
+		},
+	}
+
+	result, err := awsclient.FetchRDSInstancesPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchRDSInstancesPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings: got %d, want 0 for healthy DBI", len(r.Findings))
+	}
+	// Fields["status"] should be the display value — empty for healthy silence.
+	// (The display column reads Fields["status"], not Resource.Status.)
+	if got := r.Fields["status"]; got != "" {
+		t.Errorf("Fields[\"status\"]: got %q, want %q (healthy silence)", got, "")
+	}
+}
+
+// TestPR03e_DBIFetcher_FailedEmitsFinding asserts that a "failed" RDS instance
+// emits one SevBroken Finding with CodeDBIFailed and Status=="".
+func TestPR03e_DBIFetcher_FailedEmitsFinding(t *testing.T) {
+	mock := &pr03eRDSMock{
+		instances: []rdstypes.DBInstance{
+			{
+				DBInstanceIdentifier:  aws.String("prod-dbi-failed"),
+				DBInstanceArn:         aws.String("arn:aws:rds:us-east-1:000000000000:db:prod-dbi-failed"),
+				DBInstanceStatus:      aws.String("failed"),
+				BackupRetentionPeriod: aws.Int32(7),
+				PubliclyAccessible:    aws.Bool(false),
+				StorageEncrypted:      aws.Bool(true),
+				DeletionProtection:    aws.Bool(true),
+			},
+		},
+	}
+
+	result, err := awsclient.FetchRDSInstancesPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchRDSInstancesPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for failed DBI", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeDBIFailed {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeDBIFailed)
+	}
+	if f.Severity != domain.SevBroken {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevBroken", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03e_DBIColor_ReadsWave1First pins that the dbi Color func evaluates
+// Findings before the legacy Fields["status"] switch.
+//
+// Setup: Finding{SevWarn, wave1} + Fields["status"]="" (healthy).
+// Expect: ColorWarning (Findings wins over healthy-silence).
+func TestPR03e_DBIColor_ReadsWave1First(t *testing.T) {
+	td := resource.FindResourceType("dbi")
+	if td == nil {
+		t.Fatal("dbi type def not found in registry")
+	}
+
+	r := resource.Resource{
+		Type: "dbi",
+		Findings: []domain.Finding{
+			{Code: awsclient.CodeDBIPubliclyAccessible, Phrase: "publicly accessible", Severity: domain.SevWarn, Source: "wave1"},
+		},
+		Fields: map[string]string{"status": ""},
+	}
+	if got := td.Color(r); got != resource.ColorWarning {
+		t.Errorf("dbi Color with wave1 SevWarn + status=empty: got %v, want ColorWarning (Findings must take precedence)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DBI mock
+// ---------------------------------------------------------------------------
+
+type pr03eRDSMock struct {
+	instances []rdstypes.DBInstance
+}
+
+func (m *pr03eRDSMock) DescribeDBInstances(
+	_ context.Context,
+	_ *rdssdk.DescribeDBInstancesInput,
+	_ ...func(*rdssdk.Options),
+) (*rdssdk.DescribeDBInstancesOutput, error) {
+	return &rdssdk.DescribeDBInstancesOutput{DBInstances: m.instances}, nil
+}
+
+// =============================================================================
+// DBI-SNAP (RDS DB Snapshot)
+// =============================================================================
+
+// TestPR03e_DBISnapFetcher_HealthyEmitsNoFinding asserts that an available,
+// encrypted RDS snapshot produces Status=="", no Findings, and
+// Fields["status"] set to the display phrase.
+func TestPR03e_DBISnapFetcher_HealthyEmitsNoFinding(t *testing.T) {
+	mock := &pr03eRDSSnapshotMock{
+		output: &rdssdk.DescribeDBSnapshotsOutput{
+			DBSnapshots: []rdstypes.DBSnapshot{
+				{
+					DBSnapshotIdentifier: aws.String("snap-healthy"),
+					DBInstanceIdentifier: aws.String("prod-dbi-1"),
+					SnapshotType:         aws.String("automated"),
+					Status:               aws.String("available"),
+					Encrypted:            aws.Bool(true),
+				},
+			},
+		},
+	}
+
+	result, err := awsclient.FetchDBISnapshotsPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchDBISnapshotsPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings: got %d, want 0 for healthy DBI snapshot", len(r.Findings))
+	}
+}
+
+// TestPR03e_DBISnapFetcher_CreatingEmitsFinding asserts that a "creating"
+// snapshot emits one SevWarn Finding with CodeDBISnapCreating and Status=="".
+func TestPR03e_DBISnapFetcher_CreatingEmitsFinding(t *testing.T) {
+	mock := &pr03eRDSSnapshotMock{
+		output: &rdssdk.DescribeDBSnapshotsOutput{
+			DBSnapshots: []rdstypes.DBSnapshot{
+				{
+					DBSnapshotIdentifier: aws.String("snap-creating"),
+					DBInstanceIdentifier: aws.String("prod-dbi-1"),
+					SnapshotType:         aws.String("manual"),
+					Status:               aws.String("creating"),
+					Encrypted:            aws.Bool(true),
+				},
+			},
+		},
+	}
+
+	result, err := awsclient.FetchDBISnapshotsPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchDBISnapshotsPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for creating DBI snapshot", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeDBISnapCreating {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeDBISnapCreating)
+	}
+	if f.Severity != domain.SevWarn {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevWarn", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03e_DBISnapColor_ReadsWave1First pins that the dbi-snap Color func
+// evaluates Findings before the legacy Fields["status"] switch.
+//
+// Setup: Finding{SevWarn, wave1} + Fields["status"]="available".
+// Expect: ColorWarning (Findings wins over legacy "available"→ColorHealthy).
+func TestPR03e_DBISnapColor_ReadsWave1First(t *testing.T) {
+	td := resource.FindResourceType("dbi-snap")
+	if td == nil {
+		t.Fatal("dbi-snap type def not found in registry")
+	}
+
+	r := resource.Resource{
+		Type: "dbi-snap",
+		Findings: []domain.Finding{
+			{Code: awsclient.CodeDBISnapUnencrypted, Phrase: "unencrypted", Severity: domain.SevWarn, Source: "wave1"},
+		},
+		Fields: map[string]string{"status": "available"},
+	}
+	if got := td.Color(r); got != resource.ColorWarning {
+		t.Errorf("dbi-snap Color with wave1 SevWarn + status=available: got %v, want ColorWarning (Findings must take precedence)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DBI-SNAP mock
+// ---------------------------------------------------------------------------
+
+type pr03eRDSSnapshotMock struct {
+	output *rdssdk.DescribeDBSnapshotsOutput
+}
+
+func (m *pr03eRDSSnapshotMock) DescribeDBSnapshots(
+	_ context.Context,
+	_ *rdssdk.DescribeDBSnapshotsInput,
+	_ ...func(*rdssdk.Options),
+) (*rdssdk.DescribeDBSnapshotsOutput, error) {
+	return m.output, nil
+}
+
+// =============================================================================
+// DBC (DocumentDB / Aurora Cluster)
+// =============================================================================
+
+// TestPR03e_DBCFetcher_HealthyEmitsNoFinding asserts that a healthy "available"
+// DocDB cluster produces Status=="", no Findings, and Fields["status"]=="".
+func TestPR03e_DBCFetcher_HealthyEmitsNoFinding(t *testing.T) {
+	mock := &pr03eDocDBMock{
+		clusters: []rdstypes.DBCluster{
+			{
+				DBClusterIdentifier:   aws.String("prod-docdb-healthy"),
+				Status:                aws.String("available"),
+				Engine:                aws.String("aurora-mysql"),
+				DeletionProtection:    aws.Bool(true),
+				StorageEncrypted:      aws.Bool(true),
+				BackupRetentionPeriod: aws.Int32(7),
+				DBClusterMembers: []rdstypes.DBClusterMember{
+					{DBInstanceIdentifier: aws.String("prod-docdb-healthy-01"), IsClusterWriter: aws.Bool(true)},
+				},
+			},
+		},
+	}
+
+	result, err := awsclient.FetchRDSDBClustersPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchRDSDBClustersPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings: got %d, want 0 for healthy DBC", len(r.Findings))
+	}
+}
+
+// TestPR03e_DBCFetcher_FailedEmitsFinding asserts that a "failed" cluster emits
+// one SevBroken Finding with CodeDBCFailed and Status=="".
+func TestPR03e_DBCFetcher_FailedEmitsFinding(t *testing.T) {
+	mock := &pr03eDocDBMock{
+		clusters: []rdstypes.DBCluster{
+			{
+				DBClusterIdentifier: aws.String("prod-docdb-failed"),
+				Status:              aws.String("failed"),
+				Engine:              aws.String("aurora-mysql"),
+			},
+		},
+	}
+
+	result, err := awsclient.FetchRDSDBClustersPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchRDSDBClustersPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for failed DBC", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeDBCFailed {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeDBCFailed)
+	}
+	if f.Severity != domain.SevBroken {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevBroken", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03e_DBCColor_ReadsWave1First pins that the dbc Color func evaluates
+// Findings before the legacy Fields["status"] switch.
+//
+// Setup: Finding{SevWarn, wave1} + Fields["status"]="" (healthy silence).
+// Expect: ColorWarning (Findings wins over structural).
+func TestPR03e_DBCColor_ReadsWave1First(t *testing.T) {
+	td := resource.FindResourceType("dbc")
+	if td == nil {
+		t.Fatal("dbc type def not found in registry")
+	}
+
+	r := resource.Resource{
+		Type: "dbc",
+		Findings: []domain.Finding{
+			{Code: awsclient.CodeDBCDeletionProtectionOff, Phrase: "delete-protection off", Severity: domain.SevWarn, Source: "wave1"},
+		},
+		Fields: map[string]string{"status": ""},
+	}
+	if got := td.Color(r); got != resource.ColorWarning {
+		t.Errorf("dbc Color with wave1 SevWarn + status=empty: got %v, want ColorWarning (Findings must take precedence)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DBC mock — uses RDS DescribeDBClusters (handles both Aurora and DocDB)
+// ---------------------------------------------------------------------------
+
+type pr03eDocDBMock struct {
+	clusters []rdstypes.DBCluster
+}
+
+func (m *pr03eDocDBMock) DescribeDBClusters(
+	_ context.Context,
+	_ *rdssdk.DescribeDBClustersInput,
+	_ ...func(*rdssdk.Options),
+) (*rdssdk.DescribeDBClustersOutput, error) {
+	return &rdssdk.DescribeDBClustersOutput{DBClusters: m.clusters}, nil
+}
+
+// =============================================================================
+// DBC-SNAP (DocumentDB / Aurora Cluster Snapshot)
+// =============================================================================
+
+// TestPR03e_DBCSnapFetcher_HealthyEmitsNoFinding asserts that a healthy
+// "available" RDS cluster snapshot produces Status=="", no Findings.
+func TestPR03e_DBCSnapFetcher_HealthyEmitsNoFinding(t *testing.T) {
+	mock := &pr03eRDSClusterSnapshotMock{
+		output: &rdssdk.DescribeDBClusterSnapshotsOutput{
+			DBClusterSnapshots: []rdstypes.DBClusterSnapshot{
+				{
+					DBClusterSnapshotIdentifier: aws.String("csnap-healthy"),
+					DBClusterIdentifier:         aws.String("prod-aurora-01"),
+					SnapshotType:                aws.String("automated"),
+					Status:                      aws.String("available"),
+					Engine:                      aws.String("aurora-mysql"),
+					StorageEncrypted:            aws.Bool(true),
+				},
+			},
+		},
+	}
+
+	result, err := awsclient.FetchRDSDBClusterSnapshotsPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchRDSDBClusterSnapshotsPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings: got %d, want 0 for healthy DBC snapshot", len(r.Findings))
+	}
+}
+
+// TestPR03e_DBCSnapFetcher_CreatingEmitsFinding asserts that a "creating"
+// cluster snapshot emits one SevWarn Finding with CodeDBCSnapCreating and Status=="".
+func TestPR03e_DBCSnapFetcher_CreatingEmitsFinding(t *testing.T) {
+	mock := &pr03eRDSClusterSnapshotMock{
+		output: &rdssdk.DescribeDBClusterSnapshotsOutput{
+			DBClusterSnapshots: []rdstypes.DBClusterSnapshot{
+				{
+					DBClusterSnapshotIdentifier: aws.String("csnap-creating"),
+					DBClusterIdentifier:         aws.String("prod-aurora-01"),
+					SnapshotType:                aws.String("manual"),
+					Status:                      aws.String("creating"),
+					Engine:                      aws.String("aurora-mysql"),
+					StorageEncrypted:            aws.Bool(true),
+				},
+			},
+		},
+	}
+
+	result, err := awsclient.FetchRDSDBClusterSnapshotsPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchRDSDBClusterSnapshotsPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for creating DBC snapshot", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeDBCSnapCreating {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeDBCSnapCreating)
+	}
+	if f.Severity != domain.SevWarn {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevWarn", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03e_DBCSnapColor_ReadsWave1First pins that the dbc-snap Color func
+// evaluates Findings before the legacy Fields["status"] switch.
+//
+// Setup: Finding{SevBroken, wave1} + Fields["status"]="available".
+// Expect: ColorBroken (Findings wins over legacy "available"→ColorHealthy).
+func TestPR03e_DBCSnapColor_ReadsWave1First(t *testing.T) {
+	td := resource.FindResourceType("dbc-snap")
+	if td == nil {
+		t.Fatal("dbc-snap type def not found in registry")
+	}
+
+	r := resource.Resource{
+		Type: "dbc-snap",
+		Findings: []domain.Finding{
+			{Code: awsclient.CodeDBCSnapFailed, Phrase: "failed", Severity: domain.SevBroken, Source: "wave1"},
+		},
+		Fields: map[string]string{"status": "available"},
+	}
+	if got := td.Color(r); got != resource.ColorBroken {
+		t.Errorf("dbc-snap Color with wave1 SevBroken + status=available: got %v, want ColorBroken (Findings must take precedence)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DBC-SNAP mock
+// ---------------------------------------------------------------------------
+
+type pr03eRDSClusterSnapshotMock struct {
+	output *rdssdk.DescribeDBClusterSnapshotsOutput
+}
+
+func (m *pr03eRDSClusterSnapshotMock) DescribeDBClusterSnapshots(
+	_ context.Context,
+	_ *rdssdk.DescribeDBClusterSnapshotsInput,
+	_ ...func(*rdssdk.Options),
+) (*rdssdk.DescribeDBClusterSnapshotsOutput, error) {
+	return m.output, nil
+}
+
+// =============================================================================
+// S3 (Simple Storage Service)
+// =============================================================================
+
+// TestPR03e_S3Fetcher_HealthyEmitsNoFinding asserts that a healthy S3 bucket
+// produces Status=="", no Findings, and no Issues. S3 has no Wave-1 signals.
+func TestPR03e_S3Fetcher_HealthyEmitsNoFinding(t *testing.T) {
+	mock := &pr03eS3ListMock{
+		output: &s3sdk.ListBucketsOutput{
+			Buckets: []s3types.Bucket{
+				{Name: aws.String("my-prod-bucket")},
+			},
+		},
+	}
+
+	result, err := awsclient.FetchS3BucketsPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchS3BucketsPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (s3 fetcher must not write Status)", r.Status, "")
+	}
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings: got %d, want 0 (s3 has no Wave-1 signals)", len(r.Findings))
+	}
+	if len(r.Issues) != 0 {
+		t.Errorf("Issues: got %v, want nil (s3 has no Wave-1 signals)", r.Issues)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// S3 mock
+// ---------------------------------------------------------------------------
+
+type pr03eS3ListMock struct {
+	output *s3sdk.ListBucketsOutput
+}
+
+func (m *pr03eS3ListMock) ListBuckets(
+	_ context.Context,
+	_ *s3sdk.ListBucketsInput,
+	_ ...func(*s3sdk.Options),
+) (*s3sdk.ListBucketsOutput, error) {
+	return m.output, nil
+}
+
+// =============================================================================
+// REDIS (ElastiCache Replication Group)
+// =============================================================================
+
+// TestPR03e_RedisFetcher_HealthyEmitsNoFinding asserts that a healthy
+// "available" replication group produces Status=="", no Findings.
+func TestPR03e_RedisFetcher_HealthyEmitsNoFinding(t *testing.T) {
+	mock := &pr03eRedisRGMock{
+		output: &elasticache.DescribeReplicationGroupsOutput{
+			ReplicationGroups: []elasticachetypes.ReplicationGroup{
+				{
+					ReplicationGroupId: aws.String("prod-redis-healthy"),
+					Status:             aws.String("available"),
+					Engine:             aws.String("redis"),
+					MultiAZ:            elasticachetypes.MultiAZStatusEnabled,
+					AutomaticFailover:  elasticachetypes.AutomaticFailoverStatusEnabled,
+				},
+			},
+		},
+	}
+
+	result, err := awsclient.FetchRedisPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchRedisPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings: got %d, want 0 for healthy Redis RG", len(r.Findings))
+	}
+}
+
+// TestPR03e_RedisFetcher_CreatingEmitsFinding asserts that a "creating"
+// replication group emits one SevWarn Finding with CodeRedisCreating and Status=="".
+func TestPR03e_RedisFetcher_CreatingEmitsFinding(t *testing.T) {
+	mock := &pr03eRedisRGMock{
+		output: &elasticache.DescribeReplicationGroupsOutput{
+			ReplicationGroups: []elasticachetypes.ReplicationGroup{
+				{
+					ReplicationGroupId: aws.String("dev-redis-creating"),
+					Status:             aws.String("creating"),
+					Engine:             aws.String("redis"),
+					MultiAZ:            elasticachetypes.MultiAZStatusDisabled,
+					AutomaticFailover:  elasticachetypes.AutomaticFailoverStatusDisabling,
+				},
+			},
+		},
+	}
+
+	result, err := awsclient.FetchRedisPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchRedisPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for creating Redis RG", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeRedisCreating {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeRedisCreating)
+	}
+	if f.Severity != domain.SevWarn {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevWarn", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03e_RedisColor_ReadsWave1First pins that the redis Color func evaluates
+// Findings before the legacy Fields["status"] switch.
+//
+// Setup: Finding{SevWarn, wave1} + Fields["status"]="" (healthy silence).
+// Expect: ColorWarning (Findings wins over structural).
+func TestPR03e_RedisColor_ReadsWave1First(t *testing.T) {
+	td := resource.FindResourceType("redis")
+	if td == nil {
+		t.Fatal("redis type def not found in registry")
+	}
+
+	r := resource.Resource{
+		Type: "redis",
+		Findings: []domain.Finding{
+			{Code: awsclient.CodeRedisMultiAZWithoutAutoFailover, Phrase: "multi-AZ without auto-failover", Severity: domain.SevWarn, Source: "wave1"},
+		},
+		Fields: map[string]string{"status": ""},
+	}
+	if got := td.Color(r); got != resource.ColorWarning {
+		t.Errorf("redis Color with wave1 SevWarn + status=empty: got %v, want ColorWarning (Findings must take precedence)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Redis mock
+// ---------------------------------------------------------------------------
+
+type pr03eRedisRGMock struct {
+	output *elasticache.DescribeReplicationGroupsOutput
+}
+
+func (m *pr03eRedisRGMock) DescribeReplicationGroups(
+	_ context.Context,
+	_ *elasticache.DescribeReplicationGroupsInput,
+	_ ...func(*elasticache.Options),
+) (*elasticache.DescribeReplicationGroupsOutput, error) {
+	return m.output, nil
+}
+
+// =============================================================================
+// OPENSEARCH
+// =============================================================================
+
+// TestPR03e_OpenSearchFetcher_HealthyEmitsNoFinding asserts that a healthy
+// "Active" OpenSearch domain produces Status=="", no Findings.
+func TestPR03e_OpenSearchFetcher_HealthyEmitsNoFinding(t *testing.T) {
+	domainName := "analytics-prod"
+	listMock := &pr03eOSListMock{
+		output: &opensearchsdk.ListDomainNamesOutput{
+			DomainNames: []ostypes.DomainInfo{
+				{DomainName: aws.String(domainName)},
+			},
+		},
+	}
+	describeMock := &pr03eOSDescribeMock{
+		output: &opensearchsdk.DescribeDomainsOutput{
+			DomainStatusList: []ostypes.DomainStatus{
+				{
+					ARN:                    aws.String("arn:aws:es:us-east-1:000000000000:domain/" + domainName),
+					DomainId:               aws.String("000000000000/" + domainName),
+					DomainName:             aws.String(domainName),
+					EngineVersion:          aws.String("OpenSearch_2.11"),
+					Created:                aws.Bool(true),
+					Deleted:                aws.Bool(false),
+					Processing:             aws.Bool(false),
+					UpgradeProcessing:      aws.Bool(false),
+					DomainProcessingStatus: ostypes.DomainProcessingStatusTypeActive,
+					EncryptionAtRestOptions: &ostypes.EncryptionAtRestOptions{
+						Enabled: aws.Bool(true),
+					},
+				},
+			},
+		},
+	}
+
+	resources, err := awsclient.FetchOpenSearchDomains(context.Background(), listMock, describeMock)
+	if err != nil {
+		t.Fatalf("FetchOpenSearchDomains: unexpected error: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resources))
+	}
+	r := resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings: got %d, want 0 for healthy OpenSearch domain", len(r.Findings))
+	}
+}
+
+// TestPR03e_OpenSearchFetcher_IsolatedEmitsFinding asserts that an "Isolated"
+// domain (DomainProcessingStatus) emits one SevBroken Finding with
+// CodeOpenSearchIsolated and Status=="".
+func TestPR03e_OpenSearchFetcher_IsolatedEmitsFinding(t *testing.T) {
+	domainName := "analytics-isolated"
+	listMock := &pr03eOSListMock{
+		output: &opensearchsdk.ListDomainNamesOutput{
+			DomainNames: []ostypes.DomainInfo{
+				{DomainName: aws.String(domainName)},
+			},
+		},
+	}
+	describeMock := &pr03eOSDescribeMock{
+		output: &opensearchsdk.DescribeDomainsOutput{
+			DomainStatusList: []ostypes.DomainStatus{
+				{
+					ARN:                    aws.String("arn:aws:es:us-east-1:000000000000:domain/" + domainName),
+					DomainId:               aws.String("000000000000/" + domainName),
+					DomainName:             aws.String(domainName),
+					EngineVersion:          aws.String("OpenSearch_2.11"),
+					Created:                aws.Bool(true),
+					Deleted:                aws.Bool(false),
+					Processing:             aws.Bool(false),
+					UpgradeProcessing:      aws.Bool(false),
+					DomainProcessingStatus: ostypes.DomainProcessingStatusTypeIsolated,
+					EncryptionAtRestOptions: &ostypes.EncryptionAtRestOptions{
+						Enabled: aws.Bool(true),
+					},
+				},
+			},
+		},
+	}
+
+	resources, err := awsclient.FetchOpenSearchDomains(context.Background(), listMock, describeMock)
+	if err != nil {
+		t.Fatalf("FetchOpenSearchDomains: unexpected error: %v", err)
+	}
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resources))
+	}
+	r := resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for isolated OpenSearch domain", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeOpenSearchIsolated {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeOpenSearchIsolated)
+	}
+	if f.Severity != domain.SevBroken {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevBroken", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03e_OpenSearchColor_ReadsWave1First pins that the opensearch Color func
+// evaluates Findings before the legacy Fields["status"] switch.
+//
+// Setup: Finding{SevBroken, wave1} + Fields["status"]="active" (healthy).
+// Expect: ColorBroken (Findings wins over legacy "active"→ColorHealthy).
+func TestPR03e_OpenSearchColor_ReadsWave1First(t *testing.T) {
+	td := resource.FindResourceType("opensearch")
+	if td == nil {
+		t.Fatal("opensearch type def not found in registry")
+	}
+
+	r := resource.Resource{
+		Type: "opensearch",
+		Findings: []domain.Finding{
+			{Code: awsclient.CodeOpenSearchIsolated, Phrase: "isolated", Severity: domain.SevBroken, Source: "wave1"},
+		},
+		Fields: map[string]string{"status": "active"},
+	}
+	if got := td.Color(r); got != resource.ColorBroken {
+		t.Errorf("opensearch Color with wave1 SevBroken + status=active: got %v, want ColorBroken (Findings must take precedence)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OpenSearch mocks
+// ---------------------------------------------------------------------------
+
+type pr03eOSListMock struct {
+	output *opensearchsdk.ListDomainNamesOutput
+}
+
+func (m *pr03eOSListMock) ListDomainNames(
+	_ context.Context,
+	_ *opensearchsdk.ListDomainNamesInput,
+	_ ...func(*opensearchsdk.Options),
+) (*opensearchsdk.ListDomainNamesOutput, error) {
+	return m.output, nil
+}
+
+type pr03eOSDescribeMock struct {
+	output *opensearchsdk.DescribeDomainsOutput
+}
+
+func (m *pr03eOSDescribeMock) DescribeDomains(
+	_ context.Context,
+	_ *opensearchsdk.DescribeDomainsInput,
+	_ ...func(*opensearchsdk.Options),
+) (*opensearchsdk.DescribeDomainsOutput, error) {
+	return m.output, nil
+}
+
+// =============================================================================
+// DDB (DynamoDB)
+// =============================================================================
+
+// TestPR03e_DDBFetcher_HealthyEmitsNoFinding asserts that an ACTIVE DynamoDB
+// table produces Status=="", no Findings.
+func TestPR03e_DDBFetcher_HealthyEmitsNoFinding(t *testing.T) {
+	tableName := "prod-orders"
+	listStub := &pr03eDDBListStub{names: []string{tableName}}
+	descStub := &pr03eDDBDescribeStub{
+		tables: map[string]*ddbtypes.TableDescription{
+			tableName: {
+				TableName:   aws.String(tableName),
+				TableArn:    aws.String("arn:aws:dynamodb:us-east-1:000000000000:table/" + tableName),
+				TableStatus: ddbtypes.TableStatusActive,
+				ItemCount:   aws.Int64(42000),
+			},
+		},
+	}
+
+	result, err := awsclient.FetchDynamoDBTablesPage(context.Background(), listStub, descStub, "")
+	if err != nil {
+		t.Fatalf("FetchDynamoDBTablesPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings: got %d, want 0 for healthy DDB table", len(r.Findings))
+	}
+	// Fields["status"] should be the healthy display phrase (empty string per spec).
+	if got := r.Fields["status"]; got != "" {
+		t.Errorf("Fields[\"status\"]: got %q, want %q (healthy silence)", got, "")
+	}
+}
+
+// TestPR03e_DDBFetcher_KMSKeyInaccessibleEmitsFinding asserts that a table in
+// INACCESSIBLE_ENCRYPTION_CREDENTIALS state emits one SevBroken Finding with
+// CodeDDBKMSKeyInaccessible and Status=="".
+func TestPR03e_DDBFetcher_KMSKeyInaccessibleEmitsFinding(t *testing.T) {
+	tableName := "prod-secrets-kms-locked"
+	listStub := &pr03eDDBListStub{names: []string{tableName}}
+	descStub := &pr03eDDBDescribeStub{
+		tables: map[string]*ddbtypes.TableDescription{
+			tableName: {
+				TableName:   aws.String(tableName),
+				TableArn:    aws.String("arn:aws:dynamodb:us-east-1:000000000000:table/" + tableName),
+				TableStatus: ddbtypes.TableStatusInaccessibleEncryptionCredentials,
+			},
+		},
+	}
+
+	result, err := awsclient.FetchDynamoDBTablesPage(context.Background(), listStub, descStub, "")
+	if err != nil {
+		t.Fatalf("FetchDynamoDBTablesPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for KMS-inaccessible DDB table", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeDDBKMSKeyInaccessible {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeDDBKMSKeyInaccessible)
+	}
+	if f.Severity != domain.SevBroken {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevBroken", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03e_DDBColor_ReadsWave1First pins that the ddb Color func evaluates
+// Findings before the legacy Fields["status"] switch.
+//
+// Setup: Finding{SevWarn, wave1} + Fields["status"]="" (healthy).
+// Expect: ColorWarning (Findings wins over healthy-silence).
+func TestPR03e_DDBColor_ReadsWave1First(t *testing.T) {
+	td := resource.FindResourceType("ddb")
+	if td == nil {
+		t.Fatal("ddb type def not found in registry")
+	}
+
+	r := resource.Resource{
+		Type: "ddb",
+		Findings: []domain.Finding{
+			{Code: awsclient.CodeDDBCreating, Phrase: "creating", Severity: domain.SevWarn, Source: "wave1"},
+		},
+		Fields: map[string]string{"status": ""},
+	}
+	if got := td.Color(r); got != resource.ColorWarning {
+		t.Errorf("ddb Color with wave1 SevWarn + status=empty: got %v, want ColorWarning (Findings must take precedence)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DDB mocks
+// ---------------------------------------------------------------------------
+
+type pr03eDDBListStub struct {
+	names []string
+}
+
+func (s *pr03eDDBListStub) ListTables(_ context.Context, _ *ddksdk.ListTablesInput, _ ...func(*ddksdk.Options)) (*ddksdk.ListTablesOutput, error) {
+	return &ddksdk.ListTablesOutput{TableNames: s.names}, nil
+}
+
+type pr03eDDBDescribeStub struct {
+	tables map[string]*ddbtypes.TableDescription
+}
+
+func (s *pr03eDDBDescribeStub) DescribeTable(_ context.Context, in *ddksdk.DescribeTableInput, _ ...func(*ddksdk.Options)) (*ddksdk.DescribeTableOutput, error) {
+	if in == nil || in.TableName == nil {
+		return &ddksdk.DescribeTableOutput{}, nil
+	}
+	td, ok := s.tables[*in.TableName]
+	if !ok {
+		return &ddksdk.DescribeTableOutput{}, nil
+	}
+	return &ddksdk.DescribeTableOutput{Table: td}, nil
+}
+
+// =============================================================================
+// REDSHIFT
+// =============================================================================
+
+// TestPR03e_RedshiftFetcher_HealthyEmitsNoFinding asserts that a healthy
+// "available" Redshift cluster produces Status=="", no Findings, and
+// Fields["status"]=="available" (the display column uses raw status for Redshift).
+func TestPR03e_RedshiftFetcher_HealthyEmitsNoFinding(t *testing.T) {
+	mock := &pr03eRedshiftMock{
+		output: &redshiftsdk.DescribeClustersOutput{
+			Clusters: []redshifttypes.Cluster{
+				{
+					ClusterIdentifier:      aws.String("prod-dwh"),
+					ClusterStatus:          aws.String("available"),
+					PubliclyAccessible:     aws.Bool(false),
+					Encrypted:              aws.Bool(true),
+					NodeType:               aws.String("ra3.xlplus"),
+					NumberOfNodes:          aws.Int32(2),
+					DBName:                 aws.String("dev"),
+					ClusterAvailabilityStatus: aws.String("Available"),
+				},
+			},
+		},
+	}
+
+	result, err := awsclient.FetchRedshiftClustersPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchRedshiftClustersPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings: got %d, want 0 for healthy Redshift cluster", len(r.Findings))
+	}
+}
+
+// TestPR03e_RedshiftFetcher_HardwareFailureEmitsFinding asserts that a cluster
+// in "hardware-failure" status emits one SevBroken Finding with
+// CodeRedshiftHardwareFailure and Status=="".
+func TestPR03e_RedshiftFetcher_HardwareFailureEmitsFinding(t *testing.T) {
+	mock := &pr03eRedshiftMock{
+		output: &redshiftsdk.DescribeClustersOutput{
+			Clusters: []redshifttypes.Cluster{
+				{
+					ClusterIdentifier: aws.String("prod-dwh-broken"),
+					ClusterStatus:     aws.String("hardware-failure"),
+					NodeType:          aws.String("ra3.xlplus"),
+					NumberOfNodes:     aws.Int32(2),
+					DBName:            aws.String("dev"),
+				},
+			},
+		},
+	}
+
+	result, err := awsclient.FetchRedshiftClustersPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchRedshiftClustersPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for hardware-failure Redshift cluster", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeRedshiftHardwareFailure {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeRedshiftHardwareFailure)
+	}
+	if f.Severity != domain.SevBroken {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevBroken", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03e_RedshiftColor_ReadsWave1First pins that the redshift Color func
+// evaluates Findings before the legacy Fields["cluster_status"] switch.
+//
+// Setup: Finding{SevWarn, wave1} + Fields["cluster_status"]="available".
+// Expect: ColorWarning (Findings wins over legacy "available"→ColorHealthy).
+func TestPR03e_RedshiftColor_ReadsWave1First(t *testing.T) {
+	td := resource.FindResourceType("redshift")
+	if td == nil {
+		t.Fatal("redshift type def not found in registry")
+	}
+
+	r := resource.Resource{
+		Type: "redshift",
+		Findings: []domain.Finding{
+			{Code: awsclient.CodeRedshiftPubliclyAccessible, Phrase: "publicly accessible", Severity: domain.SevWarn, Source: "wave1"},
+		},
+		Fields: map[string]string{
+			"cluster_status": "available",
+			"status":         "available",
+		},
+	}
+	if got := td.Color(r); got != resource.ColorWarning {
+		t.Errorf("redshift Color with wave1 SevWarn + cluster_status=available: got %v, want ColorWarning (Findings must take precedence)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Redshift mock
+// ---------------------------------------------------------------------------
+
+type pr03eRedshiftMock struct {
+	output *redshiftsdk.DescribeClustersOutput
+}
+
+func (m *pr03eRedshiftMock) DescribeClusters(
+	_ context.Context,
+	_ *redshiftsdk.DescribeClustersInput,
+	_ ...func(*redshiftsdk.Options),
+) (*redshiftsdk.DescribeClustersOutput, error) {
+	return m.output, nil
+}
+
+// =============================================================================
+// MSK (Amazon Managed Streaming for Apache Kafka)
+// =============================================================================
+
+// TestPR03e_MSKFetcher_HealthyEmitsNoFinding asserts that a healthy "ACTIVE"
+// MSK cluster produces Status=="", no Findings, and Fields["state"]=="ACTIVE".
+func TestPR03e_MSKFetcher_HealthyEmitsNoFinding(t *testing.T) {
+	mock := &pr03eMSKMock{
+		output: &kafkasdk.ListClustersV2Output{
+			ClusterInfoList: []kafkatypes.Cluster{
+				{
+					ClusterName:    aws.String("prod-kafka"),
+					ClusterArn:     aws.String("arn:aws:kafka:us-east-1:000000000000:cluster/prod-kafka/abc123"),
+					ClusterType:    kafkatypes.ClusterTypeProvisioned,
+					State:          kafkatypes.ClusterStateActive,
+					CurrentVersion: aws.String("2.8.1"),
+				},
+			},
+		},
+	}
+
+	result, err := awsclient.FetchMSKClustersPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchMSKClustersPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings: got %d, want 0 for healthy MSK cluster", len(r.Findings))
+	}
+	if got := r.Fields["state"]; got != "ACTIVE" {
+		t.Errorf("Fields[\"state\"]: got %q, want %q (state must be preserved in Fields)", got, "ACTIVE")
+	}
+}
+
+// TestPR03e_MSKFetcher_FailedEmitsFinding asserts that a "FAILED" MSK cluster
+// emits one SevBroken Finding with CodeMSKFailed and Status=="".
+func TestPR03e_MSKFetcher_FailedEmitsFinding(t *testing.T) {
+	mock := &pr03eMSKMock{
+		output: &kafkasdk.ListClustersV2Output{
+			ClusterInfoList: []kafkatypes.Cluster{
+				{
+					ClusterName:    aws.String("prod-kafka-broken"),
+					ClusterArn:     aws.String("arn:aws:kafka:us-east-1:000000000000:cluster/prod-kafka-broken/def456"),
+					ClusterType:    kafkatypes.ClusterTypeProvisioned,
+					State:          kafkatypes.ClusterStateFailed,
+					CurrentVersion: aws.String("2.8.1"),
+				},
+			},
+		},
+	}
+
+	result, err := awsclient.FetchMSKClustersPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchMSKClustersPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for failed MSK cluster", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeMSKFailed {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeMSKFailed)
+	}
+	if f.Severity != domain.SevBroken {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevBroken", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03e_MSKColor_ReadsWave1First pins that the msk Color func evaluates
+// Findings before the legacy Fields["state"] switch.
+//
+// Setup: Finding{SevWarn, wave1} + Fields["state"]="ACTIVE".
+// Expect: ColorWarning (Findings wins over legacy "ACTIVE"→ColorHealthy).
+func TestPR03e_MSKColor_ReadsWave1First(t *testing.T) {
+	td := resource.FindResourceType("msk")
+	if td == nil {
+		t.Fatal("msk type def not found in registry")
+	}
+
+	r := resource.Resource{
+		Type: "msk",
+		Findings: []domain.Finding{
+			{Code: awsclient.CodeMSKCreating, Phrase: "creating", Severity: domain.SevWarn, Source: "wave1"},
+		},
+		Fields: map[string]string{"state": "ACTIVE"},
+	}
+	if got := td.Color(r); got != resource.ColorWarning {
+		t.Errorf("msk Color with wave1 SevWarn + state=ACTIVE: got %v, want ColorWarning (Findings must take precedence)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MSK mock
+// ---------------------------------------------------------------------------
+
+type pr03eMSKMock struct {
+	output *kafkasdk.ListClustersV2Output
+}
+
+func (m *pr03eMSKMock) ListClustersV2(
+	_ context.Context,
+	_ *kafkasdk.ListClustersV2Input,
+	_ ...func(*kafkasdk.Options),
+) (*kafkasdk.ListClustersV2Output, error) {
+	return m.output, nil
+}
+
+// =============================================================================
+// EFS (Elastic File System)
+// =============================================================================
+
+// TestPR03e_EFSFetcher_HealthyEmitsNoFinding asserts that a healthy "available"
+// EFS filesystem produces Status=="", no Findings, and Fields["status"] set.
+func TestPR03e_EFSFetcher_HealthyEmitsNoFinding(t *testing.T) {
+	mock := &pr03eEFSMock{
+		output: &efssdk.DescribeFileSystemsOutput{
+			FileSystems: []efstypes.FileSystemDescription{
+				{
+					FileSystemId:    aws.String("fs-0abc1234"),
+					FileSystemArn:   aws.String("arn:aws:elasticfilesystem:us-east-1:000000000000:file-system/fs-0abc1234"),
+					LifeCycleState:  efstypes.LifeCycleStateAvailable,
+					NumberOfMountTargets: 2,
+					Name:            aws.String("prod-data"),
+					PerformanceMode: efstypes.PerformanceModeGeneralPurpose,
+					ThroughputMode:  efstypes.ThroughputModeBursting,
+					Encrypted:       aws.Bool(true),
+				},
+			},
+		},
+	}
+
+	result, err := awsclient.FetchEFSFileSystemsPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchEFSFileSystemsPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings: got %d, want 0 for healthy EFS filesystem", len(r.Findings))
+	}
+}
+
+// TestPR03e_EFSFetcher_ErrorEmitsFinding asserts that an "error" lifecycle state
+// emits one SevBroken Finding with CodeEFSError and Status=="".
+func TestPR03e_EFSFetcher_ErrorEmitsFinding(t *testing.T) {
+	mock := &pr03eEFSMock{
+		output: &efssdk.DescribeFileSystemsOutput{
+			FileSystems: []efstypes.FileSystemDescription{
+				{
+					FileSystemId:         aws.String("fs-0abc5678"),
+					FileSystemArn:        aws.String("arn:aws:elasticfilesystem:us-east-1:000000000000:file-system/fs-0abc5678"),
+					LifeCycleState:       efstypes.LifeCycleStateError,
+					NumberOfMountTargets: 0,
+					PerformanceMode:      efstypes.PerformanceModeGeneralPurpose,
+					ThroughputMode:       efstypes.ThroughputModeBursting,
+					Encrypted:            aws.Bool(true),
+				},
+			},
+		},
+	}
+
+	result, err := awsclient.FetchEFSFileSystemsPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchEFSFileSystemsPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) < 1 {
+		t.Fatalf("Findings: got %d, want >= 1 for error EFS filesystem", len(r.Findings))
+	}
+	// Find the EFSError finding (there may also be a CodeEFSNoMountTargets finding).
+	var found bool
+	for _, f := range r.Findings {
+		if f.Code == awsclient.CodeEFSError {
+			found = true
+			if f.Severity != domain.SevBroken {
+				t.Errorf("Findings[CodeEFSError].Severity: got %v, want domain.SevBroken", f.Severity)
+			}
+			if f.Source != "wave1" {
+				t.Errorf("Findings[CodeEFSError].Source: got %q, want %q", f.Source, "wave1")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("Findings: missing CodeEFSError; got %v", r.Findings)
+	}
+}
+
+// TestPR03e_EFSColor_ReadsWave1First pins that the efs Color func evaluates
+// Findings before the legacy Fields["status"] switch.
+//
+// Setup: Finding{SevWarn, wave1} + Fields["status"]="available".
+// Expect: ColorWarning (Findings wins over legacy "available"→ColorHealthy).
+func TestPR03e_EFSColor_ReadsWave1First(t *testing.T) {
+	td := resource.FindResourceType("efs")
+	if td == nil {
+		t.Fatal("efs type def not found in registry")
+	}
+
+	r := resource.Resource{
+		Type: "efs",
+		Findings: []domain.Finding{
+			{Code: awsclient.CodeEFSCreating, Phrase: "creating", Severity: domain.SevWarn, Source: "wave1"},
+		},
+		Fields: map[string]string{"status": "available"},
+	}
+	if got := td.Color(r); got != resource.ColorWarning {
+		t.Errorf("efs Color with wave1 SevWarn + status=available: got %v, want ColorWarning (Findings must take precedence)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EFS mock
+// ---------------------------------------------------------------------------
+
+type pr03eEFSMock struct {
+	output *efssdk.DescribeFileSystemsOutput
+}
+
+func (m *pr03eEFSMock) DescribeFileSystems(
+	_ context.Context,
+	_ *efssdk.DescribeFileSystemsInput,
+	_ ...func(*efssdk.Options),
+) (*efssdk.DescribeFileSystemsOutput, error) {
+	return m.output, nil
+}
+
+// =============================================================================
+// KINESIS
+// =============================================================================
+
+// TestPR03e_KinesisFetcher_HealthyEmitsNoFinding asserts that a healthy "ACTIVE"
+// Kinesis stream produces Status=="", no Findings, and Fields["status"]=="ACTIVE".
+func TestPR03e_KinesisFetcher_HealthyEmitsNoFinding(t *testing.T) {
+	mock := &pr03eKinesisMock{
+		output: &kinesissdk.ListStreamsOutput{
+			StreamSummaries: []kinesistypes.StreamSummary{
+				{
+					StreamName:   aws.String("prod-events"),
+					StreamARN:    aws.String("arn:aws:kinesis:us-east-1:000000000000:stream/prod-events"),
+					StreamStatus: kinesistypes.StreamStatusActive,
+					StreamModeDetails: &kinesistypes.StreamModeDetails{
+						StreamMode: kinesistypes.StreamModeOnDemand,
+					},
+				},
+			},
+		},
+	}
+
+	result, err := awsclient.FetchKinesisStreamsPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchKinesisStreamsPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 0 {
+		t.Errorf("Findings: got %d, want 0 for healthy Kinesis stream", len(r.Findings))
+	}
+	// Healthy streams: Fields["status"] == "" (healthy silence), raw state in Fields["stream_status"].
+	if got := r.Fields["status"]; got != "" {
+		t.Errorf("Fields[\"status\"]: got %q, want %q (healthy streams must have blank status phrase)", got, "")
+	}
+	if got := r.Fields["stream_status"]; got != "ACTIVE" {
+		t.Errorf("Fields[\"stream_status\"]: got %q, want %q (raw AWS state must be in stream_status)", got, "ACTIVE")
+	}
+}
+
+// TestPR03e_KinesisFetcher_CreatingEmitsFinding asserts that a "CREATING"
+// stream emits one SevWarn Finding with CodeKinesisCreating and Status=="".
+func TestPR03e_KinesisFetcher_CreatingEmitsFinding(t *testing.T) {
+	mock := &pr03eKinesisMock{
+		output: &kinesissdk.ListStreamsOutput{
+			StreamSummaries: []kinesistypes.StreamSummary{
+				{
+					StreamName:   aws.String("dev-events-creating"),
+					StreamARN:    aws.String("arn:aws:kinesis:us-east-1:000000000000:stream/dev-events-creating"),
+					StreamStatus: kinesistypes.StreamStatusCreating,
+					StreamModeDetails: &kinesistypes.StreamModeDetails{
+						StreamMode: kinesistypes.StreamModeProvisioned,
+					},
+				},
+			},
+		},
+	}
+
+	result, err := awsclient.FetchKinesisStreamsPage(context.Background(), mock, "")
+	if err != nil {
+		t.Fatalf("FetchKinesisStreamsPage: unexpected error: %v", err)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	r := result.Resources[0]
+
+	if r.Status != "" {
+		t.Errorf("Status: got %q, want %q (fetcher must stop writing Status)", r.Status, "")
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings: got %d, want 1 for creating Kinesis stream", len(r.Findings))
+	}
+	f := r.Findings[0]
+	if f.Code != awsclient.CodeKinesisCreating {
+		t.Errorf("Findings[0].Code: got %q, want %q", f.Code, awsclient.CodeKinesisCreating)
+	}
+	if f.Severity != domain.SevWarn {
+		t.Errorf("Findings[0].Severity: got %v, want domain.SevWarn", f.Severity)
+	}
+	if f.Source != "wave1" {
+		t.Errorf("Findings[0].Source: got %q, want %q", f.Source, "wave1")
+	}
+}
+
+// TestPR03e_KinesisColor_ReadsWave1First pins that the kinesis Color func
+// evaluates Findings before the legacy Fields["status"] switch.
+//
+// Setup: Finding{SevWarn, wave1} + Fields["status"]="ACTIVE".
+// Expect: ColorWarning (Findings wins over legacy "ACTIVE"→ColorHealthy).
+func TestPR03e_KinesisColor_ReadsWave1First(t *testing.T) {
+	td := resource.FindResourceType("kinesis")
+	if td == nil {
+		t.Fatal("kinesis type def not found in registry")
+	}
+
+	r := resource.Resource{
+		Type: "kinesis",
+		Findings: []domain.Finding{
+			{Code: awsclient.CodeKinesisCreating, Phrase: "creating", Severity: domain.SevWarn, Source: "wave1"},
+		},
+		Fields: map[string]string{"status": "ACTIVE"},
+	}
+	if got := td.Color(r); got != resource.ColorWarning {
+		t.Errorf("kinesis Color with wave1 SevWarn + status=ACTIVE: got %v, want ColorWarning (Findings must take precedence)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Kinesis mock
+// ---------------------------------------------------------------------------
+
+type pr03eKinesisMock struct {
+	output *kinesissdk.ListStreamsOutput
+}
+
+func (m *pr03eKinesisMock) ListStreams(
+	_ context.Context,
+	_ *kinesissdk.ListStreamsInput,
+	_ ...func(*kinesissdk.Options),
+) (*kinesissdk.ListStreamsOutput, error) {
+	return m.output, nil
+}

--- a/tests/unit/qa_dbc_snapshots_test.go
+++ b/tests/unit/qa_dbc_snapshots_test.go
@@ -79,8 +79,12 @@ func TestQA_DBCSnapshots_FetchSuccess(t *testing.T) {
 	}
 
 	r2 := resources[1]
-	if r2.Status != "creating" {
-		t.Errorf("expected Status 'creating', got %q", r2.Status)
+	// fetcher must not write Status; phrase lives in Fields["status"].
+	if r2.Status != "" {
+		t.Errorf("expected Status %q, got %q", "", r2.Status)
+	}
+	if r2.Fields["status"] != "creating" {
+		t.Errorf("expected Fields[\"status\"] 'creating', got %q", r2.Fields["status"])
 	}
 	if r2.Fields["snapshot_type"] != "manual" {
 		t.Errorf("expected snapshot_type 'manual', got %q", r2.Fields["snapshot_type"])

--- a/tests/unit/qa_dbi_color_test.go
+++ b/tests/unit/qa_dbi_color_test.go
@@ -57,8 +57,8 @@ func TestDbiColor(t *testing.T) {
 			want:   resource.ColorBroken,
 		},
 		{
-			name:   "inaccessible_encryption_credentials",
-			fields: map[string]string{"status": "inaccessible-encryption-credentials"},
+			name:   "encryption_key_unavailable",
+			fields: map[string]string{"status": "encryption key unavailable"},
 			want:   resource.ColorBroken,
 		},
 		{

--- a/tests/unit/qa_efs_test.go
+++ b/tests/unit/qa_efs_test.go
@@ -83,8 +83,8 @@ func TestFetchEFSFileSystems_ParsesMultiple(t *testing.T) {
 	if r0.Status != "" {
 		t.Errorf("resource[0].Status: expected blank (healthy), got %q", r0.Status)
 	}
-	if len(r0.Issues) != 0 {
-		t.Errorf("resource[0].Issues: expected empty for healthy FS, got %v", r0.Issues)
+	if len(r0.Findings) != 0 {
+		t.Errorf("resource[0].Findings: expected empty for healthy FS, got %v", r0.Findings)
 	}
 
 	// Verify required fields — derived `status` key replaced the AWS-raw `life_cycle_state` key.
@@ -112,20 +112,24 @@ func TestFetchEFSFileSystems_ParsesMultiple(t *testing.T) {
 
 	// Verify second file system (LifeCycleState=creating + NumberOfMountTargets=0):
 	// two coexisting §3.1 W1 signals. Broken ("no mount targets") wins precedence;
-	// Warning ("creating") is hidden. Expected Status = "no mount targets (+1)",
-	// Issues = ["no mount targets", "creating"] per spec rule 7.
+	// Warning ("creating") is hidden. Fields["status"] = "no mount targets" (top finding phrase only),
+	// Findings carries both signals per spec rule 7.
 	r1 := resources[1]
-	if r1.Status != "no mount targets (+1)" {
-		t.Errorf("resource[1].Status: expected %q, got %q", "no mount targets (+1)", r1.Status)
+	// Fetcher does not write Resource.Status — it is always "".
+	if r1.Status != "" {
+		t.Errorf("resource[1].Status: expected %q (fetcher must not write Status), got %q", "", r1.Status)
 	}
-	wantIssues := []string{"no mount targets", "creating"}
-	if len(r1.Issues) != len(wantIssues) {
-		t.Fatalf("resource[1].Issues: expected %v, got %v", wantIssues, r1.Issues)
+	if r1.Fields["status"] != "no mount targets (+1)" {
+		t.Errorf("resource[1].Fields[\"status\"]: expected %q, got %q", "no mount targets (+1)", r1.Fields["status"])
 	}
-	for i, want := range wantIssues {
-		if r1.Issues[i] != want {
-			t.Errorf("resource[1].Issues[%d]: expected %q, got %q", i, want, r1.Issues[i])
-		}
+	if len(r1.Findings) != 2 {
+		t.Fatalf("resource[1].Findings: expected 2 findings, got %d: %v", len(r1.Findings), r1.Findings)
+	}
+	if r1.Findings[0].Phrase != "no mount targets" {
+		t.Errorf("resource[1].Findings[0].Phrase: expected %q, got %q", "no mount targets", r1.Findings[0].Phrase)
+	}
+	if r1.Findings[1].Phrase != "creating" {
+		t.Errorf("resource[1].Findings[1].Phrase: expected %q, got %q", "creating", r1.Findings[1].Phrase)
 	}
 	if r1.Name != "" {
 		t.Errorf("resource[1].Name: expected empty, got %q", r1.Name)

--- a/tests/unit/qa_kinesis_test.go
+++ b/tests/unit/qa_kinesis_test.go
@@ -54,23 +54,27 @@ func TestFetchKinesisStreams_ParsesMultipleStreams(t *testing.T) {
 	if r.ID != "my-stream-1" {
 		t.Errorf("expected ID 'my-stream-1', got %q", r.ID)
 	}
-	if r.Status != "ACTIVE" {
-		t.Errorf("expected Status 'ACTIVE', got %q", r.Status)
+	// Healthy streams: Status=="" and Fields["status"]=="" (healthy silence).
+	if r.Status != "" {
+		t.Errorf("expected Status %q (healthy silence), got %q", "", r.Status)
 	}
 	if r.Fields["stream_name"] != "my-stream-1" {
 		t.Errorf("expected Fields[stream_name] 'my-stream-1', got %q", r.Fields["stream_name"])
 	}
-	if r.Fields["status"] != "ACTIVE" {
-		t.Errorf("expected Fields[status] 'ACTIVE', got %q", r.Fields["status"])
+	if r.Fields["status"] != "" {
+		t.Errorf("expected Fields[status] %q (healthy silence), got %q", "", r.Fields["status"])
 	}
 	if r.Fields["stream_arn"] == "" {
 		t.Error("expected Fields[stream_arn] to be non-empty")
 	}
 
-	// Verify second stream
+	// Verify second stream: Status=="" (fetcher does not write Status), phrase is in Fields["status"].
 	r2 := resources[1]
-	if r2.Status != "CREATING" {
-		t.Errorf("expected Status 'CREATING', got %q", r2.Status)
+	if r2.Status != "" {
+		t.Errorf("expected Status %q (fetcher does not write Status), got %q", "", r2.Status)
+	}
+	if r2.Fields["status"] != "creating" {
+		t.Errorf("expected Fields[status] %q for CREATING stream, got %q", "creating", r2.Fields["status"])
 	}
 
 	// Verify RawStruct is set

--- a/tests/unit/qa_msk_test.go
+++ b/tests/unit/qa_msk_test.go
@@ -71,8 +71,12 @@ func TestFetchMSKClusters_ParsesMultipleClusters(t *testing.T) {
 	if r0.Name != "events-cluster" {
 		t.Errorf("resource[0].Name: expected %q, got %q", "events-cluster", r0.Name)
 	}
-	if r0.Status != "ACTIVE" {
-		t.Errorf("resource[0].Status: expected %q, got %q", "ACTIVE", r0.Status)
+	// Healthy cluster: Status=="" (fetcher does not write Status), raw state in Fields["state"].
+	if r0.Status != "" {
+		t.Errorf("resource[0].Status: expected %q (healthy silence), got %q", "", r0.Status)
+	}
+	if r0.Fields["state"] != "ACTIVE" {
+		t.Errorf("resource[0].Fields[\"state\"]: expected %q, got %q", "ACTIVE", r0.Fields["state"])
 	}
 	if r0.Fields["cluster_type"] != "PROVISIONED" {
 		t.Errorf("resource[0].Fields[\"cluster_type\"]: expected %q, got %q", "PROVISIONED", r0.Fields["cluster_type"])
@@ -81,10 +85,13 @@ func TestFetchMSKClusters_ParsesMultipleClusters(t *testing.T) {
 		t.Errorf("resource[0].Fields[\"version\"]: expected %q, got %q", "2.8.1", r0.Fields["version"])
 	}
 
-	// Verify second cluster
+	// Verify second cluster: Status=="" (fetcher does not write Status), phrase in Fields["status"].
 	r1 := resources[1]
-	if r1.Status != "CREATING" {
-		t.Errorf("resource[1].Status: expected %q, got %q", "CREATING", r1.Status)
+	if r1.Status != "" {
+		t.Errorf("resource[1].Status: expected %q (fetcher does not write Status), got %q", "", r1.Status)
+	}
+	if r1.Fields["status"] != "creating" {
+		t.Errorf("resource[1].Fields[\"status\"]: expected %q for CREATING cluster, got %q", "creating", r1.Fields["status"])
 	}
 	if r1.Fields["cluster_type"] != "SERVERLESS" {
 		t.Errorf("resource[1].Fields[\"cluster_type\"]: expected %q, got %q", "SERVERLESS", r1.Fields["cluster_type"])

--- a/tests/unit/qa_rds_test.go
+++ b/tests/unit/qa_rds_test.go
@@ -74,7 +74,7 @@ func fixtureRDSInstancesExtended() []resource.Resource {
 		resource.Resource{
 			ID:     "stopped-db",
 			Name:   "stopped-db",
-			Status: "stopped",
+			Status: "", // fetcher writes phrase to Fields["status"], not Status
 			Fields: map[string]string{
 				"db_identifier":  "stopped-db",
 				"engine":         "mysql",
@@ -88,7 +88,7 @@ func fixtureRDSInstancesExtended() []resource.Resource {
 		resource.Resource{
 			ID:     "creating-db",
 			Name:   "creating-db",
-			Status: "creating",
+			Status: "", // fetcher writes phrase to Fields["status"], not Status
 			Fields: map[string]string{
 				"db_identifier":  "creating-db",
 				"engine":         "postgres",
@@ -102,7 +102,7 @@ func fixtureRDSInstancesExtended() []resource.Resource {
 		resource.Resource{
 			ID:     "prod-postgres-primary",
 			Name:   "prod-postgres-primary",
-			Status: "available",
+			Status: "", // fetcher writes phrase to Fields["status"], not Status
 			Fields: map[string]string{
 				"db_identifier":  "prod-postgres-primary",
 				"engine":         "postgres",

--- a/tests/unit/wave2_field_updates_test.go
+++ b/tests/unit/wave2_field_updates_test.go
@@ -15,7 +15,6 @@ package unit
 import (
 	"context"
 	"net/url"
-	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -1094,21 +1093,31 @@ func TestFetchDBC_MultiWarningStatusPhrase(t *testing.T) {
 		t.Error("Fields[\"cis_flags\"] unexpectedly present — universal rule U10 requires its removal")
 	}
 
+	// Fetcher does not write Resource.Status — always "".
+	if r.Status != "" {
+		t.Errorf("Status = %q, want %q (fetcher must not write Status)", r.Status, "")
+	}
+
 	// §4 top phrase for delete-protection off + unencrypted + no backups:
 	// precedence order = delete-protection first, then not-encrypted, then
 	// no-automated-backups — so the top is "delete-protection off" with (+2).
 	const want = "delete-protection off (+2)"
-	if r.Status != want {
-		t.Errorf("Status = %q, want %q (spec §4 multi-warning top phrase)", r.Status, want)
-	}
 	if r.Fields["status"] != want {
-		t.Errorf("Fields[\"status\"] = %q, want %q", r.Fields["status"], want)
+		t.Errorf("Fields[\"status\"] = %q, want %q (spec §4 multi-warning top phrase)", r.Fields["status"], want)
 	}
 
-	// Issues slice enumerates every active warning (rule 7 — detail view renders each individually).
-	wantIssues := []string{"delete-protection off", "not encrypted at rest", "no automated backups"}
-	if !reflect.DeepEqual(r.Issues, wantIssues) {
-		t.Errorf("Issues = %v, want %v", r.Issues, wantIssues)
+	// Findings slice enumerates every active warning (rule 7 — detail view renders each individually).
+	if len(r.Findings) != 3 {
+		t.Fatalf("Findings = %v, want 3 findings", r.Findings)
+	}
+	wantPhrases := []string{"delete-protection off", "not encrypted at rest", "no automated backups"}
+	for i, want := range wantPhrases {
+		if r.Findings[i].Phrase != want {
+			t.Errorf("Findings[%d].Phrase = %q, want %q", i, r.Findings[i].Phrase, want)
+		}
+		if r.Findings[i].Source != "wave1" {
+			t.Errorf("Findings[%d].Source = %q, want %q", i, r.Findings[i].Source, "wave1")
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Migrates 14 database-category fetchers from legacy `Resource.Status + Resource.Issues []string` to canonical `[]domain.Finding`
- Adds 9 new `*_codes.go` files: `dbc`, `ddb`, `efs`, `kinesis`, `msk`, `opensearch`, `rds`, `redis`, `redshift`
- Fixes `table_render.go` status column to prefer `Findings[0].Phrase` over `Fields["status"]` (Findings now take priority)
- Updates all affected tests to assert on `r.Findings[i].Code/Severity/Phrase`

Closes the Phase 03 → Phase 04 gap: the remaining database fetchers that were left using the legacy pattern after PR #314 was closed.

## Test plan

- [ ] `go test ./tests/unit/` passes (all 37 test files including new `phase03_databases_pr03e_test.go`)
- [ ] `go vet ./...` clean
- [ ] `go fix -inline -diff ./...` reports no changes
- [ ] verify-readonly: no write API calls in `internal/aws/*.go`
- [ ] Snapshot tests pass (`Golden|Scenario`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)