### PR TITLE
feat(runtime): scaffold internal/runtime package contracts (AS-146)

### DIFF
--- a/internal/runtime/intent.go
+++ b/internal/runtime/intent.go
@@ -1,0 +1,92 @@
+package runtime
+
+import (
+	"github.com/k2m30/a9s/v3/internal/domain"
+	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// UIIntent is the contract by which the runtime tells an adapter to
+// update UI state. Every intent is a closed type — adapters apply them
+// by type-switching on the concrete variants below.
+//
+// The runtime returns []UIIntent + []TaskRequest from HandleEvent; the
+// adapter walks its view tree applying matching intents and turns each
+// TaskRequest into platform-specific async work. This preserves today's
+// stack-walking semantics (every matching view in the stack receives the
+// update) without exposing renderer types to the shared core.
+type UIIntent interface {
+	isIntent()
+}
+
+// IssueBadgePatch describes the issue-badge state for a single resource
+// type. Used by both PatchMenu (top-level menu badge) and embedded inside
+// PatchResourceList (list-view badge).
+type IssueBadgePatch struct {
+	Count     int
+	Truncated bool
+}
+
+// ListEnrichmentPatch carries Wave 2 enrichment data for the rows of a
+// resource-list view. Findings is keyed by Resource.ID; nil means clear.
+type ListEnrichmentPatch struct {
+	Findings map[string]resource.EnrichmentFinding
+}
+
+// PatchResourceList instructs the adapter to apply the contained patches
+// to every resource-list view for ResourceType. Nil sub-patches are
+// no-ops; non-nil sub-patches replace the corresponding state.
+type PatchResourceList struct {
+	ResourceType string
+	Issues       *IssueBadgePatch
+	Enrichment   *ListEnrichmentPatch
+}
+
+func (PatchResourceList) isIntent() {}
+
+// PatchDetail instructs the adapter to apply the contained patches to
+// every detail view matching ResourceType (and ResourceID, if non-empty).
+// Empty ResourceID targets all detail views of the given type.
+type PatchDetail struct {
+	ResourceType string
+	ResourceID   string
+	Findings     []domain.Finding
+	Attention    map[domain.FindingCode]domain.AttentionDetail
+	FieldUpdates map[string]string
+}
+
+func (PatchDetail) isIntent() {}
+
+// PatchMenu instructs the adapter to update the top-level menu badge for
+// ResourceType.
+type PatchMenu struct {
+	ResourceType string
+	Issues       int
+	Truncated    bool
+}
+
+func (PatchMenu) isIntent() {}
+
+// PushScreen asks the adapter to materialize and push the named screen
+// onto its view stack with the given context.
+type PushScreen struct {
+	ID      ScreenID
+	Context ScreenContext
+}
+
+func (PushScreen) isIntent() {}
+
+// PopScreen asks the adapter to pop the topmost screen off its view
+// stack. The runtime owns no view stack itself; this is purely a
+// renderer-shaped instruction.
+type PopScreen struct{}
+
+func (PopScreen) isIntent() {}
+
+// ReplaceScreen asks the adapter to replace the topmost screen with the
+// named screen and the given context.
+type ReplaceScreen struct {
+	ID      ScreenID
+	Context ScreenContext
+}
+
+func (ReplaceScreen) isIntent() {}

--- a/internal/runtime/orchestrator.go
+++ b/internal/runtime/orchestrator.go
@@ -1,0 +1,50 @@
+package runtime
+
+import (
+	"github.com/k2m30/a9s/v3/internal/catalog"
+	"github.com/k2m30/a9s/v3/internal/session"
+)
+
+// Event is the marker interface for inputs the runtime accepts from an
+// adapter. Phase 05 PR-05a-scaffold defines it as an empty interface so
+// the Core skeleton compiles without depending on yet-to-be-created
+// concrete event types; PR-05b introduces the typed cmd/event split and
+// will replace this declaration with the typed event interface.
+type Event interface{}
+
+// Core is the platform-agnostic app-core orchestrator. It owns session
+// state and the catalog of resource types, dispatches inbound events to
+// the appropriate handler, and returns a list of UI intents plus task
+// requests that adapters apply to their renderer-specific state.
+//
+// The handlers are not yet wired in PR-05a-scaffold — that work lands in
+// per-handler PRs AS-72-h1..h8. This struct exists so dependent PRs can
+// reference the entry-point type while the handler moves are sequenced.
+type Core struct {
+	session *session.Session
+	types   []catalog.ResourceTypeDef
+}
+
+// New constructs a Core bound to the given session and catalog snapshot.
+// The catalog slice is borrowed, not copied — callers must treat
+// catalog.ResourceTypes as immutable for the lifetime of the Core, which
+// matches the existing static-catalog contract.
+func New(s *session.Session, types []catalog.ResourceTypeDef) *Core {
+	return &Core{session: s, types: types}
+}
+
+// Session returns the runtime-owned session handle. Adapters need this
+// during the migration to read state the per-handler PRs have not yet
+// migrated; the field becomes private-only once handler moves complete.
+func (c *Core) Session() *session.Session { return c.session }
+
+// Types returns the catalog snapshot the Core was constructed with.
+func (c *Core) Types() []catalog.ResourceTypeDef { return c.types }
+
+// HandleEvent is the single entry point adapters call to deliver an
+// inbound event. It returns the UI intents to apply and the background
+// tasks to start. The skeleton returns nil, nil — handler wiring lands
+// in AS-72-h1..h8.
+func (c *Core) HandleEvent(_ Event) ([]UIIntent, []TaskRequest) {
+	return nil, nil
+}

--- a/internal/runtime/orchestrator.go
+++ b/internal/runtime/orchestrator.go
@@ -10,7 +10,7 @@ import (
 // the Core skeleton compiles without depending on yet-to-be-created
 // concrete event types; PR-05b introduces the typed cmd/event split and
 // will replace this declaration with the typed event interface.
-type Event interface{}
+type Event any
 
 // Core is the platform-agnostic app-core orchestrator. It owns session
 // state and the catalog of resource types, dispatches inbound events to

--- a/internal/runtime/screens.go
+++ b/internal/runtime/screens.go
@@ -1,0 +1,46 @@
+// Package runtime owns the platform-agnostic app core: session ownership,
+// app-core dispatch, fetcher invocation, selectors, queries, tasks, and
+// generation stamping. It MUST NOT import Bubble Tea, Lipgloss, Bubbles, or
+// any other renderer toolkit. Renderer adapters (today: internal/tui)
+// translate runtime events/intents to and from their native message types.
+//
+// This file defines the screen-descriptor contract used by adapters to
+// render multi-screen workflows (logs, CloudTrail, cost views, …) without
+// growing central shell switches. Phase 05 PR-05a-scaffold creates the
+// types only; per-handler PRs (AS-72-h1..h8) wire them to live behavior.
+package runtime
+
+import "github.com/k2m30/a9s/v3/internal/domain"
+
+// ScreenID is the stable identifier for a registered screen. Adapters use
+// it to look up the renderer-specific builder; the shared core never
+// constructs renderer types itself.
+type ScreenID string
+
+// ScreenContext is the input handed to an adapter when the runtime asks
+// it to push, replace, or otherwise materialize a screen. Renderer-free.
+type ScreenContext struct {
+	ResourceType string
+	ResourceID   string
+	Capability   domain.CapabilityID
+	// Query is the zero value when the screen is not query-driven.
+	Query domain.QuerySpec
+}
+
+// ScreenDescriptor declaratively describes one registrable screen. Used by
+// the adapter to wire its builder map and by the runtime to validate that
+// a capability resolves to a known screen.
+type ScreenDescriptor struct {
+	ID    ScreenID
+	Title string
+}
+
+// ScreenRegistry is the runtime-side registry of declared screens. The
+// renderer adapter owns the parallel map from ScreenID to its concrete
+// builder type (e.g. tea.Model factory). Capability dispatch flows
+// CapabilityID -> ScreenID -> renderer-specific builder.
+type ScreenRegistry interface {
+	Register(ScreenDescriptor)
+	Get(ScreenID) (ScreenDescriptor, bool)
+	ScreenForCapability(domain.CapabilityID) (ScreenID, bool)
+}

--- a/internal/runtime/state.go
+++ b/internal/runtime/state.go
@@ -1,0 +1,46 @@
+package runtime
+
+import (
+	"github.com/k2m30/a9s/v3/internal/domain"
+	"github.com/k2m30/a9s/v3/internal/resource"
+	"github.com/k2m30/a9s/v3/internal/session"
+)
+
+// RuntimeState is the view-ready snapshot that adapters render from when
+// they need a one-shot read of runtime state (initial mount, debug
+// overlays, future IPC bridges). It is a snapshot, not a live handle —
+// adapters should still react to UIIntent for incremental updates.
+//
+// Per-handler PRs (AS-72-h1..h8) populate the fields below as the
+// corresponding handler logic moves out of internal/tui.
+type RuntimeState struct {
+	// ResourceCache mirrors session.Session.ResourceCache for the active
+	// session: per-resource-type cached list state.
+	ResourceCache map[string]*session.ResourceCacheEntry
+
+	// EnrichmentFindings carries the most-recent Wave 2 findings per
+	// resource type, keyed by ResourceType -> ResourceID -> finding.
+	EnrichmentFindings map[string]map[string]resource.EnrichmentFinding
+
+	// MenuBadges is the current per-resource-type issue badge state used
+	// to render the main menu.
+	MenuBadges map[string]IssueBadgePatch
+
+	// DetailFindings is the most-recent finding set for the focused
+	// detail view, keyed by FindingCode for stable ordering.
+	DetailFindings   []domain.Finding
+	DetailAttention  map[domain.FindingCode]domain.AttentionDetail
+	DetailResourceID string
+
+	// Tasks is the runtime's view of every in-flight or recently-
+	// completed background task. Keyed by TaskKey.
+	Tasks map[TaskKey]TaskState
+
+	// AvailabilityProgress / EnrichmentProgress mirror the queue
+	// progress counters on session.Session for adapters that render a
+	// progress UI.
+	AvailabilityChecked int
+	AvailabilityTotal   int
+	EnrichmentChecked   int
+	EnrichmentTotal     int
+}

--- a/internal/runtime/tasks.go
+++ b/internal/runtime/tasks.go
@@ -1,0 +1,66 @@
+package runtime
+
+import (
+	"context"
+	"time"
+)
+
+// TaskKind names a family of background tasks ("enrich", "related",
+// "logsource-discover", future query scans, …). Concrete kind constants
+// land alongside the per-handler PRs that own each task family.
+type TaskKind string
+
+// TaskKey uniquely identifies one background task. Scope is kind-specific
+// (resource-type, resource-id, query-id, …) and is opaque to the
+// scheduler — equality on TaskKey is the dedup key.
+type TaskKey struct {
+	Kind  TaskKind
+	Scope string
+}
+
+// TaskStatus tracks the lifecycle of a background task. Adapters render
+// progress and final state from this value plus TaskState.Progress.
+type TaskStatus int
+
+const (
+	TaskPending TaskStatus = iota
+	TaskRunning
+	TaskPartial
+	TaskComplete
+	TaskFailed
+	TaskCancelled
+)
+
+// CachePolicy controls how long a task's result remains valid before a
+// fresh request must be issued. CacheUntilRotate ties freshness to
+// session.Session.Rotate (profile / region switch), matching the
+// generation-counter contract used elsewhere in the runtime.
+type CachePolicy int
+
+const (
+	CacheNone CachePolicy = iota
+	CacheSession
+	CacheUntilRotate
+)
+
+// TaskState is the runtime-owned record for one in-flight or completed
+// background task. Cancel is non-nil while Status is TaskPending,
+// TaskRunning, or TaskPartial; nil after a terminal status.
+type TaskState struct {
+	Key       TaskKey
+	Status    TaskStatus
+	Progress  float64 // 0..1; -1 = indeterminate
+	StartedAt time.Time
+	Cache     CachePolicy
+	Cancel    context.CancelFunc
+	Err       error
+}
+
+// TaskRequest is what the runtime returns from HandleEvent to ask the
+// adapter to start (or refresh) a background task. The adapter is
+// responsible for translating it into platform-specific async work and
+// emitting the corresponding events back into the runtime.
+type TaskRequest struct {
+	Key   TaskKey
+	Cache CachePolicy
+}


### PR DESCRIPTION
## Summary

Phase 05 PR-05a-scaffold — introduces the platform-agnostic `internal/runtime/` package with the type-only contracts that all per-handler PRs (`AS-72-h1..h8`) depend on. Scaffold-only: handlers are not yet wired, no behavior change in `internal/tui/`.

- `screens.go` — `ScreenID`, `ScreenContext`, `ScreenDescriptor`, `ScreenRegistry` (per spec §"Screen and task contracts").
- `tasks.go` — `TaskKind`, `TaskKey`, `TaskStatus`, `CachePolicy`, `TaskState`, `TaskRequest`.
- `intent.go` — `UIIntent` marker interface plus `PatchResourceList` / `PatchDetail` / `PatchMenu` / `PushScreen` / `PopScreen` / `ReplaceScreen` and the `IssueBadgePatch` / `ListEnrichmentPatch` payloads (per spec §"UIIntent contract").
- `state.go` — `RuntimeState` view-ready snapshot of caches, findings, queue progress, task state.
- `orchestrator.go` — `Core` struct (owns `*session.Session`, `[]catalog.ResourceTypeDef`) with `HandleEvent` skeleton returning `nil, nil`.

Spec ref: [`docs/refactor/05-boundary.md`](docs/refactor/05-boundary.md) §"5a-extract".

## Notes / deviations from issue text

- The issue lists `catalog.ResourceTypeMap`; the catalog actually exports `var ResourceTypes []ResourceTypeDef`. `Core` is wired to `[]catalog.ResourceTypeDef` (snapshot of `catalog.ResourceTypes`), which matches the existing static-catalog contract.
- `HandleEvent` takes a local `Event` marker interface (`type Event interface{}`). The typed cmd/event split lands in PR-05b per the spec's migration discipline; the marker keeps the entry-point signature stable for AS-72-h1..h8 while avoiding a transitional concrete type.
- Patch payloads `IssueBadgePatch{Count, Truncated}` and `ListEnrichmentPatch{Findings map[string]resource.EnrichmentFinding}` are shaped to absorb today's `SetEnrichmentState(unified, issueTruncated, msg.Findings)` call site without rework when AS-72-h1..h8 land.

## Test plan

- [x] `go build github.com/k2m30/a9s/v3/internal/runtime` — green.
- [x] `go list -f '{{.Imports}}' github.com/k2m30/a9s/v3/internal/runtime | tr ' ' '\n' | grep -E 'bubbletea|lipgloss|bubbles'` — zero hits.
- [x] Required types present (`rg` checks for `ScreenDescriptor` / `ScreenRegistry`, `TaskKey` / `TaskState` / `TaskStatus`, `UIIntent`, `Core`).
- [x] `go build github.com/k2m30/a9s/v3/internal/tui` — still green.
- [x] `go build ./...` — green.
- [x] `go vet ./internal/runtime/...` — clean.
- [x] `go test ./internal/runtime/... ./internal/tui/...` — green.
- [ ] `make ready-to-push` (deferred — local `golangci-lint` is incompatible with the repo's Go 1.26 toolchain in this environment; CI runs the full gate).

Refs: AS-146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)