### PR TITLE
docs(process): apply Stage 5 NEEDS CHANGES from PR #339 (post-merge fix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Quick reference:
 
 - Pre-push gate (Stage 6): `make ready-to-push`
 - Pre-release gate (Stage 7): `make ready-to-release`
-- New work must be assigned by the CEO (or CTO on CEO's behalf). Never browse the backlog and self-assign.
+- Under CAE-1, CTO auto-pulls `todo, unassigned` issues in the active project every heartbeat (see [`docs/development-process.md`](docs/development-process.md) §"Continuous Autonomous Execution"). Other agents (Architect, QA, Coder, DevOps, etc.) act only on explicit dispatch from CTO or Architect — they never browse the backlog or pick up undispatched work.
 
 ## GitHub
 

--- a/docs/development-process.md
+++ b/docs/development-process.md
@@ -104,7 +104,7 @@ Every unit of work goes through these stages. Stages 1, 2, 4, 6, 6.5 may be **sk
 - **Trigger**: CEO/board files an issue, *or* a `todo, unassigned` issue exists in the active project (under CAE-1, the CTO auto-pulls these every heartbeat).
 - **Action**: Triage type (bug · feature · refactor · ops · docs), set priority, set size, name the owning Paperclip agent, draft acceptance criteria. Dispatch immediately; no waiting for explicit per-issue CEO approval on in-scope work.
 - **Exit**: Issue meets DoR and is dispatched to the owning agent (or to Architect when size ≥ M).
-- **Anti-pattern (post-CAE-1)**: CTO auto-pulls `todo, unassigned` issues in active projects every heartbeat, runs Stage 1 (size, AC, owner), and dispatches. CEO retains net-new strategic direction; CTO owns in-scope execution. Self-assigning *outside* the active project remains an anti-pattern. Other agents (Architect, QA, Coder, etc.) still act only on explicit dispatch from CTO or Architect — they do not browse the backlog.
+- **Anti-pattern (post-CAE-1)**: Self-assigning `todo, unassigned` issues *outside* the active project — CTO auto-pull is in-scope only. Other agents (Architect, QA, Coder, etc.) browsing the backlog or picking up undispatched work — they still act only on explicit dispatch from CTO or Architect. Waiting on CEO/board approval before dispatching in-scope ready work.
 
 ### Stage 2 — Spec & Design
 
@@ -270,7 +270,7 @@ Every "Primary" cell holds a **Paperclip agent name**. The "Tools" column lists 
 | Stage | Primary (Paperclip) | Helpers (Paperclip) | Reviewers (Paperclip) | Tools invoked in-session |
 |---|---|---|---|---|
 | 1 Intake | CTO | — | — | — |
-| 2 Spec | Architect | DevOps (consultative, optional) | CTO | `a9s-resource-spec`, `a9s-architect` |
+| 2 Spec | Architect | DevOps (consultative, optional) | — *(post-hoc only under CAE-1; CTO/board may comment but Stage 2 has no exit gate)* | `a9s-resource-spec`, `a9s-architect` |
 | 3 Tests | QA | — | Architect | `a9s-qa-stories`, `a9s-qa`, `a9s-related-qa` |
 | 4 Impl | Coder | — | — | `a9s-coder`, `a9s-integrator`, `a9s-fixtures` |
 | 5 Review | (parallel reviewers below) | — | CodeReviewer, CodexReviewer, Architect (≥M), CTO (final), CodeRabbit (external) | `a9s-tui-reviewer`, `a9s-consistency-checker`, `test-coverage-analyzer`, `a9s-security-auditor`, `a9s-docs-reviewer`, `tui-ux-auditor`, `a9s-arch-review` |


### PR DESCRIPTION
## Summary

Post-merge follow-up to [AS-161](https://pc.hub42.dev/AS/issues/AS-161) / [PR #339](https://github.com/k2m30/a9s/pull/339) (CAE-1 SSOT). PR #339 was merged at `15:32:49Z` with the original head `5dd77164` (parented on `8ea85fc`), **not** the rework `968474f` (parented on `3f011f96`) that addressed three Stage-5 NEEDS CHANGES verdicts. The rework was on a detached commit and never reached main, leaving three SSOT contradictions live on `main`.

This PR reapplies the same three editorial fixes on top of `main`.

## Three fixes — verbatim from `968474f`

| # | File:line | Prior verdict | Fix |
|---|---|---|---|
| 1 | `docs/development-process.md:107` | Architect + CodexReviewer (joint) | Rewrote per Architect's verbatim suggested text — only prohibited cases (out-of-project self-assign, non-CTO backlog browsing, waiting-on-board) remain. Required behavior continues to live in §CAE-1 rule 2 + Stage 1 Trigger/Action. |
| 2 | `CLAUDE.md:13` | CodeReviewer NO-LAZINESS | Replaced contradicting line with CAE-1-aligned text + SSOT reference. |
| 3 | `docs/development-process.md:273` | CodeReviewer NO-DEFERRING | Stage 2 Reviewers cell now `— *(post-hoc only under CAE-1; CTO/board may comment but Stage 2 has no exit gate)*` to match narrative at `:116/:118`. |

## Why this is low-risk re-review

- Architect verdicted **APPROVED** on the patch content of `968474f` in [AS-176](https://pc.hub42.dev/AS/issues/AS-176) post-merge re-review at 15:48Z.
- CodexReviewer + CodeReviewer post-merge re-review verdicts (AS-175 / AS-167) confirmed the original NEEDS CHANGES findings remain on main but did not flag new issues with the rework content.
- Diff content here is byte-identical to the detached `968474f` (`+3/-3` total in 2 files).

## Test plan

- [x] `markdownlint-cli2 CLAUDE.md docs/development-process.md` — 0 errors.
- [x] Lines verified against `origin/main` before edit (all three contradictions present).
- [ ] Stage 5: CodeReviewer + CodexReviewer + Architect re-verdict on this commit.
- [ ] CTO final sign-off + merge.

## Tracking

- Follow-up issue: filing alongside this PR.
- Closes the post-merge gaps from CEO's [3-gaps review](https://pc.hub42.dev/AS/issues/AS-161#comment-...) on AS-161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)