### PR TITLE
test(runtime): runtime-direct unit coverage for HandleRelatedNavigate + helpers (AS-201)

### DIFF
--- a/internal/runtime/handlers_related_test.go
+++ b/internal/runtime/handlers_related_test.go
@@ -1,0 +1,336 @@
+// handlers_related_test.go — same-package internal tests for the
+// unexported helpers in handlers_related.go.
+//
+// The public seam (*runtime.Core).HandleRelatedNavigate is exercised from
+// tests/unit/runtime_handlers_related_test.go (Cases A–K). This file pins the
+// helper-level precedence and cache-coverage rules the public seam cannot
+// observe directly (e.g. dedup of LazyResourceCache + ResourceCache, the
+// truncated-vs-missing-page-vs-no-entry fan-out, and the FetchFilter detection
+// step inside resolveRelatedNavigate).
+//
+// HARD CONSTRAINT (per AS-203 acceptance): this file MUST NOT import
+// charm.land/bubbletea/v2, lipgloss, or bubbles.
+package runtime
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/k2m30/a9s/v3/internal/domain"
+	"github.com/k2m30/a9s/v3/internal/resource"
+	"github.com/k2m30/a9s/v3/internal/session"
+)
+
+// ─── relatedFetchTasks — Cases a–f ─────────────────────────────────────────
+
+// Case a — all IDs covered by ResourceCache only → no fetch.
+func TestRelatedFetchTasks_AllCachedViaResourceCache_Nil(t *testing.T) {
+	s := session.New()
+	s.ResourceCache["ec2"] = &session.ResourceCacheEntry{
+		Resources: []resource.Resource{{ID: "i-1"}, {ID: "i-2"}},
+	}
+
+	got := relatedFetchTasks(s, "ec2", []string{"i-1", "i-2"})
+	if got != nil {
+		t.Errorf("got %+v, want nil", got)
+	}
+}
+
+// Case b — all IDs covered by LazyResourceCache only → no fetch.
+func TestRelatedFetchTasks_AllCachedViaLazyCache_Nil(t *testing.T) {
+	s := session.New()
+	s.LazyResourceCache["ec2"] = []resource.Resource{{ID: "i-1"}, {ID: "i-2"}}
+
+	got := relatedFetchTasks(s, "ec2", []string{"i-1", "i-2"})
+	if got != nil {
+		t.Errorf("got %+v, want nil", got)
+	}
+}
+
+// Case c — coverage split across both caches, fully covered → no fetch.
+// Proves dedup logic considers both maps when computing "missing".
+func TestRelatedFetchTasks_MixedFullCoverage_Nil(t *testing.T) {
+	s := session.New()
+	s.ResourceCache["ec2"] = &session.ResourceCacheEntry{
+		Resources: []resource.Resource{{ID: "i-1"}},
+	}
+	s.LazyResourceCache["ec2"] = []resource.Resource{{ID: "i-2"}}
+
+	got := relatedFetchTasks(s, "ec2", []string{"i-1", "i-2"})
+	if got != nil {
+		t.Errorf("got %+v, want nil", got)
+	}
+}
+
+// Case d — miss with ResourceCache.Pagination.IsTruncated==true → KindFetchMore.
+func TestRelatedFetchTasks_MissTruncated_FetchMore(t *testing.T) {
+	s := session.New()
+	s.ResourceCache["ec2"] = &session.ResourceCacheEntry{
+		Resources:  []resource.Resource{{ID: "i-1"}},
+		Pagination: &domain.PaginationMeta{IsTruncated: true},
+	}
+
+	got := relatedFetchTasks(s, "ec2", []string{"i-1", "i-2"})
+	want := []TaskRequest{{
+		Key:   TaskKey{Kind: KindFetchMore, Scope: "ec2"},
+		Cache: CacheNone,
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+// Case e — miss with ResourceCache present but Pagination==nil → KindFetchResources.
+func TestRelatedFetchTasks_MissPaginationNil_FetchResources(t *testing.T) {
+	s := session.New()
+	s.ResourceCache["ec2"] = &session.ResourceCacheEntry{
+		Resources: []resource.Resource{{ID: "i-1"}},
+	}
+
+	got := relatedFetchTasks(s, "ec2", []string{"i-1", "i-2"})
+	want := []TaskRequest{{
+		Key:   TaskKey{Kind: KindFetchResources, Scope: "ec2"},
+		Cache: CacheNone,
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+// Case f — miss with no ResourceCache entry at all (LazyResourceCache only
+// covers some, not all) → KindFetchResources.
+func TestRelatedFetchTasks_MissNoResourceCache_LazyOnly_FetchResources(t *testing.T) {
+	s := session.New()
+	s.LazyResourceCache["ec2"] = []resource.Resource{{ID: "i-1"}}
+
+	got := relatedFetchTasks(s, "ec2", []string{"i-1", "i-2"})
+	want := []TaskRequest{{
+		Key:   TaskKey{Kind: KindFetchResources, Scope: "ec2"},
+		Cache: CacheNone,
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+// ─── relatedCacheSnapshot — Cases a–d ──────────────────────────────────────
+
+// snapResource is a tiny accessor that returns the IDs visible in the snapshot
+// for the given shortName, preserving order.
+func snapResourceIDs(snap map[string][]resource.Resource, shortName string) []string {
+	rs := snap[shortName]
+	ids := make([]string, 0, len(rs))
+	for _, r := range rs {
+		ids = append(ids, r.ID)
+	}
+	return ids
+}
+
+// Case a — ResourceCache only → snapshot mirrors ResourceCache.
+func TestRelatedCacheSnapshot_ResourceCacheOnly(t *testing.T) {
+	s := session.New()
+	s.ResourceCache["ec2"] = &session.ResourceCacheEntry{
+		Resources: []resource.Resource{{ID: "i-1"}, {ID: "i-2"}},
+	}
+
+	snap := relatedCacheSnapshot(s)
+	got := snapResourceIDs(snap, "ec2")
+	want := []string{"i-1", "i-2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ec2 IDs = %v, want %v", got, want)
+	}
+}
+
+// Case b — LazyResourceCache only → snapshot mirrors LazyResourceCache.
+func TestRelatedCacheSnapshot_LazyCacheOnly(t *testing.T) {
+	s := session.New()
+	s.LazyResourceCache["ec2"] = []resource.Resource{{ID: "i-1"}, {ID: "i-2"}}
+
+	snap := relatedCacheSnapshot(s)
+	got := snapResourceIDs(snap, "ec2")
+	want := []string{"i-1", "i-2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ec2 IDs = %v, want %v", got, want)
+	}
+}
+
+// Case c — Both, no ID collision → snapshot is the union (ResourceCache rows
+// first, then any LazyResourceCache rows not already present).
+func TestRelatedCacheSnapshot_BothNoCollision_Union(t *testing.T) {
+	s := session.New()
+	s.ResourceCache["ec2"] = &session.ResourceCacheEntry{
+		Resources: []resource.Resource{{ID: "i-1"}},
+	}
+	s.LazyResourceCache["ec2"] = []resource.Resource{{ID: "i-2"}}
+
+	snap := relatedCacheSnapshot(s)
+
+	got := map[string]struct{}{}
+	for _, r := range snap["ec2"] {
+		got[r.ID] = struct{}{}
+	}
+	for _, id := range []string{"i-1", "i-2"} {
+		if _, ok := got[id]; !ok {
+			t.Errorf("missing %q in snapshot: have %v", id, snap["ec2"])
+		}
+	}
+	if len(snap["ec2"]) != 2 {
+		t.Errorf("len(snapshot) = %d, want 2", len(snap["ec2"]))
+	}
+}
+
+// Case d — Both, ID collision on "i-1" → snapshot contains exactly one entry
+// for "i-1", and that entry is the ResourceCache version. We distinguish the
+// two source rows by their Name field.
+func TestRelatedCacheSnapshot_BothCollision_ResourceCacheWins(t *testing.T) {
+	s := session.New()
+	s.ResourceCache["ec2"] = &session.ResourceCacheEntry{
+		Resources: []resource.Resource{{ID: "i-1", Name: "from-resource-cache"}},
+	}
+	s.LazyResourceCache["ec2"] = []resource.Resource{{ID: "i-1", Name: "from-lazy-cache"}}
+
+	snap := relatedCacheSnapshot(s)
+
+	if len(snap["ec2"]) != 1 {
+		t.Fatalf("len(snapshot) = %d, want 1 (dedup expected)", len(snap["ec2"]))
+	}
+	if got := snap["ec2"][0].Name; got != "from-resource-cache" {
+		t.Errorf("Name = %q, want %q (ResourceCache must win on collision)",
+			got, "from-resource-cache")
+	}
+}
+
+// ─── resolveRelatedNavigate — Cases a–h ────────────────────────────────────
+
+// Case a — unknown type → Flash with FlashIsError true.
+func TestResolveRelatedNavigate_Unknown_Flash(t *testing.T) {
+	got := resolveRelatedNavigate(
+		RelatedNavigateEvent{TargetType: "definitely-not-a-real-type"},
+		nil,
+	)
+	if got.Kind != NavigationKindFlash {
+		t.Errorf("Kind = %v, want NavigationKindFlash", got.Kind)
+	}
+	if !got.FlashIsError {
+		t.Error("FlashIsError = false, want true")
+	}
+}
+
+// Case b — child type → EnterChildView, RelatedIDs preserved.
+func TestResolveRelatedNavigate_ChildType_EnterChildView(t *testing.T) {
+	const childShort = "test_child_resolve_b"
+	resource.RegisterChildType(resource.ResourceTypeDef{
+		Name:      "Test Child",
+		ShortName: childShort,
+	})
+	t.Cleanup(func() { resource.UnregisterChildType(childShort) })
+
+	relatedIDs := []string{"x-1", "x-2"}
+	got := resolveRelatedNavigate(
+		RelatedNavigateEvent{TargetType: childShort, RelatedIDs: relatedIDs},
+		nil,
+	)
+	if got.Kind != NavigationKindEnterChildView {
+		t.Errorf("Kind = %v, want NavigationKindEnterChildView", got.Kind)
+	}
+	if !reflect.DeepEqual(got.RelatedIDs, relatedIDs) {
+		t.Errorf("RelatedIDs = %v, want %v", got.RelatedIDs, relatedIDs)
+	}
+}
+
+// Case c — TargetID present + in cache → Detail.
+func TestResolveRelatedNavigate_TargetIDHit_Detail(t *testing.T) {
+	cache := map[string][]resource.Resource{
+		"ec2": {{ID: "i-1"}},
+	}
+	got := resolveRelatedNavigate(
+		RelatedNavigateEvent{TargetType: "ec2", TargetID: "i-1"},
+		cache,
+	)
+	if got.Kind != NavigationKindDetail {
+		t.Errorf("Kind = %v, want NavigationKindDetail", got.Kind)
+	}
+	if got.TargetID != "i-1" {
+		t.Errorf("TargetID = %q, want %q", got.TargetID, "i-1")
+	}
+}
+
+// Case d — single RelatedIDs hit → Detail.
+func TestResolveRelatedNavigate_SingleRelatedIDHit_Detail(t *testing.T) {
+	cache := map[string][]resource.Resource{
+		"ec2": {{ID: "i-1"}},
+	}
+	got := resolveRelatedNavigate(
+		RelatedNavigateEvent{TargetType: "ec2", RelatedIDs: []string{"i-1"}},
+		cache,
+	)
+	if got.Kind != NavigationKindDetail {
+		t.Errorf("Kind = %v, want NavigationKindDetail", got.Kind)
+	}
+}
+
+// Case e — FetchFilter + registered filtered fetcher → FilteredList with
+// FetchFilter set.
+func TestResolveRelatedNavigate_FetchFilter_RegisteredFetcher_FilteredList(t *testing.T) {
+	resource.RegisterFilteredPaginated("ec2",
+		func(_ context.Context, _ any, _ map[string]string, _ string) (domain.FetchResult, error) {
+			return domain.FetchResult{}, nil
+		})
+	t.Cleanup(func() { resource.UnregisterFilteredPaginated("ec2") })
+
+	filter := map[string]string{"vpc-id": "vpc-1"}
+	got := resolveRelatedNavigate(
+		RelatedNavigateEvent{TargetType: "ec2", FetchFilter: filter},
+		nil,
+	)
+	if got.Kind != NavigationKindFilteredList {
+		t.Errorf("Kind = %v, want NavigationKindFilteredList", got.Kind)
+	}
+	if !reflect.DeepEqual(got.FetchFilter, filter) {
+		t.Errorf("FetchFilter = %v, want %v", got.FetchFilter, filter)
+	}
+}
+
+// Case f — TargetID present + miss → FilteredList with FilterText==TargetID.
+func TestResolveRelatedNavigate_TargetIDMiss_FilteredList(t *testing.T) {
+	got := resolveRelatedNavigate(
+		RelatedNavigateEvent{TargetType: "ec2", TargetID: "i-missing"},
+		nil,
+	)
+	if got.Kind != NavigationKindFilteredList {
+		t.Errorf("Kind = %v, want NavigationKindFilteredList", got.Kind)
+	}
+	if got.FilterText != "i-missing" {
+		t.Errorf("FilterText = %q, want %q", got.FilterText, "i-missing")
+	}
+	if got.TargetID != "i-missing" {
+		t.Errorf("TargetID = %q, want %q", got.TargetID, "i-missing")
+	}
+}
+
+// Case g — multiple RelatedIDs, no FetchFilter → FilteredList with RelatedIDs.
+func TestResolveRelatedNavigate_MultipleRelatedIDs_FilteredList(t *testing.T) {
+	relatedIDs := []string{"i-1", "i-2"}
+	got := resolveRelatedNavigate(
+		RelatedNavigateEvent{TargetType: "ec2", RelatedIDs: relatedIDs},
+		nil,
+	)
+	if got.Kind != NavigationKindFilteredList {
+		t.Errorf("Kind = %v, want NavigationKindFilteredList", got.Kind)
+	}
+	if !reflect.DeepEqual(got.RelatedIDs, relatedIDs) {
+		t.Errorf("RelatedIDs = %v, want %v", got.RelatedIDs, relatedIDs)
+	}
+}
+
+// Case h — default → ResourceList.
+func TestResolveRelatedNavigate_Default_ResourceList(t *testing.T) {
+	got := resolveRelatedNavigate(
+		RelatedNavigateEvent{TargetType: "ec2"},
+		nil,
+	)
+	if got.Kind != NavigationKindResourceList {
+		t.Errorf("Kind = %v, want NavigationKindResourceList", got.Kind)
+	}
+}

--- a/internal/runtime/handlers_related_test.go
+++ b/internal/runtime/handlers_related_test.go
@@ -116,7 +116,7 @@ func TestRelatedFetchTasks_MissNoResourceCache_LazyOnly_FetchResources(t *testin
 
 // ─── relatedCacheSnapshot — Cases a–d ──────────────────────────────────────
 
-// snapResource is a tiny accessor that returns the IDs visible in the snapshot
+// snapResourceIDs is a tiny accessor that returns the IDs visible in the snapshot
 // for the given shortName, preserving order.
 func snapResourceIDs(snap map[string][]resource.Resource, shortName string) []string {
 	rs := snap[shortName]

--- a/tests/unit/runtime_handlers_related_test.go
+++ b/tests/unit/runtime_handlers_related_test.go
@@ -1,0 +1,304 @@
+// runtime_handlers_related_test.go — public-seam coverage for
+// (*runtime.Core).HandleRelatedNavigate after the AS-150 migration moved the
+// handler out of internal/tui into internal/runtime.
+//
+// Cases A–K mirror the Stage 2 scope on AS-201. The runtime seam is exactly
+// what AS-150 exposed — these tests stand up *runtime.Core directly through
+// runtime.New(session.New(), catalog.ResourceTypes) and assert the
+// NavigationResult + []TaskRequest pair returned for each branch.
+//
+// HARD CONSTRAINT (per AS-203 acceptance): this file MUST NOT import
+// charm.land/bubbletea/v2, lipgloss, or bubbles. The migration's whole point
+// was decoupling the handler from Bubble Tea; bringing the framework back in
+// here would defeat the test.
+package unit
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/k2m30/a9s/v3/internal/catalog"
+	"github.com/k2m30/a9s/v3/internal/domain"
+	"github.com/k2m30/a9s/v3/internal/resource"
+	"github.com/k2m30/a9s/v3/internal/runtime"
+	"github.com/k2m30/a9s/v3/internal/session"
+)
+
+// newRuntimeCore returns a fresh *runtime.Core bound to a clean session and
+// the static catalog. Test cases mutate the returned session's caches
+// directly to seed each branch.
+func newRuntimeCore(t *testing.T) (*runtime.Core, *session.Session) {
+	t.Helper()
+	s := session.New()
+	c := runtime.New(s, catalog.ResourceTypes)
+	return c, s
+}
+
+// Case A — unknown target type → Flash with FlashIsError true, no tasks.
+func TestHandleRelatedNavigate_UnknownType_Flash(t *testing.T) {
+	c, _ := newRuntimeCore(t)
+
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType: "definitely-not-a-real-type",
+	})
+
+	if result.Kind != runtime.NavigationKindFlash {
+		t.Errorf("Kind = %v, want NavigationKindFlash", result.Kind)
+	}
+	if !result.FlashIsError {
+		t.Error("FlashIsError = false, want true")
+	}
+	if len(tasks) != 0 {
+		t.Errorf("len(tasks) = %d, want 0", len(tasks))
+	}
+}
+
+// Case B — child type (e.g. "s3_objects") → EnterChildView, no tasks.
+//
+// Registers a transient child type for this test so the assertion does not
+// depend on internal/aws being imported (which would pull init() side effects
+// into tests/unit).
+func TestHandleRelatedNavigate_ChildType_EnterChildView(t *testing.T) {
+	const childShort = "test_child_type_handle_related_b"
+	resource.RegisterChildType(resource.ResourceTypeDef{
+		Name:      "Test Child",
+		ShortName: childShort,
+	})
+	t.Cleanup(func() { resource.UnregisterChildType(childShort) })
+
+	c, _ := newRuntimeCore(t)
+
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType: childShort,
+	})
+
+	if result.Kind != runtime.NavigationKindEnterChildView {
+		t.Errorf("Kind = %v, want NavigationKindEnterChildView", result.Kind)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("len(tasks) = %d, want 0", len(tasks))
+	}
+}
+
+// Case C — top-level cache hit via TargetID → Detail, no tasks.
+func TestHandleRelatedNavigate_TopLevelCacheHit_TargetID_Detail(t *testing.T) {
+	c, s := newRuntimeCore(t)
+	s.ResourceCache["ec2"] = &session.ResourceCacheEntry{
+		Resources: []resource.Resource{{ID: "i-1"}},
+	}
+
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType: "ec2",
+		TargetID:   "i-1",
+	})
+
+	if result.Kind != runtime.NavigationKindDetail {
+		t.Errorf("Kind = %v, want NavigationKindDetail", result.Kind)
+	}
+	if result.TargetID != "i-1" {
+		t.Errorf("TargetID = %q, want %q", result.TargetID, "i-1")
+	}
+	if len(tasks) != 0 {
+		t.Errorf("len(tasks) = %d, want 0", len(tasks))
+	}
+}
+
+// Case D — top-level cache hit via single RelatedIDs → Detail, no tasks.
+func TestHandleRelatedNavigate_TopLevelCacheHit_SingleRelatedID_Detail(t *testing.T) {
+	c, s := newRuntimeCore(t)
+	s.ResourceCache["ec2"] = &session.ResourceCacheEntry{
+		Resources: []resource.Resource{{ID: "i-1"}},
+	}
+
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType: "ec2",
+		RelatedIDs: []string{"i-1"},
+	})
+
+	if result.Kind != runtime.NavigationKindDetail {
+		t.Errorf("Kind = %v, want NavigationKindDetail", result.Kind)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("len(tasks) = %d, want 0", len(tasks))
+	}
+}
+
+// Case E — FetchFilter + registered filtered fetcher → FilteredList with
+// FetchFilter preserved and a single KindFetchFiltered task.
+//
+// Registers a no-op filtered paginated fetcher for the test type. t.Cleanup
+// unregisters it so test order does not matter.
+func TestHandleRelatedNavigate_FetchFilter_RegisteredFetcher_FilteredList(t *testing.T) {
+	resource.RegisterFilteredPaginated("ec2",
+		func(_ context.Context, _ any, _ map[string]string, _ string) (domain.FetchResult, error) {
+			return domain.FetchResult{}, nil
+		})
+	t.Cleanup(func() { resource.UnregisterFilteredPaginated("ec2") })
+
+	c, _ := newRuntimeCore(t)
+
+	filter := map[string]string{"vpc-id": "vpc-1"}
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType:  "ec2",
+		FetchFilter: filter,
+	})
+
+	if result.Kind != runtime.NavigationKindFilteredList {
+		t.Errorf("Kind = %v, want NavigationKindFilteredList", result.Kind)
+	}
+	if !reflect.DeepEqual(result.FetchFilter, filter) {
+		t.Errorf("FetchFilter = %v, want %v", result.FetchFilter, filter)
+	}
+	wantTasks := []runtime.TaskRequest{{
+		Key:   runtime.TaskKey{Kind: runtime.KindFetchFiltered, Scope: "ec2"},
+		Cache: runtime.CacheNone,
+	}}
+	if !reflect.DeepEqual(tasks, wantTasks) {
+		t.Errorf("tasks = %+v, want %+v", tasks, wantTasks)
+	}
+}
+
+// Case F — TargetID cache miss (no filtered fetcher, no cache entry) →
+// FilteredList with FilterText==TargetID and a single KindFetchResources task.
+func TestHandleRelatedNavigate_TargetIDCacheMiss_FilteredList(t *testing.T) {
+	c, _ := newRuntimeCore(t)
+
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType: "ec2",
+		TargetID:   "i-missing",
+	})
+
+	if result.Kind != runtime.NavigationKindFilteredList {
+		t.Errorf("Kind = %v, want NavigationKindFilteredList", result.Kind)
+	}
+	if result.FilterText != "i-missing" {
+		t.Errorf("FilterText = %q, want %q", result.FilterText, "i-missing")
+	}
+	if result.TargetID != "i-missing" {
+		t.Errorf("TargetID = %q, want %q", result.TargetID, "i-missing")
+	}
+	wantTasks := []runtime.TaskRequest{{
+		Key:   runtime.TaskKey{Kind: runtime.KindFetchResources, Scope: "ec2"},
+		Cache: runtime.CacheNone,
+	}}
+	if !reflect.DeepEqual(tasks, wantTasks) {
+		t.Errorf("tasks = %+v, want %+v", tasks, wantTasks)
+	}
+}
+
+// Case G — multiple RelatedIDs cache miss, no further pages → FilteredList
+// with RelatedIDs preserved and a single KindFetchResources task.
+func TestHandleRelatedNavigate_MultipleRelatedIDs_CacheMiss_FetchResources(t *testing.T) {
+	c, _ := newRuntimeCore(t)
+
+	relatedIDs := []string{"i-1", "i-2"}
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType: "ec2",
+		RelatedIDs: relatedIDs,
+	})
+
+	if result.Kind != runtime.NavigationKindFilteredList {
+		t.Errorf("Kind = %v, want NavigationKindFilteredList", result.Kind)
+	}
+	if !reflect.DeepEqual(result.RelatedIDs, relatedIDs) {
+		t.Errorf("RelatedIDs = %v, want %v", result.RelatedIDs, relatedIDs)
+	}
+	wantTasks := []runtime.TaskRequest{{
+		Key:   runtime.TaskKey{Kind: runtime.KindFetchResources, Scope: "ec2"},
+		Cache: runtime.CacheNone,
+	}}
+	if !reflect.DeepEqual(tasks, wantTasks) {
+		t.Errorf("tasks = %+v, want %+v", tasks, wantTasks)
+	}
+}
+
+// Case H — multiple RelatedIDs, partial coverage + truncated cache →
+// FilteredList with a single KindFetchMore task (continuation).
+func TestHandleRelatedNavigate_MultipleRelatedIDs_PartialCoverage_Truncated_FetchMore(t *testing.T) {
+	c, s := newRuntimeCore(t)
+	s.ResourceCache["ec2"] = &session.ResourceCacheEntry{
+		Resources:  []resource.Resource{{ID: "i-1"}},
+		Pagination: &domain.PaginationMeta{IsTruncated: true},
+	}
+
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType: "ec2",
+		RelatedIDs: []string{"i-1", "i-2"},
+	})
+
+	if result.Kind != runtime.NavigationKindFilteredList {
+		t.Errorf("Kind = %v, want NavigationKindFilteredList", result.Kind)
+	}
+	wantTasks := []runtime.TaskRequest{{
+		Key:   runtime.TaskKey{Kind: runtime.KindFetchMore, Scope: "ec2"},
+		Cache: runtime.CacheNone,
+	}}
+	if !reflect.DeepEqual(tasks, wantTasks) {
+		t.Errorf("tasks = %+v, want %+v", tasks, wantTasks)
+	}
+}
+
+// Case I — multiple RelatedIDs fully covered by ResourceCache → FilteredList
+// with no fetch task.
+func TestHandleRelatedNavigate_MultipleRelatedIDs_FullyCached_NoFetch(t *testing.T) {
+	c, s := newRuntimeCore(t)
+	s.ResourceCache["ec2"] = &session.ResourceCacheEntry{
+		Resources: []resource.Resource{{ID: "i-1"}, {ID: "i-2"}},
+	}
+
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType: "ec2",
+		RelatedIDs: []string{"i-1", "i-2"},
+	})
+
+	if result.Kind != runtime.NavigationKindFilteredList {
+		t.Errorf("Kind = %v, want NavigationKindFilteredList", result.Kind)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("len(tasks) = %d, want 0", len(tasks))
+	}
+}
+
+// Case J — no IDs, no filter, no targetID → ResourceList with a single
+// KindFetchResources task.
+func TestHandleRelatedNavigate_NoIDsNoFilter_ResourceList(t *testing.T) {
+	c, _ := newRuntimeCore(t)
+
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType: "ec2",
+	})
+
+	if result.Kind != runtime.NavigationKindResourceList {
+		t.Errorf("Kind = %v, want NavigationKindResourceList", result.Kind)
+	}
+	wantTasks := []runtime.TaskRequest{{
+		Key:   runtime.TaskKey{Kind: runtime.KindFetchResources, Scope: "ec2"},
+		Cache: runtime.CacheNone,
+	}}
+	if !reflect.DeepEqual(tasks, wantTasks) {
+		t.Errorf("tasks = %+v, want %+v", tasks, wantTasks)
+	}
+}
+
+// Case K — pure-lazy passthrough for Detail: TargetID hit lives only in
+// LazyResourceCache; ResourceCache has no entry for the type.
+//
+// This proves relatedCacheSnapshot includes LazyResourceCache when resolving
+// the TargetID Detail branch.
+func TestHandleRelatedNavigate_PureLazyCacheHit_Detail(t *testing.T) {
+	c, s := newRuntimeCore(t)
+	s.LazyResourceCache["ec2"] = []resource.Resource{{ID: "i-1"}}
+
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType: "ec2",
+		TargetID:   "i-1",
+	})
+
+	if result.Kind != runtime.NavigationKindDetail {
+		t.Errorf("Kind = %v, want NavigationKindDetail", result.Kind)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("len(tasks) = %d, want 0", len(tasks))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds runtime-direct unit coverage for the four entry points the AS-150 migration moved onto `*runtime.Core` so the seam is exercised directly, not just via the Bubble Tea adapter.
- `tests/unit/runtime_handlers_related_test.go` (package `unit`) — Cases A–K on `(*runtime.Core).HandleRelatedNavigate`, covering every reachable `NavigationKind`, the per-branch `TaskRequest` shape, and the `LazyResourceCache` passthrough for the Detail branch (Case K).
- `internal/runtime/handlers_related_test.go` (package `runtime`) — helper Cases a–h on the unexported `relatedFetchTasks` / `relatedCacheSnapshot` / `resolveRelatedNavigate`, pinning truncated-vs-missing-page fan-out, dedup across both caches (`ResourceCache` wins on ID collision), and the FetchFilter-precedence rules.

Both files import zero Bubble Tea / Lipgloss / Bubbles symbols by design — see the grep check below.

## Implemented Cases

Public seam (`tests/unit/runtime_handlers_related_test.go`):

| Case | Behaviour | Status |
|------|-----------|--------|
| A | Unknown target type → Flash, FlashIsError | ✅ |
| B | Child type → EnterChildView | ✅ |
| C | Top-level cache hit via TargetID → Detail | ✅ |
| D | Top-level cache hit via single RelatedIDs → Detail | ✅ |
| E | FetchFilter + registered filtered fetcher → FilteredList + KindFetchFiltered | ✅ |
| F | TargetID cache miss → FilteredList (FilterText=TargetID) + KindFetchResources | ✅ |
| G | Multiple RelatedIDs cache miss → FilteredList + KindFetchResources | ✅ |
| H | Multiple RelatedIDs partial coverage + truncated cache → FilteredList + KindFetchMore | ✅ |
| I | Multiple RelatedIDs fully cached → FilteredList, no fetch | ✅ |
| J | No IDs, no filter, no targetID → ResourceList + KindFetchResources | ✅ |
| K | Pure-lazy passthrough for Detail (LazyResourceCache only) | ✅ |

`NavigationKindUnknown` is unreachable from the public seam by design — no test included, per the Stage 2 scope.

Internal helpers (`internal/runtime/handlers_related_test.go`):

| Case | Helper | Behaviour | Status |
|------|--------|-----------|--------|
| a | `relatedFetchTasks` | All-cached via ResourceCache only → nil | ✅ |
| b | `relatedFetchTasks` | All-cached via LazyResourceCache only → nil | ✅ |
| c | `relatedFetchTasks` | Mixed full coverage across both caches → nil | ✅ |
| d | `relatedFetchTasks` | Miss + truncated cache → KindFetchMore | ✅ |
| e | `relatedFetchTasks` | Miss + Pagination==nil → KindFetchResources | ✅ |
| f | `relatedFetchTasks` | Miss + no ResourceCache entry (LazyOnly) → KindFetchResources | ✅ |
| a | `relatedCacheSnapshot` | ResourceCache only → mirrors ResourceCache | ✅ |
| b | `relatedCacheSnapshot` | LazyResourceCache only → mirrors LazyResourceCache | ✅ |
| c | `relatedCacheSnapshot` | Both, no collision → union | ✅ |
| d | `relatedCacheSnapshot` | Both, ID collision → ResourceCache wins (verified via `Name`) | ✅ |
| a | `resolveRelatedNavigate` | Unknown → Flash + FlashIsError | ✅ |
| b | `resolveRelatedNavigate` | Child type → EnterChildView, RelatedIDs preserved | ✅ |
| c | `resolveRelatedNavigate` | TargetID hit → Detail | ✅ |
| d | `resolveRelatedNavigate` | Single RelatedIDs hit → Detail | ✅ |
| e | `resolveRelatedNavigate` | FetchFilter + registered fetcher → FilteredList | ✅ |
| f | `resolveRelatedNavigate` | TargetID miss → FilteredList (FilterText=TargetID) | ✅ |
| g | `resolveRelatedNavigate` | Multiple RelatedIDs → FilteredList with RelatedIDs | ✅ |
| h | `resolveRelatedNavigate` | Default → ResourceList | ✅ |

## Stacking note

AS-203 dispatch said "Branch from `main`", but `internal/runtime/handlers_related.go` does **not** yet live on `main` — it is on `phase-05-pr-05a-h-handlers_related` (PR #345, still open). This PR is therefore based on that branch so the tests compile against the symbols they cover. Once PR #345 lands on `main`, the safe path is either:

1. Re-target this PR's base to `main` (no rebase needed; the diff is purely test files), or
2. Cherry-pick this commit onto a fresh branch from `main`.

CodeReviewer / CodexReviewer can choose. cc @Architect.

## Verification (per the AS-203 acceptance list)

- `go build ./...` — clean.
- `go vet ./internal/runtime/... ./tests/unit/...` — clean.
- `go test ./internal/runtime/ ./tests/unit/ -count=1 -timeout 240s` — both packages green (`internal/runtime` 18 new helper tests; `tests/unit` 11 new public-seam tests plus prior suite).
- `grep -nE '^\s+"(charm.land/bubbletea|github.com/charmbracelet/lipgloss|github.com/charmbracelet/bubbles)' tests/unit/runtime_handlers_related_test.go internal/runtime/handlers_related_test.go` — zero hits.
- `golangci-lint` could not run locally: the host's binary was built against Go 1.25 while the module targets 1.26; falling back to CI's lint stage.

## Test plan

- [ ] CI green on Stage 6 lanes (build, test, lint, security, gofix).
- [ ] CodeReviewer sign-off (XS size — only the always-runs reviewers per Stage 5).
- [ ] CodexReviewer sign-off.
- [ ] After PR #345 merges, decide between re-target vs. cherry-pick (see "Stacking note").

🤖 Generated with [Claude Code](https://claude.com/claude-code)