### PR TITLE
refactor(runtime): collapse related-navigation resolver SSOT (AS-202)

### DIFF
--- a/internal/tui/app_related.go
+++ b/internal/tui/app_related.go
@@ -340,7 +340,7 @@ func (m *Model) buildResourceCacheSnapshot() resource.ResourceCache {
 // enterChildForResource returns the ChildViewDef registered under Key="enter"
 // for a resource type, or nil if none is registered or its DrillCondition
 // vetoes the given row. Mirror of (ResourceListModel).enterChildFor — used
-// when related-navigation takes the cache-hit fast path (KindDetail) and
+// when related-navigation takes the cache-hit fast path (NavigationKindDetail) and
 // must replicate manual-Enter behavior without instantiating a list view.
 func enterChildForResource(td *resource.ResourceTypeDef, r resource.Resource) *resource.ChildViewDef {
 	if td == nil {
@@ -361,7 +361,7 @@ func enterChildForResource(td *resource.ResourceTypeDef, r resource.Resource) *r
 
 // buildChildContextForResource resolves ContextKeys for a ChildViewDef given
 // the selected resource. Mirror of (ResourceListModel).buildChildContext for
-// the KindDetail fast path, without parent-context chaining ("@parent.*"
+// the NavigationKindDetail fast path, without parent-context chaining ("@parent.*"
 // sources collapse to empty because related-navigation starts from a fresh
 // detail drill, not a nested child stack).
 func buildChildContextForResource(child resource.ChildViewDef, r resource.Resource) map[string]string {
@@ -373,7 +373,7 @@ func buildChildContextForResource(child resource.ChildViewDef, r resource.Resour
 		case source == "Name":
 			ctx[param] = r.Name
 		case strings.HasPrefix(source, "@parent."):
-			// Unreachable from a related-navigation KindDetail entry — the
+			// Unreachable from a related-navigation NavigationKindDetail entry — the
 			// source resource is not a child view. Leave empty rather than
 			// reading uninitialised parent context.
 		default:

--- a/tests/integration/full_integration_helpers_test.go
+++ b/tests/integration/full_integration_helpers_test.go
@@ -325,7 +325,7 @@ func fullIntegrationEnterRelatedSingleDetail(t *testing.T, m *tui.Model, targetT
 		t.Fatalf("related %q navigation returned nil cmd; expected fetch+auto-open detail", displayName)
 	}
 
-	// Fast path: related-panel KindDetail (cache hit) pushes the detail view
+	// Fast path: related-panel NavigationKindDetail (cache hit) pushes the detail view
 	// directly and emits RelatedCheckStartedMsg without going through
 	// ResourcesLoadedMsg / NavigateMsg. Detect by scanning for that message
 	// in the returned cmd.

--- a/tests/integration/scenario_related_drill_through_test.go
+++ b/tests/integration/scenario_related_drill_through_test.go
@@ -294,7 +294,7 @@ func TestScenario_RelatedDrillThrough_All(t *testing.T) {
 //   2) Navigation integration. The direct-checker test verifies ID-format
 //      parity with the target fetcher, but does NOT exercise the actual
 //      TUI navigation — ResolveRelatedNavigate, handleRelatedNavigate,
-//      KindDetail fast path, EnterChildViewMsg dispatch, or the child-view
+//      NavigationKindDetail fast path, EnterChildViewMsg dispatch, or the child-view
 //      fetcher's ParentContext handling.
 //
 // To avoid the async race that made earlier TUI-driven tests flaky (related

--- a/tests/integration/scripted_scenario_helpers_test.go
+++ b/tests/integration/scripted_scenario_helpers_test.go
@@ -1015,7 +1015,7 @@ func (s *fullIntegrationScenario) DrillRelated(displayName string) []resource.Re
 	}
 
 	// Case 4: detail-view pushed without a NavigateMsg.
-	// handleRelatedNavigate's KindDetail + cache-hit branch pushes a detail view
+	// handleRelatedNavigate's NavigationKindDetail + cache-hit branch pushes a detail view
 	// and returns nil Cmd — no NavigateMsg is emitted, so currentResource stays
 	// pointed at the parent. Detect the push via the rendered frame title:
 	// "detail -- <id>" or "detail -- <id> (<name>)".

--- a/tests/unit/app_fetchers_dispatchers_test.go
+++ b/tests/unit/app_fetchers_dispatchers_test.go
@@ -51,7 +51,7 @@ import (
 //
 // ct-events is the only type with a registered FilteredPaginatedFetcher.
 // RelatedNavigateMsg{TargetType:"ct-events", FetchFilter:{...}} routes through
-// handleRelatedNavigate → KindFilteredList + FetchFilter branch →
+// handleRelatedNavigate → NavigationKindFilteredList + FetchFilter branch →
 // m.fetchResourcesFiltered("ct-events", filter).
 func TestFetchResourcesFiltered_NilClients_ViaRelatedNavigate(t *testing.T) {
 	withTuiVersion(t, "test")

--- a/tests/unit/app_fetchers_wave5_test.go
+++ b/tests/unit/app_fetchers_wave5_test.go
@@ -286,7 +286,7 @@ func TestFetchResourcesFiltered_NoFetcherWithDemoClients(t *testing.T) {
 
 	// Navigate to EC2 list, then send RelatedNavigateMsg with FetchFilter for
 	// a type with no filtered fetcher. Because this goes through handleRelatedNavigate
-	// which calls m.fetchResourcesFiltered directly for KindFilteredList results,
+	// which calls m.fetchResourcesFiltered directly for NavigationKindFilteredList results,
 	// we need to trigger that path. The easiest approach: register a typed resource
 	// and send a LoadMoreMsg with FetchFilter using demo clients.
 	// Use an arbitrary short name with no fetchers registered.

--- a/tests/unit/ctevent_demo_invariants_test.go
+++ b/tests/unit/ctevent_demo_invariants_test.go
@@ -16,7 +16,7 @@ package unit_test
 //
 //	TestCtEventsDemoRightColumnCheckers — G1/G2/G3: demo checker results are
 //	  consistent: IDs with Count>0 must be in demo fixtures; Count=-1+FetchFilter
-//	  must route to KindFilteredList or KindEnterChildView; Root events must
+//	  must route to NavigationKindFilteredList or NavigationKindEnterChildView; Root events must
 //	  return Count=0 for the role checker.
 
 import (
@@ -373,7 +373,7 @@ func isAWSServiceFixture(res resource.Resource) bool {
 //
 //	G1: Count>0 IDs must each exist in the fake resource cache for TargetType.
 //	G2 (Bug C): Count=-1 + non-empty FetchFilter must route via ResolveRelatedNavigate
-//	    to KindFilteredList or KindEnterChildView.
+//	    to NavigationKindFilteredList or NavigationKindEnterChildView.
 //	G3 (Bug A): Root-identity events must return Count=0 for the role checker.
 func TestCtEventsDemoRightColumnCheckers(t *testing.T) {
 	ensureNoColor(t)
@@ -430,7 +430,7 @@ func TestCtEventsDemoRightColumnCheckers(t *testing.T) {
 				}
 
 				// G2 (Bug C): Count=-1 + non-empty FetchFilter must route to
-				// KindFilteredList or KindEnterChildView.
+				// NavigationKindFilteredList or NavigationKindEnterChildView.
 				if result.Count == -1 && len(result.FetchFilter) > 0 {
 					navMsg := runtime.RelatedNavigateEvent{
 						TargetType:  result.TargetType,
@@ -441,7 +441,7 @@ func TestCtEventsDemoRightColumnCheckers(t *testing.T) {
 					case runtime.NavigationKindFilteredList, runtime.NavigationKindEnterChildView:
 						// G2 OK
 					default:
-						t.Errorf("G2 (Bug C) FAIL: Count=-1+FetchFilter routed to %v, want KindFilteredList or KindEnterChildView — %s",
+						t.Errorf("G2 (Bug C) FAIL: Count=-1+FetchFilter routed to %v, want NavigationKindFilteredList or NavigationKindEnterChildView — %s",
 							navResult.Kind, rowLabel)
 					}
 				}

--- a/tests/unit/related_navigate_cache_enter_child_test.go
+++ b/tests/unit/related_navigate_cache_enter_child_test.go
@@ -7,9 +7,10 @@ package unit
 // EXACTLY what pressing Enter would do in the target type's list view —
 // if the type registers Children[Key="enter"], drill INTO the child view;
 // otherwise open the generic detail view. The slow path (cache miss →
-// KindFilteredList + autoOpenSingleDetail) has been doing this since
+// NavigationKindFilteredList + autoOpenSingleDetail) has been doing this since
 // commit e6dfbc9 via (ResourceListModel).enterChildFor. The fast path
-// (cache hit → KindDetail in navigation_resolve.go + app_related.go) was
+// (cache hit → NavigationKindDetail in internal/runtime/handlers_related.go +
+// app_related.go) was
 // never updated and silently stranded the operator on the generic detail
 // when the target cache was already populated.
 //
@@ -33,7 +34,7 @@ import (
 
 // setupS3ListWithCache primes the root model's resourceCache["s3"] so a
 // subsequent RelatedNavigateMsg with a matching RelatedID will take the
-// KindDetail cache-hit branch.
+// NavigationKindDetail cache-hit branch.
 func setupS3ListWithCache(t *testing.T) (tui.Model, []resource.Resource) {
 	t.Helper()
 
@@ -139,8 +140,8 @@ func TestRelatedNavigate_CacheHit_SingleRelatedID_S3_EntersChildView(t *testing.
 
 // ---------------------------------------------------------------------------
 // Pin: RelatedNavigateMsg with TargetID on s3 (cache hit) also enters child.
-// Covers the TargetID path of the KindDetail branch (navigation_resolve.go
-// line 93) in addition to the single-RelatedID path (line 102).
+// Covers the TargetID path of the NavigationKindDetail branch
+// (internal/runtime/handlers_related.go) in addition to the single-RelatedID path.
 // ---------------------------------------------------------------------------
 
 func TestRelatedNavigate_CacheHit_TargetID_S3_EntersChildView(t *testing.T) {


### PR DESCRIPTION
## Summary

AS-204 follow-up to AS-202 (collapse related-navigation resolver SSOT, Option 2). The substantive SSOT collapse work was already landed in 1d89d89 (AS-150 Stage 5 NEEDS CHANGES fix on this same parent branch). This PR finishes the comment-only sweep called out in the AS-204 spec — bare \`Kind*\` constants in \`//\` comments and references to the deleted \`internal/tui/navigation_resolve.go\` file.

## What changed

- Replace bare \`Kind(Detail|Flash|FilteredList|ResourceList|EnterChildView|Unknown)\` with \`NavigationKind\\1\` in 7 files (production \`internal/tui/app_related.go\` plus 6 test files).
- Replace stale \`navigation_resolve.go\` references with \`internal/runtime/handlers_related.go\` in \`tests/unit/related_navigate_cache_enter_child_test.go\`.

No code changes; comments only. The 7-rule navigation contract is untouched.

## Why this is comment-only

Per the AS-204 spec the rest of the work was:

1. \`internal/tui/navigation_resolve.go\` deleted ✓ — done in 1d89d89.
2. \`runtime.ResolveRelatedNavigate\` exported and the only resolver ✓ — done in 1d89d89.
3. \`runtime.HandleRelatedNavigate\` uses the exported name internally ✓ — done in 1d89d89.
4. \`tests/unit/{resolve_related_navigate,app_related_child_navigate,ctevent_demo_invariants}_test.go\` migrated to \`runtime.NavigationResult\` / \`runtime.NavigationKind*\` / \`runtime.ResolveRelatedNavigate\` ✓ — done in 1d89d89.
5. 7-rule contract unchanged ✓ — verified by green tests.

The spec's optional \`tests/unit/runtime_navigate_helpers_test.go\` helper (\`navEventFromMsg(messages.RelatedNavigateMsg) → runtime.RelatedNavigateEvent\`) is intentionally not added: AS-150 took the simpler path of authoring test inputs directly as \`runtime.RelatedNavigateEvent\`, the field set is identical, and a translation helper would be a no-op rename. Open to adding it as a follow-up if reviewers prefer the message-shape input style.

## Verification

\`\`\`text
go build ./...                — clean
go vet ./...                  — clean
go test ./tests/unit/         — ok 9.5s
go test ./tests/integration/  — ok
go test ./internal/...        — ok
git grep -nE 'tui\\.(ResolveRelatedNavigate|NavigationResult|Kind(Unknown|ResourceList|FilteredList|Detail|EnterChildView|Flash))' -- '*.go'
                              — no matches
git grep -n 'navigation_resolve' -- '*.go'
                              — no matches
\`\`\`

\`make ready-to-push\` was not run end-to-end: \`golangci-lint\` v2.12.2 in this env was built against go1.25 and refuses to load on the repo's go1.26 toolchain (\"the Go language version (go1.25) used to build golangci-lint is lower than the targeted Go version (1.26.3)\"); CGO is unavailable so \`-race\` tests cannot run. Reviewers running on a host with a matched toolchain should expect the gate to pass — the change is comment-only.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./tests/unit/\` green
- [x] \`go test ./tests/integration/\` green
- [x] \`go test ./internal/...\` green
- [x] No live \`tui.ResolveRelatedNavigate\` / \`tui.NavigationResult\` / \`tui.Kind*\` references remain
- [x] No \`navigation_resolve\` references remain in \`*.go\`

Links: AS-202, AS-204.