### PR TITLE
test(runtime): runtime-direct unit coverage for HandleRelatedNavigate + helpers (AS-201)

### DIFF
--- a/internal/runtime/handlers_related_test.go
+++ b/internal/runtime/handlers_related_test.go
@@ -266,3 +266,62 @@ func TestHandleRelatedNavigate_RelatedIDs_FullCoverage_NoTask(t *testing.T) {
 		t.Errorf("tasks = %v, want nil — full-coverage filtered list has no fetch", tasks)
 	}
 }
+
+// ─── AS-201 additions: edge cases not yet covered above ────────────────────
+
+// TestRelatedFetchTasks_MixedFullCoverage_Nil — coverage split across both
+// ResourceCache and LazyResourceCache, fully covered → no fetch. Pins that the
+// dedup-aware coverage calculation considers BOTH maps as a union before
+// emitting a fetch task.
+func TestRelatedFetchTasks_MixedFullCoverage_Nil(t *testing.T) {
+	s := newTestSession()
+	s.ResourceCache["ec2"] = &session.ResourceCacheEntry{
+		Resources: []resource.Resource{{ID: "i-1"}},
+	}
+	s.LazyResourceCache["ec2"] = []resource.Resource{{ID: "i-2"}}
+
+	got := relatedFetchTasks(s, "ec2", []string{"i-1", "i-2"})
+	if got != nil {
+		t.Errorf("got %+v, want nil — full mixed coverage should not request a fetch", got)
+	}
+}
+
+// TestRelatedFetchTasks_MissPaginationNil_FetchResources — miss with a
+// ResourceCache entry present but its Pagination is nil → KindFetchResources
+// (not KindFetchMore). Pins the precedence "no pagination info → start over"
+// vs. "pagination present and IsTruncated → continue".
+func TestRelatedFetchTasks_MissPaginationNil_FetchResources(t *testing.T) {
+	s := newTestSession()
+	s.ResourceCache["ec2"] = &session.ResourceCacheEntry{
+		Resources:  []resource.Resource{{ID: "i-1"}},
+		Pagination: nil,
+	}
+
+	got := relatedFetchTasks(s, "ec2", []string{"i-1", "i-missing"})
+	if len(got) != 1 {
+		t.Fatalf("len(tasks) = %d, want 1", len(got))
+	}
+	if got[0].Key.Kind != KindFetchResources {
+		t.Errorf("Kind = %q, want %q (Pagination==nil must fall back to full fetch)", got[0].Key.Kind, KindFetchResources)
+	}
+	if got[0].Key.Scope != "ec2" {
+		t.Errorf("Scope = %q, want %q", got[0].Key.Scope, "ec2")
+	}
+}
+
+// TestRelatedFetchTasks_MissNoResourceCache_LazyOnly_FetchResources — partial
+// miss where only LazyResourceCache has an entry (no ResourceCache entry at
+// all) → KindFetchResources. Pins that the lazy-only path correctly falls
+// through to a full-fetch request when coverage is incomplete.
+func TestRelatedFetchTasks_MissNoResourceCache_LazyOnly_FetchResources(t *testing.T) {
+	s := newTestSession()
+	s.LazyResourceCache["ec2"] = []resource.Resource{{ID: "i-1"}}
+
+	got := relatedFetchTasks(s, "ec2", []string{"i-1", "i-missing"})
+	if len(got) != 1 {
+		t.Fatalf("len(tasks) = %d, want 1", len(got))
+	}
+	if got[0].Key.Kind != KindFetchResources {
+		t.Errorf("Kind = %q, want %q", got[0].Key.Kind, KindFetchResources)
+	}
+}

--- a/tests/unit/runtime_handlers_related_test.go
+++ b/tests/unit/runtime_handlers_related_test.go
@@ -1,0 +1,304 @@
+// runtime_handlers_related_test.go — public-seam coverage for
+// (*runtime.Core).HandleRelatedNavigate after the AS-150 migration moved the
+// handler out of internal/tui into internal/runtime.
+//
+// Cases A–K mirror the Stage 2 scope on AS-201. The runtime seam is exactly
+// what AS-150 exposed — these tests stand up *runtime.Core directly through
+// runtime.New(session.New(), catalog.ResourceTypes) and assert the
+// NavigationResult + []TaskRequest pair returned for each branch.
+//
+// HARD CONSTRAINT (per AS-203 acceptance): this file MUST NOT import
+// charm.land/bubbletea/v2, lipgloss, or bubbles. The migration's whole point
+// was decoupling the handler from Bubble Tea; bringing the framework back in
+// here would defeat the test.
+package unit
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/k2m30/a9s/v3/internal/catalog"
+	"github.com/k2m30/a9s/v3/internal/domain"
+	"github.com/k2m30/a9s/v3/internal/resource"
+	"github.com/k2m30/a9s/v3/internal/runtime"
+	"github.com/k2m30/a9s/v3/internal/session"
+)
+
+// newRuntimeCore returns a fresh *runtime.Core bound to a clean session and
+// the static catalog. Test cases mutate the returned session's caches
+// directly to seed each branch.
+func newRuntimeCore(t *testing.T) (*runtime.Core, *session.Session) {
+	t.Helper()
+	s := session.New()
+	c := runtime.New(s, catalog.ResourceTypes)
+	return c, s
+}
+
+// Case A — unknown target type → Flash with FlashIsError true, no tasks.
+func TestHandleRelatedNavigate_UnknownType_Flash(t *testing.T) {
+	c, _ := newRuntimeCore(t)
+
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType: "definitely-not-a-real-type",
+	})
+
+	if result.Kind != runtime.NavigationKindFlash {
+		t.Errorf("Kind = %v, want NavigationKindFlash", result.Kind)
+	}
+	if !result.FlashIsError {
+		t.Error("FlashIsError = false, want true")
+	}
+	if len(tasks) != 0 {
+		t.Errorf("len(tasks) = %d, want 0", len(tasks))
+	}
+}
+
+// Case B — child type (e.g. "s3_objects") → EnterChildView, no tasks.
+//
+// Registers a transient child type for this test so the assertion does not
+// depend on internal/aws being imported (which would pull init() side effects
+// into tests/unit).
+func TestHandleRelatedNavigate_ChildType_EnterChildView(t *testing.T) {
+	const childShort = "test_child_type_handle_related_b"
+	resource.RegisterChildType(resource.ResourceTypeDef{
+		Name:      "Test Child",
+		ShortName: childShort,
+	})
+	t.Cleanup(func() { resource.UnregisterChildType(childShort) })
+
+	c, _ := newRuntimeCore(t)
+
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType: childShort,
+	})
+
+	if result.Kind != runtime.NavigationKindEnterChildView {
+		t.Errorf("Kind = %v, want NavigationKindEnterChildView", result.Kind)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("len(tasks) = %d, want 0", len(tasks))
+	}
+}
+
+// Case C — top-level cache hit via TargetID → Detail, no tasks.
+func TestHandleRelatedNavigate_TopLevelCacheHit_TargetID_Detail(t *testing.T) {
+	c, s := newRuntimeCore(t)
+	s.ResourceCache["ec2"] = &session.ResourceCacheEntry{
+		Resources: []resource.Resource{{ID: "i-1"}},
+	}
+
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType: "ec2",
+		TargetID:   "i-1",
+	})
+
+	if result.Kind != runtime.NavigationKindDetail {
+		t.Errorf("Kind = %v, want NavigationKindDetail", result.Kind)
+	}
+	if result.TargetID != "i-1" {
+		t.Errorf("TargetID = %q, want %q", result.TargetID, "i-1")
+	}
+	if len(tasks) != 0 {
+		t.Errorf("len(tasks) = %d, want 0", len(tasks))
+	}
+}
+
+// Case D — top-level cache hit via single RelatedIDs → Detail, no tasks.
+func TestHandleRelatedNavigate_TopLevelCacheHit_SingleRelatedID_Detail(t *testing.T) {
+	c, s := newRuntimeCore(t)
+	s.ResourceCache["ec2"] = &session.ResourceCacheEntry{
+		Resources: []resource.Resource{{ID: "i-1"}},
+	}
+
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType: "ec2",
+		RelatedIDs: []string{"i-1"},
+	})
+
+	if result.Kind != runtime.NavigationKindDetail {
+		t.Errorf("Kind = %v, want NavigationKindDetail", result.Kind)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("len(tasks) = %d, want 0", len(tasks))
+	}
+}
+
+// Case E — FetchFilter + registered filtered fetcher → FilteredList with
+// FetchFilter preserved and a single KindFetchFiltered task.
+//
+// Registers a no-op filtered paginated fetcher for the test type. t.Cleanup
+// unregisters it so test order does not matter.
+func TestHandleRelatedNavigate_FetchFilter_RegisteredFetcher_FilteredList(t *testing.T) {
+	resource.RegisterFilteredPaginated("ec2",
+		func(_ context.Context, _ any, _ map[string]string, _ string) (domain.FetchResult, error) {
+			return domain.FetchResult{}, nil
+		})
+	t.Cleanup(func() { resource.UnregisterFilteredPaginated("ec2") })
+
+	c, _ := newRuntimeCore(t)
+
+	filter := map[string]string{"vpc-id": "vpc-1"}
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType:  "ec2",
+		FetchFilter: filter,
+	})
+
+	if result.Kind != runtime.NavigationKindFilteredList {
+		t.Errorf("Kind = %v, want NavigationKindFilteredList", result.Kind)
+	}
+	if !reflect.DeepEqual(result.FetchFilter, filter) {
+		t.Errorf("FetchFilter = %v, want %v", result.FetchFilter, filter)
+	}
+	wantTasks := []runtime.TaskRequest{{
+		Key:   runtime.TaskKey{Kind: runtime.KindFetchFiltered, Scope: "ec2"},
+		Cache: runtime.CacheNone,
+	}}
+	if !reflect.DeepEqual(tasks, wantTasks) {
+		t.Errorf("tasks = %+v, want %+v", tasks, wantTasks)
+	}
+}
+
+// Case F — TargetID cache miss (no filtered fetcher, no cache entry) →
+// FilteredList with FilterText==TargetID and a single KindFetchResources task.
+func TestHandleRelatedNavigate_TargetIDCacheMiss_FilteredList(t *testing.T) {
+	c, _ := newRuntimeCore(t)
+
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType: "ec2",
+		TargetID:   "i-missing",
+	})
+
+	if result.Kind != runtime.NavigationKindFilteredList {
+		t.Errorf("Kind = %v, want NavigationKindFilteredList", result.Kind)
+	}
+	if result.FilterText != "i-missing" {
+		t.Errorf("FilterText = %q, want %q", result.FilterText, "i-missing")
+	}
+	if result.TargetID != "i-missing" {
+		t.Errorf("TargetID = %q, want %q", result.TargetID, "i-missing")
+	}
+	wantTasks := []runtime.TaskRequest{{
+		Key:   runtime.TaskKey{Kind: runtime.KindFetchResources, Scope: "ec2"},
+		Cache: runtime.CacheNone,
+	}}
+	if !reflect.DeepEqual(tasks, wantTasks) {
+		t.Errorf("tasks = %+v, want %+v", tasks, wantTasks)
+	}
+}
+
+// Case G — multiple RelatedIDs cache miss, no further pages → FilteredList
+// with RelatedIDs preserved and a single KindFetchResources task.
+func TestHandleRelatedNavigate_MultipleRelatedIDs_CacheMiss_FetchResources(t *testing.T) {
+	c, _ := newRuntimeCore(t)
+
+	relatedIDs := []string{"i-1", "i-2"}
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType: "ec2",
+		RelatedIDs: relatedIDs,
+	})
+
+	if result.Kind != runtime.NavigationKindFilteredList {
+		t.Errorf("Kind = %v, want NavigationKindFilteredList", result.Kind)
+	}
+	if !reflect.DeepEqual(result.RelatedIDs, relatedIDs) {
+		t.Errorf("RelatedIDs = %v, want %v", result.RelatedIDs, relatedIDs)
+	}
+	wantTasks := []runtime.TaskRequest{{
+		Key:   runtime.TaskKey{Kind: runtime.KindFetchResources, Scope: "ec2"},
+		Cache: runtime.CacheNone,
+	}}
+	if !reflect.DeepEqual(tasks, wantTasks) {
+		t.Errorf("tasks = %+v, want %+v", tasks, wantTasks)
+	}
+}
+
+// Case H — multiple RelatedIDs, partial coverage + truncated cache →
+// FilteredList with a single KindFetchMore task (continuation).
+func TestHandleRelatedNavigate_MultipleRelatedIDs_PartialCoverage_Truncated_FetchMore(t *testing.T) {
+	c, s := newRuntimeCore(t)
+	s.ResourceCache["ec2"] = &session.ResourceCacheEntry{
+		Resources:  []resource.Resource{{ID: "i-1"}},
+		Pagination: &domain.PaginationMeta{IsTruncated: true},
+	}
+
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType: "ec2",
+		RelatedIDs: []string{"i-1", "i-2"},
+	})
+
+	if result.Kind != runtime.NavigationKindFilteredList {
+		t.Errorf("Kind = %v, want NavigationKindFilteredList", result.Kind)
+	}
+	wantTasks := []runtime.TaskRequest{{
+		Key:   runtime.TaskKey{Kind: runtime.KindFetchMore, Scope: "ec2"},
+		Cache: runtime.CacheNone,
+	}}
+	if !reflect.DeepEqual(tasks, wantTasks) {
+		t.Errorf("tasks = %+v, want %+v", tasks, wantTasks)
+	}
+}
+
+// Case I — multiple RelatedIDs fully covered by ResourceCache → FilteredList
+// with no fetch task.
+func TestHandleRelatedNavigate_MultipleRelatedIDs_FullyCached_NoFetch(t *testing.T) {
+	c, s := newRuntimeCore(t)
+	s.ResourceCache["ec2"] = &session.ResourceCacheEntry{
+		Resources: []resource.Resource{{ID: "i-1"}, {ID: "i-2"}},
+	}
+
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType: "ec2",
+		RelatedIDs: []string{"i-1", "i-2"},
+	})
+
+	if result.Kind != runtime.NavigationKindFilteredList {
+		t.Errorf("Kind = %v, want NavigationKindFilteredList", result.Kind)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("len(tasks) = %d, want 0", len(tasks))
+	}
+}
+
+// Case J — no IDs, no filter, no targetID → ResourceList with a single
+// KindFetchResources task.
+func TestHandleRelatedNavigate_NoIDsNoFilter_ResourceList(t *testing.T) {
+	c, _ := newRuntimeCore(t)
+
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType: "ec2",
+	})
+
+	if result.Kind != runtime.NavigationKindResourceList {
+		t.Errorf("Kind = %v, want NavigationKindResourceList", result.Kind)
+	}
+	wantTasks := []runtime.TaskRequest{{
+		Key:   runtime.TaskKey{Kind: runtime.KindFetchResources, Scope: "ec2"},
+		Cache: runtime.CacheNone,
+	}}
+	if !reflect.DeepEqual(tasks, wantTasks) {
+		t.Errorf("tasks = %+v, want %+v", tasks, wantTasks)
+	}
+}
+
+// Case K — pure-lazy passthrough for Detail: TargetID hit lives only in
+// LazyResourceCache; ResourceCache has no entry for the type.
+//
+// This proves relatedCacheSnapshot includes LazyResourceCache when resolving
+// the TargetID Detail branch.
+func TestHandleRelatedNavigate_PureLazyCacheHit_Detail(t *testing.T) {
+	c, s := newRuntimeCore(t)
+	s.LazyResourceCache["ec2"] = []resource.Resource{{ID: "i-1"}}
+
+	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
+		TargetType: "ec2",
+		TargetID:   "i-1",
+	})
+
+	if result.Kind != runtime.NavigationKindDetail {
+		t.Errorf("Kind = %v, want NavigationKindDetail", result.Kind)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("len(tasks) = %d, want 0", len(tasks))
+	}
+}


### PR DESCRIPTION
## Summary

Runtime-direct unit coverage for `(*runtime.Core).HandleRelatedNavigate` and its unexported helpers, complementing the test layer PR #345 landed when AS-150 was merged. Pure-additive: zero production-code changes, three new helper tests in the same package plus an external public-seam test file.

**Replaces auto-closed PR #347** (closed by `base_ref_deleted` when its stacked base `phase-05-pr-05a-h-handlers_related` was deleted post-merge of PR #345 / AS-150). Per CTO note on AS-246, this fresh PR targets `main` directly.

## What changed vs. PR #347

PR #345 went through two rounds of NEEDS CHANGES rework before merging, and its final form already includes substantial coverage of `relatedFetchTasks`, `relatedCacheSnapshot`, and `HandleRelatedNavigate` in `internal/runtime/handlers_related_test.go`. To avoid duplicate tests, this PR keeps only:

1. **Three new `relatedFetchTasks` edge cases** (appended to the existing `internal/runtime/handlers_related_test.go`):
   - `TestRelatedFetchTasks_MixedFullCoverage_Nil` — coverage split across both `ResourceCache` and `LazyResourceCache`, fully covered. Pins that the dedup-aware union of both maps is considered before emitting a task.
   - `TestRelatedFetchTasks_MissPaginationNil_FetchResources` — miss with cache entry present but `Pagination == nil` → `KindFetchResources` (distinct from `Pagination{IsTruncated:false}` already covered by `TestRelatedFetchTasks_PartialCoverage_NotTruncated_FetchAll`).
   - `TestRelatedFetchTasks_MissNoResourceCache_LazyOnly_FetchResources` — partial miss with only `LazyResourceCache` populated (no `ResourceCache` entry at all) → `KindFetchResources`.

2. **New `tests/unit/runtime_handlers_related_test.go` — public-seam coverage** (Cases A–K, 11 tests). This is the file's main value: it stands up `*runtime.Core` from `tests/unit` (external package) and proves that the AS-150 migration left a clean seam — i.e. the post-migration handler can be exercised without importing `charm.land/bubbletea/v2`, `lipgloss`, or `bubbles`.

The duplicate `relatedCacheSnapshot_*`, `relatedFetchTasks_*`, and `resolveRelatedNavigate_*` cases from the original PR #347 are **dropped**: they would have duplicated existing tests on `main` (`TestRelatedCacheSnapshot_MergePrecedence`, `TestRelatedCacheSnapshot_LazyOnly`, `TestRelatedFetchTasks_FullCoverage_NoTask`, `TestRelatedFetchTasks_LazyFullCoverage_NoTask`, `TestRelatedFetchTasks_PartialCoverage_TruncatedCache_FetchMore`, `TestRelatedFetchTasks_FullMiss_FetchAll`, `TestRelatedFetchTasks_PartialCoverage_NotTruncated_FetchAll`, and the comprehensive table-driven `TestResolveRelatedNavigate` in `tests/unit/resolve_related_navigate_test.go`).

## Tests / Verification

- `go build ./...` — clean.
- `go vet ./internal/runtime/... ./tests/unit/...` — clean.
- `go test ./internal/runtime/ ./tests/unit/ -count=1 -timeout 240s` — both packages PASS (full suite, not just the new tests).
- `go test ./internal/runtime/ ./tests/unit/ -run 'HandleRelatedNavigate|RelatedFetchTasks|RelatedCacheSnapshot|ResolveRelatedNavigate' -count=1 -timeout 240s` — targeted runs PASS.
- `grep -nE '^\s+"(charm.land/bubbletea|github.com/charmbracelet/lipgloss|github.com/charmbracelet/bubbles)' tests/unit/runtime_handlers_related_test.go internal/runtime/handlers_related_test.go` — **zero hits** (the AS-201 acceptance invariant).
- `golangci-lint` could not run locally (host's binary built against Go 1.25; module targets 1.26). Will rely on CI Lint lane.

## Stage 5 history (carries over from PR #347)

Original PR #347 received NEEDS CHANGES from all 3 Stage 5 reviewers (Architect AS-224, CodexReviewer, CodeReviewer AS-222). The unanimous blocking item was procedural: *"after PR #345 lands on `main`, re-target this PR's base to `main`."* The substantive review of the test code itself was positive — Architect explicitly noted *"The substantive review above does not need to be redone — only re-confirm head SHA and CI state per AS-124 retro."*

## Closes / Refs

- Replaces PR #347 (closed by `base_ref_deleted`)
- Tracks AS-201 (test scope), AS-246 (rework + retarget)
- Implements AS-203 dispatch acceptance criteria
