### PR TITLE
refactor(runtime): collapse related-navigation resolver SSOT (AS-202)

### DIFF
--- a/internal/runtime/related.go
+++ b/internal/runtime/related.go
@@ -72,7 +72,7 @@ func BuildChildContextForResource(child resource.ChildViewDef, r resource.Resour
 		case source == "Name":
 			ctx[param] = r.Name
 		case strings.HasPrefix(source, "@parent."):
-			// no parent stack in related-navigation KindDetail entry
+			// no parent stack in related-navigation NavigationKindDetail entry
 		default:
 			ctx[param] = r.Fields[source]
 		}

--- a/tests/integration/full_integration_helpers_test.go
+++ b/tests/integration/full_integration_helpers_test.go
@@ -325,7 +325,7 @@ func fullIntegrationEnterRelatedSingleDetail(t *testing.T, m *tui.Model, targetT
 		t.Fatalf("related %q navigation returned nil cmd; expected fetch+auto-open detail", displayName)
 	}
 
-	// Fast path: related-panel KindDetail (cache hit) pushes the detail view
+	// Fast path: related-panel NavigationKindDetail (cache hit) pushes the detail view
 	// directly and emits RelatedCheckStartedMsg without going through
 	// ResourcesLoadedMsg / NavigateMsg. Detect by scanning for that message
 	// in the returned cmd.

--- a/tests/integration/scenario_related_drill_through_test.go
+++ b/tests/integration/scenario_related_drill_through_test.go
@@ -294,7 +294,7 @@ func TestScenario_RelatedDrillThrough_All(t *testing.T) {
 //   2) Navigation integration. The direct-checker test verifies ID-format
 //      parity with the target fetcher, but does NOT exercise the actual
 //      TUI navigation — ResolveRelatedNavigate, handleRelatedNavigate,
-//      KindDetail fast path, EnterChildViewMsg dispatch, or the child-view
+//      NavigationKindDetail fast path, EnterChildViewMsg dispatch, or the child-view
 //      fetcher's ParentContext handling.
 //
 // To avoid the async race that made earlier TUI-driven tests flaky (related

--- a/tests/integration/scripted_scenario_helpers_test.go
+++ b/tests/integration/scripted_scenario_helpers_test.go
@@ -1015,7 +1015,7 @@ func (s *fullIntegrationScenario) DrillRelated(displayName string) []resource.Re
 	}
 
 	// Case 4: detail-view pushed without a NavigateMsg.
-	// handleRelatedNavigate's KindDetail + cache-hit branch pushes a detail view
+	// handleRelatedNavigate's NavigationKindDetail + cache-hit branch pushes a detail view
 	// and returns nil Cmd — no NavigateMsg is emitted, so currentResource stays
 	// pointed at the parent. Detect the push via the rendered frame title:
 	// "detail -- <id>" or "detail -- <id> (<name>)".

--- a/tests/unit/app_fetchers_dispatchers_test.go
+++ b/tests/unit/app_fetchers_dispatchers_test.go
@@ -51,7 +51,7 @@ import (
 //
 // ct-events is the only type with a registered FilteredPaginatedFetcher.
 // RelatedNavigateMsg{TargetType:"ct-events", FetchFilter:{...}} routes through
-// handleRelatedNavigate → KindFilteredList + FetchFilter branch →
+// handleRelatedNavigate → NavigationKindFilteredList + FetchFilter branch →
 // m.fetchResourcesFiltered("ct-events", filter).
 func TestFetchResourcesFiltered_NilClients_ViaRelatedNavigate(t *testing.T) {
 	withTuiVersion(t, "test")

--- a/tests/unit/app_fetchers_wave5_test.go
+++ b/tests/unit/app_fetchers_wave5_test.go
@@ -286,7 +286,7 @@ func TestFetchResourcesFiltered_NoFetcherWithDemoClients(t *testing.T) {
 
 	// Navigate to EC2 list, then send RelatedNavigateMsg with FetchFilter for
 	// a type with no filtered fetcher. Because this goes through handleRelatedNavigate
-	// which calls m.fetchResourcesFiltered directly for KindFilteredList results,
+	// which calls m.fetchResourcesFiltered directly for NavigationKindFilteredList results,
 	// we need to trigger that path. The easiest approach: register a typed resource
 	// and send a LoadMoreMsg with FetchFilter using demo clients.
 	// Use an arbitrary short name with no fetchers registered.

--- a/tests/unit/ctevent_demo_invariants_test.go
+++ b/tests/unit/ctevent_demo_invariants_test.go
@@ -16,7 +16,7 @@ package unit_test
 //
 //	TestCtEventsDemoRightColumnCheckers — G1/G2/G3: demo checker results are
 //	  consistent: IDs with Count>0 must be in demo fixtures; Count=-1+FetchFilter
-//	  must route to KindFilteredList or KindEnterChildView; Root events must
+//	  must route to NavigationKindFilteredList or NavigationKindEnterChildView; Root events must
 //	  return Count=0 for the role checker.
 
 import (
@@ -373,7 +373,7 @@ func isAWSServiceFixture(res resource.Resource) bool {
 //
 //	G1: Count>0 IDs must each exist in the fake resource cache for TargetType.
 //	G2 (Bug C): Count=-1 + non-empty FetchFilter must route via ResolveRelatedNavigate
-//	    to KindFilteredList or KindEnterChildView.
+//	    to NavigationKindFilteredList or NavigationKindEnterChildView.
 //	G3 (Bug A): Root-identity events must return Count=0 for the role checker.
 func TestCtEventsDemoRightColumnCheckers(t *testing.T) {
 	ensureNoColor(t)
@@ -430,7 +430,7 @@ func TestCtEventsDemoRightColumnCheckers(t *testing.T) {
 				}
 
 				// G2 (Bug C): Count=-1 + non-empty FetchFilter must route to
-				// KindFilteredList or KindEnterChildView.
+				// NavigationKindFilteredList or NavigationKindEnterChildView.
 				if result.Count == -1 && len(result.FetchFilter) > 0 {
 					navMsg := runtime.RelatedNavigateEvent{
 						TargetType:  result.TargetType,
@@ -441,7 +441,7 @@ func TestCtEventsDemoRightColumnCheckers(t *testing.T) {
 					case runtime.NavigationKindFilteredList, runtime.NavigationKindEnterChildView:
 						// G2 OK
 					default:
-						t.Errorf("G2 (Bug C) FAIL: Count=-1+FetchFilter routed to %v, want KindFilteredList or KindEnterChildView — %s",
+						t.Errorf("G2 (Bug C) FAIL: Count=-1+FetchFilter routed to %v, want NavigationKindFilteredList or NavigationKindEnterChildView — %s",
 							navResult.Kind, rowLabel)
 					}
 				}

--- a/tests/unit/related_navigate_cache_enter_child_test.go
+++ b/tests/unit/related_navigate_cache_enter_child_test.go
@@ -7,10 +7,10 @@ package unit
 // EXACTLY what pressing Enter would do in the target type's list view —
 // if the type registers Children[Key="enter"], drill INTO the child view;
 // otherwise open the generic detail view. The slow path (cache miss →
-// KindFilteredList + autoOpenSingleDetail) has been doing this since
+// NavigationKindFilteredList + autoOpenSingleDetail) has been doing this since
 // commit e6dfbc9 via (ResourceListModel).enterChildFor. The fast path
-// (cache hit → KindDetail in navigation_resolve.go + app_related.go) was
-// never updated and silently stranded the operator on the generic detail
+// (cache hit → NavigationKindDetail in internal/runtime/handlers_related.go)
+// was never updated and silently stranded the operator on the generic detail
 // when the target cache was already populated.
 //
 // This test pins the fast-path fix using s3 (Children[Key="enter"] →
@@ -33,7 +33,7 @@ import (
 
 // setupS3ListWithCache primes the root model's resourceCache["s3"] so a
 // subsequent RelatedNavigateMsg with a matching RelatedID will take the
-// KindDetail cache-hit branch.
+// NavigationKindDetail cache-hit branch.
 func setupS3ListWithCache(t *testing.T) (tui.Model, []resource.Resource) {
 	t.Helper()
 
@@ -139,8 +139,8 @@ func TestRelatedNavigate_CacheHit_SingleRelatedID_S3_EntersChildView(t *testing.
 
 // ---------------------------------------------------------------------------
 // Pin: RelatedNavigateMsg with TargetID on s3 (cache hit) also enters child.
-// Covers the TargetID path of the KindDetail branch (navigation_resolve.go
-// line 93) in addition to the single-RelatedID path (line 102).
+// Covers the TargetID path of the NavigationKindDetail branch
+// (internal/runtime/handlers_related.go) in addition to the single-RelatedID path.
 // ---------------------------------------------------------------------------
 
 func TestRelatedNavigate_CacheHit_TargetID_S3_EntersChildView(t *testing.T) {


### PR DESCRIPTION
## Summary

Recreated PR for AS-202 / AS-204 against `main` after the original [PR #350](https://github.com/k2m30/a9s/pull/350) was auto-closed by `base_ref_deleted` (the stacked base `phase-05-pr-05a-h-handlers_related` was deleted when its grandparent [PR #345](https://github.com/k2m30/a9s/pull/345) merged).

The actual SSOT collapse work (delete `internal/tui/navigation_resolve.go`, make `runtime.ResolveRelatedNavigate` the only resolver) already landed via [#345](https://github.com/k2m30/a9s/pull/345) and [#349](https://github.com/k2m30/a9s/pull/349). What remained was the comment-only sweep enumerated in AS-204's "Comment-only updates" list — references to the deleted file and bare `Kind*` constants in `//`-comments.

This PR is **comment-only** (+16 / −16 across 8 files):
- Replace `Kind*` → `NavigationKind*` in 8 files (1 production: `internal/runtime/related.go`; 3 integration tests; 4 unit tests)
- Replace `navigation_resolve.go` → `internal/runtime/handlers_related.go` references in 1 unit test

Issue: AS-248 (Coder rework dispatch) — implements the AS-204 sweep against the merged main tree. AS-202 / AS-204 are the underlying refactor.

## Verification (Stage 6 gate evidence)

| Gate | Result | Notes |
|------|--------|-------|
| `go build ./...` | PASS | clean |
| `go vet ./...` | PASS | clean |
| `go test ./tests/unit/` | PASS | ok 9.4s |
| `go test ./tests/integration/` | PASS | ok |
| `go test ./internal/...` | PASS | ok |
| `golangci-lint run --new-from-rev=origin/main ./...` | PASS | 0 issues |
| `golangci-lint run ./...` | 2 baseline | both pre-existing on `main` (`internal/aws/cb_issue_enrichment.go:104` + `internal/tui/app_handlers.go:91`, modernize/slicesbackward) — not in this diff |
| `govulncheck ./...` | PASS | No vulnerabilities found |
| `make verify-readonly` | PASS | trivial — comment-only |
| `go test -race` | NOT RUN | sandbox env has no `gcc`; CGO unavailable. Will run in CI. |

Sweep verification:

```
git grep -nE '\bKind(Detail|Flash|FilteredList|ResourceList|EnterChildView|Unknown)\b' -- '*.go'
  — no matches
git grep -n 'navigation_resolve' -- '*.go'
  — no matches
```

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] Unit tests pass
- [x] Integration tests pass
- [x] `internal/...` tests pass
- [x] `golangci-lint --new-from-rev=origin/main` — 0 new issues
- [x] `govulncheck` — no vulnerabilities
- [ ] CI on main-targeted HEAD (race-enabled; runs on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)