### PR TITLE
docs(refactor): spec PR-05a-h2 — field migration + handler port (AS-315)

### DIFF
--- a/docs/refactor/05-pr-05a-h2.md
+++ b/docs/refactor/05-pr-05a-h2.md
@@ -1,0 +1,306 @@
+# PR-05a-h2 — Migrate `tui.Model` adapter fields to `session.Session`; port handler bodies to `runtime.Core`
+
+**Parent program**: AS-72 (Phase-05 PR-05a-extract). Predecessor: AS-147 / PR #353 (handler-file split + runtime/handlers.go stub). Spec contract: [`05-boundary.md`](./05-boundary.md) §"5a-extract".
+
+This document is the Stage 2 design output for AS-315. The work is split into two child PRs because the field migration alone exceeds 600 LOC churn and the combined diff would exceed the 1500-LOC sizing ceiling.
+
+## Why this work exists
+
+After AS-147 (PR #353) the original `internal/tui/app_handlers.go` was deleted and its handler bodies were redistributed across thematic sibling files in `internal/tui/`:
+
+| File | Handlers it now owns |
+|---|---|
+| `internal/tui/app_input.go` | `handleKeyMsg` (keyboard dispatcher; stays in tui per `05-boundary.md:222`) |
+| `internal/tui/app_flash.go` | `handleFlash`, `handleClearFlash`, `handleAPIError` |
+| `internal/tui/app_session.go` | `handleClientsReady`, `handleProfileSelected`, `handleRegionSelected`, `handleThemeSelected`, `handleProfilesLoaded` |
+| `internal/tui/app_screens.go` | `handleValueRevealed`, `handleEnterChildView` |
+
+Those handlers cannot move to `internal/runtime/` because they read/write fields that live on `tui.Model`, not on `session.Session`. Those fields are session-scoped state — they belong on `Session`. Moving them lets the handler bodies port cleanly without forcing the runtime to acquire a Bubble Tea-flavoured "connection state" surface.
+
+`internal/runtime/handlers.go` already exists on `main` as a **50-line documentation-only stub** created by AS-147. It carries the package doc explaining where the handler bodies went and what the next migration looks like, but it has no `(c *Core) Handle*` methods yet. The H3 PR (handler port) replaces that package doc with real Core methods.
+
+## Boundary invariant (unchanged)
+
+`internal/runtime/` MUST remain Bubble Tea-free.
+
+```bash
+go list -f '{{.Imports}}' github.com/k2m30/a9s/v3/internal/runtime | grep -E 'bubbletea|lipgloss|bubbles'
+# expected: zero hits
+```
+
+## PR-05a-h2 (AS-315a) — Field migration only
+
+**Scope**: mechanical move of 13 session-scoped fields from `tui.Model` to `session.Session`. No behaviour change. No new `Core` methods.
+
+### Fields moved
+
+From `internal/tui/app.go:69-114` to `internal/session/session.go`:
+
+| Field | Type | Owned-by reason |
+|---|---|---|
+| `profile` | `string` | session identity |
+| `region` | `string` | session identity |
+| `clients` | `*awsclient.ServiceClients` | session-scoped transport |
+| `identity` | `*awsclient.CallerIdentity` | session-scoped account ID |
+| `identityFetching` | `bool` | session-scoped fetch latch |
+| `connectGen` | `int` | session-scoped staleness counter |
+| `pendingRefresh` | `bool` | session-scoped reconnect flag |
+| `hasPrevState` | `bool` | session-scoped rollback latch |
+| `prevProfile` | `string` | session-scoped rollback target |
+| `prevRegion` | `string` | session-scoped rollback target |
+| `preSuppliedClients` | `*awsclient.ServiceClients` | session-scoped bootstrap channel |
+| `command` | `string` | session-scoped one-shot navigation flag |
+| `noCache` | `bool` | session-scoped policy |
+
+The remaining `tui.Model` fields (`width`, `height`, `appCtx`, `appCancel`, `stack`, `inputMode`, `cmdInput`, `flash`, `errorHistory`, `showErrorHint`, `tabPrefix`, `tabMatches`, `tabIndex`, `keys`, `viewConfig`, `configErr`, `activeTheme`, `headerCache`, `headerCacheKey`, `isDemo`) are UI-shell concerns and stay on `Model`.
+
+### Access pattern
+
+`Session` is already embedded as `*session.Session` in `tui.Model` (Phase 02). Field promotion means existing access sites (`m.profile`, `m.region`, …) continue to compile after the field is added to `Session` — provided the field name is exported and there's no shadowing. Two design choices:
+
+- **Option A — exported promoted fields.** Rename `profile` → `Profile` etc. on `Session`. All `m.profile` access sites change to `m.Profile`. Mechanical sed across `internal/tui/`. Field-level synchronization stays where it is today (single-threaded `Update` loop on `tui.Model`).
+- **Option B — keep lowercase, add accessors.** Add `Session.Profile() string` / `Session.SetProfile(string)` etc. Forces explicit get/set; verbose at every site; no real benefit because the `Session` is already mutated freely from the `Update`-loop goroutine.
+
+**Decision: Option A.** Matches the existing pattern (`Session.AvailabilityGen`, `Session.ResourceCache`, `Session.RelatedGen` are all exported promoted fields today). Exported is the established convention; switching to accessors here would be inconsistent with what the rest of `Session` does. The Coder must apply the rename across `internal/tui/` and `tests/unit/` in a single PR.
+
+### `Option` setter compatibility
+
+Existing constructors `WithProfile`, `WithRegion`, `WithIsDemo`, `WithNoCache`, `WithClients` set fields on `Model`. After migration they set fields on `m.Session`:
+
+```go
+func WithProfile(profile string) Option {
+    return func(m *Model) { m.Session.Profile = profile }
+}
+```
+
+`WithClients` sets `m.Session.PreSuppliedClients = clients`. (Or — at the Coder's discretion — keep these as a thin wrapper that mutates `Session`; the public option signature stays unchanged so call sites do not break.)
+
+### Files modified
+
+- `internal/session/session.go` — add 13 fields. Update `Session.Rotate()` to clear `identity`, `identityFetching`, `pendingRefresh`, `hasPrevState`, `prevProfile`, `prevRegion`, and bump `connectGen` (so stale `ClientsReadyMsg` from a pre-rotate connect attempt is rejected). Do **NOT** clear `profile`, `region`, `clients`, `preSuppliedClients`, `command`, `noCache` — those are set by the caller before/after rotation.
+- `internal/tui/app.go` — remove the 13 field declarations from `type Model struct` (lines 69-114). Update `Option` setters. Update accessors that read these fields (e.g. `View()` reads `m.profile`).
+- `internal/tui/app_flash.go`, `app_session.go`, `app_screens.go`, `app_input.go`, `app_handlers_navigate.go`, `app_enrich_fold.go`, `fetch_adapter.go`, `probe_adapter.go`, `runtime_adapter.go`, `runtime_adapter_related.go` — rename field accesses (`m.profile` → `m.Profile`, etc.). The original `app_handlers.go` no longer exists post-PR-353; the handler bodies referencing these fields now live across the four `app_*.go` files above.
+- `internal/tui/views/identity.go` — same rename if it touches these fields directly. (Verify with grep.)
+- `cmd/a9s/main.go` — verify no direct field access; the `Option` API is the only public surface.
+- `tests/unit/*.go` — about 20 files reference these fields directly. Coder must run `grep -l 'tui\.Model{[^}]*\(profile\|region\|clients\|connectGen\|noCache\)' tests/unit/` plus the m-receiver accessor scan, and update each one.
+
+### Acceptance (AS-315a)
+
+```bash
+# Fields removed from tui.Model:
+rg '^\s+(profile|region|clients|connectGen|pendingRefresh|hasPrevState|prevProfile|prevRegion|preSuppliedClients|command|noCache|identity|identityFetching)\s+\w' internal/tui/app.go
+# expected: zero hits
+
+# Fields present on session.Session:
+rg '\b(Profile|Region|Clients|ConnectGen|PendingRefresh|HasPrevState|PrevProfile|PrevRegion|PreSuppliedClients|Command|NoCache|Identity|IdentityFetching)\b' internal/session/session.go
+# expected: 13 hits (one struct field per row)
+
+# Boundary unchanged:
+go list -f '{{.Imports}}' github.com/k2m30/a9s/v3/internal/runtime | grep -E 'bubbletea|lipgloss|bubbles'
+# expected: zero hits
+
+# Build + tests + race + lint + security:
+make ready-to-push
+```
+
+### Sizing (AS-315a)
+
+L. Estimated 600–800 LOC churn. Strictly mechanical — no new logic.
+
+---
+
+## PR-05a-h3 (AS-315b) — UIIntent / TaskRequest additions + handler port
+
+**Depends on**: AS-315a merged.
+
+**Scope**: port the handler bodies that don't push views to `runtime.Core`. The four view-stack-pushing handlers (`handleProfilesLoaded`, `handleValueRevealed`, `handleEnterChildView`, `handleThemeSelected`) stay in `tui` until the screen-builder registry is wired in a successor PR — they need `PushScreen` / `PopScreen` adapter dispatch that does not yet exist concretely. Punching that adapter in here is a side quest larger than the migration itself.
+
+### Handlers ported (6)
+
+Each existing handler body in its current `internal/tui/app_*.go` file becomes a thin adapter that calls a new `(c *Core) Handle*` method in `internal/runtime/handlers.go`:
+
+| Handler | Current location (post-PR-353) | New Core method | New intents | New TaskRequests |
+|---|---|---|---|---|
+| `handleFlash(FlashMsg)` | `internal/tui/app_flash.go:25` | `HandleFlash(FlashEvent) ([]UIIntent, []TaskRequest)` | `FlashIntent` (exists), `AppendErrorHistoryIntent` | `FlashTickPayload` |
+| `handleClearFlash(ClearFlashMsg)` | `internal/tui/app_flash.go:38` | `HandleClearFlash(ClearFlashEvent)` | `ClearFlashIntent` (exists), `SetErrorHintIntent` | none |
+| `handleAPIError(APIErrorMsg)` | `internal/tui/app_flash.go:49` | `HandleAPIError(APIErrorEvent)` | `FlashIntent`, `ClearActiveListLoadingIntent`, `AppendErrorHistoryIntent` | `FlashTickPayload` |
+| `handleClientsReady(ClientsReadyMsg)` | `internal/tui/app_session.go:28` | `HandleClientsReady(ClientsReadyEvent)` | `FlashIntent` (rollback path), `RefreshActiveListIntent` (pending-refresh path) | `FetchIdentityPayload`, `LoadAvailCachePayload`, `DemoPrefetchCountsPayload`, `EmitNavigatePayload` (one-shot `-c` flag) |
+| `handleProfileSelected(ProfileSelectedMsg)` | `internal/tui/app_session.go:174` | `HandleProfileSelected(ProfileSelectedEvent)` | `MenuClearAvailabilityIntent`, `PopSelectorIntent`, `FlashIntent` | `ConnectPayload` |
+| `handleRegionSelected(RegionSelectedMsg)` | `internal/tui/app_session.go:201` | `HandleRegionSelected(RegionSelectedEvent)` | `MenuClearAvailabilityIntent`, `PopSelectorIntent`, `FlashIntent` | `ConnectPayload` |
+
+`handleClientsReady` is by far the most complex. Its body decides among rollback / pre-supplied-clients / type-asserted-clients paths, then conditionally fires identity, availability, demo prefetch, and pending-refresh commands. The Coder is free to introduce private helpers on `Core` to keep `HandleClientsReady` readable.
+
+### Handlers deferred (4)
+
+These stay in their current `internal/tui/app_*.go` files until the screen-builder registry lands, because each one constructs a view object via `views.New*` and pushes it onto `m.stack`. Forcing them across the boundary now requires either (a) wiring a full screen-builder registry as a side quest, or (b) inventing a closure-carrying intent that smuggles renderer types through the runtime — both outside the scope of AS-315.
+
+| Handler | Current location | Why deferred |
+|---|---|---|
+| `handleProfilesLoaded` | `internal/tui/app_session.go:279` | Calls `views.NewProfile(...)`, pushes a `*SelectorModel` |
+| `handleValueRevealed` | `internal/tui/app_screens.go:22` | Calls `views.NewReveal(...)`, pushes a `*RevealModel` |
+| `handleEnterChildView` | `internal/tui/app_screens.go:37` | Calls `views.NewChildResourceList(...)`, pushes a `*ResourceListModel` |
+| `handleThemeSelected` | `internal/tui/app_session.go:227` | Mutates `styles.ApplyTheme(...)` (renderer-side), iterates `m.stack` to invalidate `*ResourceListModel` style caches, pops the selector |
+
+A successor PR (PR-05a-h4) will tackle these together when the screen-builder registry is wired.
+
+### New UIIntent variants (in `internal/runtime/intent.go`)
+
+```go
+// SetErrorHintIntent toggles the persistent error-hint marker shown after a
+// flash error has expired.
+type SetErrorHintIntent struct{ Show bool }
+func (SetErrorHintIntent) isIntent() {}
+
+// AppendErrorHistoryIntent records an error-history entry on the adapter's
+// session-scoped error log.
+type AppendErrorHistoryIntent struct {
+    Time    time.Time
+    Message string
+}
+func (AppendErrorHistoryIntent) isIntent() {}
+
+// ClearActiveListLoadingIntent clears the loading badge on the active
+// resource-list view, if any. No-op when the active view is not a
+// ResourceListModel.
+type ClearActiveListLoadingIntent struct{}
+func (ClearActiveListLoadingIntent) isIntent() {}
+
+// MenuClearAvailabilityIntent asks the adapter to wipe per-resource-type
+// availability state from the main-menu view (so the next probe pass
+// repopulates it from scratch).
+type MenuClearAvailabilityIntent struct{}
+func (MenuClearAvailabilityIntent) isIntent() {}
+
+// PopSelectorIntent pops the topmost view if it is a SelectorModel.
+// No-op otherwise. Used by handlers that close a transient selector after
+// the user picks a value.
+type PopSelectorIntent struct{}
+func (PopSelectorIntent) isIntent() {}
+
+// RefreshActiveListIntent asks the adapter to refresh the active
+// resource-list view. No-op when the active view is not a ResourceListModel.
+type RefreshActiveListIntent struct{}
+func (RefreshActiveListIntent) isIntent() {}
+```
+
+### New TaskRequest payloads (in `internal/runtime/tasks.go`)
+
+```go
+const (
+    TaskKindConnect              TaskKind = "connect"
+    TaskKindFetchIdentity        TaskKind = "fetch-identity"
+    TaskKindLoadAvailCache       TaskKind = "load-avail-cache"
+    TaskKindDemoPrefetchCounts   TaskKind = "demo-prefetch-counts"
+    TaskKindFlashTick            TaskKind = "flash-tick"
+    TaskKindEmitNavigate         TaskKind = "emit-navigate"
+)
+
+type ConnectPayload struct {
+    Profile string
+    Region  string
+    Gen     int
+}
+func (ConnectPayload) isTaskPayload() {}
+
+type FetchIdentityPayload struct{}
+func (FetchIdentityPayload) isTaskPayload() {}
+
+type LoadAvailCachePayload struct{}
+func (LoadAvailCachePayload) isTaskPayload() {}
+
+type DemoPrefetchCountsPayload struct{}
+func (DemoPrefetchCountsPayload) isTaskPayload() {}
+
+type FlashTickPayload struct {
+    Gen      int
+    Duration time.Duration
+}
+func (FlashTickPayload) isTaskPayload() {}
+
+type EmitNavigatePayload struct {
+    Target       string // messages.NavigateTarget value as string; adapter re-types
+    ResourceType string
+}
+func (EmitNavigatePayload) isTaskPayload() {}
+```
+
+The adapter in `internal/tui/runtime_adapter.go` adds new cases to `applyIntent` (per intent variant) and to `runtimeTasksToCmd` (per payload variant). The closure builders for `connectAWS`, `fetchIdentity`, `loadAvailabilityCache`, `demoPrefetchCounts` already exist in `tui` — wrap them as `tea.Cmd` per the existing `enrichDetailCmd` pattern.
+
+### Rotate semantics (cross-cut from AS-315a)
+
+`Session.Rotate()` is currently called by `handleProfileSelected` and `handleRegionSelected` (`m.Rotate()` via field promotion). After the handler port, `(c *Core) HandleProfileSelected` calls `c.Session().Rotate()` directly. The Rotate behaviour itself is unchanged.
+
+### Files added
+
+- `internal/runtime/handlers_test.go` — Core-direct unit coverage for each ported handler. Pattern: construct `runtime.New(session.New(), nil)` (or a small fixture catalog), call `core.Handle*(event)`, assert returned `[]UIIntent` and `[]TaskRequest`.
+
+### Files modified
+
+- `internal/runtime/handlers.go` — **replace** the existing 50-line package-doc stub (created by AS-147) with six new `(c *Core) Handle*` methods. The package doc may be retained at the top of the file but the "honest disposition: those handler bodies remain in the TUI adapter" paragraph becomes obsolete and is removed in this PR.
+- `internal/runtime/orchestrator.go` — extend `HandleEvent` switch with the six new event types (or — more cleanly — keep the existing `HandleEnrichDetail`-style separate entrypoints, mirroring the existing pattern; the Coder picks the style).
+- `internal/runtime/intent.go` — add 6 new intent variants.
+- `internal/runtime/tasks.go` — add 6 new payload variants and TaskKind constants.
+- `internal/tui/app_flash.go` — `handleFlash`, `handleClearFlash`, `handleAPIError` shrink to thin adapters (≤10 LOC each) that build the runtime event, call the Core method, apply intents, return the task closure batch.
+- `internal/tui/app_session.go` — `handleClientsReady`, `handleProfileSelected`, `handleRegionSelected` shrink to thin adapters (≤12 LOC each — `handleClientsReady` is allowed slightly more for its private-helper dispatch).
+- `internal/tui/runtime_adapter.go` — extend `applyIntent` with 6 new cases; extend `runtimeTasksToCmd` with 6 new payload cases.
+- `internal/tui/app.go` — `Update` switch unchanged (event types still arrive as the existing `messages.*Msg` variants).
+
+### Acceptance (AS-315b)
+
+```bash
+# Six Core handler methods land in handlers.go (replacing the AS-147 stub):
+rg 'func \(c \*Core\) Handle' internal/runtime/handlers.go | wc -l
+# expected: 6
+
+# Boundary unchanged:
+go list -f '{{.Imports}}' github.com/k2m30/a9s/v3/internal/runtime | grep -E 'bubbletea|lipgloss|bubbles'
+# expected: zero hits
+
+# Six tui-side adapters shrunk to ≤12 LOC each. Each handler now lives in
+# its post-PR-353 file (app_flash.go for the three flash handlers,
+# app_session.go for the three session handlers):
+for h in handleFlash handleClearFlash handleAPIError; do
+  awk "/^func \\(m Model\\) ${h}\\(/,/^}/" internal/tui/app_flash.go | wc -l
+done
+for h in handleClientsReady handleProfileSelected handleRegionSelected; do
+  awk "/^func \\(m Model\\) ${h}\\(/,/^}/" internal/tui/app_session.go | wc -l
+done
+# expected: each ≤12 lines (10 body + signature + close brace);
+# handleClientsReady may run to ≤16 if it dispatches into ≥2 private (c *Core) helpers
+
+# Per-handler Core-direct unit tests exist:
+rg 'func Test.*Handle(Flash|ClearFlash|APIError|ClientsReady|ProfileSelected|RegionSelected)' internal/runtime/handlers_test.go | wc -l
+# expected: ≥6
+
+# make ready-to-push passes:
+make ready-to-push
+```
+
+### Sizing (AS-315b)
+
+L. Estimated 700–1000 LOC (300 new Core methods + 200 thin adapters + 100 intents/tasks + 300 tests). Under the 1500-LOC ceiling.
+
+---
+
+## Out of scope (both PRs)
+
+- The four view-stack-pushing handlers (`handleProfilesLoaded`, `handleValueRevealed`, `handleEnterChildView`, `handleThemeSelected`) — wait for the screen-builder registry. Track separately.
+- `handleKeyMsg` — explicitly stays in `tui` per `05-boundary.md:222`.
+- The `Cmd`/`Event` typed-message split — that is PR-05b proper, not PR-05a.
+- The `domain.Gen` collapse — that is PR-05a-gens, separately tracked.
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| Field rename ripples through tests in unexpected places | Coder runs `grep -rn 'm\.\(profile\|region\|...\)' tests/unit/ internal/tui/` before declaring the rename complete; the diff is auditable. |
+| `handleClientsReady` is too large to port cleanly | Coder splits into private Core helpers (`(c *Core) clientsReadySuccess`, `(c *Core) clientsReadyRollback`). Keep `HandleClientsReady` as the dispatch; helpers carry the branches. |
+| `Session.Rotate()` clearing more fields than before changes refresh behaviour | The new Rotate clears `identity`, `identityFetching`, `pendingRefresh`, `hasPrevState`, `prevProfile`, `prevRegion`. Today these are set by `handleProfileSelected` / `handleRegionSelected` after `m.Rotate()` was called — moving the clear into Rotate is the same end-state. Verify with `make test-race`. |
+| Tests construct `tui.Model{...}` literal with the migrated fields | Coder converts to `tui.New(...)` using `WithProfile`/`WithRegion`/`WithClients`. Catches at compile time. |
+| Spec drifts from `main` again before AS-315a/b ship | Both child PRs rebase on `main` immediately before they push for review; reviewers catch via `mergeStateStatus = BEHIND` in PR rollup. |
+
+## Cross-references
+
+- Spec contract: [`05-boundary.md`](./05-boundary.md) §"5a-extract"
+- Predecessor PR: #353 (AS-147) — split `app_handlers.go` and created `internal/runtime/handlers.go` stub
+- Sibling: [`05-pr-05a-h4-screen-registry`] — TBD; tackles the four view-stack handlers when the screen-builder registry lands.


### PR DESCRIPTION
## Stage 2 spec for AS-315 (Phase-05 PR-05a-h2 + h3)

Adds `docs/refactor/05-pr-05a-h2.md` — the design output for the field migration + handler port follow-up to PR #353 (AS-147).

**Docs-only.** No code touched. Rebased on current `main` after the rework round; the file in this PR is the only change against `origin/main`.

## What it specifies

- **AS-315a (PR-05a-h2)** — Mechanical migration of 13 session-scoped fields from `tui.Model` to `session.Session` with `Option`-setter rewrite. ~600-800 LOC churn. Child issue: AS-323 (Coder), AS-326 (QA).
- **AS-315b (PR-05a-h3)** — Port 6 of the 10 post-PR-353 handler bodies to `(c *Core) Handle*` methods on `internal/runtime/handlers.go` (replacing the existing 50-line package-doc stub from AS-147). Adds 6 new `UIIntent` variants + 6 new `TaskRequest` payloads. ~700-1000 LOC. Child issue: AS-324 (Coder, blocked on AS-323), AS-327 (QA).
- 4 view-stack handlers (`handleProfilesLoaded`, `handleValueRevealed`, `handleEnterChildView`, `handleThemeSelected`) explicitly deferred to a successor PR (`PR-05a-h4`) once the screen-builder registry is wired. `handleKeyMsg` explicitly stays in tui per `05-boundary.md:222`.

## Rework round (post-Stage-5 NEEDS CHANGES)

Both Stage 5 reviewers (CXR + CR) flagged that the original spec referenced `internal/tui/app_handlers.go` (deleted by PR #353) and claimed `internal/runtime/handlers.go` "does not exist today" (it does — PR #353 created the 50-line stub). The PR was also `BEHIND main` with a duplicated test commit (`870e4ee` shadowing PR #351's `0a8bc49`).

Fixes in this push:

- **Rebased on `main`.** Branch is now one commit on top of `origin/main`; the duplicated AS-201 test commit is gone (skipped as already-applied during rebase).
- **Refreshed file topology.** Every reference to `internal/tui/app_handlers.go` updated to the correct post-PR-353 file (`app_flash.go`, `app_session.go`, `app_input.go`, `app_screens.go`). Added a clear "Why this work exists" table at the top of the spec mapping each handler to its current file.
- **`internal/runtime/handlers.go` framed correctly.** "Files added" → only `handlers_test.go`. "Files modified" → `handlers.go` (replace stub with real Core methods). Reflects the AS-147 deliverable.
- **Tightened field line range** from `61-115` → `69-114` (verified against current `internal/tui/app.go`).
- **Fixed the acceptance loop** at the bottom of AS-315b: was `awk ... internal/tui/app_handlers.go | wc -l` against a non-existent file (silently passes). Now iterates the actual files: `app_flash.go` for the three flash handlers, `app_session.go` for the three session handlers. Allows `handleClientsReady` up to 16 LOC for private-helper dispatch.
- **Risk register addition**: spec drift mitigation — both child PRs rebase on main immediately before pushing.

## Coder/QA dispatch

Already split into 4 children with rejection-proof scope blocks:

| Issue | Half | Agent | Status |
|---|---|---|---|
| AS-323 | Field migration impl | Coder | `in_progress` (Coder claimed at 08:30Z; local branch `phase-05-pr-05a-h2-fields` already has the migration commit) |
| AS-326 | Field migration QA | QA | `todo` |
| AS-324 | Handler port impl | Coder | `blocked` on AS-323 merging |
| AS-327 | Handler port QA | QA | `todo` |

## Verification

```bash
# 1 file in this PR:
gh pr diff 354 --name-only
# expected: docs/refactor/05-pr-05a-h2.md (1 file)

# Not behind main:
gh pr view 354 --json mergeStateStatus
# expected: not BEHIND
```

— Architect rework round 1
