### PR TITLE
feat(phase-05-pr-05a-h2): migrate 13 session-scoped fields tui.Model → session.Session (AS-323)

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -45,6 +45,58 @@ type ResourceCacheEntry struct {
 // Session owns the in-memory orchestration state for the active
 // profile/region session.
 type Session struct {
+	// Session identity — set by the caller (tui.New / handler) before/after Rotate.
+	Profile string
+	Region  string
+
+	// Session-scoped AWS transport. Set by handleClientsReady; cleared
+	// explicitly by handlers, not by Rotate (the caller decides whether to
+	// reuse the still-valid old clients on a rotation that may fail).
+	Clients *awsclient.ServiceClients
+
+	// PreSuppliedClients is the bootstrap-channel transport supplied by tests
+	// or demo mode via WithClients. Lives across Rotate because it represents
+	// a static input, not a live session.
+	PreSuppliedClients *awsclient.ServiceClients
+
+	// Identity is the resolved caller identity (account ID, ARN, role). Set
+	// by handleIdentityLoaded; cleared by Rotate so a stale identity from the
+	// pre-rotate session cannot leak into the next.
+	Identity *awsclient.CallerIdentity
+
+	// IdentityFetching latches that an identity fetch is in flight, so the
+	// header can show a spinner. Cleared by Rotate.
+	IdentityFetching bool
+
+	// ConnectGen is the staleness counter for AWS connect attempts. Bumped on
+	// every profile/region switch so a slow pre-switch ClientsReadyMsg arriving
+	// after the user has switched again is rejected by the gen guard.
+	// Rotate() bumps this; handlers MUST NOT bump it manually.
+	ConnectGen int
+
+	// PendingRefresh marks that a successful ClientsReady should re-fetch the
+	// active resource list (set by profile/region switch handlers). Cleared by
+	// Rotate; re-set to true after Rotate in the switch handlers.
+	PendingRefresh bool
+
+	// Rollback target for an in-flight profile/region switch. Captured BEFORE
+	// Rotate (via local vars) so the rapid A→B→C case keeps A as the rollback
+	// target. Cleared by Rotate; restored explicitly by the switch handler.
+	HasPrevState bool
+	PrevProfile  string
+	PrevRegion   string
+
+	// Command is the one-shot resource short name to navigate to on the first
+	// ClientsReadyMsg (from the -c CLI flag). Cleared by the handler after use;
+	// not cleared by Rotate (a profile switch should not lose the flag if the
+	// initial connect failed and rolled back).
+	Command string
+
+	// NoCache disables on-disk availability caching and background probes
+	// (set by the --no-cache / --demo CLI flags). Survives Rotate — it is a
+	// static policy, not session state.
+	NoCache bool
+
 	// Wave 1 availability scan.
 	AvailabilityGen int      // bumped on profile/region switch to cancel stale probes
 	AvailQueue      []string // resource short names remaining to probe
@@ -52,12 +104,12 @@ type Session struct {
 	AvailTotal      int      // total types to probe in current gen
 
 	// Wave 2 issue-enrichment dispatch.
-	ProbeResources  map[string][]resource.Resource // retained first-page resources from Wave 1
-	ProbeTruncated  map[string]bool                // per-type truncation signal from Wave 1 probe
-	EnrichQueue     []string                       // resource types pending Wave 2 enrichment
-	EnrichmentGen   int                            // session-wide gen counter for Wave 2
-	EnrichChecked   int                            // number of enrichment probes completed in current gen
-	EnrichTotal     int                            // total enrichment probes to run in current gen
+	ProbeResources map[string][]resource.Resource // retained first-page resources from Wave 1
+	ProbeTruncated map[string]bool                // per-type truncation signal from Wave 1 probe
+	EnrichQueue    []string                       // resource types pending Wave 2 enrichment
+	EnrichmentGen  int                            // session-wide gen counter for Wave 2
+	EnrichChecked  int                            // number of enrichment probes completed in current gen
+	EnrichTotal    int                            // total enrichment probes to run in current gen
 
 	// Per-type Wave 2 finding state (feature 018-enrichment-visibility).
 	// NOTE: EnrichmentFindings was moved to tui.Model in PR-03a-fold so that
@@ -91,13 +143,16 @@ type Session struct {
 	// every ClientsReadyMsg so FetchIAMPoliciesByIDsFull uses the session store.
 	IAMPolicies PolicyStore
 
-	// Identity is the per-session cache for the AWS caller's account ID.
-	// Replaces the package-level globals previously in
-	// internal/aws/identity_cache.go (identityCacheMu / cachedAccountID /
-	// cachedAccountErr). Wired into *ServiceClients.IdentityStore on every
-	// ClientsReadyMsg so Pattern-C related checkers (Glue tags, EBS Backup)
-	// see a per-profile/region scoped cache rather than a process-global one.
-	Identity IdentityStore
+	// IdentityStore is the per-session cache for the AWS caller's account ID
+	// used by Pattern-C related checkers. Replaces the package-level globals
+	// previously in internal/aws/identity_cache.go (identityCacheMu /
+	// cachedAccountID / cachedAccountErr). Wired into *ServiceClients.
+	// IdentityStore on every ClientsReadyMsg so Pattern-C related checkers
+	// (Glue tags, EBS Backup) see a per-profile/region scoped cache rather
+	// than a process-global one. Distinct from Session.Identity (the resolved
+	// *awsclient.CallerIdentity) which holds the human-readable identity
+	// metadata for the header / IdentityModel.
+	IdentityStore IdentityStore
 
 	// RuleSets is the per-session, single-slot cache for the SES v1
 	// DescribeActiveReceiptRuleSet response. Replaces the package-level
@@ -126,7 +181,7 @@ func New() *Session {
 		EnrichmentGen:          1,
 		PolicyDocCache:         &awsclient.PolicyDocumentCache{},
 		IAMPolicies:            NewPolicyStore(),
-		Identity:               NewIdentityStore(),
+		IdentityStore:          NewIdentityStore(),
 		RuleSets:               NewRuleSetStore(),
 	}
 }
@@ -146,6 +201,20 @@ func (s *Session) Rotate() {
 	s.EnrichGen++
 	s.AvailabilityGen++
 	s.EnrichmentGen++
+	s.ConnectGen++
+
+	// Session-identity / rollback-latch / fetch-latch fields. Profile/Region/
+	// Clients/PreSuppliedClients/Command/NoCache are deliberately NOT cleared
+	// — the caller (handleProfileSelected / handleRegionSelected) is responsible
+	// for setting Profile/Region to the new target, and for capturing rollback
+	// state via local vars BEFORE Rotate (so the rapid A→B→C case keeps A as
+	// the rollback target).
+	s.Identity = nil
+	s.IdentityFetching = false
+	s.PendingRefresh = false
+	s.HasPrevState = false
+	s.PrevProfile = ""
+	s.PrevRegion = ""
 
 	s.EnrichQueue = nil
 	s.ProbeResources = nil
@@ -169,9 +238,9 @@ func (s *Session) Rotate() {
 	// prior account/profile cannot leak into the next session.
 	s.IAMPolicies = NewPolicyStore()
 
-	// Identity: reset to a fresh store so the cached account ID + sticky
+	// IdentityStore: reset to a fresh store so the cached account ID + sticky
 	// failure (if any) from the prior session cannot leak into the next.
-	s.Identity = NewIdentityStore()
+	s.IdentityStore = NewIdentityStore()
 
 	// RuleSets: reset to a fresh store so the cached SES rule set from the
 	// prior session cannot leak into the next.

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -3,6 +3,7 @@ package session_test
 import (
 	"testing"
 
+	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/session"
 )
@@ -173,6 +174,99 @@ func TestSession_Rotate_ResetsQueueState(t *testing.T) {
 	}
 	if s.ProbeTruncated != nil {
 		t.Errorf("ProbeTruncated after Rotate() = %v, want nil", s.ProbeTruncated)
+	}
+}
+
+// TestSession_Rotate_ConnectGenAndIdentityLatches pins the PR-05a-h2 contract
+// for the lifecycle fields that Rotate() OWNS: ConnectGen must increment by
+// exactly 1, and Identity / IdentityFetching / PendingRefresh / HasPrevState /
+// PrevProfile / PrevRegion must all be zeroed.
+//
+// Without this test a future regression that forgets to bump ConnectGen would
+// allow a pre-switch ClientsReadyMsg to be accepted as fresh after a profile
+// switch, and a regression that fails to clear Identity / IdentityFetching
+// would leak the previous account's caller identity into the new session.
+func TestSession_Rotate_ConnectGenAndIdentityLatches(t *testing.T) {
+	t.Parallel()
+
+	s := session.New()
+
+	// Seed the latches with non-zero values from a fictional pre-switch state.
+	s.ConnectGen = 5
+	s.Identity = &awsclient.CallerIdentity{AccountID: "111122223333"}
+	s.IdentityFetching = true
+	s.PendingRefresh = true
+	s.HasPrevState = true
+	s.PrevProfile = "old-profile"
+	s.PrevRegion = "us-east-1"
+
+	s.Rotate()
+
+	if s.ConnectGen != 6 {
+		t.Errorf("ConnectGen after Rotate() = %d, want 6", s.ConnectGen)
+	}
+	if s.Identity != nil {
+		t.Errorf("Identity after Rotate() = %+v, want nil — pre-switch identity must not leak", s.Identity)
+	}
+	if s.IdentityFetching {
+		t.Error("IdentityFetching after Rotate() = true, want false — in-flight latch must be cleared")
+	}
+	if s.PendingRefresh {
+		t.Error("PendingRefresh after Rotate() = true, want false")
+	}
+	if s.HasPrevState {
+		t.Error("HasPrevState after Rotate() = true, want false — rollback latch must be cleared so the caller can re-seed it")
+	}
+	if s.PrevProfile != "" {
+		t.Errorf("PrevProfile after Rotate() = %q, want \"\"", s.PrevProfile)
+	}
+	if s.PrevRegion != "" {
+		t.Errorf("PrevRegion after Rotate() = %q, want \"\"", s.PrevRegion)
+	}
+}
+
+// TestSession_Rotate_PreservesProfileRegionClientsCommandNoCache pins the
+// PR-05a-h2 preserve-list contract. Rotate() MUST NOT touch Profile, Region,
+// Clients, PreSuppliedClients, Command, or NoCache — the caller
+// (handleProfileSelected / handleRegionSelected / cmd/a9s/main.go bootstrap)
+// owns those fields and writes the next target into Profile/Region
+// immediately after Rotate. Clearing them inside Rotate would either drop the
+// just-written target or silently undo bootstrap state (e.g. demo --clients).
+func TestSession_Rotate_PreservesProfileRegionClientsCommandNoCache(t *testing.T) {
+	t.Parallel()
+
+	s := session.New()
+
+	// Seed the preserve-list. Use distinguishable values so a regression that
+	// zeros them is obvious in the test output.
+	preClients := &awsclient.ServiceClients{}
+	preSupplied := &awsclient.ServiceClients{}
+	s.Profile = "dev-account"
+	s.Region = "eu-central-1"
+	s.Clients = preClients
+	s.PreSuppliedClients = preSupplied
+	s.Command = "ec2"
+	s.NoCache = true
+
+	s.Rotate()
+
+	if s.Profile != "dev-account" {
+		t.Errorf("Profile after Rotate() = %q, want %q (preserve-list)", s.Profile, "dev-account")
+	}
+	if s.Region != "eu-central-1" {
+		t.Errorf("Region after Rotate() = %q, want %q (preserve-list)", s.Region, "eu-central-1")
+	}
+	if s.Clients != preClients {
+		t.Errorf("Clients after Rotate() = %p, want %p (preserve-list — caller swaps after reconnect)", s.Clients, preClients)
+	}
+	if s.PreSuppliedClients != preSupplied {
+		t.Errorf("PreSuppliedClients after Rotate() = %p, want %p (preserve-list — demo/test bootstrap channel)", s.PreSuppliedClients, preSupplied)
+	}
+	if s.Command != "ec2" {
+		t.Errorf("Command after Rotate() = %q, want %q (preserve-list — one-shot CLI -c flag)", s.Command, "ec2")
+	}
+	if !s.NoCache {
+		t.Error("NoCache after Rotate() = false, want true (preserve-list — CLI --no-cache flag)")
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -59,16 +59,12 @@ type errorEntry struct {
 // handleProfileSelected / handleRegionSelected call m.Rotate() to invalidate
 // in-flight async results on switch.
 type Model struct {
-	*session.Session // embedded: session-scoped orchestration state
+	*session.Session               // embedded: session-scoped orchestration state (incl. Profile, Region, Clients, Identity, ConnectGen, etc. after PR-05a-h2)
 	core             *runtime.Core // platform-agnostic app core (shares same *session.Session)
 
 	// --- UI shell state ---
 	width  int
 	height int
-
-	profile string
-	region  string
-	clients *awsclient.ServiceClients
 
 	appCtx    context.Context
 	appCancel context.CancelFunc
@@ -90,45 +86,32 @@ type Model struct {
 	tabMatches []string
 	tabIndex   int
 
-	keys           keys.Map
-	viewConfig     *config.ViewsConfig
-	pendingRefresh bool   // set after profile/region switch to refresh on ClientsReadyMsg
-	connectGen     int    // incremented on profile/region switch; stale ClientsReadyMsg ignored
-	hasPrevState   bool   // true while prevProfile/prevRegion hold the rollback target
-	prevProfile    string // last stable profile before any in-flight switch, restored on failure
-	prevRegion     string // last stable region before any in-flight switch, restored on failure
-	configErr      error  // non-nil if views config was found but corrupt
-	activeTheme    string // current theme filename (for selector "(current)" indicator)
-	command        string // initial resource short name to navigate to on first ClientsReadyMsg (from -c flag)
-
-	identity         *awsclient.CallerIdentity
-	identityFetching bool
+	keys        keys.Map
+	viewConfig  *config.ViewsConfig
+	configErr   error  // non-nil if views config was found but corrupt
+	activeTheme string // current theme filename (for selector "(current)" indicator)
 
 	// headerCache avoids re-computing the header string every render when
 	// profile, region, version, and right-side content haven't changed.
 	headerCache    string
 	headerCacheKey string
 
-	preSuppliedClients *awsclient.ServiceClients
-
-	noCache bool
-	isDemo  bool // true when running in --demo mode (synthetic clients); controls Wave 2 skip
+	isDemo bool // true when running in --demo mode (synthetic clients); controls Wave 2 skip
 }
-
 
 // Option configures the root Model.
 type Option func(*Model)
 
-// WithProfile overrides the profile field on the model. Used in tests that need
+// WithProfile overrides the profile field on the session. Used in tests that need
 // a specific profile string without going through the live AWS bootstrap path.
 func WithProfile(profile string) Option {
-	return func(m *Model) { m.profile = profile }
+	return func(m *Model) { m.Profile = profile }
 }
 
-// WithRegion overrides the region field on the model. Used in tests that need
+// WithRegion overrides the region field on the session. Used in tests that need
 // a specific region string without going through the live AWS bootstrap path.
 func WithRegion(region string) Option {
-	return func(m *Model) { m.region = region }
+	return func(m *Model) { m.Region = region }
 }
 
 // WithIsDemo marks the session as demo mode, which skips Wave 2 enrichment.
@@ -143,7 +126,7 @@ func WithIsDemo(demo bool) Option {
 // WithNoCache disables resource availability caching and background checks.
 func WithNoCache(disabled bool) Option {
 	return func(m *Model) {
-		m.noCache = disabled
+		m.NoCache = disabled
 	}
 }
 
@@ -151,7 +134,7 @@ func WithNoCache(disabled bool) Option {
 // synthetic ClientsReadyMsg instead of initiating a live AWS connection.
 func WithClients(clients *awsclient.ServiceClients) Option {
 	return func(m *Model) {
-		m.preSuppliedClients = clients
+		m.PreSuppliedClients = clients
 	}
 }
 
@@ -166,7 +149,7 @@ func WithActiveTheme(name string) Option {
 // directly on startup instead of the main menu. The caller is responsible for
 // resolving the input via resource.FindResourceType.
 func WithCommand(name string) Option {
-	return func(m *Model) { m.command = name }
+	return func(m *Model) { m.Command = name }
 }
 
 // New constructs the initial Model.
@@ -188,11 +171,11 @@ func New(profile, region string, opts ...Option) Model {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	sess := session.New()
+	sess.Profile = profile
+	sess.Region = region
 	m := Model{
 		Session:     sess,
 		core:        runtime.New(sess, resource.AllResourceTypes()),
-		profile:     profile,
-		region:      region,
 		keys:        k,
 		stack:       []views.View{&menu},
 		cmdInput:    ti,
@@ -259,9 +242,9 @@ func (m Model) ActiveListResources() []resource.Resource {
 // When pre-supplied clients are present (demo mode or tests), emits a synthetic
 // ClientsReadyMsg immediately. Otherwise initiates the live AWS connection flow.
 func (m Model) Init() tea.Cmd {
-	if m.preSuppliedClients != nil {
+	if m.PreSuppliedClients != nil {
 		preCmd := func() tea.Msg {
-			return messages.ClientsReadyMsg{Clients: m.preSuppliedClients}
+			return messages.ClientsReadyMsg{Clients: m.PreSuppliedClients}
 		}
 		if m.configErr != nil {
 			return tea.Batch(preCmd, func() tea.Msg {
@@ -275,8 +258,8 @@ func (m Model) Init() tea.Cmd {
 	}
 	connectCmd := func() tea.Msg {
 		return messages.InitConnectMsg{
-			Profile: m.profile,
-			Region:  m.region,
+			Profile: m.Profile,
+			Region:  m.Region,
 		}
 	}
 	if m.configErr != nil {
@@ -335,7 +318,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case messages.ClearFlashMsg:
 		return m.handleClearFlash(msg)
 	case messages.InitConnectMsg:
-		cmd := m.connectAWS(msg.Profile, msg.Region, m.connectGen)
+		cmd := m.connectAWS(msg.Profile, msg.Region, m.ConnectGen)
 		return m, cmd
 	case messages.ClientsReadyMsg:
 		return m.handleClientsReady(msg)
@@ -650,8 +633,8 @@ func (m Model) View() tea.View {
 
 	active := m.activeView()
 
-	headerProfile := m.profile
-	headerRegion := m.region
+	headerProfile := m.Profile
+	headerRegion := m.Region
 	if sel, ok := active.(*views.SelectorModel); ok {
 		if sel.Title() == "aws-regions" {
 			headerRegion = "..."
@@ -1012,35 +995,35 @@ func (m Model) headerRight() string {
 
 // accountBadge returns the account alias (preferred) or account ID for the header.
 func (m Model) accountBadge() string {
-	if m.identity == nil {
+	if m.Identity == nil {
 		return ""
 	}
-	if m.identity.AccountAlias != "" {
-		return m.identity.AccountAlias
+	if m.Identity.AccountAlias != "" {
+		return m.Identity.AccountAlias
 	}
-	return m.identity.AccountID
+	return m.Identity.AccountID
 }
 
 // identityRoleName returns the identity name (role or user) for the header.
 func (m Model) identityRoleName() string {
-	if m.identity == nil {
+	if m.Identity == nil {
 		return ""
 	}
-	return m.identity.IdentityName
+	return m.Identity.IdentityName
 }
 
 // identityToViewData converts the cached CallerIdentity to a view-layer IdentityData.
 func (m Model) identityToViewData() views.IdentityData {
-	if m.identity == nil {
+	if m.Identity == nil {
 		return views.IdentityData{}
 	}
 	return views.IdentityData{
-		AccountID:     m.identity.AccountID,
-		AccountAlias:  m.identity.AccountAlias,
-		ARN:           m.identity.Arn,
-		RoleName:      m.identity.RoleName,
-		UserName:      m.identity.UserName,
-		SessionName:   m.identity.SessionName,
-		IsAssumedRole: m.identity.IsAssumedRole,
+		AccountID:     m.Identity.AccountID,
+		AccountAlias:  m.Identity.AccountAlias,
+		ARN:           m.Identity.Arn,
+		RoleName:      m.Identity.RoleName,
+		UserName:      m.Identity.UserName,
+		SessionName:   m.Identity.SessionName,
+		IsAssumedRole: m.Identity.IsAssumedRole,
 	}
 }

--- a/internal/tui/app_input.go
+++ b/internal/tui/app_input.go
@@ -59,15 +59,15 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if _, ok := m.activeView().(*views.IdentityModel); ok {
 			return m.updateActiveView(msg)
 		}
-		id := views.NewIdentity(m.profile, m.region, m.keys)
-		if m.identity != nil {
+		id := views.NewIdentity(m.Profile, m.Region, m.keys)
+		if m.Identity != nil {
 			data := m.identityToViewData()
 			id.SetIdentity(data)
 		}
 		id.SetSize(m.innerSize())
 		m.pushView(&id)
 		// Always re-fetch on i press
-		m.identityFetching = true
+		m.IdentityFetching = true
 		cmd := m.fetchIdentity()
 		return m, cmd
 	}

--- a/internal/tui/app_session.go
+++ b/internal/tui/app_session.go
@@ -3,11 +3,12 @@ package tui
 // app_session.go — AWS-session lifecycle handlers: clients-ready bootstrap,
 // profile/region/theme selectors, and the profile-list loader. Split out of
 // internal/tui/app_handlers.go in Phase-05 PR-05a-h1 (AS-147). These handlers
-// mutate tui-Model fields (profile, region, identity, clients, connectGen,
-// pendingRefresh, hasPrevState, prevProfile, prevRegion, activeTheme,
-// headerCacheKey, preSuppliedClients, command, noCache) that have not yet
-// migrated to session.Session; once they do, these bodies move to *Core
-// methods returning ([]UIIntent, []TaskRequest) in a follow-up PR.
+// mutate session.Session fields (Profile, Region, Identity, Clients, ConnectGen,
+// PendingRefresh, HasPrevState, PrevProfile, PrevRegion, PreSuppliedClients,
+// Command, NoCache — migrated to Session in AS-315a / PR-05a-h2) plus
+// tui-Model UI-shell fields (activeTheme, headerCacheKey). Handler bodies
+// move to *Core methods returning ([]UIIntent, []TaskRequest) in AS-315b /
+// PR-05a-h3.
 
 import (
 	"fmt"
@@ -27,20 +28,20 @@ import (
 // pending refresh (after profile/region switch).
 func (m Model) handleClientsReady(msg messages.ClientsReadyMsg) (tea.Model, tea.Cmd) {
 	// Ignore stale results from a superseded connect (rapid profile/region switch)
-	if msg.Gen != m.connectGen {
+	if msg.Gen != m.ConnectGen {
 		return m, nil
 	}
 
 	if msg.Err != nil {
 		// Rollback profile/region to previous stable values on connect failure
-		if m.hasPrevState {
-			m.profile = m.prevProfile
-			m.region = m.prevRegion
+		if m.HasPrevState {
+			m.Profile = m.PrevProfile
+			m.Region = m.PrevRegion
 		}
-		m.hasPrevState = false
-		m.prevProfile = ""
-		m.prevRegion = ""
-		m.pendingRefresh = false
+		m.HasPrevState = false
+		m.PrevProfile = ""
+		m.PrevRegion = ""
+		m.PendingRefresh = false
 		newGen := m.flash.gen + 1
 		m.flash = flashState{text: msg.Err.Error(), isError: true, active: true, gen: newGen}
 		m.errorHistory = append(m.errorHistory, errorEntry{time: time.Now(), message: msg.Err.Error()})
@@ -53,7 +54,7 @@ func (m Model) handleClientsReady(msg messages.ClientsReadyMsg) (tea.Model, tea.
 		// Restore them using the still-valid old clients.
 		//
 		// IMPORTANT: Session.Rotate already swapped in fresh PolicyStore /
-		// IdentityStore on m, so the retained transport clients (m.clients)
+		// IdentityStore on m, so the retained transport clients (m.Clients)
 		// still point at the PRE-rotate stores. Without rewiring here,
 		// Pattern-C related checks (Glue tags, EBS Backup) and IAM lazy-add
 		// would read sticky state from the now-discarded old stores — the
@@ -62,13 +63,13 @@ func (m Model) handleClientsReady(msg messages.ClientsReadyMsg) (tea.Model, tea.
 		// successful reconnect. Rewire on rollback too. (P3 finding.)
 		var cmds []tea.Cmd
 		cmds = append(cmds, clearFlash)
-		if m.clients != nil {
-			m.clients.SetIAMPolicies(m.IAMPolicies)
-			m.clients.SetIdentityStore(m.Identity)
-			m.clients.SetRuleSets(m.RuleSets)
-			m.identityFetching = true
+		if m.Clients != nil {
+			m.Clients.SetIAMPolicies(m.IAMPolicies)
+			m.Clients.SetIdentityStore(m.IdentityStore)
+			m.Clients.SetRuleSets(m.RuleSets)
+			m.IdentityFetching = true
 			cmds = append(cmds, m.fetchIdentity())
-			if m.noCache {
+			if m.NoCache {
 				cmds = append(cmds, m.demoPrefetchCounts())
 			} else {
 				cmds = append(cmds, m.loadAvailabilityCache())
@@ -77,32 +78,32 @@ func (m Model) handleClientsReady(msg messages.ClientsReadyMsg) (tea.Model, tea.
 		return m, tea.Batch(cmds...)
 	}
 	if msg.Clients == nil {
-		if m.clients == nil && m.preSuppliedClients != nil {
+		if m.Clients == nil && m.PreSuppliedClients != nil {
 			// Fall back to pre-supplied clients (demo path) when msg carries no clients.
 			// Wire per-session capability stores into the transport layer.
-			m.preSuppliedClients.SetIAMPolicies(m.IAMPolicies)
-			m.preSuppliedClients.SetIdentityStore(m.Identity)
-			m.preSuppliedClients.SetRuleSets(m.RuleSets)
-			m.clients = m.preSuppliedClients
+			m.PreSuppliedClients.SetIAMPolicies(m.IAMPolicies)
+			m.PreSuppliedClients.SetIdentityStore(m.IdentityStore)
+			m.PreSuppliedClients.SetRuleSets(m.RuleSets)
+			m.Clients = m.PreSuppliedClients
 		}
 	} else if clients, ok := msg.Clients.(*awsclient.ServiceClients); ok {
 		// Per-session stores: SES rule sets, IAM policies, and identity all
-		// live on m.{RuleSets,IAMPolicies,Identity} after PR-02b/c/d. The
+		// live on m.{RuleSets,IAMPolicies,IdentityStore} after PR-02b/c/d. The
 		// legacy ClearAllSESRuleSetCaches global-clear is gone — fresh
 		// session = fresh store, wired here via thread-safe setters.
 		clients.SetIAMPolicies(m.IAMPolicies)
-		clients.SetIdentityStore(m.Identity)
+		clients.SetIdentityStore(m.IdentityStore)
 		clients.SetRuleSets(m.RuleSets)
-		m.clients = clients
+		m.Clients = clients
 	} else {
 		wrongTypeErr := fmt.Errorf("internal: unexpected ClientsReadyMsg.Clients type %T", msg.Clients)
 		return m, func() tea.Msg {
 			return messages.APIErrorMsg{Err: wrongTypeErr}
 		}
 	}
-	m.hasPrevState = false
-	m.prevProfile = ""
-	m.prevRegion = ""
+	m.HasPrevState = false
+	m.PrevProfile = ""
+	m.PrevRegion = ""
 
 	// Emit a one-shot NavigateMsg if the -c flag set an initial command. Only
 	// fire while the app is still at the main menu (stack depth 1). If the
@@ -111,9 +112,9 @@ func (m Model) handleClientsReady(msg messages.ClientsReadyMsg) (tea.Model, tea.
 	// the user is doing. Cleared after first use so that subsequent
 	// ClientsReadyMsg (profile/region switch) don't re-navigate.
 	var navigateCmd tea.Cmd
-	if m.command != "" {
+	if m.Command != "" {
 		if len(m.stack) == 1 {
-			target := m.command
+			target := m.Command
 			navigateCmd = func() tea.Msg {
 				return messages.NavigateMsg{
 					Target:       messages.TargetResourceList,
@@ -121,27 +122,27 @@ func (m Model) handleClientsReady(msg messages.ClientsReadyMsg) (tea.Model, tea.
 				}
 			}
 		}
-		m.command = "" // always clear, even if skipped, to prevent stale re-navigation
+		m.Command = "" // always clear, even if skipped, to prevent stale re-navigation
 	}
 
-	if m.profile == "" {
-		m.profile = "default"
+	if m.Profile == "" {
+		m.Profile = "default"
 	}
-	if m.region == "" {
+	if m.Region == "" {
 		if msg.Region != "" {
-			m.region = msg.Region
+			m.Region = msg.Region
 		} else {
 			configPath := awsclient.DefaultConfigPath()
-			m.region = awsclient.GetDefaultRegion(configPath, m.profile)
+			m.Region = awsclient.GetDefaultRegion(configPath, m.Profile)
 		}
 	}
 	// In demo/no-cache mode, prefetch all counts synchronously in one cmd so the
 	// main menu shows counts immediately without the async probe pipeline.
 	// Skip identity fetch in demo mode — the profile/region are synthetic.
-	if m.noCache {
+	if m.NoCache {
 		availCmd := m.demoPrefetchCounts()
-		if m.pendingRefresh {
-			m.pendingRefresh = false
+		if m.PendingRefresh {
+			m.PendingRefresh = false
 			if rl, ok := m.activeView().(*views.ResourceListModel); ok {
 				m.flash = flashState{text: "Connected. Refreshing...", active: true}
 				cmd := m.refreshResourceList(*rl)
@@ -152,14 +153,14 @@ func (m Model) handleClientsReady(msg messages.ClientsReadyMsg) (tea.Model, tea.
 	}
 
 	// Fetch identity on every clients-ready event
-	m.identityFetching = true
+	m.IdentityFetching = true
 	identityCmd := m.fetchIdentity()
 
 	// Load disk cache which then fires background probes for expired/missing entries.
 	availCmd := m.loadAvailabilityCache()
 
-	if m.pendingRefresh {
-		m.pendingRefresh = false
+	if m.PendingRefresh {
+		m.PendingRefresh = false
 		if rl, ok := m.activeView().(*views.ResourceListModel); ok {
 			m.flash = flashState{text: "Connected. Refreshing...", active: true}
 			cmd := m.refreshResourceList(*rl)
@@ -172,54 +173,66 @@ func (m Model) handleClientsReady(msg messages.ClientsReadyMsg) (tea.Model, tea.
 // handleProfileSelected switches the AWS profile, pops the profile selector,
 // and reconnects.
 func (m Model) handleProfileSelected(msg messages.ProfileSelectedMsg) (tea.Model, tea.Cmd) {
-	m.Rotate()
-	m.connectGen++
-	// Only save prev on first switch; rapid A→B→C keeps A as rollback target
-	if !m.hasPrevState {
-		m.hasPrevState = true
-		m.prevProfile = m.profile
-		m.prevRegion = m.region
+	// Capture rollback state BEFORE Rotate (which now clears HasPrevState/
+	// PrevProfile/PrevRegion). Only save prev on first switch; rapid A→B→C
+	// keeps A as rollback target.
+	hadPrev := m.HasPrevState
+	prevProf := m.PrevProfile
+	prevReg := m.PrevRegion
+	if !hadPrev {
+		hadPrev = true
+		prevProf = m.Profile
+		prevReg = m.Region
 	}
-	m.profile = msg.Profile
-	m.region = "" // clear so handleClientsReady resolves the new profile's default region
-	m.identity = nil
+	m.Rotate() // bumps ConnectGen; clears Identity/IdentityFetching/PendingRefresh/HasPrevState/...
+	m.HasPrevState = hadPrev
+	m.PrevProfile = prevProf
+	m.PrevRegion = prevReg
+	m.Profile = msg.Profile
+	m.Region = "" // clear so handleClientsReady resolves the new profile's default region
 	if menu, ok := m.stack[0].(*views.MainMenuModel); ok {
 		menu.ClearAvailability()
 	}
-	m.pendingRefresh = true
+	m.PendingRefresh = true
 	if _, ok := m.activeView().(*views.SelectorModel); ok {
 		m.popView()
 	}
 	flashCmd := func() tea.Msg {
 		return messages.FlashMsg{Text: "Switching to " + msg.Profile + "..."}
 	}
-	return m, tea.Batch(flashCmd, m.connectAWS(msg.Profile, "", m.connectGen))
+	return m, tea.Batch(flashCmd, m.connectAWS(msg.Profile, "", m.ConnectGen))
 }
 
 // handleRegionSelected switches the AWS region, pops the region selector,
 // and reconnects.
 func (m Model) handleRegionSelected(msg messages.RegionSelectedMsg) (tea.Model, tea.Cmd) {
-	m.Rotate()
-	m.connectGen++
-	// Only save prev on first switch; rapid switches keep original as rollback target
-	if !m.hasPrevState {
-		m.hasPrevState = true
-		m.prevProfile = m.profile
-		m.prevRegion = m.region
+	// Capture rollback state BEFORE Rotate (which now clears HasPrevState/
+	// PrevProfile/PrevRegion). Only save prev on first switch; rapid switches
+	// keep original as rollback target.
+	hadPrev := m.HasPrevState
+	prevProf := m.PrevProfile
+	prevReg := m.PrevRegion
+	if !hadPrev {
+		hadPrev = true
+		prevProf = m.Profile
+		prevReg = m.Region
 	}
-	m.region = msg.Region
-	m.identity = nil
+	m.Rotate() // bumps ConnectGen; clears Identity/IdentityFetching/PendingRefresh/HasPrevState/...
+	m.HasPrevState = hadPrev
+	m.PrevProfile = prevProf
+	m.PrevRegion = prevReg
+	m.Region = msg.Region
 	if menu, ok := m.stack[0].(*views.MainMenuModel); ok {
 		menu.ClearAvailability()
 	}
-	m.pendingRefresh = true
+	m.PendingRefresh = true
 	if _, ok := m.activeView().(*views.SelectorModel); ok {
 		m.popView()
 	}
 	flashCmd := func() tea.Msg {
 		return messages.FlashMsg{Text: "Switching to " + msg.Region + "..."}
 	}
-	return m, tea.Batch(flashCmd, m.connectAWS(m.profile, msg.Region, m.connectGen))
+	return m, tea.Batch(flashCmd, m.connectAWS(m.Profile, msg.Region, m.ConnectGen))
 }
 
 // handleThemeSelected applies the selected theme, invalidates style caches,
@@ -277,7 +290,7 @@ func (m Model) handleThemeSelected(msg messages.ThemeSelectedMsg) (tea.Model, te
 
 // handleProfilesLoaded pushes the profile selector view onto the stack.
 func (m Model) handleProfilesLoaded(msg profilesLoadedMsg) (tea.Model, tea.Cmd) {
-	p := views.NewProfile(msg.profiles, m.profile, m.keys)
+	p := views.NewProfile(msg.profiles, m.Profile, m.keys)
 	p.SetSize(m.innerSize())
 	m.pushView(&p)
 	return m, nil

--- a/internal/tui/fetch_adapter.go
+++ b/internal/tui/fetch_adapter.go
@@ -23,7 +23,7 @@ type profilesLoadedMsg struct {
 // fetchResources returns a tea.Cmd that calls Core.FetchResources and
 // converts the result to ResourcesLoadedMsg or APIErrorMsg.
 func (m *Model) fetchResources(resourceType string) tea.Cmd {
-	ctx, clients := m.appCtx, m.clients
+	ctx, clients := m.appCtx, m.Clients
 	return func() tea.Msg {
 		res, err := m.core.FetchResources(ctx, clients, resourceType)
 		// Partial-success contract: fetchers may return BOTH a non-empty
@@ -44,7 +44,7 @@ func (m *Model) fetchResources(resourceType string) tea.Cmd {
 
 // fetchResourcesFiltered returns a tea.Cmd for a server-side filtered fetch.
 func (m *Model) fetchResourcesFiltered(resourceType string, filter map[string]string) tea.Cmd {
-	ctx, clients := m.appCtx, m.clients
+	ctx, clients := m.appCtx, m.Clients
 	return func() tea.Msg {
 		res, err := m.core.FetchResourcesFiltered(ctx, clients, resourceType, filter)
 		if err != nil && len(res.Resources) == 0 {
@@ -62,7 +62,7 @@ func (m *Model) fetchResourcesFiltered(resourceType string, filter map[string]st
 // fetchAMIDetail returns a tea.Cmd that fetches a single AMI by ID and
 // navigates to its detail view.
 func (m *Model) fetchAMIDetail(imageID string) tea.Cmd {
-	ctx, clients := m.appCtx, m.clients
+	ctx, clients := m.appCtx, m.Clients
 	return func() tea.Msg {
 		res, err := m.core.FetchAMIDetail(ctx, clients, imageID)
 		if err != nil {
@@ -78,7 +78,7 @@ func (m *Model) fetchAMIDetail(imageID string) tea.Cmd {
 
 // fetchChildResources returns a tea.Cmd for paginated child resource loading.
 func (m *Model) fetchChildResources(childType string, parentCtx map[string]string) tea.Cmd {
-	ctx, clients := m.appCtx, m.clients
+	ctx, clients := m.appCtx, m.Clients
 	return func() tea.Msg {
 		res, err := m.core.FetchChildResources(ctx, clients, childType, parentCtx)
 		if err != nil {
@@ -95,7 +95,7 @@ func (m *Model) fetchChildResources(childType string, parentCtx map[string]strin
 // fetchMoreResources returns a tea.Cmd that fetches the next page of a
 // paginated resource list using the continuation token from LoadMoreMsg.
 func (m *Model) fetchMoreResources(msg messages.LoadMoreMsg) tea.Cmd {
-	ctx, clients := m.appCtx, m.clients
+	ctx, clients := m.appCtx, m.Clients
 	p := runtime.FetchMoreParams{
 		ResourceType: msg.ResourceType,
 		Token:        msg.ContinuationToken,
@@ -119,7 +119,7 @@ func (m *Model) fetchMoreResources(msg messages.LoadMoreMsg) tea.Cmd {
 
 // fetchIdentity returns a tea.Cmd that fetches the AWS caller identity.
 func (m *Model) fetchIdentity() tea.Cmd {
-	ctx, clients := m.appCtx, m.clients
+	ctx, clients := m.appCtx, m.Clients
 	return func() tea.Msg {
 		identity, err := m.core.FetchIdentity(ctx, clients)
 		if err != nil {
@@ -142,7 +142,7 @@ func (m *Model) fetchProfiles() tea.Cmd {
 
 // fetchRevealValue returns a tea.Cmd that calls the registered reveal fetcher.
 func (m *Model) fetchRevealValue(resourceType, resourceID string) tea.Cmd {
-	ctx, clients := m.appCtx, m.clients
+	ctx, clients := m.appCtx, m.Clients
 	return func() tea.Msg {
 		value, err := m.core.FetchRevealValue(ctx, clients, resourceType, resourceID)
 		if err != nil {

--- a/internal/tui/probe_adapter.go
+++ b/internal/tui/probe_adapter.go
@@ -19,8 +19,8 @@ import (
 // loadAvailabilityCache returns a tea.Cmd that reads the availability cache
 // from disk and converts the result to AvailabilityCacheLoadedMsg.
 func (m *Model) loadAvailabilityCache() tea.Cmd {
-	profile := m.profile
-	region := m.region
+	profile := m.Profile
+	region := m.Region
 	return func() tea.Msg {
 		cf, err := m.core.LoadAvailabilityCache(profile, region)
 		if err != nil || cf == nil {
@@ -63,7 +63,7 @@ func (m *Model) loadAvailabilityCache() tea.Cmd {
 // probeResourceAvailability returns a tea.Cmd that runs a Wave-1 availability
 // probe for shortName and converts the result to AvailabilityCheckedMsg.
 func (m *Model) probeResourceAvailability(shortName string, gen int) tea.Cmd {
-	ctx, clients := m.appCtx, m.clients
+	ctx, clients := m.appCtx, m.Clients
 	return func() tea.Msg {
 		r := m.core.ProbeResourceAvailability(ctx, clients, shortName)
 		return messages.AvailabilityCheckedMsg{
@@ -82,11 +82,11 @@ func (m *Model) probeResourceAvailability(shortName string, gen int) tea.Cmd {
 // saveAvailabilityCache returns a tea.Cmd that persists the current
 // availability state to disk. No-op when caching is disabled (noCache=true).
 func (m *Model) saveAvailabilityCache() tea.Cmd {
-	if m.noCache {
+	if m.NoCache {
 		return nil
 	}
-	profile := m.profile
-	region := m.region
+	profile := m.Profile
+	region := m.Region
 
 	// Collect availability, truncation, and issue counts from main menu.
 	var entries map[string]int
@@ -117,7 +117,7 @@ func (m *Model) saveAvailabilityCache() tea.Cmd {
 // Used when pre-supplied clients are present and no-cache is active so the
 // main menu shows counts immediately without the async probe pipeline.
 func (m *Model) demoPrefetchCounts() tea.Cmd {
-	ctx, clients := m.appCtx, m.clients
+	ctx, clients := m.appCtx, m.Clients
 	gen := m.AvailabilityGen
 	return func() tea.Msg {
 		r := m.core.DemoPrefetchCounts(ctx, clients)
@@ -158,7 +158,7 @@ func (m *Model) refreshResourceListWithEnrichmentRerun(
 // probeEnrichment returns a tea.Cmd that runs the registered Wave-2 enricher
 // for shortName and converts the result to EnrichmentCheckedMsg.
 func (m *Model) probeEnrichment(shortName string, gen int) tea.Cmd {
-	ctx, clients := m.appCtx, m.clients
+	ctx, clients := m.appCtx, m.Clients
 	typeGen := m.EnrichmentTypeGen[shortName]
 	if awsclient.IssueEnricherRegistry[shortName].Fn == nil {
 		return nil

--- a/internal/tui/probe_enrichment_cache_test.go
+++ b/internal/tui/probe_enrichment_cache_test.go
@@ -69,11 +69,11 @@ func TestProbeEnrichment_CacheSnapshotMergesProbeResources(t *testing.T) {
 	// (m.core.ProbeEnrichment) sees the seeded ProbeResources without a nil
 	// receiver panic.
 	sess := session.New()
+	sess.Clients = &awsclient.ServiceClients{} // non-nil so closure passes the nil-check
 	m := &Model{
 		Session: sess,
 		core:    runtime.New(sess, catalog.ResourceTypes),
 		appCtx:  context.Background(),
-		clients: &awsclient.ServiceClients{}, // non-nil so closure passes the nil-check
 	}
 	m.ProbeResources = map[string][]resource.Resource{
 		"dbi": {

--- a/internal/tui/runtime_adapter.go
+++ b/internal/tui/runtime_adapter.go
@@ -19,7 +19,7 @@
 //     fields without parsing TaskKey.Scope or accepting side-channel
 //     arguments. The closure builder stays in the adapter because it
 //     returns tea.Cmd and reads adapter-owned state (m.appCtx,
-//     m.clients, the embedded session's EnrichGen and PolicyDocCache)
+//     m.Clients, the embedded session's EnrichGen and PolicyDocCache)
 //     that has not yet migrated to the runtime core.
 package tui
 
@@ -112,7 +112,7 @@ func (m Model) enrichDetailCmd(p runtime.EnrichDetailPayload) tea.Cmd {
 	enricher := resource.GetDetailEnricher(p.ResourceType)
 	gen := m.EnrichGen             // session-owned, promoted via embedded *Session
 	policyDocs := m.PolicyDocCache // session-owned, promoted via embedded *Session
-	clients := m.clients
+	clients := m.Clients
 	appCtx := m.appCtx
 	dctx := &awsclient.DetailEnrichmentCtx{
 		Clients:    clients,

--- a/internal/tui/runtime_adapter_navigate.go
+++ b/internal/tui/runtime_adapter_navigate.go
@@ -12,7 +12,7 @@
 // handleCopy, handleRefresh / refreshResourceList, handleReveal,
 // handleIdentityLoaded, and handleIdentityError stay here as TUI-only
 // helpers because every line of their bodies depends on adapter state
-// (view stack, view-typed methods, flashState, m.identity, tea.Cmd
+// (view stack, view-typed methods, flashState, m.Identity, tea.Cmd
 // returns). Their runtime-policy parts (cache-mutation gen bumps,
 // per-type enrichment-rerun bookkeeping) are reads/writes against the
 // embedded *Session — same data the runtime sees through c.session.
@@ -237,7 +237,7 @@ func (m Model) handleNavigate(msg messages.NavigateMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case runtime.NavigateKindFetchProfiles:
-		if m.preSuppliedClients != nil {
+		if m.PreSuppliedClients != nil {
 			return m, func() tea.Msg {
 				return messages.FlashMsg{
 					Text:    "context switching is disabled in demo mode",
@@ -248,7 +248,7 @@ func (m Model) handleNavigate(msg messages.NavigateMsg) (tea.Model, tea.Cmd) {
 		return m, navigateTasksToCmd(m, msg, result, tasks)
 
 	case runtime.NavigateKindPushRegion:
-		if m.preSuppliedClients != nil {
+		if m.PreSuppliedClients != nil {
 			return m, func() tea.Msg {
 				return messages.FlashMsg{
 					Text:    "region switching is disabled in demo mode",
@@ -261,7 +261,7 @@ func (m Model) handleNavigate(msg messages.NavigateMsg) (tea.Model, tea.Cmd) {
 		for i, r := range regions {
 			regionCodes[i] = r.Code
 		}
-		rg := views.NewRegion(regionCodes, m.region, m.keys)
+		rg := views.NewRegion(regionCodes, m.Region, m.keys)
 		rg.SetSize(m.innerSize())
 		m.pushView(&rg)
 		return m, nil
@@ -388,7 +388,7 @@ func (m Model) handleCopy() (tea.Model, tea.Cmd) {
 func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 	// Main menu: restart availability checks (no-op in no-cache mode).
 	if _, ok := m.activeView().(*views.MainMenuModel); ok {
-		if m.noCache {
+		if m.NoCache {
 			return m, nil
 		}
 		// Increment gen to cancel any in-flight probes and enrichment.
@@ -432,8 +432,8 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 		// replace the slot here.
 		if rt == "ses" {
 			m.RuleSets = session.NewRuleSetStore()
-			if m.clients != nil {
-				m.clients.SetRuleSets(m.RuleSets)
+			if m.Clients != nil {
+				m.Clients.SetRuleSets(m.RuleSets)
 			}
 		}
 		m.flash = flashState{text: "Refreshing...", isError: false, active: true}
@@ -480,8 +480,8 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 		// Swap (see detail-view path above): protects against in-flight blocked
 		// DescribeActiveReceiptRuleSet fetchers re-poisoning the cache.
 		m.RuleSets = session.NewRuleSetStore()
-		if m.clients != nil {
-			m.clients.SetRuleSets(m.RuleSets)
+		if m.Clients != nil {
+			m.Clients.SetRuleSets(m.RuleSets)
 		}
 	}
 	m.flash = flashState{text: "Refreshing...", isError: false, active: true}
@@ -559,12 +559,12 @@ func (m Model) handleReveal() (tea.Model, tea.Cmd) {
 }
 
 // handleIdentityLoaded caches the identity and updates the identity view if
-// active. Adapter-side because m.identity / m.identityFetching live on the
+// active. Adapter-side because m.Identity / m.IdentityFetching live on the
 // TUI Model today.
 func (m Model) handleIdentityLoaded(msg messages.IdentityLoadedMsg) (tea.Model, tea.Cmd) {
-	m.identityFetching = false
+	m.IdentityFetching = false
 	if id, ok := msg.Identity.(*awsclient.CallerIdentity); ok {
-		m.identity = id
+		m.Identity = id
 	}
 	if idView, ok := m.activeView().(*views.IdentityModel); ok {
 		data := m.identityToViewData()
@@ -576,7 +576,7 @@ func (m Model) handleIdentityLoaded(msg messages.IdentityLoadedMsg) (tea.Model, 
 // handleIdentityError clears the fetching flag and updates the identity view
 // if active. Adapter-side for the same reason as handleIdentityLoaded.
 func (m Model) handleIdentityError(msg messages.IdentityErrorMsg) (tea.Model, tea.Cmd) {
-	m.identityFetching = false
+	m.IdentityFetching = false
 	if idView, ok := m.activeView().(*views.IdentityModel); ok {
 		idView.SetError(msg.Err)
 	}

--- a/internal/tui/runtime_adapter_related.go
+++ b/internal/tui/runtime_adapter_related.go
@@ -16,7 +16,7 @@
 // It asks runtime.Core whether any RelatedDefs are registered for the source
 // type, and if so fans out one checker goroutine per def via relatedCheckCmd
 // (capped by runtime.MaxConcurrentProbes). The actual probe loop stays here in
-// the adapter because it depends on m.clients, m.appCtx, and tea.Cmd —
+// the adapter because it depends on m.Clients, m.appCtx, and tea.Cmd —
 // platform glue that does not belong in internal/runtime.
 //
 // Decision-locus follow-up (PR-05b): a few branches in this adapter still walk
@@ -124,11 +124,11 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigateMsg) (tea.Model
 		if result.TargetID != "" {
 			// Exact AMI navigation should fetch by image ID instead of falling
 			// back to the owned-AMI list, which misses public and third-party images.
-			// PR-05b: when m.clients moves into the runtime Core, the runtime will
+			// PR-05b: when m.Clients moves into the runtime Core, the runtime will
 			// emit a typed FetchAMIDetail TaskRequest and this branch collapses
 			// into runtimeTasksToCmd; the adapter override stays for now because
 			// client selection is adapter-owned state.
-			if msg.TargetType == "ami" && m.clients != nil {
+			if msg.TargetType == "ami" && m.Clients != nil {
 				cmd := m.fetchAMIDetail(result.TargetID)
 				return m, cmd
 			}
@@ -527,7 +527,7 @@ func (m Model) relatedCheckCmd(res resource.Resource) tea.Cmd {
 			if def.NeedsTargetCache {
 				if _, inMainCache := mainCacheKeys[def.TargetType]; !inMainCache {
 					if pf := resource.GetPaginatedFetcher(def.TargetType); pf != nil {
-						if fr, err := pf(ctx, m.clients, ""); err == nil {
+						if fr, err := pf(ctx, m.Clients, ""); err == nil {
 							isTrunc := fr.Pagination != nil && fr.Pagination.IsTruncated
 							if prev, hasPrev := localCache[def.TargetType]; hasPrev && prev.IsTruncated {
 								isTrunc = true
@@ -546,7 +546,7 @@ func (m Model) relatedCheckCmd(res resource.Resource) tea.Cmd {
 					}
 				}
 			}
-			result := def.Checker(ctx, m.clients, res, localCache)
+			result := def.Checker(ctx, m.Clients, res, localCache)
 			result.TargetType = def.TargetType
 			var lazyAdded map[string][]resource.Resource
 			var lazyAddError error
@@ -554,7 +554,7 @@ func (m Model) relatedCheckCmd(res resource.Resource) tea.Cmd {
 				if ff := resource.GetFetchByIDs(def.TargetType); ff != nil {
 					missing := runtime.MissingFromCache(localCache, def.TargetType, result.ResourceIDs)
 					if len(missing) > 0 {
-						extra, fetchErr := ff(ctx, m.clients, missing)
+						extra, fetchErr := ff(ctx, m.Clients, missing)
 						if fetchErr != nil {
 							lazyAddError = fetchErr
 						}


### PR DESCRIPTION
## Summary

Mechanical move of 13 session-scoped fields from `tui.Model` to `session.Session` (AS-315a / PR-05a-h2). Spec: `docs/refactor/05-pr-05a-h2.md` §\"PR-05a-h2 (AS-315a) — Field migration only\".

Fields migrated:
- `Profile`, `Region`, `Clients`, `Identity`, `IdentityFetching`, `ConnectGen`, `PendingRefresh`, `HasPrevState`, `PrevProfile`, `PrevRegion`, `PreSuppliedClients`, `Command`, `NoCache`

`Session.Rotate()` now owns:
- bumping `ConnectGen`
- clearing `Identity`, `IdentityFetching`, `PendingRefresh`, `HasPrevState`, `PrevProfile`, `PrevRegion`

`Profile`, `Region`, `Clients`, `PreSuppliedClients`, `Command`, `NoCache` deliberately survive Rotate per the AS-323 scope.

## Notable adjustments to preserve behaviour

- **Field-name collision**: the existing `Identity IdentityStore` field (per-session AccountID cache for Pattern-C checkers) is renamed to `IdentityStore IdentityStore` to free `Identity` for the new `*awsclient.CallerIdentity`. SetIdentityStore call sites now pass `m.IdentityStore`.
- **Handler restructure**: `handleProfileSelected` / `handleRegionSelected` capture rollback state (HasPrevState/PrevProfile/PrevRegion) into local vars BEFORE Rotate, then restore after. Without this, Rotate's clear would collapse the \"rapid A→B→C keeps A as rollback target\" semantics noted in the handler comment.
- Manual `m.connectGen++` and `m.identity = nil` after Rotate are removed (Rotate owns them now).

## Acceptance

```bash
rg '^\s+(profile|region|clients|connectGen|pendingRefresh|hasPrevState|prevProfile|prevRegion|preSuppliedClients|command|noCache|identity|identityFetching)\s+\w' internal/tui/app.go
# 0 hits ✓

rg '\b(Profile|Region|Clients|ConnectGen|PendingRefresh|HasPrevState|PrevProfile|PrevRegion|PreSuppliedClients|Command|NoCache|Identity|IdentityFetching)\b' internal/session/session.go
# 31 hits ✓ (≥ 13 required)

go list -f '{{.Imports}}' github.com/k2m30/a9s/v3/internal/runtime | grep -E 'bubbletea|lipgloss|bubbles'
# 0 hits ✓
```

## Test plan

- [x] `go build ./...` green
- [x] `go vet ./...` green
- [x] `go test ./...` green (build + unit + integration)
- [x] `gofmt -l` clean on changed files
- [x] Manual Rotate semantic test (locally): clear+preserve fields work as scoped
- [x] Manual `tui.New(WithProfile(\"foo\"))` test: m.Profile / m.Session.Profile round-trip
- [ ] CI lint + race (local env mismatch on golangci-lint v2 + no cgo for `-race`)

## Cross-references

- Parent: AS-315
- Sibling: AS-315b / AS-324 (handler port to runtime.Core; depends on this merging first)
- QA sibling: AS-326 (failing tests written in parallel — should be rebased onto this PR)
- Spec: `docs/refactor/05-pr-05a-h2.md` §\"PR-05a-h2 (AS-315a)\"
- Contract: `docs/refactor/05-boundary.md` §\"5a-extract\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)