### PR TITLE
feat(phase-05-pr-05a): un-embed session, shrink app.go to 420 LOC (AS-155)

### DIFF
--- a/internal/runtime/handlers.go
+++ b/internal/runtime/handlers.go
@@ -1,50 +1,289 @@
-// handlers.go — placeholder for shell-level handlers migrated out of
-// internal/tui/app_handlers.go.
-//
-// PR-05a-h1 (AS-147) moves the dispatcher entry "app_handlers.go" out of
-// internal/tui per the file-level inventory in docs/refactor/05-boundary.md
-// §"5a-extract". The handlers that lived in that file are renderer-shell
-// concerns — keyboard dispatch (handleKeyMsg), flash state with tea.Tick
-// timers (handleFlash, handleClearFlash, handleAPIError), AWS client
-// lifecycle (handleClientsReady), profile/region selection wrappers
-// (handleProfileSelected, handleRegionSelected), theme application
-// (handleThemeSelected), and view-stack push helpers (handleProfilesLoaded,
-// handleValueRevealed, handleEnterChildView).
-//
-// Each of those touches Bubble Tea types (tea.Cmd, tea.KeyMsg, tea.Tick,
-// key.Matches) or tui.Model fields (m.flash, m.errorHistory, m.clients,
-// m.profile, m.region, m.identity, m.connectGen, m.pendingRefresh, the
-// view stack m.stack, the keys map m.keys, the input mode, …) that are
-// adapter-owned in the Phase 05 boundary. None of them touch session.Session
-// state beyond a single c.session.Rotate() call in profile/region select.
-//
-// Honest disposition: those handler bodies remain in the TUI adapter,
-// redistributed across thematic sibling files:
-//
-//   internal/tui/app_input.go     — handleKeyMsg (keyboard dispatcher)
-//   internal/tui/app_flash.go     — handleFlash, handleClearFlash, handleAPIError
-//   internal/tui/app_session.go   — handleClientsReady, handleProfileSelected,
-//                                   handleRegionSelected, handleThemeSelected,
-//                                   handleProfilesLoaded
-//   internal/tui/app_screens.go   — handleValueRevealed, handleEnterChildView
-//
-// internal/tui/app_handlers.go is deleted as required by the spec exit
-// criterion ("ls internal/tui/app_handlers*.go" → no such file or directory
-// for the bare file). The sibling tui-side files keep the (tea.Model, tea.Cmd)
-// adapter signatures intact.
-//
-// A follow-up PR will migrate tui.Model fields (profile, region, identity,
-// clients, connectGen, pendingRefresh, hasPrevState, prevProfile, prevRegion,
-// preSuppliedClients, command, noCache) to session.Session. Once they live
-// on Session, the handler bodies can move to *Core methods returning
-// ([]UIIntent, []TaskRequest) — with new intents for the connect lifecycle
-// (ConnectIntent, IdentityClearIntent) and a connect TaskRequest for the
-// AWS bootstrap. That migration is multi-PR scope and is intentionally
-// deferred from this PR per the M sizing on AS-147.
-//
-// For now this file exists to satisfy the spec's path-level acceptance
-// (test -f internal/runtime/handlers.go) and to document why it has no
-// Core methods yet. Adding stub methods here without real semantics would
-// be premature — it would lock in shapes before the field-migration PR
-// can establish the right contracts.
 package runtime
+
+import (
+	"errors"
+	"time"
+
+	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/tui/messages"
+)
+
+// errWrongClientsType is returned by HandleClientsReady when ev.Clients is
+// non-nil but is not *awsclient.ServiceClients — an impossible branch in
+// production that is guarded here so the adapter's APIError path classifies it.
+var errWrongClientsType = errors.New("internal: ClientsReadyEvent.Clients has unexpected concrete type")
+
+// FlashEvent asks the core to display a transient flash message.
+type FlashEvent struct {
+	Text    string
+	IsError bool
+	NewGen  int
+}
+
+// ClearFlashEvent asks the core to clear the current flash if the gen matches.
+type ClearFlashEvent struct {
+	Gen        int
+	CurrentGen int
+	IsError    bool
+}
+
+// APIErrorEvent carries an AWS API error to be displayed and logged.
+type APIErrorEvent struct {
+	Err    error
+	NewGen int
+}
+
+// ClientsReadyEvent is dispatched by the adapter after an AWS connect attempt
+// completes (success or failure).
+type ClientsReadyEvent struct {
+	Gen         int
+	NewGen      int
+	Err         error
+	Clients     any // *awsclient.ServiceClients or nil
+	Region      string
+	HasActiveRL bool
+	StackDepth  int
+}
+
+// ProfileSelectedEvent is dispatched when the user confirms a profile switch.
+type ProfileSelectedEvent struct {
+	Profile string
+	NewGen  int
+}
+
+// RegionSelectedEvent is dispatched when the user confirms a region switch.
+type RegionSelectedEvent struct {
+	Region string
+	NewGen int
+}
+
+// HandleFlash processes a FlashEvent and returns the resulting intents and tasks.
+func (c *Core) HandleFlash(ev FlashEvent) ([]UIIntent, []TaskRequest) {
+	intents := []UIIntent{FlashIntent{Text: ev.Text, IsError: ev.IsError}}
+	if ev.IsError {
+		intents = append(intents, AppendErrorHistoryIntent{Time: time.Now(), Message: ev.Text})
+	}
+	tasks := []TaskRequest{
+		{
+			Key:     TaskKey{Kind: TaskKindFlashTick},
+			Payload: FlashTickPayload{Gen: ev.NewGen, Duration: 2 * time.Second},
+		},
+	}
+	return intents, tasks
+}
+
+// HandleClearFlash processes a ClearFlashEvent. Stale gens are discarded.
+func (c *Core) HandleClearFlash(ev ClearFlashEvent) ([]UIIntent, []TaskRequest) {
+	if ev.Gen != ev.CurrentGen {
+		return nil, nil
+	}
+	intents := []UIIntent{ClearFlash{}}
+	if ev.IsError {
+		intents = append(intents, SetErrorHintIntent{Show: true})
+	}
+	return intents, nil
+}
+
+// HandleAPIError processes an APIErrorEvent, always emitting three intents and
+// one 5-second flash tick task.
+func (c *Core) HandleAPIError(ev APIErrorEvent) ([]UIIntent, []TaskRequest) {
+	intents := []UIIntent{
+		FlashIntent{Text: ev.Err.Error(), IsError: true},
+		AppendErrorHistoryIntent{Time: time.Now(), Message: ev.Err.Error()},
+		ClearActiveListLoadingIntent{},
+	}
+	tasks := []TaskRequest{
+		{
+			Key:     TaskKey{Kind: TaskKindFlashTick},
+			Payload: FlashTickPayload{Gen: ev.NewGen, Duration: 5 * time.Second},
+		},
+	}
+	return intents, tasks
+}
+
+// HandleClientsReady processes the result of an AWS connect attempt. Stale gens
+// (ev.Gen != session.ConnectGen) are discarded.
+func (c *Core) HandleClientsReady(ev ClientsReadyEvent) ([]UIIntent, []TaskRequest) {
+	if ev.Gen != c.session.ConnectGen {
+		return nil, nil
+	}
+
+	if ev.Err != nil {
+		// Failure path — roll back to previous profile/region if available.
+		if c.session.HasPrevState {
+			c.session.Profile = c.session.PrevProfile
+			c.session.Region = c.session.PrevRegion
+		}
+		c.session.HasPrevState = false
+		c.session.PrevProfile = ""
+		c.session.PrevRegion = ""
+		c.session.PendingRefresh = false
+		c.session.ConnectGen = ev.NewGen
+
+		intents := []UIIntent{
+			FlashIntent{Text: ev.Err.Error(), IsError: true},
+			AppendErrorHistoryIntent{Time: time.Now(), Message: ev.Err.Error()},
+		}
+		tasks := []TaskRequest{
+			{
+				Key:     TaskKey{Kind: TaskKindFlashTick},
+				Payload: FlashTickPayload{Gen: ev.NewGen, Duration: 5 * time.Second},
+			},
+		}
+
+		// If we still have existing clients, re-bootstrap identity + cache.
+		if c.session.Clients != nil {
+			tasks = append(tasks, TaskRequest{Key: TaskKey{Kind: TaskKindFetchIdentity}, Payload: FetchIdentityPayload{}})
+			if c.session.NoCache {
+				tasks = append(tasks, TaskRequest{Key: TaskKey{Kind: TaskKindDemoPrefetchCounts}, Payload: DemoPrefetchCountsPayload{}})
+			} else {
+				tasks = append(tasks, TaskRequest{Key: TaskKey{Kind: TaskKindLoadAvailCache}, Payload: LoadAvailCachePayload{}})
+			}
+		}
+
+		return intents, tasks
+	}
+
+	// Success path — install clients.
+	if ev.Clients == nil && c.session.Clients == nil && c.session.PreSuppliedClients != nil {
+		c.session.Clients = c.session.PreSuppliedClients
+	} else if sc, ok := ev.Clients.(*awsclient.ServiceClients); ok {
+		c.session.Clients = sc
+	} else if ev.Clients != nil {
+		// Wrong concrete type — route through APIError task.
+		c.session.HasPrevState = false
+		c.session.PrevProfile = ""
+		c.session.PrevRegion = ""
+		c.session.ConnectGen = ev.NewGen
+		typeErr := errWrongClientsType
+		return []UIIntent{
+				FlashIntent{Text: typeErr.Error(), IsError: true},
+				AppendErrorHistoryIntent{Time: time.Now(), Message: typeErr.Error()},
+			}, []TaskRequest{
+				{Key: TaskKey{Kind: TaskKindEmitAPIError}, Payload: EmitAPIErrorPayload{Err: typeErr}},
+			}
+	}
+
+	c.session.HasPrevState = false
+	c.session.PrevProfile = ""
+	c.session.PrevRegion = ""
+	c.session.ConnectGen = ev.NewGen
+
+	var intents []UIIntent
+	var tasks []TaskRequest
+
+	// Handle -c CLI flag navigation.
+	if c.session.Command != "" {
+		if ev.StackDepth == 1 {
+			tasks = append(tasks, TaskRequest{
+				Key: TaskKey{Kind: TaskKindEmitNavigate},
+				Payload: EmitNavigatePayload{
+					Target:       messages.TargetResourceList,
+					ResourceType: c.session.Command,
+				},
+			})
+		}
+		c.session.Command = ""
+	}
+
+	if c.session.NoCache {
+		tasks = append(tasks, TaskRequest{Key: TaskKey{Kind: TaskKindDemoPrefetchCounts}, Payload: DemoPrefetchCountsPayload{}})
+		if c.session.PendingRefresh {
+			if ev.HasActiveRL {
+				intents = append(intents, RefreshActiveListIntent{}, FlashIntent{Text: "Connected. Refreshing..."})
+			}
+			c.session.PendingRefresh = false
+		}
+		return intents, tasks
+	}
+
+	// Live AWS path.
+	tasks = append(tasks,
+		TaskRequest{Key: TaskKey{Kind: TaskKindFetchIdentity}, Payload: FetchIdentityPayload{}},
+		TaskRequest{Key: TaskKey{Kind: TaskKindLoadAvailCache}, Payload: LoadAvailCachePayload{}},
+	)
+	if c.session.PendingRefresh {
+		if ev.HasActiveRL {
+			intents = append(intents, RefreshActiveListIntent{}, FlashIntent{Text: "Connected. Refreshing..."})
+		}
+		c.session.PendingRefresh = false
+	}
+	return intents, tasks
+}
+
+// HandleProfileSelected processes a profile selector confirmation. Captures
+// rollback state, rotates the session, and dispatches a connect task.
+func (c *Core) HandleProfileSelected(ev ProfileSelectedEvent) ([]UIIntent, []TaskRequest) {
+	hadPrev := c.session.HasPrevState
+	prevProf := c.session.PrevProfile
+	prevReg := c.session.PrevRegion
+	if !hadPrev {
+		prevProf = c.session.Profile
+		prevReg = c.session.Region
+	}
+
+	c.session.Rotate()
+
+	c.session.HasPrevState = true
+	c.session.PrevProfile = prevProf
+	c.session.PrevRegion = prevReg
+	c.session.Profile = ev.Profile
+	c.session.Region = ""
+	c.session.PendingRefresh = true
+
+	intents := []UIIntent{
+		MenuClearAvailabilityIntent{},
+		PopSelectorIntent{},
+		FlashIntent{Text: "Switching to " + ev.Profile + "..."},
+	}
+	tasks := []TaskRequest{
+		{
+			Key:     TaskKey{Kind: TaskKindConnect},
+			Payload: ConnectPayload{Profile: ev.Profile, Region: "", Gen: c.session.ConnectGen},
+		},
+		{
+			Key:     TaskKey{Kind: TaskKindFlashTick},
+			Payload: FlashTickPayload{Gen: ev.NewGen, Duration: 2 * time.Second},
+		},
+	}
+	return intents, tasks
+}
+
+// HandleRegionSelected processes a region selector confirmation. Mirrors
+// HandleProfileSelected but preserves the current profile.
+func (c *Core) HandleRegionSelected(ev RegionSelectedEvent) ([]UIIntent, []TaskRequest) {
+	hadPrev := c.session.HasPrevState
+	prevProf := c.session.PrevProfile
+	prevReg := c.session.PrevRegion
+	if !hadPrev {
+		prevProf = c.session.Profile
+		prevReg = c.session.Region
+	}
+
+	capturedProfile := c.session.Profile
+
+	c.session.Rotate()
+
+	c.session.HasPrevState = true
+	c.session.PrevProfile = prevProf
+	c.session.PrevRegion = prevReg
+	c.session.Region = ev.Region
+	c.session.PendingRefresh = true
+
+	intents := []UIIntent{
+		MenuClearAvailabilityIntent{},
+		PopSelectorIntent{},
+		FlashIntent{Text: "Switching to " + ev.Region + "..."},
+	}
+	tasks := []TaskRequest{
+		{
+			Key:     TaskKey{Kind: TaskKindConnect},
+			Payload: ConnectPayload{Profile: capturedProfile, Region: ev.Region, Gen: c.session.ConnectGen},
+		},
+		{
+			Key:     TaskKey{Kind: TaskKindFlashTick},
+			Payload: FlashTickPayload{Gen: ev.NewGen, Duration: 2 * time.Second},
+		},
+	}
+	return intents, tasks
+}

--- a/internal/runtime/handlers_test.go
+++ b/internal/runtime/handlers_test.go
@@ -1,0 +1,1014 @@
+// handlers_test.go — unit tests for the 6 handlers ported from
+// internal/tui in Phase-05 PR-05a-h3 (AS-324).
+//
+// Package runtime (not runtime_test) so we can access unexported fields
+// such as c.session directly, and read session-owned fields like
+// ConnectGen, HasPrevState, PrevProfile, PrevRegion, PendingRefresh,
+// etc., to assert state mutations made by the handlers.
+package runtime
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/session"
+	"github.com/k2m30/a9s/v3/internal/tui/messages"
+)
+
+// ---- helpers ---------------------------------------------------------------
+
+// newCore returns a Core with a fresh session and nil catalog (the 6 ported
+// handlers do not consult the catalog).
+func newCore() *Core {
+	return New(session.New(), nil)
+}
+
+// findFlashIntent returns the first FlashIntent in xs, or (FlashIntent{}, false).
+func findFlashIntent(xs []UIIntent) (FlashIntent, bool) {
+	for _, x := range xs {
+		if fi, ok := x.(FlashIntent); ok {
+			return fi, true
+		}
+	}
+	return FlashIntent{}, false
+}
+
+// findClearFlash returns true when xs contains a ClearFlash intent.
+func findClearFlash(xs []UIIntent) bool {
+	for _, x := range xs {
+		if _, ok := x.(ClearFlash); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// findSetErrorHint returns (intent, found).
+func findSetErrorHint(xs []UIIntent) (SetErrorHintIntent, bool) {
+	for _, x := range xs {
+		if h, ok := x.(SetErrorHintIntent); ok {
+			return h, true
+		}
+	}
+	return SetErrorHintIntent{}, false
+}
+
+// findAppendErrorHistory returns true when xs contains AppendErrorHistoryIntent.
+func findAppendErrorHistory(xs []UIIntent) bool {
+	for _, x := range xs {
+		if _, ok := x.(AppendErrorHistoryIntent); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// findClearActiveListLoading returns true when xs contains ClearActiveListLoadingIntent.
+func findClearActiveListLoading(xs []UIIntent) bool {
+	for _, x := range xs {
+		if _, ok := x.(ClearActiveListLoadingIntent); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// findFlashTick returns the first FlashTickPayload in tasks, or (FlashTickPayload{}, false).
+func findFlashTick(tasks []TaskRequest) (FlashTickPayload, bool) {
+	for _, t := range tasks {
+		if p, ok := t.Payload.(FlashTickPayload); ok {
+			return p, true
+		}
+	}
+	return FlashTickPayload{}, false
+}
+
+// hasTaskKind returns true when tasks contains at least one request with Kind k.
+func hasTaskKind(tasks []TaskRequest, k TaskKind) bool {
+	for _, t := range tasks {
+		if t.Key.Kind == k {
+			return true
+		}
+	}
+	return false
+}
+
+// findMenuClearAvailability returns true when xs contains MenuClearAvailabilityIntent.
+func findMenuClearAvailability(xs []UIIntent) bool {
+	for _, x := range xs {
+		if _, ok := x.(MenuClearAvailabilityIntent); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// findPopSelector returns true when xs contains PopSelectorIntent.
+func findPopSelector(xs []UIIntent) bool {
+	for _, x := range xs {
+		if _, ok := x.(PopSelectorIntent); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// findRefreshActiveList returns true when xs contains RefreshActiveListIntent.
+func findRefreshActiveList(xs []UIIntent) bool {
+	for _, x := range xs {
+		if _, ok := x.(RefreshActiveListIntent); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// findConnectPayload returns the ConnectPayload from the first TaskKindConnect task.
+func findConnectPayload(tasks []TaskRequest) (ConnectPayload, bool) {
+	for _, t := range tasks {
+		if t.Key.Kind == TaskKindConnect {
+			if p, ok := t.Payload.(ConnectPayload); ok {
+				return p, true
+			}
+		}
+	}
+	return ConnectPayload{}, false
+}
+
+// findEmitNavigatePayload returns the EmitNavigatePayload from the first
+// TaskKindEmitNavigate task.
+func findEmitNavigatePayload(tasks []TaskRequest) (EmitNavigatePayload, bool) {
+	for _, t := range tasks {
+		if t.Key.Kind == TaskKindEmitNavigate {
+			if p, ok := t.Payload.(EmitNavigatePayload); ok {
+				return p, true
+			}
+		}
+	}
+	return EmitNavigatePayload{}, false
+}
+
+// ---- HandleFlash tests -----------------------------------------------------
+
+// TestHandleFlash_NotError: IsError=false → single FlashIntent, no
+// AppendErrorHistoryIntent, one FlashTick with the right gen and 2 s duration.
+func TestHandleFlash_NotError(t *testing.T) {
+	c := newCore()
+	intents, tasks := c.HandleFlash(FlashEvent{Text: "hello", IsError: false, NewGen: 3})
+
+	// exactly one FlashIntent
+	fi, ok := findFlashIntent(intents)
+	if !ok {
+		t.Fatal("expected FlashIntent, got none")
+	}
+	if fi.Text != "hello" {
+		t.Errorf("FlashIntent.Text = %q, want %q", fi.Text, "hello")
+	}
+	if fi.IsError {
+		t.Error("FlashIntent.IsError = true, want false")
+	}
+
+	// no AppendErrorHistoryIntent
+	if findAppendErrorHistory(intents) {
+		t.Error("unexpected AppendErrorHistoryIntent for non-error flash")
+	}
+
+	// FlashTick with correct gen and 2 s
+	tick, ok := findFlashTick(tasks)
+	if !ok {
+		t.Fatal("expected FlashTickPayload task, got none")
+	}
+	if tick.Gen != 3 {
+		t.Errorf("FlashTickPayload.Gen = %d, want 3", tick.Gen)
+	}
+	if tick.Duration != 2*time.Second {
+		t.Errorf("FlashTickPayload.Duration = %v, want 2s", tick.Duration)
+	}
+}
+
+// TestHandleFlash_IsError: IsError=true → FlashIntent + AppendErrorHistoryIntent
+// + FlashTick with 2 s.
+func TestHandleFlash_IsError(t *testing.T) {
+	c := newCore()
+	intents, tasks := c.HandleFlash(FlashEvent{Text: "bad thing", IsError: true, NewGen: 7})
+
+	fi, ok := findFlashIntent(intents)
+	if !ok {
+		t.Fatal("expected FlashIntent")
+	}
+	if fi.Text != "bad thing" {
+		t.Errorf("FlashIntent.Text = %q, want %q", fi.Text, "bad thing")
+	}
+	if !fi.IsError {
+		t.Error("FlashIntent.IsError = false, want true")
+	}
+
+	if !findAppendErrorHistory(intents) {
+		t.Error("expected AppendErrorHistoryIntent for error flash, got none")
+	}
+
+	tick, ok := findFlashTick(tasks)
+	if !ok {
+		t.Fatal("expected FlashTickPayload task")
+	}
+	if tick.Gen != 7 {
+		t.Errorf("FlashTickPayload.Gen = %d, want 7", tick.Gen)
+	}
+	if tick.Duration != 2*time.Second {
+		t.Errorf("FlashTickPayload.Duration = %v, want 2s", tick.Duration)
+	}
+}
+
+// ---- HandleClearFlash tests ------------------------------------------------
+
+// TestHandleClearFlash_StaleGen: Gen != CurrentGen → nil, nil.
+func TestHandleClearFlash_StaleGen(t *testing.T) {
+	c := newCore()
+	intents, tasks := c.HandleClearFlash(ClearFlashEvent{Gen: 1, CurrentGen: 2, IsError: false})
+	if intents != nil {
+		t.Errorf("expected nil intents for stale gen, got %v", intents)
+	}
+	if tasks != nil {
+		t.Errorf("expected nil tasks for stale gen, got %v", tasks)
+	}
+}
+
+// TestHandleClearFlash_CurrentGen_NotError: matching gen, non-error flash →
+// ClearFlash intent only, no SetErrorHintIntent.
+func TestHandleClearFlash_CurrentGen_NotError(t *testing.T) {
+	c := newCore()
+	intents, tasks := c.HandleClearFlash(ClearFlashEvent{Gen: 5, CurrentGen: 5, IsError: false})
+
+	if !findClearFlash(intents) {
+		t.Error("expected ClearFlash intent")
+	}
+	if _, ok := findSetErrorHint(intents); ok {
+		t.Error("unexpected SetErrorHintIntent for non-error flash clear")
+	}
+	if tasks != nil {
+		t.Errorf("expected nil tasks, got %v", tasks)
+	}
+}
+
+// TestHandleClearFlash_CurrentGen_IsError: matching gen, error flash →
+// ClearFlash + SetErrorHintIntent{Show:true}.
+func TestHandleClearFlash_CurrentGen_IsError(t *testing.T) {
+	c := newCore()
+	intents, tasks := c.HandleClearFlash(ClearFlashEvent{Gen: 5, CurrentGen: 5, IsError: true})
+
+	if !findClearFlash(intents) {
+		t.Error("expected ClearFlash intent")
+	}
+	hint, ok := findSetErrorHint(intents)
+	if !ok {
+		t.Error("expected SetErrorHintIntent, got none")
+	}
+	if !hint.Show {
+		t.Error("SetErrorHintIntent.Show = false, want true")
+	}
+	if tasks != nil {
+		t.Errorf("expected nil tasks, got %v", tasks)
+	}
+}
+
+// ---- HandleAPIError tests --------------------------------------------------
+
+// TestHandleAPIError_UnknownError: plain errors.New error → classifier returns
+// "Unknown", handler uses err.Error() as flash text.
+func TestHandleAPIError_UnknownError(t *testing.T) {
+	c := newCore()
+	err := errors.New("boom")
+	intents, tasks := c.HandleAPIError(APIErrorEvent{Err: err, NewGen: 4})
+
+	fi, ok := findFlashIntent(intents)
+	if !ok {
+		t.Fatal("expected FlashIntent")
+	}
+	if fi.Text != "boom" {
+		t.Errorf("FlashIntent.Text = %q, want %q", fi.Text, "boom")
+	}
+	if !fi.IsError {
+		t.Error("FlashIntent.IsError = false, want true")
+	}
+
+	if !findAppendErrorHistory(intents) {
+		t.Error("expected AppendErrorHistoryIntent")
+	}
+	if !findClearActiveListLoading(intents) {
+		t.Error("expected ClearActiveListLoadingIntent")
+	}
+
+	tick, ok := findFlashTick(tasks)
+	if !ok {
+		t.Fatal("expected FlashTickPayload task")
+	}
+	if tick.Duration != 5*time.Second {
+		t.Errorf("FlashTickPayload.Duration = %v, want 5s", tick.Duration)
+	}
+	if tick.Gen != 4 {
+		t.Errorf("FlashTickPayload.Gen = %d, want 4", tick.Gen)
+	}
+}
+
+// TestHandleAPIError_AlwaysEmitsThreeIntents: regardless of error type, the
+// three mandatory intents must always be present.
+func TestHandleAPIError_AlwaysEmitsThreeIntents(t *testing.T) {
+	c := newCore()
+	intents, _ := c.HandleAPIError(APIErrorEvent{Err: errors.New("any"), NewGen: 1})
+
+	if _, ok := findFlashIntent(intents); !ok {
+		t.Error("missing FlashIntent")
+	}
+	if !findAppendErrorHistory(intents) {
+		t.Error("missing AppendErrorHistoryIntent")
+	}
+	if !findClearActiveListLoading(intents) {
+		t.Error("missing ClearActiveListLoadingIntent")
+	}
+}
+
+// TestHandleAPIError_AlwaysEmitsFlashTick: the 5 s tick is always scheduled.
+func TestHandleAPIError_AlwaysEmitsFlashTick(t *testing.T) {
+	c := newCore()
+	_, tasks := c.HandleAPIError(APIErrorEvent{Err: errors.New("any"), NewGen: 9})
+
+	tick, ok := findFlashTick(tasks)
+	if !ok {
+		t.Fatal("expected FlashTickPayload task")
+	}
+	if tick.Duration != 5*time.Second {
+		t.Errorf("FlashTickPayload.Duration = %v, want 5s", tick.Duration)
+	}
+}
+
+// ---- HandleClientsReady tests ----------------------------------------------
+
+// TestHandleClientsReady_StaleGen: ev.Gen != session.ConnectGen → nil, nil.
+func TestHandleClientsReady_StaleGen(t *testing.T) {
+	c := newCore()
+	// session.New() seeds ConnectGen=0; send Gen=99 which is != 0
+	intents, tasks := c.HandleClientsReady(ClientsReadyEvent{
+		Gen: 99, NewGen: 1,
+	})
+	if intents != nil {
+		t.Errorf("expected nil intents for stale gen, got %v", intents)
+	}
+	if tasks != nil {
+		t.Errorf("expected nil tasks for stale gen, got %v", tasks)
+	}
+}
+
+// TestHandleClientsReady_Failure_RollsBackPrevState: failure with HasPrevState=true
+// restores PrevProfile/PrevRegion and clears the latch.
+func TestHandleClientsReady_Failure_RollsBackPrevState(t *testing.T) {
+	c := newCore()
+	s := c.session
+	s.ConnectGen = 5
+	s.HasPrevState = true
+	s.PrevProfile = "old-profile"
+	s.PrevRegion = "old-region"
+	s.Profile = "new-profile"
+	s.Region = "new-region"
+
+	c.HandleClientsReady(ClientsReadyEvent{ //nolint:ineffassign,staticcheck // crash-verification; return values intentionally ignored
+		Gen: 5, NewGen: 6,
+		Err: errors.New("connect failed"),
+	})
+	//nolint:ineffassign,staticcheck // return values used above; re-reading session state here
+	_ = s // used to read session fields below
+
+	if s.Profile != "old-profile" {
+		t.Errorf("Profile after rollback = %q, want %q", s.Profile, "old-profile")
+	}
+	if s.Region != "old-region" {
+		t.Errorf("Region after rollback = %q, want %q", s.Region, "old-region")
+	}
+	if s.HasPrevState {
+		t.Error("HasPrevState should be cleared after rollback")
+	}
+	if s.PrevProfile != "" {
+		t.Errorf("PrevProfile should be cleared, got %q", s.PrevProfile)
+	}
+	if s.PrevRegion != "" {
+		t.Errorf("PrevRegion should be cleared, got %q", s.PrevRegion)
+	}
+	if s.PendingRefresh {
+		t.Error("PendingRefresh should be cleared after failure")
+	}
+}
+
+// TestHandleClientsReady_Failure_EmitsErrorIntents: failure path emits
+// FlashIntent(IsError=true) + AppendErrorHistoryIntent + FlashTick(5s).
+func TestHandleClientsReady_Failure_EmitsErrorIntents(t *testing.T) {
+	c := newCore()
+	s := c.session
+	s.ConnectGen = 2
+
+	intents, tasks := c.HandleClientsReady(ClientsReadyEvent{
+		Gen: 2, NewGen: 3,
+		Err: errors.New("no route to host"),
+	})
+
+	fi, ok := findFlashIntent(intents)
+	if !ok {
+		t.Fatal("expected FlashIntent")
+	}
+	if !fi.IsError {
+		t.Error("FlashIntent.IsError = false, want true")
+	}
+	if fi.Text != "no route to host" {
+		t.Errorf("FlashIntent.Text = %q, want %q", fi.Text, "no route to host")
+	}
+	if !findAppendErrorHistory(intents) {
+		t.Error("expected AppendErrorHistoryIntent")
+	}
+
+	tick, ok := findFlashTick(tasks)
+	if !ok {
+		t.Fatal("expected FlashTickPayload task")
+	}
+	if tick.Duration != 5*time.Second {
+		t.Errorf("FlashTickPayload.Duration = %v, want 5s", tick.Duration)
+	}
+	if tick.Gen != 3 {
+		t.Errorf("FlashTickPayload.Gen = %d, want 3", tick.Gen)
+	}
+}
+
+// TestHandleClientsReady_Failure_WithExistingClients_FiresBootstrapTasks:
+// when session.Clients != nil, failure path also fires FetchIdentity +
+// LoadAvailCache.
+func TestHandleClientsReady_Failure_WithExistingClients_FiresBootstrapTasks(t *testing.T) {
+	c := newCore()
+	s := c.session
+	s.ConnectGen = 2
+	s.Clients = &awsclient.ServiceClients{}
+
+	_, tasks := c.HandleClientsReady(ClientsReadyEvent{
+		Gen: 2, NewGen: 3,
+		Err: errors.New("oops"),
+	})
+
+	if !hasTaskKind(tasks, TaskKindFetchIdentity) {
+		t.Error("expected TaskKindFetchIdentity when session has existing clients")
+	}
+	if !hasTaskKind(tasks, TaskKindLoadAvailCache) {
+		t.Error("expected TaskKindLoadAvailCache when session has existing clients and NoCache=false")
+	}
+}
+
+// TestHandleClientsReady_Failure_WithExistingClients_NoCache: NoCache=true →
+// DemoPrefetchCounts instead of LoadAvailCache.
+func TestHandleClientsReady_Failure_WithExistingClients_NoCache(t *testing.T) {
+	c := newCore()
+	s := c.session
+	s.ConnectGen = 2
+	s.Clients = &awsclient.ServiceClients{}
+	s.NoCache = true
+
+	_, tasks := c.HandleClientsReady(ClientsReadyEvent{
+		Gen: 2, NewGen: 3,
+		Err: errors.New("oops"),
+	})
+
+	if !hasTaskKind(tasks, TaskKindFetchIdentity) {
+		t.Error("expected TaskKindFetchIdentity")
+	}
+	if !hasTaskKind(tasks, TaskKindDemoPrefetchCounts) {
+		t.Error("expected TaskKindDemoPrefetchCounts when NoCache=true")
+	}
+	if hasTaskKind(tasks, TaskKindLoadAvailCache) {
+		t.Error("unexpected TaskKindLoadAvailCache when NoCache=true")
+	}
+}
+
+// TestHandleClientsReady_Success_PreSuppliedClients: ev.Clients==nil with
+// PreSuppliedClients set → installs PreSuppliedClients into session.Clients.
+func TestHandleClientsReady_Success_PreSuppliedClients(t *testing.T) {
+	c := newCore()
+	s := c.session
+	s.ConnectGen = 1
+	pre := &awsclient.ServiceClients{}
+	s.PreSuppliedClients = pre
+
+	c.HandleClientsReady(ClientsReadyEvent{ //nolint:ineffassign,staticcheck // crash-verification
+		Gen: 1, NewGen: 2,
+		Clients: nil, // triggers PreSuppliedClients path
+	})
+
+	if s.Clients != pre {
+		t.Error("expected session.Clients to be set to PreSuppliedClients")
+	}
+}
+
+// TestHandleClientsReady_Success_InstallsClients: ev.Clients as *ServiceClients
+// → installs into session.Clients.
+func TestHandleClientsReady_Success_InstallsClients(t *testing.T) {
+	c := newCore()
+	s := c.session
+	s.ConnectGen = 1
+	fresh := &awsclient.ServiceClients{}
+
+	c.HandleClientsReady(ClientsReadyEvent{ //nolint:ineffassign,staticcheck // crash-verification
+		Gen: 1, NewGen: 2,
+		Clients: fresh,
+	})
+
+	if s.Clients != fresh {
+		t.Error("expected session.Clients to be set to ev.Clients")
+	}
+	if s.HasPrevState {
+		t.Error("HasPrevState should be cleared on success")
+	}
+}
+
+// TestHandleClientsReady_Success_PendingRefreshWithActiveRL: PendingRefresh=true
+// AND HasActiveRL=true → RefreshActiveListIntent + "Connected. Refreshing..."
+// flash, PendingRefresh cleared.
+func TestHandleClientsReady_Success_PendingRefreshWithActiveRL(t *testing.T) {
+	c := newCore()
+	s := c.session
+	s.ConnectGen = 1
+	s.PendingRefresh = true
+
+	intents, _ := c.HandleClientsReady(ClientsReadyEvent{
+		Gen: 1, NewGen: 2,
+		Clients:     &awsclient.ServiceClients{},
+		HasActiveRL: true,
+	})
+
+	if !findRefreshActiveList(intents) {
+		t.Error("expected RefreshActiveListIntent when PendingRefresh=true and HasActiveRL=true")
+	}
+	fi, ok := findFlashIntent(intents)
+	if !ok {
+		t.Error("expected FlashIntent for PendingRefresh path")
+	}
+	if fi.Text != "Connected. Refreshing..." {
+		t.Errorf("FlashIntent.Text = %q, want %q", fi.Text, "Connected. Refreshing...")
+	}
+	if s.PendingRefresh {
+		t.Error("PendingRefresh should be cleared after refresh")
+	}
+}
+
+// TestHandleClientsReady_Success_PendingRefresh_NoActiveRL: PendingRefresh=true
+// but HasActiveRL=false → no RefreshActiveListIntent, PendingRefresh cleared.
+func TestHandleClientsReady_Success_PendingRefresh_NoActiveRL(t *testing.T) {
+	c := newCore()
+	s := c.session
+	s.ConnectGen = 1
+	s.PendingRefresh = true
+
+	intents, _ := c.HandleClientsReady(ClientsReadyEvent{
+		Gen: 1, NewGen: 2,
+		Clients:     &awsclient.ServiceClients{},
+		HasActiveRL: false,
+	})
+
+	if findRefreshActiveList(intents) {
+		t.Error("unexpected RefreshActiveListIntent when HasActiveRL=false")
+	}
+	if s.PendingRefresh {
+		t.Error("PendingRefresh should still be cleared even when HasActiveRL=false")
+	}
+}
+
+// TestHandleClientsReady_Success_NoCache: NoCache=true → DemoPrefetchCounts
+// task instead of FetchIdentity + LoadAvailCache.
+func TestHandleClientsReady_Success_NoCache(t *testing.T) {
+	c := newCore()
+	s := c.session
+	s.ConnectGen = 1
+	s.NoCache = true
+
+	_, tasks := c.HandleClientsReady(ClientsReadyEvent{
+		Gen: 1, NewGen: 2,
+		Clients: &awsclient.ServiceClients{},
+	})
+
+	if !hasTaskKind(tasks, TaskKindDemoPrefetchCounts) {
+		t.Error("expected TaskKindDemoPrefetchCounts when NoCache=true")
+	}
+	if hasTaskKind(tasks, TaskKindFetchIdentity) {
+		t.Error("unexpected TaskKindFetchIdentity when NoCache=true")
+	}
+	if hasTaskKind(tasks, TaskKindLoadAvailCache) {
+		t.Error("unexpected TaskKindLoadAvailCache when NoCache=true")
+	}
+}
+
+// TestHandleClientsReady_Success_LivePath: normal live AWS path → FetchIdentity
+// + LoadAvailCache tasks.
+func TestHandleClientsReady_Success_LivePath(t *testing.T) {
+	c := newCore()
+	s := c.session
+	s.ConnectGen = 1
+
+	_, tasks := c.HandleClientsReady(ClientsReadyEvent{
+		Gen: 1, NewGen: 2,
+		Clients: &awsclient.ServiceClients{},
+	})
+
+	if !hasTaskKind(tasks, TaskKindFetchIdentity) {
+		t.Error("expected TaskKindFetchIdentity on live path")
+	}
+	if !hasTaskKind(tasks, TaskKindLoadAvailCache) {
+		t.Error("expected TaskKindLoadAvailCache on live path")
+	}
+}
+
+// TestHandleClientsReady_Success_Command_StackDepth1: Command set + StackDepth==1
+// → EmitNavigate task + Command cleared.
+func TestHandleClientsReady_Success_Command_StackDepth1(t *testing.T) {
+	c := newCore()
+	s := c.session
+	s.ConnectGen = 1
+	s.Command = "ec2"
+
+	_, tasks := c.HandleClientsReady(ClientsReadyEvent{
+		Gen: 1, NewGen: 2,
+		Clients:    &awsclient.ServiceClients{},
+		StackDepth: 1,
+	})
+
+	nav, ok := findEmitNavigatePayload(tasks)
+	if !ok {
+		t.Fatal("expected TaskKindEmitNavigate task when Command set and StackDepth==1")
+	}
+	if nav.Target != messages.TargetResourceList {
+		t.Errorf("EmitNavigatePayload.Target = %v, want TargetResourceList", nav.Target)
+	}
+	if nav.ResourceType != "ec2" {
+		t.Errorf("EmitNavigatePayload.ResourceType = %q, want %q", nav.ResourceType, "ec2")
+	}
+	if s.Command != "" {
+		t.Errorf("session.Command should be cleared after use, got %q", s.Command)
+	}
+}
+
+// TestHandleClientsReady_Success_Command_StackDepth2: Command set but
+// StackDepth > 1 → NO EmitNavigate, Command still cleared.
+func TestHandleClientsReady_Success_Command_StackDepth2(t *testing.T) {
+	c := newCore()
+	s := c.session
+	s.ConnectGen = 1
+	s.Command = "rds"
+
+	_, tasks := c.HandleClientsReady(ClientsReadyEvent{
+		Gen: 1, NewGen: 2,
+		Clients:    &awsclient.ServiceClients{},
+		StackDepth: 2,
+	})
+
+	if hasTaskKind(tasks, TaskKindEmitNavigate) {
+		t.Error("unexpected TaskKindEmitNavigate when StackDepth > 1")
+	}
+	if s.Command != "" {
+		t.Errorf("session.Command should still be cleared when StackDepth>1, got %q", s.Command)
+	}
+}
+
+// ---- HandleProfileSelected tests -------------------------------------------
+
+// TestHandleProfileSelected_FirstSwitch: no prior latch → captures current
+// Profile/Region as rollback target, bumps ConnectGen, sets new Profile, clears
+// Region, sets PendingRefresh, emits correct intents and tasks.
+func TestHandleProfileSelected_FirstSwitch(t *testing.T) {
+	c := newCore()
+	s := c.session
+	s.Profile = "original-profile"
+	s.Region = "us-east-1"
+	initialConnectGen := s.ConnectGen
+
+	intents, tasks := c.HandleProfileSelected(ProfileSelectedEvent{
+		Profile: "new-profile",
+		NewGen:  5,
+	})
+
+	// rollback latch captured before Rotate
+	if !s.HasPrevState {
+		t.Error("HasPrevState should be true after first switch")
+	}
+	if s.PrevProfile != "original-profile" {
+		t.Errorf("PrevProfile = %q, want %q", s.PrevProfile, "original-profile")
+	}
+	if s.PrevRegion != "us-east-1" {
+		t.Errorf("PrevRegion = %q, want %q", s.PrevRegion, "us-east-1")
+	}
+
+	// ConnectGen bumped by Rotate
+	if s.ConnectGen != initialConnectGen+1 {
+		t.Errorf("ConnectGen = %d, want %d", s.ConnectGen, initialConnectGen+1)
+	}
+
+	// new profile set, region cleared
+	if s.Profile != "new-profile" {
+		t.Errorf("Profile = %q, want %q", s.Profile, "new-profile")
+	}
+	if s.Region != "" {
+		t.Errorf("Region = %q, want empty after profile switch", s.Region)
+	}
+
+	// PendingRefresh set
+	if !s.PendingRefresh {
+		t.Error("PendingRefresh should be true after profile switch")
+	}
+
+	// intents: MenuClearAvailability, PopSelector, Flash
+	if !findMenuClearAvailability(intents) {
+		t.Error("expected MenuClearAvailabilityIntent")
+	}
+	if !findPopSelector(intents) {
+		t.Error("expected PopSelectorIntent")
+	}
+	fi, ok := findFlashIntent(intents)
+	if !ok {
+		t.Fatal("expected FlashIntent")
+	}
+	if fi.Text != "Switching to new-profile..." {
+		t.Errorf("FlashIntent.Text = %q, want %q", fi.Text, "Switching to new-profile...")
+	}
+
+	// tasks: Connect + FlashTick
+	cp, ok := findConnectPayload(tasks)
+	if !ok {
+		t.Fatal("expected TaskKindConnect")
+	}
+	if cp.Profile != "new-profile" {
+		t.Errorf("ConnectPayload.Profile = %q, want %q", cp.Profile, "new-profile")
+	}
+	if cp.Region != "" {
+		t.Errorf("ConnectPayload.Region = %q, want empty", cp.Region)
+	}
+	if cp.Gen != s.ConnectGen {
+		t.Errorf("ConnectPayload.Gen = %d, want %d", cp.Gen, s.ConnectGen)
+	}
+	tick, ok := findFlashTick(tasks)
+	if !ok {
+		t.Fatal("expected FlashTickPayload task")
+	}
+	if tick.Gen != 5 {
+		t.Errorf("FlashTickPayload.Gen = %d, want 5", tick.Gen)
+	}
+	if tick.Duration != 2*time.Second {
+		t.Errorf("FlashTickPayload.Duration = %v, want 2s", tick.Duration)
+	}
+}
+
+// TestHandleProfileSelected_SecondSwitch_PreservesRollbackTarget: rapid A→B→C
+// case — second switch must keep A (not B) as the rollback target.
+func TestHandleProfileSelected_SecondSwitch_PreservesRollbackTarget(t *testing.T) {
+	c := newCore()
+	s := c.session
+	s.Profile = "profile-A"
+	s.Region = "us-east-1"
+
+	// First switch A→B
+	c.HandleProfileSelected(ProfileSelectedEvent{Profile: "profile-B", NewGen: 1}) //nolint:ineffassign,staticcheck // return values intentionally ignored
+
+	// At this point PrevProfile should be "profile-A"
+	if s.PrevProfile != "profile-A" {
+		t.Fatalf("after first switch PrevProfile = %q, want %q", s.PrevProfile, "profile-A")
+	}
+
+	// Second switch B→C; must keep rollback target as A
+	c.HandleProfileSelected(ProfileSelectedEvent{Profile: "profile-C", NewGen: 2}) //nolint:ineffassign,staticcheck // return values intentionally ignored
+
+	if s.PrevProfile != "profile-A" {
+		t.Errorf("after second switch PrevProfile = %q, want %q (rapid A→B→C must keep A)", s.PrevProfile, "profile-A")
+	}
+}
+
+// ---- HandleRegionSelected tests --------------------------------------------
+
+// TestHandleRegionSelected_FirstSwitch: mirrors HandleProfileSelected — captures
+// rollback latch, bumps ConnectGen, sets region, preserves profile in ConnectPayload.
+func TestHandleRegionSelected_FirstSwitch(t *testing.T) {
+	c := newCore()
+	s := c.session
+	s.Profile = "my-profile"
+	s.Region = "eu-west-1"
+	initialConnectGen := s.ConnectGen
+
+	intents, tasks := c.HandleRegionSelected(RegionSelectedEvent{
+		Region: "ap-southeast-1",
+		NewGen: 8,
+	})
+
+	// rollback latch
+	if !s.HasPrevState {
+		t.Error("HasPrevState should be true after first region switch")
+	}
+	if s.PrevProfile != "my-profile" {
+		t.Errorf("PrevProfile = %q, want %q", s.PrevProfile, "my-profile")
+	}
+	if s.PrevRegion != "eu-west-1" {
+		t.Errorf("PrevRegion = %q, want %q", s.PrevRegion, "eu-west-1")
+	}
+
+	// ConnectGen bumped
+	if s.ConnectGen != initialConnectGen+1 {
+		t.Errorf("ConnectGen = %d, want %d", s.ConnectGen, initialConnectGen+1)
+	}
+
+	// new region set
+	if s.Region != "ap-southeast-1" {
+		t.Errorf("Region = %q, want %q", s.Region, "ap-southeast-1")
+	}
+
+	// PendingRefresh set
+	if !s.PendingRefresh {
+		t.Error("PendingRefresh should be true after region switch")
+	}
+
+	// intents
+	if !findMenuClearAvailability(intents) {
+		t.Error("expected MenuClearAvailabilityIntent")
+	}
+	if !findPopSelector(intents) {
+		t.Error("expected PopSelectorIntent")
+	}
+	fi, ok := findFlashIntent(intents)
+	if !ok {
+		t.Fatal("expected FlashIntent")
+	}
+	if fi.Text != "Switching to ap-southeast-1..." {
+		t.Errorf("FlashIntent.Text = %q, want %q", fi.Text, "Switching to ap-southeast-1...")
+	}
+
+	// ConnectPayload preserves existing Profile, sets new Region
+	cp, ok := findConnectPayload(tasks)
+	if !ok {
+		t.Fatal("expected TaskKindConnect")
+	}
+	if cp.Profile != "my-profile" {
+		t.Errorf("ConnectPayload.Profile = %q, want %q", cp.Profile, "my-profile")
+	}
+	if cp.Region != "ap-southeast-1" {
+		t.Errorf("ConnectPayload.Region = %q, want %q", cp.Region, "ap-southeast-1")
+	}
+	if cp.Gen != s.ConnectGen {
+		t.Errorf("ConnectPayload.Gen = %d, want %d", cp.Gen, s.ConnectGen)
+	}
+	tick, ok := findFlashTick(tasks)
+	if !ok {
+		t.Fatal("expected FlashTickPayload task")
+	}
+	if tick.Gen != 8 {
+		t.Errorf("FlashTickPayload.Gen = %d, want 8", tick.Gen)
+	}
+	if tick.Duration != 2*time.Second {
+		t.Errorf("FlashTickPayload.Duration = %v, want 2s", tick.Duration)
+	}
+}
+
+// TestHandleRegionSelected_SecondSwitch_PreservesRollbackTarget: rapid R1→R2→R3
+// case keeps R1 as rollback target.
+func TestHandleRegionSelected_SecondSwitch_PreservesRollbackTarget(t *testing.T) {
+	c := newCore()
+	s := c.session
+	s.Profile = "p"
+	s.Region = "us-east-1"
+
+	c.HandleRegionSelected(RegionSelectedEvent{Region: "eu-west-1", NewGen: 1}) //nolint:ineffassign,staticcheck // return values intentionally ignored
+
+	if s.PrevRegion != "us-east-1" {
+		t.Fatalf("after first switch PrevRegion = %q, want %q", s.PrevRegion, "us-east-1")
+	}
+
+	c.HandleRegionSelected(RegionSelectedEvent{Region: "ap-southeast-1", NewGen: 2}) //nolint:ineffassign,staticcheck // return values intentionally ignored
+
+	if s.PrevRegion != "us-east-1" {
+		t.Errorf("after second switch PrevRegion = %q, want %q (rapid switch must keep original)", s.PrevRegion, "us-east-1")
+	}
+}
+
+// TestHandleRegionSelected_ConnectPayload_ProfilePreserved: the ConnectPayload
+// must carry the session's current Profile (not empty string) when the region
+// changes.
+func TestHandleRegionSelected_ConnectPayload_ProfilePreserved(t *testing.T) {
+	c := newCore()
+	s := c.session
+	s.Profile = "prod"
+	s.Region = "us-west-2"
+
+	_, tasks := c.HandleRegionSelected(RegionSelectedEvent{Region: "us-east-2", NewGen: 1})
+
+	cp, ok := findConnectPayload(tasks)
+	if !ok {
+		t.Fatal("expected TaskKindConnect")
+	}
+	// Profile must come from s.Profile (captured before Rotate clears it —
+	// the handler assigns s.Region = ev.Region but never touches s.Profile).
+	// After Rotate s.Profile is still "prod" (Rotate does not clear Profile).
+	if cp.Profile != "prod" {
+		t.Errorf("ConnectPayload.Profile = %q, want %q", cp.Profile, "prod")
+	}
+}
+
+// TestHandleClientsReady_Success_ClearsHasPrevState: success path always clears
+// HasPrevState, PrevProfile, PrevRegion.
+func TestHandleClientsReady_Success_ClearsHasPrevState(t *testing.T) {
+	c := newCore()
+	s := c.session
+	s.ConnectGen = 1
+	s.HasPrevState = true
+	s.PrevProfile = "was-this"
+	s.PrevRegion = "was-there"
+
+	c.HandleClientsReady(ClientsReadyEvent{ //nolint:ineffassign,staticcheck // crash-verification
+		Gen: 1, NewGen: 2,
+		Clients: &awsclient.ServiceClients{},
+	})
+
+	if s.HasPrevState {
+		t.Error("HasPrevState should be cleared on success")
+	}
+	if s.PrevProfile != "" {
+		t.Errorf("PrevProfile should be cleared, got %q", s.PrevProfile)
+	}
+	if s.PrevRegion != "" {
+		t.Errorf("PrevRegion should be cleared, got %q", s.PrevRegion)
+	}
+}
+
+// TestHandleFlash_FlashTickKind: FlashTick task always uses TaskKindFlashTick.
+func TestHandleFlash_FlashTickKind(t *testing.T) {
+	c := newCore()
+	_, tasks := c.HandleFlash(FlashEvent{Text: "x", IsError: false, NewGen: 1})
+	if !hasTaskKind(tasks, TaskKindFlashTick) {
+		t.Error("expected TaskKindFlashTick task")
+	}
+}
+
+// TestHandleAPIError_FlashTickKind: HandleAPIError always uses TaskKindFlashTick.
+func TestHandleAPIError_FlashTickKind(t *testing.T) {
+	c := newCore()
+	_, tasks := c.HandleAPIError(APIErrorEvent{Err: errors.New("e"), NewGen: 1})
+	if !hasTaskKind(tasks, TaskKindFlashTick) {
+		t.Error("expected TaskKindFlashTick task")
+	}
+}
+
+// TestHandleClearFlash_ZeroGen_IsStale: Gen=0, CurrentGen=0 are EQUAL so not
+// stale — should emit ClearFlash (verifies the stale guard is Gen != CurrentGen,
+// not Gen < CurrentGen).
+func TestHandleClearFlash_ZeroGen_BothZero_NotStale(t *testing.T) {
+	c := newCore()
+	intents, _ := c.HandleClearFlash(ClearFlashEvent{Gen: 0, CurrentGen: 0, IsError: false})
+	if !findClearFlash(intents) {
+		t.Error("Gen==CurrentGen==0 should NOT be stale; expected ClearFlash intent")
+	}
+}
+
+// TestHandleProfileSelected_ConnectGen_UsedInPayload: ConnectPayload.Gen must
+// equal the post-Rotate ConnectGen (the gen captured after Rotate, not before).
+func TestHandleProfileSelected_ConnectGen_UsedInPayload(t *testing.T) {
+	c := newCore()
+	s := c.session
+	s.Profile = "p"
+	s.Region = "r"
+	// Force a specific starting ConnectGen
+	s.ConnectGen = 10
+
+	_, tasks := c.HandleProfileSelected(ProfileSelectedEvent{Profile: "q", NewGen: 1})
+
+	cp, ok := findConnectPayload(tasks)
+	if !ok {
+		t.Fatal("expected TaskKindConnect")
+	}
+	// Rotate bumps ConnectGen from 10 to 11; ConnectPayload must carry 11.
+	if cp.Gen != 11 {
+		t.Errorf("ConnectPayload.Gen = %d, want 11 (post-Rotate ConnectGen)", cp.Gen)
+	}
+}
+
+// TestHandleClientsReady_Failure_NilClients_NoBootstrapTasks: failure with
+// session.Clients == nil → no FetchIdentity / LoadAvailCache tasks.
+func TestHandleClientsReady_Failure_NilClients_NoBootstrapTasks(t *testing.T) {
+	c := newCore()
+	s := c.session
+	s.ConnectGen = 1
+	// s.Clients is nil (default from session.New())
+
+	_, tasks := c.HandleClientsReady(ClientsReadyEvent{
+		Gen: 1, NewGen: 2,
+		Err: errors.New("first connect failed"),
+	})
+
+	if hasTaskKind(tasks, TaskKindFetchIdentity) {
+		t.Error("unexpected TaskKindFetchIdentity when session.Clients == nil")
+	}
+	if hasTaskKind(tasks, TaskKindLoadAvailCache) {
+		t.Error("unexpected TaskKindLoadAvailCache when session.Clients == nil")
+	}
+	if hasTaskKind(tasks, TaskKindDemoPrefetchCounts) {
+		t.Error("unexpected TaskKindDemoPrefetchCounts when session.Clients == nil")
+	}
+}
+
+// Sentinel to ensure the time import is used (AppendErrorHistoryIntent carries time.Time).
+var _ = time.Now

--- a/internal/runtime/intent.go
+++ b/internal/runtime/intent.go
@@ -1,6 +1,8 @@
 package runtime
 
 import (
+	"time"
+
 	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
@@ -147,3 +149,55 @@ func (FlashIntent) isIntent() {}
 type ClearFlash struct{}
 
 func (ClearFlash) isIntent() {}
+
+// SetErrorHintIntent toggles the persistent "errors visible — press ! to view"
+// hint shown after an error flash auto-clears (the adapter's showErrorHint
+// flag). HandleClearFlash emits this when the cleared flash carried an error.
+type SetErrorHintIntent struct {
+	Show bool
+}
+
+func (SetErrorHintIntent) isIntent() {}
+
+// AppendErrorHistoryIntent appends one entry to the adapter's per-session
+// error log used by the `!` overlay. HandleFlash / HandleAPIError /
+// HandleClientsReady emit this in error paths so the history matches the
+// flash text the user saw.
+type AppendErrorHistoryIntent struct {
+	Time    time.Time
+	Message string
+}
+
+func (AppendErrorHistoryIntent) isIntent() {}
+
+// ClearActiveListLoadingIntent tells the adapter to clear the loading
+// indicator on the currently-active resource-list view (if any). Emitted by
+// HandleAPIError so a failed AWS call removes the spinner immediately rather
+// than waiting for the next render.
+type ClearActiveListLoadingIntent struct{}
+
+func (ClearActiveListLoadingIntent) isIntent() {}
+
+// MenuClearAvailabilityIntent tells the adapter to reset the main-menu
+// availability counts before a profile/region switch reconnect. Emitted by
+// HandleProfileSelected / HandleRegionSelected so the menu shows the
+// "checking…" state until the new session reports back.
+type MenuClearAvailabilityIntent struct{}
+
+func (MenuClearAvailabilityIntent) isIntent() {}
+
+// PopSelectorIntent tells the adapter to pop the top view from its stack if
+// (and only if) that view is the profile/region/theme selector. Emitted by
+// the selector-confirm handlers so they do not need to inspect renderer
+// state to know whether the selector is on screen.
+type PopSelectorIntent struct{}
+
+func (PopSelectorIntent) isIntent() {}
+
+// RefreshActiveListIntent tells the adapter to re-fetch the currently-active
+// resource-list view, if there is one. Emitted by HandleClientsReady when
+// PendingRefresh is set so a successful post-switch connect refreshes the
+// list the user was viewing.
+type RefreshActiveListIntent struct{}
+
+func (RefreshActiveListIntent) isIntent() {}

--- a/internal/runtime/tasks.go
+++ b/internal/runtime/tasks.go
@@ -3,6 +3,8 @@ package runtime
 import (
 	"context"
 	"time"
+
+	"github.com/k2m30/a9s/v3/internal/tui/messages"
 )
 
 // TaskKind names a family of background tasks ("enrich", "related",
@@ -22,6 +24,44 @@ const (
 	// TaskKindSaveCache asks the adapter to persist the current availability
 	// state to disk. TaskKey.Scope is empty.
 	TaskKindSaveCache TaskKind = "save-cache"
+
+	// TaskKindConnect asks the adapter to start an AWS connect attempt for the
+	// profile/region carried by ConnectPayload, tagged with the current
+	// session ConnectGen so a slow-arriving ClientsReadyMsg can be rejected
+	// when the user switches again before this one returns.
+	TaskKindConnect TaskKind = "connect"
+
+	// TaskKindFetchIdentity asks the adapter to fetch the caller-identity
+	// record for the current session and dispatch it back as an
+	// IdentityLoadedMsg.
+	TaskKindFetchIdentity TaskKind = "fetch-identity"
+
+	// TaskKindLoadAvailCache asks the adapter to load the on-disk availability
+	// cache for the current profile/region and dispatch the result back as
+	// AvailabilityCacheLoadedMsg.
+	TaskKindLoadAvailCache TaskKind = "load-avail-cache"
+
+	// TaskKindDemoPrefetchCounts asks the adapter to run the demo-mode
+	// synchronous prefetch that emits AvailabilityPrefetchedMsg. Used in
+	// --no-cache and --demo paths to avoid the async probe pipeline.
+	TaskKindDemoPrefetchCounts TaskKind = "demo-prefetch-counts"
+
+	// TaskKindFlashTick asks the adapter to schedule a ClearFlashMsg dispatch
+	// after FlashTickPayload.Duration. The payload's Gen is the flash gen the
+	// scheduled dispatch should reference so a stale tick is rejected.
+	TaskKindFlashTick TaskKind = "flash-tick"
+
+	// TaskKindEmitNavigate asks the adapter to dispatch a one-shot
+	// NavigateMsg derived from the -c CLI flag. Used by HandleClientsReady
+	// on first connect when Command is set and the user is still on the
+	// main menu.
+	TaskKindEmitNavigate TaskKind = "emit-navigate"
+
+	// TaskKindEmitAPIError asks the adapter to dispatch a messages.APIErrorMsg
+	// back through the input pipeline, used by HandleClientsReady's
+	// impossible "wrong concrete type on ClientsReadyMsg.Clients" branch to
+	// route the error through HandleAPIError's classification flow.
+	TaskKindEmitAPIError TaskKind = "emit-api-error"
 )
 
 // TaskKey uniquely identifies one background task. Scope is kind-specific
@@ -98,3 +138,66 @@ type TaskRequest struct {
 	Cache   CachePolicy
 	Payload TaskPayload
 }
+
+// ConnectPayload carries the profile/region/gen the adapter must use when
+// starting an AWS connect attempt. The gen is captured at dispatch time so
+// the resulting ClientsReadyMsg can be rejected by the gen guard if the
+// user switches again before the connect returns.
+type ConnectPayload struct {
+	Profile string
+	Region  string
+	Gen     int
+}
+
+func (ConnectPayload) isTaskPayload() {}
+
+// FetchIdentityPayload carries no fields — fetching the caller identity
+// reads directly from the live session.Session via the adapter. The empty
+// struct exists so the runtime can request the task via the typed
+// TaskRequest contract instead of an opaque TaskKey alone.
+type FetchIdentityPayload struct{}
+
+func (FetchIdentityPayload) isTaskPayload() {}
+
+// LoadAvailCachePayload carries no fields — the adapter resolves the
+// on-disk cache path from the live session profile/region.
+type LoadAvailCachePayload struct{}
+
+func (LoadAvailCachePayload) isTaskPayload() {}
+
+// DemoPrefetchCountsPayload carries no fields — the adapter runs the demo
+// fixture prefetch using its retained PreSuppliedClients reference.
+type DemoPrefetchCountsPayload struct{}
+
+func (DemoPrefetchCountsPayload) isTaskPayload() {}
+
+// FlashTickPayload carries the duration the adapter should sleep before
+// emitting a ClearFlashMsg, and the flash gen that ClearFlashMsg should
+// reference. The runtime owns the gen (computed at dispatch time) so the
+// stale-clear guard works the same as it did before extraction.
+type FlashTickPayload struct {
+	Gen      int
+	Duration time.Duration
+}
+
+func (FlashTickPayload) isTaskPayload() {}
+
+// EmitNavigatePayload carries the one-shot navigation the adapter must
+// dispatch as messages.NavigateMsg on first successful connect, derived
+// from the -c / Command field on the session. Target is the typed
+// ViewTarget the renderer uses for its dispatch.
+type EmitNavigatePayload struct {
+	Target       messages.ViewTarget
+	ResourceType string
+}
+
+func (EmitNavigatePayload) isTaskPayload() {}
+
+// EmitAPIErrorPayload carries the error the adapter must dispatch as
+// messages.APIErrorMsg. Used by HandleClientsReady's impossible
+// "wrong concrete type on Clients" branch.
+type EmitAPIErrorPayload struct {
+	Err error
+}
+
+func (EmitAPIErrorPayload) isTaskPayload() {}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -3,9 +3,9 @@
 // per-type caches, and the generation counters that invalidate stale async
 // results on profile/region switch or refresh.
 //
-// Session is embedded as *session.Session into tui.Model. Field promotion
-// means access sites like m.ResourceCache, m.ProbeResources, m.RelatedGen
-// resolve transparently to the embedded Session.
+// Session is held as Session *session.Session on tui.Model. Access sites use
+// m.Session.ResourceCache, m.Session.ProbeResources, m.Session.RelatedGen etc.
+// directly.
 //
 // Rules of ownership:
 //

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -52,15 +52,17 @@ type errorEntry struct {
 // AWS clients, and routes all messages to the active child view.
 //
 // The Model pairs a UI shell (view stack, header, input mode, flash, theme)
-// with an embedded *session.Session that owns the in-memory orchestration
-// state tied to the active profile/region session. Field promotion means all
-// access sites like `m.ResourceCache` resolve transparently to the embedded
-// Session — see internal/session/session.go for the ownership contract.
-// handleProfileSelected / handleRegionSelected call m.Rotate() to invalidate
-// in-flight async results on switch.
+// with a named Session *session.Session field that owns the in-memory
+// orchestration state tied to the active profile/region session (un-embedded
+// in PR-05a-final to make session ownership explicit at every call site).
+// Access sites use m.Session.ResourceCache, m.Session.ProbeResources,
+// m.Session.RelatedGen, m.Session.Profile, m.Session.Clients, etc. —
+// see internal/session/session.go for the ownership contract.
+// handleProfileSelected / handleRegionSelected call m.Session.Rotate() to
+// invalidate in-flight async results on switch.
 type Model struct {
-	*session.Session               // embedded: session-scoped orchestration state (incl. Profile, Region, Clients, Identity, ConnectGen, etc. after PR-05a-h2)
-	core             *runtime.Core // platform-agnostic app core (shares same *session.Session)
+	Session *session.Session // session-scoped orchestration state (incl. Profile, Region, Clients, Identity, ConnectGen, etc. after PR-05a-h2; un-embedded in PR-05a-final)
+	core    *runtime.Core    // platform-agnostic app core (shares same *session.Session)
 
 	// --- UI shell state ---
 	width  int
@@ -105,13 +107,13 @@ type Option func(*Model)
 // WithProfile overrides the profile field on the session. Used in tests that need
 // a specific profile string without going through the live AWS bootstrap path.
 func WithProfile(profile string) Option {
-	return func(m *Model) { m.Profile = profile }
+	return func(m *Model) { m.Session.Profile = profile }
 }
 
 // WithRegion overrides the region field on the session. Used in tests that need
 // a specific region string without going through the live AWS bootstrap path.
 func WithRegion(region string) Option {
-	return func(m *Model) { m.Region = region }
+	return func(m *Model) { m.Session.Region = region }
 }
 
 // WithIsDemo marks the session as demo mode, which skips Wave 2 enrichment.
@@ -126,7 +128,7 @@ func WithIsDemo(demo bool) Option {
 // WithNoCache disables resource availability caching and background checks.
 func WithNoCache(disabled bool) Option {
 	return func(m *Model) {
-		m.NoCache = disabled
+		m.Session.NoCache = disabled
 	}
 }
 
@@ -134,7 +136,7 @@ func WithNoCache(disabled bool) Option {
 // synthetic ClientsReadyMsg instead of initiating a live AWS connection.
 func WithClients(clients *awsclient.ServiceClients) Option {
 	return func(m *Model) {
-		m.PreSuppliedClients = clients
+		m.Session.PreSuppliedClients = clients
 	}
 }
 
@@ -149,7 +151,7 @@ func WithActiveTheme(name string) Option {
 // directly on startup instead of the main menu. The caller is responsible for
 // resolving the input via resource.FindResourceType.
 func WithCommand(name string) Option {
-	return func(m *Model) { m.Command = name }
+	return func(m *Model) { m.Session.Command = name }
 }
 
 // New constructs the initial Model.
@@ -204,47 +206,13 @@ func (m Model) Cancel() {
 	}
 }
 
-// EnrichmentGen returns the current session-wide enrichment generation counter.
-// This accessor is used by tests to capture the pre-switch gen value and verify
-// that post-switch messages carrying the old gen are correctly discarded.
-//
-// Note: the method name shadows the promoted Session.EnrichmentGen field.
-// All write sites MUST use m.Session.EnrichmentGen explicitly.
-func (m Model) EnrichmentGen() int {
-	return m.Session.EnrichmentGen
-}
-
-// ActiveDetailResource is an exported test-only accessor for the top-of-stack
-// DetailModel resource — production code does not call it.
-// Lives outside _test.go because tests in tests/unit/ are package unit_test
-// and can't see same-package test helpers.
-// Returns ok=false when the active view is not a DetailModel.
-func (m Model) ActiveDetailResource() (resource.Resource, bool) {
-	if d, ok := m.activeView().(*views.DetailModel); ok {
-		return d.SourceResource(), true
-	}
-	return resource.Resource{}, false
-}
-
-// ActiveListResources is an exported test-only accessor for the top-of-stack
-// ResourceListModel's resource slice — production code does not call it.
-// Lives outside _test.go because tests in tests/unit/ are package unit_test
-// and can't see same-package test helpers.
-// Returns nil if the active view is not a ResourceListModel.
-func (m Model) ActiveListResources() []resource.Resource {
-	if rl, ok := m.activeView().(*views.ResourceListModel); ok {
-		return rl.AllResources()
-	}
-	return nil
-}
-
 // Init implements tea.Model. Fires a command to establish the AWS session.
 // When pre-supplied clients are present (demo mode or tests), emits a synthetic
 // ClientsReadyMsg immediately. Otherwise initiates the live AWS connection flow.
 func (m Model) Init() tea.Cmd {
-	if m.PreSuppliedClients != nil {
+	if m.Session.PreSuppliedClients != nil {
 		preCmd := func() tea.Msg {
-			return messages.ClientsReadyMsg{Clients: m.PreSuppliedClients}
+			return messages.ClientsReadyMsg{Clients: m.Session.PreSuppliedClients}
 		}
 		if m.configErr != nil {
 			return tea.Batch(preCmd, func() tea.Msg {
@@ -258,8 +226,8 @@ func (m Model) Init() tea.Cmd {
 	}
 	connectCmd := func() tea.Msg {
 		return messages.InitConnectMsg{
-			Profile: m.Profile,
-			Region:  m.Region,
+			Profile: m.Session.Profile,
+			Region:  m.Session.Region,
 		}
 	}
 	if m.configErr != nil {
@@ -318,7 +286,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case messages.ClearFlashMsg:
 		return m.handleClearFlash(msg)
 	case messages.InitConnectMsg:
-		cmd := m.connectAWS(msg.Profile, msg.Region, m.ConnectGen)
+		cmd := m.connectAWS(msg.Profile, msg.Region, m.Session.ConnectGen)
 		return m, cmd
 	case messages.ClientsReadyMsg:
 		return m.handleClientsReady(msg)
@@ -381,7 +349,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if rl.ParentContext() == nil && !rl.EscPops() {
 					rt := rl.ResourceType()
 					sortColIdx, sortAsc := rl.SortState()
-					updatedModel.ResourceCache[rt] = &session.ResourceCacheEntry{
+					updatedModel.Session.ResourceCache[rt] = &session.ResourceCacheEntry{
 						Resources:     rl.AllResources(),
 						Pagination:    rl.PaginationState(),
 						FilterText:    rl.FilterText(),
@@ -396,8 +364,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// Active view is not a ResourceList for this type (e.g., detail or menu).
 				// Cache resources directly from the message so handleRelatedNavigate
 				// can find them when navigating to a related resource type.
-				if _, alreadyCached := updatedModel.ResourceCache[msg.ResourceType]; !alreadyCached {
-					updatedModel.ResourceCache[msg.ResourceType] = &session.ResourceCacheEntry{
+				if _, alreadyCached := updatedModel.Session.ResourceCache[msg.ResourceType]; !alreadyCached {
+					updatedModel.Session.ResourceCache[msg.ResourceType] = &session.ResourceCacheEntry{
 						Resources: msg.Resources,
 					}
 				}
@@ -412,15 +380,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// NOTE: This check runs regardless of which view is currently active —
 			// the user may have navigated away from the resource list before the
 			// fetch returned, but the rerun must still fire.
-			if msg.TypeGen != 0 && msg.TypeGen == updatedModel.EnrichmentTypeGen[msg.ResourceType] {
-				if updatedModel.ProbeResources == nil {
-					updatedModel.ProbeResources = make(map[string][]resource.Resource)
+			if msg.TypeGen != 0 && msg.TypeGen == updatedModel.Session.EnrichmentTypeGen[msg.ResourceType] {
+				if updatedModel.Session.ProbeResources == nil {
+					updatedModel.Session.ProbeResources = make(map[string][]resource.Resource)
 				}
-				updatedModel.ProbeResources[msg.ResourceType] = msg.Resources
-				if updatedModel.ProbeTruncated == nil {
-					updatedModel.ProbeTruncated = make(map[string]bool)
+				updatedModel.Session.ProbeResources[msg.ResourceType] = msg.Resources
+				if updatedModel.Session.ProbeTruncated == nil {
+					updatedModel.Session.ProbeTruncated = make(map[string]bool)
 				}
-				updatedModel.ProbeTruncated[msg.ResourceType] = msg.Pagination != nil && msg.Pagination.IsTruncated
+				updatedModel.Session.ProbeTruncated[msg.ResourceType] = msg.Pagination != nil && msg.Pagination.IsTruncated
 				cmd = tea.Batch(cmd, updatedModel.probeEnrichment(msg.ResourceType, updatedModel.Session.EnrichmentGen))
 			}
 			return updatedModel, cmd
@@ -442,7 +410,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleEnrichDetail(msg)
 	case messages.EnrichDetailResultMsg:
 		// Discard stale enrichment results (same convention as relatedGen).
-		if msg.Generation != 0 && msg.Generation != m.EnrichGen {
+		if msg.Generation != 0 && msg.Generation != m.Session.EnrichGen {
 			return m, nil
 		}
 		// Surface enrichment errors as a flash message.
@@ -465,7 +433,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// stamps Generation=0 onto results. Generation=0 is therefore the safe
 		// sentinel for test/manual injection (always accepted). Any non-zero
 		// generation that doesn't match the current relatedGen is stale and dropped.
-		if msg.Generation != 0 && msg.Generation != m.RelatedGen {
+		if msg.Generation != 0 && msg.Generation != m.Session.RelatedGen {
 			return m, nil
 		}
 		// Accumulate in relatedCache so re-entering the same detail skips re-dispatch.
@@ -479,8 +447,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if sourceID != "" {
 			ck := session.RelatedCacheKey(msg.ResourceType, sourceID)
-			existing, _ := m.RelatedCache.Get(ck)
-			m.RelatedCache.Set(ck, append(existing, session.RelatedCacheResult{
+			existing, _ := m.Session.RelatedCache.Get(ck)
+			m.Session.RelatedCache.Set(ck, append(existing, session.RelatedCacheResult{
 				DefDisplayName: msg.DefDisplayName,
 				Result:         msg.Result,
 			}))
@@ -500,10 +468,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if td := resource.FindResourceType(aliasName); td != nil {
 				shortName = td.ShortName
 			}
-			if _, exists := m.ResourceCache[shortName]; exists {
+			if _, exists := m.Session.ResourceCache[shortName]; exists {
 				continue
 			}
-			if _, lazyExists := m.LazyResourceCache[shortName]; lazyExists {
+			if _, lazyExists := m.Session.LazyResourceCache[shortName]; lazyExists {
 				continue
 			}
 			// Site 4: derive findings before storing in ResourceCache so cached
@@ -516,7 +484,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if pagination == nil && entry.IsTruncated {
 				pagination = &resource.PaginationMeta{IsTruncated: true}
 			}
-			m.ResourceCache[shortName] = &session.ResourceCacheEntry{
+			m.Session.ResourceCache[shortName] = &session.ResourceCacheEntry{
 				Resources:  entry.Resources,
 				Pagination: pagination,
 			}
@@ -541,7 +509,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Site 5: derive findings across the new slice before merging into
 			// LazyResourceCache (PR-03a-shim wire-up).
 			(&m).deriveFindingsForType(shortName, extra)
-			existing := m.LazyResourceCache[shortName]
+			existing := m.Session.LazyResourceCache[shortName]
 			known := make(map[string]struct{}, len(existing))
 			for _, r := range existing {
 				known[r.ID] = struct{}{}
@@ -553,7 +521,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				known[r.ID] = struct{}{}
 				existing = append(existing, r)
 			}
-			m.LazyResourceCache[shortName] = existing
+			m.Session.LazyResourceCache[shortName] = existing
 		}
 		// Surface FetchByIDs failures as a visible flash error. Partial results
 		// are already merged above; the flash informs the operator that some IDs
@@ -633,8 +601,8 @@ func (m Model) View() tea.View {
 
 	active := m.activeView()
 
-	headerProfile := m.Profile
-	headerRegion := m.Region
+	headerProfile := m.Session.Profile
+	headerRegion := m.Session.Region
 	if sel, ok := active.(*views.SelectorModel); ok {
 		if sel.Title() == "aws-regions" {
 			headerRegion = "..."
@@ -931,7 +899,7 @@ func (m *Model) cacheTopLevelResourceList(rl views.ResourceListModel) {
 	}
 	rt := rl.ResourceType()
 	sortColIdx, sortAsc := rl.SortState()
-	m.ResourceCache[rt] = &session.ResourceCacheEntry{
+	m.Session.ResourceCache[rt] = &session.ResourceCacheEntry{
 		Resources:     rl.AllResources(),
 		Pagination:    rl.PaginationState(),
 		FilterText:    rl.FilterText(),
@@ -995,35 +963,35 @@ func (m Model) headerRight() string {
 
 // accountBadge returns the account alias (preferred) or account ID for the header.
 func (m Model) accountBadge() string {
-	if m.Identity == nil {
+	if m.Session.Identity == nil {
 		return ""
 	}
-	if m.Identity.AccountAlias != "" {
-		return m.Identity.AccountAlias
+	if m.Session.Identity.AccountAlias != "" {
+		return m.Session.Identity.AccountAlias
 	}
-	return m.Identity.AccountID
+	return m.Session.Identity.AccountID
 }
 
 // identityRoleName returns the identity name (role or user) for the header.
 func (m Model) identityRoleName() string {
-	if m.Identity == nil {
+	if m.Session.Identity == nil {
 		return ""
 	}
-	return m.Identity.IdentityName
+	return m.Session.Identity.IdentityName
 }
 
 // identityToViewData converts the cached CallerIdentity to a view-layer IdentityData.
 func (m Model) identityToViewData() views.IdentityData {
-	if m.Identity == nil {
+	if m.Session.Identity == nil {
 		return views.IdentityData{}
 	}
 	return views.IdentityData{
-		AccountID:     m.Identity.AccountID,
-		AccountAlias:  m.Identity.AccountAlias,
-		ARN:           m.Identity.Arn,
-		RoleName:      m.Identity.RoleName,
-		UserName:      m.Identity.UserName,
-		SessionName:   m.Identity.SessionName,
-		IsAssumedRole: m.Identity.IsAssumedRole,
+		AccountID:     m.Session.Identity.AccountID,
+		AccountAlias:  m.Session.Identity.AccountAlias,
+		ARN:           m.Session.Identity.Arn,
+		RoleName:      m.Session.Identity.RoleName,
+		UserName:      m.Session.Identity.UserName,
+		SessionName:   m.Session.Identity.SessionName,
+		IsAssumedRole: m.Session.Identity.IsAssumedRole,
 	}
 }

--- a/internal/tui/app_accessors.go
+++ b/internal/tui/app_accessors.go
@@ -1,0 +1,41 @@
+// app_accessors.go — exported Model accessors for tests and external callers.
+//
+// These methods live outside _test.go so that tests in tests/unit/ (package
+// unit_test) can reach them without being in the same package. Production code
+// does not call them.
+package tui
+
+import (
+	"github.com/k2m30/a9s/v3/internal/resource"
+	"github.com/k2m30/a9s/v3/internal/tui/views"
+)
+
+// EnrichmentGen returns the current session-wide enrichment generation counter.
+// This accessor is used by tests to capture the pre-switch gen value and verify
+// that post-switch messages carrying the old gen are correctly discarded.
+//
+// Note: the method name shadows the promoted Session.EnrichmentGen field.
+// All write sites MUST use m.Session.EnrichmentGen explicitly.
+func (m Model) EnrichmentGen() int {
+	return m.Session.EnrichmentGen
+}
+
+// ActiveDetailResource is an exported test-only accessor for the top-of-stack
+// DetailModel resource — production code does not call it.
+// Returns ok=false when the active view is not a DetailModel.
+func (m Model) ActiveDetailResource() (resource.Resource, bool) {
+	if d, ok := m.activeView().(*views.DetailModel); ok {
+		return d.SourceResource(), true
+	}
+	return resource.Resource{}, false
+}
+
+// ActiveListResources is an exported test-only accessor for the top-of-stack
+// ResourceListModel's resource slice — production code does not call it.
+// Returns nil if the active view is not a ResourceListModel.
+func (m Model) ActiveListResources() []resource.Resource {
+	if rl, ok := m.activeView().(*views.ResourceListModel); ok {
+		return rl.AllResources()
+	}
+	return nil
+}

--- a/internal/tui/app_enrich_fold.go
+++ b/internal/tui/app_enrich_fold.go
@@ -47,13 +47,13 @@ func (m *Model) applyEnrichment(resourceType string, findings map[string]resourc
 		}
 	}
 
-	if entry, ok := m.ResourceCache[canon]; ok {
+	if entry, ok := m.Session.ResourceCache[canon]; ok {
 		apply(entry.Resources)
 	}
-	if rows, ok := m.LazyResourceCache[canon]; ok {
+	if rows, ok := m.Session.LazyResourceCache[canon]; ok {
 		apply(rows)
 	}
-	if rows, ok := m.ProbeResources[canon]; ok {
+	if rows, ok := m.Session.ProbeResources[canon]; ok {
 		apply(rows)
 	}
 }
@@ -157,7 +157,7 @@ func stripWave2(findings []domain.Finding) []domain.Finding {
 // cache. Used by main-menu Ctrl+R to ensure the next list-open doesn't
 // rehydrate stale wave2 attention state via findingsFromRows.
 func clearAllWave2(m *Model) {
-	for _, entry := range m.ResourceCache {
+	for _, entry := range m.Session.ResourceCache {
 		if entry == nil {
 			continue
 		}
@@ -166,13 +166,13 @@ func clearAllWave2(m *Model) {
 			entry.Resources[i].AttentionDetails = nil
 		}
 	}
-	for _, rows := range m.LazyResourceCache {
+	for _, rows := range m.Session.LazyResourceCache {
 		for i := range rows {
 			rows[i].Findings = stripWave2(rows[i].Findings)
 			rows[i].AttentionDetails = nil
 		}
 	}
-	for _, rows := range m.ProbeResources {
+	for _, rows := range m.Session.ProbeResources {
 		for i := range rows {
 			rows[i].Findings = stripWave2(rows[i].Findings)
 			rows[i].AttentionDetails = nil

--- a/internal/tui/app_input.go
+++ b/internal/tui/app_input.go
@@ -59,15 +59,15 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if _, ok := m.activeView().(*views.IdentityModel); ok {
 			return m.updateActiveView(msg)
 		}
-		id := views.NewIdentity(m.Profile, m.Region, m.keys)
-		if m.Identity != nil {
+		id := views.NewIdentity(m.Session.Profile, m.Session.Region, m.keys)
+		if m.Session.Identity != nil {
 			data := m.identityToViewData()
 			id.SetIdentity(data)
 		}
 		id.SetSize(m.innerSize())
 		m.pushView(&id)
 		// Always re-fetch on i press
-		m.IdentityFetching = true
+		m.Session.IdentityFetching = true
 		cmd := m.fetchIdentity()
 		return m, cmd
 	}

--- a/internal/tui/app_session.go
+++ b/internal/tui/app_session.go
@@ -28,20 +28,20 @@ import (
 // pending refresh (after profile/region switch).
 func (m Model) handleClientsReady(msg messages.ClientsReadyMsg) (tea.Model, tea.Cmd) {
 	// Ignore stale results from a superseded connect (rapid profile/region switch)
-	if msg.Gen != m.ConnectGen {
+	if msg.Gen != m.Session.ConnectGen {
 		return m, nil
 	}
 
 	if msg.Err != nil {
 		// Rollback profile/region to previous stable values on connect failure
-		if m.HasPrevState {
-			m.Profile = m.PrevProfile
-			m.Region = m.PrevRegion
+		if m.Session.HasPrevState {
+			m.Session.Profile = m.Session.PrevProfile
+			m.Session.Region = m.Session.PrevRegion
 		}
-		m.HasPrevState = false
-		m.PrevProfile = ""
-		m.PrevRegion = ""
-		m.PendingRefresh = false
+		m.Session.HasPrevState = false
+		m.Session.PrevProfile = ""
+		m.Session.PrevRegion = ""
+		m.Session.PendingRefresh = false
 		newGen := m.flash.gen + 1
 		m.flash = flashState{text: msg.Err.Error(), isError: true, active: true, gen: newGen}
 		m.errorHistory = append(m.errorHistory, errorEntry{time: time.Now(), message: msg.Err.Error()})
@@ -54,7 +54,7 @@ func (m Model) handleClientsReady(msg messages.ClientsReadyMsg) (tea.Model, tea.
 		// Restore them using the still-valid old clients.
 		//
 		// IMPORTANT: Session.Rotate already swapped in fresh PolicyStore /
-		// IdentityStore on m, so the retained transport clients (m.Clients)
+		// IdentityStore on m, so the retained transport clients (m.Session.Clients)
 		// still point at the PRE-rotate stores. Without rewiring here,
 		// Pattern-C related checks (Glue tags, EBS Backup) and IAM lazy-add
 		// would read sticky state from the now-discarded old stores — the
@@ -63,13 +63,13 @@ func (m Model) handleClientsReady(msg messages.ClientsReadyMsg) (tea.Model, tea.
 		// successful reconnect. Rewire on rollback too. (P3 finding.)
 		var cmds []tea.Cmd
 		cmds = append(cmds, clearFlash)
-		if m.Clients != nil {
-			m.Clients.SetIAMPolicies(m.IAMPolicies)
-			m.Clients.SetIdentityStore(m.IdentityStore)
-			m.Clients.SetRuleSets(m.RuleSets)
-			m.IdentityFetching = true
+		if m.Session.Clients != nil {
+			m.Session.Clients.SetIAMPolicies(m.Session.IAMPolicies)
+			m.Session.Clients.SetIdentityStore(m.Session.IdentityStore)
+			m.Session.Clients.SetRuleSets(m.Session.RuleSets)
+			m.Session.IdentityFetching = true
 			cmds = append(cmds, m.fetchIdentity())
-			if m.NoCache {
+			if m.Session.NoCache {
 				cmds = append(cmds, m.demoPrefetchCounts())
 			} else {
 				cmds = append(cmds, m.loadAvailabilityCache())
@@ -78,32 +78,32 @@ func (m Model) handleClientsReady(msg messages.ClientsReadyMsg) (tea.Model, tea.
 		return m, tea.Batch(cmds...)
 	}
 	if msg.Clients == nil {
-		if m.Clients == nil && m.PreSuppliedClients != nil {
+		if m.Session.Clients == nil && m.Session.PreSuppliedClients != nil {
 			// Fall back to pre-supplied clients (demo path) when msg carries no clients.
 			// Wire per-session capability stores into the transport layer.
-			m.PreSuppliedClients.SetIAMPolicies(m.IAMPolicies)
-			m.PreSuppliedClients.SetIdentityStore(m.IdentityStore)
-			m.PreSuppliedClients.SetRuleSets(m.RuleSets)
-			m.Clients = m.PreSuppliedClients
+			m.Session.PreSuppliedClients.SetIAMPolicies(m.Session.IAMPolicies)
+			m.Session.PreSuppliedClients.SetIdentityStore(m.Session.IdentityStore)
+			m.Session.PreSuppliedClients.SetRuleSets(m.Session.RuleSets)
+			m.Session.Clients = m.Session.PreSuppliedClients
 		}
 	} else if clients, ok := msg.Clients.(*awsclient.ServiceClients); ok {
 		// Per-session stores: SES rule sets, IAM policies, and identity all
 		// live on m.{RuleSets,IAMPolicies,IdentityStore} after PR-02b/c/d. The
 		// legacy ClearAllSESRuleSetCaches global-clear is gone — fresh
 		// session = fresh store, wired here via thread-safe setters.
-		clients.SetIAMPolicies(m.IAMPolicies)
-		clients.SetIdentityStore(m.IdentityStore)
-		clients.SetRuleSets(m.RuleSets)
-		m.Clients = clients
+		clients.SetIAMPolicies(m.Session.IAMPolicies)
+		clients.SetIdentityStore(m.Session.IdentityStore)
+		clients.SetRuleSets(m.Session.RuleSets)
+		m.Session.Clients = clients
 	} else {
 		wrongTypeErr := fmt.Errorf("internal: unexpected ClientsReadyMsg.Clients type %T", msg.Clients)
 		return m, func() tea.Msg {
 			return messages.APIErrorMsg{Err: wrongTypeErr}
 		}
 	}
-	m.HasPrevState = false
-	m.PrevProfile = ""
-	m.PrevRegion = ""
+	m.Session.HasPrevState = false
+	m.Session.PrevProfile = ""
+	m.Session.PrevRegion = ""
 
 	// Emit a one-shot NavigateMsg if the -c flag set an initial command. Only
 	// fire while the app is still at the main menu (stack depth 1). If the
@@ -112,9 +112,9 @@ func (m Model) handleClientsReady(msg messages.ClientsReadyMsg) (tea.Model, tea.
 	// the user is doing. Cleared after first use so that subsequent
 	// ClientsReadyMsg (profile/region switch) don't re-navigate.
 	var navigateCmd tea.Cmd
-	if m.Command != "" {
+	if m.Session.Command != "" {
 		if len(m.stack) == 1 {
-			target := m.Command
+			target := m.Session.Command
 			navigateCmd = func() tea.Msg {
 				return messages.NavigateMsg{
 					Target:       messages.TargetResourceList,
@@ -122,27 +122,27 @@ func (m Model) handleClientsReady(msg messages.ClientsReadyMsg) (tea.Model, tea.
 				}
 			}
 		}
-		m.Command = "" // always clear, even if skipped, to prevent stale re-navigation
+		m.Session.Command = "" // always clear, even if skipped, to prevent stale re-navigation
 	}
 
-	if m.Profile == "" {
-		m.Profile = "default"
+	if m.Session.Profile == "" {
+		m.Session.Profile = "default"
 	}
-	if m.Region == "" {
+	if m.Session.Region == "" {
 		if msg.Region != "" {
-			m.Region = msg.Region
+			m.Session.Region = msg.Region
 		} else {
 			configPath := awsclient.DefaultConfigPath()
-			m.Region = awsclient.GetDefaultRegion(configPath, m.Profile)
+			m.Session.Region = awsclient.GetDefaultRegion(configPath, m.Session.Profile)
 		}
 	}
 	// In demo/no-cache mode, prefetch all counts synchronously in one cmd so the
 	// main menu shows counts immediately without the async probe pipeline.
 	// Skip identity fetch in demo mode — the profile/region are synthetic.
-	if m.NoCache {
+	if m.Session.NoCache {
 		availCmd := m.demoPrefetchCounts()
-		if m.PendingRefresh {
-			m.PendingRefresh = false
+		if m.Session.PendingRefresh {
+			m.Session.PendingRefresh = false
 			if rl, ok := m.activeView().(*views.ResourceListModel); ok {
 				m.flash = flashState{text: "Connected. Refreshing...", active: true}
 				cmd := m.refreshResourceList(*rl)
@@ -153,14 +153,14 @@ func (m Model) handleClientsReady(msg messages.ClientsReadyMsg) (tea.Model, tea.
 	}
 
 	// Fetch identity on every clients-ready event
-	m.IdentityFetching = true
+	m.Session.IdentityFetching = true
 	identityCmd := m.fetchIdentity()
 
 	// Load disk cache which then fires background probes for expired/missing entries.
 	availCmd := m.loadAvailabilityCache()
 
-	if m.PendingRefresh {
-		m.PendingRefresh = false
+	if m.Session.PendingRefresh {
+		m.Session.PendingRefresh = false
 		if rl, ok := m.activeView().(*views.ResourceListModel); ok {
 			m.flash = flashState{text: "Connected. Refreshing...", active: true}
 			cmd := m.refreshResourceList(*rl)
@@ -176,31 +176,31 @@ func (m Model) handleProfileSelected(msg messages.ProfileSelectedMsg) (tea.Model
 	// Capture rollback state BEFORE Rotate (which now clears HasPrevState/
 	// PrevProfile/PrevRegion). Only save prev on first switch; rapid A→B→C
 	// keeps A as rollback target.
-	hadPrev := m.HasPrevState
-	prevProf := m.PrevProfile
-	prevReg := m.PrevRegion
+	hadPrev := m.Session.HasPrevState
+	prevProf := m.Session.PrevProfile
+	prevReg := m.Session.PrevRegion
 	if !hadPrev {
 		hadPrev = true
-		prevProf = m.Profile
-		prevReg = m.Region
+		prevProf = m.Session.Profile
+		prevReg = m.Session.Region
 	}
-	m.Rotate() // bumps ConnectGen; clears Identity/IdentityFetching/PendingRefresh/HasPrevState/...
-	m.HasPrevState = hadPrev
-	m.PrevProfile = prevProf
-	m.PrevRegion = prevReg
-	m.Profile = msg.Profile
-	m.Region = "" // clear so handleClientsReady resolves the new profile's default region
+	m.Session.Rotate() // bumps ConnectGen; clears Identity/IdentityFetching/PendingRefresh/HasPrevState/...
+	m.Session.HasPrevState = hadPrev
+	m.Session.PrevProfile = prevProf
+	m.Session.PrevRegion = prevReg
+	m.Session.Profile = msg.Profile
+	m.Session.Region = "" // clear so handleClientsReady resolves the new profile's default region
 	if menu, ok := m.stack[0].(*views.MainMenuModel); ok {
 		menu.ClearAvailability()
 	}
-	m.PendingRefresh = true
+	m.Session.PendingRefresh = true
 	if _, ok := m.activeView().(*views.SelectorModel); ok {
 		m.popView()
 	}
 	flashCmd := func() tea.Msg {
 		return messages.FlashMsg{Text: "Switching to " + msg.Profile + "..."}
 	}
-	return m, tea.Batch(flashCmd, m.connectAWS(msg.Profile, "", m.ConnectGen))
+	return m, tea.Batch(flashCmd, m.connectAWS(msg.Profile, "", m.Session.ConnectGen))
 }
 
 // handleRegionSelected switches the AWS region, pops the region selector,
@@ -209,30 +209,30 @@ func (m Model) handleRegionSelected(msg messages.RegionSelectedMsg) (tea.Model, 
 	// Capture rollback state BEFORE Rotate (which now clears HasPrevState/
 	// PrevProfile/PrevRegion). Only save prev on first switch; rapid switches
 	// keep original as rollback target.
-	hadPrev := m.HasPrevState
-	prevProf := m.PrevProfile
-	prevReg := m.PrevRegion
+	hadPrev := m.Session.HasPrevState
+	prevProf := m.Session.PrevProfile
+	prevReg := m.Session.PrevRegion
 	if !hadPrev {
 		hadPrev = true
-		prevProf = m.Profile
-		prevReg = m.Region
+		prevProf = m.Session.Profile
+		prevReg = m.Session.Region
 	}
-	m.Rotate() // bumps ConnectGen; clears Identity/IdentityFetching/PendingRefresh/HasPrevState/...
-	m.HasPrevState = hadPrev
-	m.PrevProfile = prevProf
-	m.PrevRegion = prevReg
-	m.Region = msg.Region
+	m.Session.Rotate() // bumps ConnectGen; clears Identity/IdentityFetching/PendingRefresh/HasPrevState/...
+	m.Session.HasPrevState = hadPrev
+	m.Session.PrevProfile = prevProf
+	m.Session.PrevRegion = prevReg
+	m.Session.Region = msg.Region
 	if menu, ok := m.stack[0].(*views.MainMenuModel); ok {
 		menu.ClearAvailability()
 	}
-	m.PendingRefresh = true
+	m.Session.PendingRefresh = true
 	if _, ok := m.activeView().(*views.SelectorModel); ok {
 		m.popView()
 	}
 	flashCmd := func() tea.Msg {
 		return messages.FlashMsg{Text: "Switching to " + msg.Region + "..."}
 	}
-	return m, tea.Batch(flashCmd, m.connectAWS(m.Profile, msg.Region, m.ConnectGen))
+	return m, tea.Batch(flashCmd, m.connectAWS(m.Session.Profile, msg.Region, m.Session.ConnectGen))
 }
 
 // handleThemeSelected applies the selected theme, invalidates style caches,
@@ -290,7 +290,7 @@ func (m Model) handleThemeSelected(msg messages.ThemeSelectedMsg) (tea.Model, te
 
 // handleProfilesLoaded pushes the profile selector view onto the stack.
 func (m Model) handleProfilesLoaded(msg profilesLoadedMsg) (tea.Model, tea.Cmd) {
-	p := views.NewProfile(msg.profiles, m.Profile, m.keys)
+	p := views.NewProfile(msg.profiles, m.Session.Profile, m.keys)
 	p.SetSize(m.innerSize())
 	m.pushView(&p)
 	return m, nil

--- a/internal/tui/fetch_adapter.go
+++ b/internal/tui/fetch_adapter.go
@@ -23,7 +23,7 @@ type profilesLoadedMsg struct {
 // fetchResources returns a tea.Cmd that calls Core.FetchResources and
 // converts the result to ResourcesLoadedMsg or APIErrorMsg.
 func (m *Model) fetchResources(resourceType string) tea.Cmd {
-	ctx, clients := m.appCtx, m.Clients
+	ctx, clients := m.appCtx, m.Session.Clients
 	return func() tea.Msg {
 		res, err := m.core.FetchResources(ctx, clients, resourceType)
 		// Partial-success contract: fetchers may return BOTH a non-empty
@@ -44,7 +44,7 @@ func (m *Model) fetchResources(resourceType string) tea.Cmd {
 
 // fetchResourcesFiltered returns a tea.Cmd for a server-side filtered fetch.
 func (m *Model) fetchResourcesFiltered(resourceType string, filter map[string]string) tea.Cmd {
-	ctx, clients := m.appCtx, m.Clients
+	ctx, clients := m.appCtx, m.Session.Clients
 	return func() tea.Msg {
 		res, err := m.core.FetchResourcesFiltered(ctx, clients, resourceType, filter)
 		if err != nil && len(res.Resources) == 0 {
@@ -62,7 +62,7 @@ func (m *Model) fetchResourcesFiltered(resourceType string, filter map[string]st
 // fetchAMIDetail returns a tea.Cmd that fetches a single AMI by ID and
 // navigates to its detail view.
 func (m *Model) fetchAMIDetail(imageID string) tea.Cmd {
-	ctx, clients := m.appCtx, m.Clients
+	ctx, clients := m.appCtx, m.Session.Clients
 	return func() tea.Msg {
 		res, err := m.core.FetchAMIDetail(ctx, clients, imageID)
 		if err != nil {
@@ -78,7 +78,7 @@ func (m *Model) fetchAMIDetail(imageID string) tea.Cmd {
 
 // fetchChildResources returns a tea.Cmd for paginated child resource loading.
 func (m *Model) fetchChildResources(childType string, parentCtx map[string]string) tea.Cmd {
-	ctx, clients := m.appCtx, m.Clients
+	ctx, clients := m.appCtx, m.Session.Clients
 	return func() tea.Msg {
 		res, err := m.core.FetchChildResources(ctx, clients, childType, parentCtx)
 		if err != nil {
@@ -95,7 +95,7 @@ func (m *Model) fetchChildResources(childType string, parentCtx map[string]strin
 // fetchMoreResources returns a tea.Cmd that fetches the next page of a
 // paginated resource list using the continuation token from LoadMoreMsg.
 func (m *Model) fetchMoreResources(msg messages.LoadMoreMsg) tea.Cmd {
-	ctx, clients := m.appCtx, m.Clients
+	ctx, clients := m.appCtx, m.Session.Clients
 	p := runtime.FetchMoreParams{
 		ResourceType: msg.ResourceType,
 		Token:        msg.ContinuationToken,
@@ -119,7 +119,7 @@ func (m *Model) fetchMoreResources(msg messages.LoadMoreMsg) tea.Cmd {
 
 // fetchIdentity returns a tea.Cmd that fetches the AWS caller identity.
 func (m *Model) fetchIdentity() tea.Cmd {
-	ctx, clients := m.appCtx, m.Clients
+	ctx, clients := m.appCtx, m.Session.Clients
 	return func() tea.Msg {
 		identity, err := m.core.FetchIdentity(ctx, clients)
 		if err != nil {
@@ -142,7 +142,7 @@ func (m *Model) fetchProfiles() tea.Cmd {
 
 // fetchRevealValue returns a tea.Cmd that calls the registered reveal fetcher.
 func (m *Model) fetchRevealValue(resourceType, resourceID string) tea.Cmd {
-	ctx, clients := m.appCtx, m.Clients
+	ctx, clients := m.appCtx, m.Session.Clients
 	return func() tea.Msg {
 		value, err := m.core.FetchRevealValue(ctx, clients, resourceType, resourceID)
 		if err != nil {

--- a/internal/tui/probe_adapter.go
+++ b/internal/tui/probe_adapter.go
@@ -19,8 +19,8 @@ import (
 // loadAvailabilityCache returns a tea.Cmd that reads the availability cache
 // from disk and converts the result to AvailabilityCacheLoadedMsg.
 func (m *Model) loadAvailabilityCache() tea.Cmd {
-	profile := m.Profile
-	region := m.Region
+	profile := m.Session.Profile
+	region := m.Session.Region
 	return func() tea.Msg {
 		cf, err := m.core.LoadAvailabilityCache(profile, region)
 		if err != nil || cf == nil {
@@ -63,7 +63,7 @@ func (m *Model) loadAvailabilityCache() tea.Cmd {
 // probeResourceAvailability returns a tea.Cmd that runs a Wave-1 availability
 // probe for shortName and converts the result to AvailabilityCheckedMsg.
 func (m *Model) probeResourceAvailability(shortName string, gen int) tea.Cmd {
-	ctx, clients := m.appCtx, m.Clients
+	ctx, clients := m.appCtx, m.Session.Clients
 	return func() tea.Msg {
 		r := m.core.ProbeResourceAvailability(ctx, clients, shortName)
 		return messages.AvailabilityCheckedMsg{
@@ -82,11 +82,11 @@ func (m *Model) probeResourceAvailability(shortName string, gen int) tea.Cmd {
 // saveAvailabilityCache returns a tea.Cmd that persists the current
 // availability state to disk. No-op when caching is disabled (noCache=true).
 func (m *Model) saveAvailabilityCache() tea.Cmd {
-	if m.NoCache {
+	if m.Session.NoCache {
 		return nil
 	}
-	profile := m.Profile
-	region := m.Region
+	profile := m.Session.Profile
+	region := m.Session.Region
 
 	// Collect availability, truncation, and issue counts from main menu.
 	var entries map[string]int
@@ -117,8 +117,8 @@ func (m *Model) saveAvailabilityCache() tea.Cmd {
 // Used when pre-supplied clients are present and no-cache is active so the
 // main menu shows counts immediately without the async probe pipeline.
 func (m *Model) demoPrefetchCounts() tea.Cmd {
-	ctx, clients := m.appCtx, m.Clients
-	gen := m.AvailabilityGen
+	ctx, clients := m.appCtx, m.Session.Clients
+	gen := m.Session.AvailabilityGen
 	return func() tea.Msg {
 		r := m.core.DemoPrefetchCounts(ctx, clients)
 		return messages.AvailabilityPrefetchedMsg{
@@ -158,8 +158,8 @@ func (m *Model) refreshResourceListWithEnrichmentRerun(
 // probeEnrichment returns a tea.Cmd that runs the registered Wave-2 enricher
 // for shortName and converts the result to EnrichmentCheckedMsg.
 func (m *Model) probeEnrichment(shortName string, gen int) tea.Cmd {
-	ctx, clients := m.appCtx, m.Clients
-	typeGen := m.EnrichmentTypeGen[shortName]
+	ctx, clients := m.appCtx, m.Session.Clients
+	typeGen := m.Session.EnrichmentTypeGen[shortName]
 	if awsclient.IssueEnricherRegistry[shortName].Fn == nil {
 		return nil
 	}

--- a/internal/tui/probe_enrichment_cache_test.go
+++ b/internal/tui/probe_enrichment_cache_test.go
@@ -1,20 +1,20 @@
 package tui
 
 // probe_enrichment_cache_test.go — pin that probeEnrichment passes a cache
-// snapshot containing m.ProbeResources to the enricher closure, even when
-// m.ResourceCache is empty.
+// snapshot containing m.Session.ProbeResources to the enricher closure, even when
+// m.Session.ResourceCache is empty.
 //
 // Codex review (2026-04-25): the cross-ref enricher (e.g. dbi-snap orphan
 // detection) cannot fire on the initial enrichment pass if the cache snapshot
-// is built from m.ResourceCache alone, because that map is empty until the
+// is built from m.Session.ResourceCache alone, because that map is empty until the
 // user opens a list. ProbeResources holds the first-page rows retained by the
 // availability probe — it MUST be merged in. The fix is to call
 // m.buildResourceCacheSnapshot() (which merges all three sources) instead of
-// rolling an inline view of m.ResourceCache only.
+// rolling an inline view of m.Session.ResourceCache only.
 //
 // This test exercises the bug shape directly: register a capture-only enricher
-// for a sentinel resource type, populate m.ProbeResources["dbi"] with a sibling
-// row, leave m.ResourceCache empty, dispatch probeEnrichment, and assert the
+// for a sentinel resource type, populate m.Session.ProbeResources["dbi"] with a sibling
+// row, leave m.Session.ResourceCache empty, dispatch probeEnrichment, and assert the
 // enricher saw "dbi" in its cache argument.
 
 import (
@@ -30,9 +30,9 @@ import (
 )
 
 // TestProbeEnrichment_CacheSnapshotMergesProbeResources pins the contract
-// that probeEnrichment's cache snapshot includes m.ProbeResources, not just
-// m.ResourceCache. Pre-fix this test FAILS because the inline snapshot at
-// app_probes.go:344-353 builds only from m.ResourceCache.
+// that probeEnrichment's cache snapshot includes m.Session.ProbeResources, not just
+// m.Session.ResourceCache. Pre-fix this test FAILS because the inline snapshot at
+// app_probes.go:344-353 builds only from m.Session.ResourceCache.
 func TestProbeEnrichment_CacheSnapshotMergesProbeResources(t *testing.T) {
 	const sentinelType = "dbi-snap-probe-cache-pin"
 
@@ -75,7 +75,7 @@ func TestProbeEnrichment_CacheSnapshotMergesProbeResources(t *testing.T) {
 		core:    runtime.New(sess, catalog.ResourceTypes),
 		appCtx:  context.Background(),
 	}
-	m.ProbeResources = map[string][]resource.Resource{
+	m.Session.ProbeResources = map[string][]resource.Resource{
 		"dbi": {
 			{ID: "prod-dbi-1", Name: "prod-dbi-1"},
 		},
@@ -102,8 +102,8 @@ func TestProbeEnrichment_CacheSnapshotMergesProbeResources(t *testing.T) {
 	dbiEntry, ok := seenCache["dbi"]
 	if !ok {
 		t.Errorf("cache snapshot missing %q — enricher cannot run cross-ref signals against ProbeResources-only siblings.\n"+
-			"This is the Codex P1 regression: probeEnrichment must merge m.ProbeResources into the cache snapshot, "+
-			"not just m.ResourceCache (which is empty until the user opens a list).", "dbi")
+			"This is the Codex P1 regression: probeEnrichment must merge m.Session.ProbeResources into the cache snapshot, "+
+			"not just m.Session.ResourceCache (which is empty until the user opens a list).", "dbi")
 	}
 	if len(dbiEntry.Resources) != 1 || dbiEntry.Resources[0].ID != "prod-dbi-1" {
 		t.Errorf("cache[dbi].Resources = %v, want exactly the ProbeResources sibling row", dbiEntry.Resources)

--- a/internal/tui/runtime_adapter.go
+++ b/internal/tui/runtime_adapter.go
@@ -19,7 +19,7 @@
 //     fields without parsing TaskKey.Scope or accepting side-channel
 //     arguments. The closure builder stays in the adapter because it
 //     returns tea.Cmd and reads adapter-owned state (m.appCtx,
-//     m.Clients, the embedded session's EnrichGen and PolicyDocCache)
+//     m.Session.Clients, the embedded session's EnrichGen and PolicyDocCache)
 //     that has not yet migrated to the runtime core.
 package tui
 
@@ -105,14 +105,14 @@ func (m Model) runtimeTasksToCmd(tasks []runtime.TaskRequest) tea.Cmd {
 //
 // EnrichGen is captured from the embedded Session at dispatch time to
 // preserve stale-result-rejection semantics: the result handler in
-// app.go compares msg.Generation against m.EnrichGen on receipt.
+// app.go compares msg.Generation against m.Session.EnrichGen on receipt.
 // PolicyDocCache and clients are adapter-owned state that has not yet
 // migrated to the runtime core.
 func (m Model) enrichDetailCmd(p runtime.EnrichDetailPayload) tea.Cmd {
 	enricher := resource.GetDetailEnricher(p.ResourceType)
-	gen := m.EnrichGen             // session-owned, promoted via embedded *Session
-	policyDocs := m.PolicyDocCache // session-owned, promoted via embedded *Session
-	clients := m.Clients
+	gen := m.Session.EnrichGen             // session-owned, promoted via embedded *Session
+	policyDocs := m.Session.PolicyDocCache // session-owned, promoted via embedded *Session
+	clients := m.Session.Clients
 	appCtx := m.appCtx
 	dctx := &awsclient.DetailEnrichmentCtx{
 		Clients:    clients,

--- a/internal/tui/runtime_adapter_navigate.go
+++ b/internal/tui/runtime_adapter_navigate.go
@@ -12,7 +12,7 @@
 // handleCopy, handleRefresh / refreshResourceList, handleReveal,
 // handleIdentityLoaded, and handleIdentityError stay here as TUI-only
 // helpers because every line of their bodies depends on adapter state
-// (view stack, view-typed methods, flashState, m.Identity, tea.Cmd
+// (view stack, view-typed methods, flashState, m.Session.Identity, tea.Cmd
 // returns). Their runtime-policy parts (cache-mutation gen bumps,
 // per-type enrichment-rerun bookkeeping) are reads/writes against the
 // embedded *Session — same data the runtime sees through c.session.
@@ -124,7 +124,7 @@ func (m Model) handleNavigate(msg messages.NavigateMsg) (tea.Model, tea.Cmd) {
 			issueTrunc = menu.GetIssueTruncated()[canon]
 		}
 		rl.SetEnrichmentState(issueCount, issueTrunc, findingsFromRows(entry.Resources))
-		rl.SetTruncatedIDs(m.EnrichmentTruncatedIDs[canon])
+		rl.SetTruncatedIDs(m.Session.EnrichmentTruncatedIDs[canon])
 		m.pushView(&rl)
 		return m, nil
 
@@ -151,7 +151,7 @@ func (m Model) handleNavigate(msg messages.NavigateMsg) (tea.Model, tea.Cmd) {
 			issueTrunc = menu.GetIssueTruncated()[canon]
 		}
 		rl.SetEnrichmentState(issueCount, issueTrunc, nil)
-		rl.SetTruncatedIDs(m.EnrichmentTruncatedIDs[canon])
+		rl.SetTruncatedIDs(m.Session.EnrichmentTruncatedIDs[canon])
 		rl, initCmd := rl.Init()
 		m.pushView(&rl)
 		fetchCmd := navigateTasksToCmd(m, msg, result, tasks)
@@ -178,7 +178,7 @@ func (m Model) handleNavigate(msg messages.NavigateMsg) (tea.Model, tea.Cmd) {
 		}
 		if result.DispatchRelated && d.NeedsRelatedCheck() {
 			ck := session.RelatedCacheKey(result.ResolvedType, result.Resource.ID)
-			if cached, ok := m.RelatedCache.Get(ck); ok && len(cached) > 0 {
+			if cached, ok := m.Session.RelatedCache.Get(ck); ok && len(cached) > 0 {
 				d.ApplyRelatedResults(session.RelatedCacheReplay(result.ResolvedType, cached))
 			} else {
 				res := *result.Resource
@@ -237,7 +237,7 @@ func (m Model) handleNavigate(msg messages.NavigateMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case runtime.NavigateKindFetchProfiles:
-		if m.PreSuppliedClients != nil {
+		if m.Session.PreSuppliedClients != nil {
 			return m, func() tea.Msg {
 				return messages.FlashMsg{
 					Text:    "context switching is disabled in demo mode",
@@ -248,7 +248,7 @@ func (m Model) handleNavigate(msg messages.NavigateMsg) (tea.Model, tea.Cmd) {
 		return m, navigateTasksToCmd(m, msg, result, tasks)
 
 	case runtime.NavigateKindPushRegion:
-		if m.PreSuppliedClients != nil {
+		if m.Session.PreSuppliedClients != nil {
 			return m, func() tea.Msg {
 				return messages.FlashMsg{
 					Text:    "region switching is disabled in demo mode",
@@ -261,7 +261,7 @@ func (m Model) handleNavigate(msg messages.NavigateMsg) (tea.Model, tea.Cmd) {
 		for i, r := range regions {
 			regionCodes[i] = r.Code
 		}
-		rg := views.NewRegion(regionCodes, m.Region, m.keys)
+		rg := views.NewRegion(regionCodes, m.Session.Region, m.keys)
 		rg.SetSize(m.innerSize())
 		m.pushView(&rg)
 		return m, nil
@@ -388,22 +388,22 @@ func (m Model) handleCopy() (tea.Model, tea.Cmd) {
 func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 	// Main menu: restart availability checks (no-op in no-cache mode).
 	if _, ok := m.activeView().(*views.MainMenuModel); ok {
-		if m.NoCache {
+		if m.Session.NoCache {
 			return m, nil
 		}
 		// Increment gen to cancel any in-flight probes and enrichment.
-		m.AvailabilityGen++
+		m.Session.AvailabilityGen++
 		m.Session.EnrichmentGen++
-		m.EnrichmentRan = make(map[string]bool)
-		m.EnrichmentTypeGen = make(map[string]int)
-		m.EnrichmentTruncatedIDs = make(map[string]map[string]bool)
+		m.Session.EnrichmentRan = make(map[string]bool)
+		m.Session.EnrichmentTypeGen = make(map[string]int)
+		m.Session.EnrichmentTruncatedIDs = make(map[string]map[string]bool)
 		// Clear stale Wave 2 from all cached rows before resetting ProbeResources.
 		// Without this, opening a cached list before the new enrichment completes
 		// would show the previous run's attention state (PR #310 CodeRabbit
 		// finding B).
 		clearAllWave2(&m)
-		m.ProbeResources = make(map[string][]resource.Resource)
-		m.ProbeTruncated = make(map[string]bool)
+		m.Session.ProbeResources = make(map[string][]resource.Resource)
+		m.Session.ProbeTruncated = make(map[string]bool)
 		// Reset the menu's view-side state (availability, issue counts) in
 		// lockstep with the model-side maps above.
 		if menu, ok := m.stack[0].(*views.MainMenuModel); ok {
@@ -419,10 +419,10 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 		d.ResetRightColumn()
 		rt := d.ResourceType()
 		srcRes := d.SourceResource()
-		m.RelatedCache.Delete(session.RelatedCacheKey(rt, srcRes.ID))
-		m.RelatedGen++      // cancel in-flight results from previous batch
-		m.EnrichGen++       // cancel in-flight enrichment from previous batch
-		m.EnrichResKey = "" // force gen bump on next enrichment dispatch
+		m.Session.RelatedCache.Delete(session.RelatedCacheKey(rt, srcRes.ID))
+		m.Session.RelatedGen++      // cancel in-flight results from previous batch
+		m.Session.EnrichGen++       // cancel in-flight enrichment from previous batch
+		m.Session.EnrichResKey = "" // force gen bump on next enrichment dispatch
 		// Invalidate the SES v1 receipt rule set cache so Ctrl+R on a detail
 		// view picks up receipt-rule changes without requiring a profile/region
 		// switch. Swap (not Clear) so that any in-flight blocked
@@ -431,9 +431,9 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 		// sesActiveReceiptRuleSet captures its store reference at entry; we
 		// replace the slot here.
 		if rt == "ses" {
-			m.RuleSets = session.NewRuleSetStore()
-			if m.Clients != nil {
-				m.Clients.SetRuleSets(m.RuleSets)
+			m.Session.RuleSets = session.NewRuleSetStore()
+			if m.Session.Clients != nil {
+				m.Session.Clients.SetRuleSets(m.Session.RuleSets)
 			}
 		}
 		m.flash = flashState{text: "Refreshing...", isError: false, active: true}
@@ -475,13 +475,13 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 		(&m).applyEnrichment(rt, nil)
 	}
 
-	delete(m.ResourceCache, rt) // clear cache for refreshed type only
+	delete(m.Session.ResourceCache, rt) // clear cache for refreshed type only
 	if rt == "ses" {
 		// Swap (see detail-view path above): protects against in-flight blocked
 		// DescribeActiveReceiptRuleSet fetchers re-poisoning the cache.
-		m.RuleSets = session.NewRuleSetStore()
-		if m.Clients != nil {
-			m.Clients.SetRuleSets(m.RuleSets)
+		m.Session.RuleSets = session.NewRuleSetStore()
+		if m.Session.Clients != nil {
+			m.Session.Clients.SetRuleSets(m.Session.RuleSets)
 		}
 	}
 	m.flash = flashState{text: "Refreshing...", isError: false, active: true}
@@ -492,12 +492,12 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 	// probeResources and dispatch probeEnrichment on success.
 	if rl.ParentContext() == nil && !rl.EscPops() {
 		if _, hasEnricher := awsclient.IssueEnricherRegistry[rt]; hasEnricher {
-			m.EnrichmentTypeGen[rt]++
-			tok := m.EnrichmentTypeGen[rt]
-			delete(m.EnrichmentRan, rt)
+			m.Session.EnrichmentTypeGen[rt]++
+			tok := m.Session.EnrichmentTypeGen[rt]
+			delete(m.Session.EnrichmentRan, rt)
 			// Clear per-resource truncation markers too: if the refresh errors
 			// out, stale "?" prefixes must not persist across the rerun.
-			delete(m.EnrichmentTruncatedIDs, rt)
+			delete(m.Session.EnrichmentTruncatedIDs, rt)
 			// Wave2 already stripped above (pre-fetch cleanup). Strip any rows
 			// that entered via ProbeResources/LazyResourceCache (those paths
 			// are NOT covered by the pre-fetch cleanup above, which only
@@ -559,12 +559,12 @@ func (m Model) handleReveal() (tea.Model, tea.Cmd) {
 }
 
 // handleIdentityLoaded caches the identity and updates the identity view if
-// active. Adapter-side because m.Identity / m.IdentityFetching live on the
+// active. Adapter-side because m.Session.Identity / m.Session.IdentityFetching live on the
 // TUI Model today.
 func (m Model) handleIdentityLoaded(msg messages.IdentityLoadedMsg) (tea.Model, tea.Cmd) {
-	m.IdentityFetching = false
+	m.Session.IdentityFetching = false
 	if id, ok := msg.Identity.(*awsclient.CallerIdentity); ok {
-		m.Identity = id
+		m.Session.Identity = id
 	}
 	if idView, ok := m.activeView().(*views.IdentityModel); ok {
 		data := m.identityToViewData()
@@ -576,7 +576,7 @@ func (m Model) handleIdentityLoaded(msg messages.IdentityLoadedMsg) (tea.Model, 
 // handleIdentityError clears the fetching flag and updates the identity view
 // if active. Adapter-side for the same reason as handleIdentityLoaded.
 func (m Model) handleIdentityError(msg messages.IdentityErrorMsg) (tea.Model, tea.Cmd) {
-	m.IdentityFetching = false
+	m.Session.IdentityFetching = false
 	if idView, ok := m.activeView().(*views.IdentityModel); ok {
 		idView.SetError(msg.Err)
 	}

--- a/internal/tui/runtime_adapter_related.go
+++ b/internal/tui/runtime_adapter_related.go
@@ -16,7 +16,7 @@
 // It asks runtime.Core whether any RelatedDefs are registered for the source
 // type, and if so fans out one checker goroutine per def via relatedCheckCmd
 // (capped by runtime.MaxConcurrentProbes). The actual probe loop stays here in
-// the adapter because it depends on m.Clients, m.appCtx, and tea.Cmd —
+// the adapter because it depends on m.Session.Clients, m.appCtx, and tea.Cmd —
 // platform glue that does not belong in internal/runtime.
 //
 // Decision-locus follow-up (PR-05b): a few branches in this adapter still walk
@@ -82,7 +82,7 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigateMsg) (tea.Model
 		if rt == nil {
 			// Fetcher-only type (registered paginated fetcher but no ResourceTypeDef).
 			if len(result.RelatedIDs) > 0 {
-				if lazyRows, hasLazy := m.LazyResourceCache[msg.TargetType]; hasLazy {
+				if lazyRows, hasLazy := m.Session.LazyResourceCache[msg.TargetType]; hasLazy {
 					idSet := make(map[string]bool, len(result.RelatedIDs))
 					for _, id := range result.RelatedIDs {
 						idSet[id] = true
@@ -124,11 +124,11 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigateMsg) (tea.Model
 		if result.TargetID != "" {
 			// Exact AMI navigation should fetch by image ID instead of falling
 			// back to the owned-AMI list, which misses public and third-party images.
-			// PR-05b: when m.Clients moves into the runtime Core, the runtime will
+			// PR-05b: when m.Session.Clients moves into the runtime Core, the runtime will
 			// emit a typed FetchAMIDetail TaskRequest and this branch collapses
 			// into runtimeTasksToCmd; the adapter override stays for now because
 			// client selection is adapter-owned state.
-			if msg.TargetType == "ami" && m.Clients != nil {
+			if msg.TargetType == "ami" && m.Session.Clients != nil {
 				cmd := m.fetchAMIDetail(result.TargetID)
 				return m, cmd
 			}
@@ -149,7 +149,7 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigateMsg) (tea.Model
 
 		// RelatedIDs-based filtered list (multi or single cache miss).
 		if len(result.RelatedIDs) > 0 {
-			if entry, ok := m.ResourceCache[msg.TargetType]; ok {
+			if entry, ok := m.Session.ResourceCache[msg.TargetType]; ok {
 				idSet := make(map[string]bool, len(result.RelatedIDs))
 				for _, id := range result.RelatedIDs {
 					idSet[id] = true
@@ -161,7 +161,7 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigateMsg) (tea.Model
 					}
 				}
 				// Augment with lazy-cached resources. Prefer ResourceCache on ID collision.
-				if lazyRows, hasLazy := m.LazyResourceCache[msg.TargetType]; hasLazy {
+				if lazyRows, hasLazy := m.Session.LazyResourceCache[msg.TargetType]; hasLazy {
 					found := make(map[string]struct{}, len(filtered))
 					for _, r := range filtered {
 						found[r.ID] = struct{}{}
@@ -248,7 +248,7 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigateMsg) (tea.Model
 			// the runtime decision rather than a divergence. PR-05b will route the
 			// lazy-row slice through TaskRequest payload so the adapter no longer
 			// re-walks the cache.
-			if lazyRows, hasLazy := m.LazyResourceCache[msg.TargetType]; hasLazy {
+			if lazyRows, hasLazy := m.Session.LazyResourceCache[msg.TargetType]; hasLazy {
 				idSet := make(map[string]bool, len(result.RelatedIDs))
 				for _, id := range result.RelatedIDs {
 					idSet[id] = true
@@ -321,11 +321,11 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigateMsg) (tea.Model
 		}
 		var detailRes resource.Resource
 		var detailFound bool
-		if entry, ok := m.ResourceCache[msg.TargetType]; ok {
+		if entry, ok := m.Session.ResourceCache[msg.TargetType]; ok {
 			detailRes, detailFound = resolveDetailResource(entry.Resources)
 		}
 		if !detailFound {
-			if lazyRows, ok := m.LazyResourceCache[msg.TargetType]; ok {
+			if lazyRows, ok := m.Session.LazyResourceCache[msg.TargetType]; ok {
 				detailRes, detailFound = resolveDetailResource(lazyRows)
 			}
 		}
@@ -349,7 +349,7 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigateMsg) (tea.Model
 			m.pushView(&detail)
 			if detail.NeedsRelatedCheck() {
 				ck := session.RelatedCacheKey(msg.TargetType, r.ID)
-				if cached, ok := m.RelatedCache.Get(ck); ok && len(cached) > 0 {
+				if cached, ok := m.Session.RelatedCache.Get(ck); ok && len(cached) > 0 {
 					detail.ApplyRelatedResults(session.RelatedCacheReplay(msg.TargetType, cached))
 					return m, nil
 				}
@@ -440,7 +440,7 @@ func relatedNavigateTasksToCmd(m Model, targetType string, result runtime.Naviga
 			// When PR-05b lands the typed cmd/event split, the token rides on a
 			// structured TaskRequest payload (e.g. FetchMoreRequest) and this
 			// branch becomes a direct param pass-through.
-			if entry, ok := m.ResourceCache[targetType]; ok && entry.Pagination != nil {
+			if entry, ok := m.Session.ResourceCache[targetType]; ok && entry.Pagination != nil {
 				cmds = append(cmds, m.fetchMoreResources(messages.LoadMoreMsg{
 					ResourceType:      targetType,
 					ContinuationToken: entry.Pagination.NextToken,
@@ -486,10 +486,10 @@ func (m Model) relatedCheckCmd(res resource.Resource) tea.Cmd {
 	}
 
 	cache := m.buildResourceCacheSnapshot()
-	gen := m.RelatedGen
+	gen := m.Session.RelatedGen
 
-	mainCacheKeys := make(map[string]struct{}, len(m.ResourceCache))
-	for k := range m.ResourceCache {
+	mainCacheKeys := make(map[string]struct{}, len(m.Session.ResourceCache))
+	for k := range m.Session.ResourceCache {
 		mainCacheKeys[k] = struct{}{}
 	}
 
@@ -527,7 +527,7 @@ func (m Model) relatedCheckCmd(res resource.Resource) tea.Cmd {
 			if def.NeedsTargetCache {
 				if _, inMainCache := mainCacheKeys[def.TargetType]; !inMainCache {
 					if pf := resource.GetPaginatedFetcher(def.TargetType); pf != nil {
-						if fr, err := pf(ctx, m.Clients, ""); err == nil {
+						if fr, err := pf(ctx, m.Session.Clients, ""); err == nil {
 							isTrunc := fr.Pagination != nil && fr.Pagination.IsTruncated
 							if prev, hasPrev := localCache[def.TargetType]; hasPrev && prev.IsTruncated {
 								isTrunc = true
@@ -546,7 +546,7 @@ func (m Model) relatedCheckCmd(res resource.Resource) tea.Cmd {
 					}
 				}
 			}
-			result := def.Checker(ctx, m.Clients, res, localCache)
+			result := def.Checker(ctx, m.Session.Clients, res, localCache)
 			result.TargetType = def.TargetType
 			var lazyAdded map[string][]resource.Resource
 			var lazyAddError error
@@ -554,7 +554,7 @@ func (m Model) relatedCheckCmd(res resource.Resource) tea.Cmd {
 				if ff := resource.GetFetchByIDs(def.TargetType); ff != nil {
 					missing := runtime.MissingFromCache(localCache, def.TargetType, result.ResourceIDs)
 					if len(missing) > 0 {
-						extra, fetchErr := ff(ctx, m.Clients, missing)
+						extra, fetchErr := ff(ctx, m.Session.Clients, missing)
 						if fetchErr != nil {
 							lazyAddError = fetchErr
 						}

--- a/tests/unit/phase03_fold_test.go
+++ b/tests/unit/phase03_fold_test.go
@@ -13,7 +13,7 @@
 // ── Red-light expectations (before PR-03a-fold) ─────────────────────────────
 //
 //	Test 1/ProbeResources: fails because the handler's "all-enrichment-done"
-//	    cleanup (m.EnrichChecked >= m.EnrichTotal → m.ProbeResources = nil) runs
+//	    cleanup (m.Session.EnrichChecked >= m.Session.EnrichTotal → m.Session.ProbeResources = nil) runs
 //	    before the test can inspect the cache. After fold, applyEnrichment
 //	    must run BEFORE cleanup AND tests seed EnrichTotal=2 to keep ProbeResources
 //	    alive for inspection. Without EnrichTotal=2, this subtest ALWAYS fails.
@@ -132,7 +132,7 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 		t.Run(tc.name+"/ResourceCache", func(t *testing.T) {
 			m := newShimModel()
 
-			m.ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
+			m.Session.ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
 				Resources: []resource.Resource{
 					{ID: rid, Name: "test-" + tc.canonShort, Status: "running"},
 				},
@@ -145,7 +145,7 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 				TypeGen:      0,
 			})
 
-			entry, ok := m.ResourceCache[tc.canonShort]
+			entry, ok := m.Session.ResourceCache[tc.canonShort]
 			if !ok || len(entry.Resources) == 0 {
 				t.Fatalf("ResourceCache[%q] is empty after EnrichmentCheckedMsg", tc.canonShort)
 			}
@@ -185,7 +185,7 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 		t.Run(tc.name+"/LazyResourceCache", func(t *testing.T) {
 			m := newShimModel()
 
-			m.LazyResourceCache[tc.canonShort] = []resource.Resource{
+			m.Session.LazyResourceCache[tc.canonShort] = []resource.Resource{
 				{ID: rid, Name: "lazy-" + tc.canonShort, Status: "running"},
 			}
 
@@ -196,7 +196,7 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 				TypeGen:      0,
 			})
 
-			lazySlice, ok := m.LazyResourceCache[tc.canonShort]
+			lazySlice, ok := m.Session.LazyResourceCache[tc.canonShort]
 			if !ok || len(lazySlice) == 0 {
 				t.Fatalf("LazyResourceCache[%q] is empty after EnrichmentCheckedMsg", tc.canonShort)
 			}
@@ -215,19 +215,19 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 			m := newShimModel()
 
 			// Prevent the "all enrichment done" cleanup path (app_handlers_availability.go:
-			// if m.EnrichChecked >= m.EnrichTotal { m.ProbeResources = nil }).
+			// if m.Session.EnrichChecked >= m.Session.EnrichTotal { m.Session.ProbeResources = nil }).
 			// After EnrichChecked++ fires (0→1), we need 1 < EnrichTotal to avoid
 			// the cleanup so ProbeResources remains inspectable. Setting EnrichTotal=2
 			// simulates "one type still pending", keeping the cache alive.
-			m.EnrichTotal = 2
+			m.Session.EnrichTotal = 2
 
 			// ProbeResources is initialized via AvailabilityCheckedMsg in real usage,
 			// but for the fold test we set it directly — the fold must walk ProbeResources
 			// just as it walks the other two caches.
-			if m.ProbeResources == nil {
-				m.ProbeResources = make(map[string][]resource.Resource)
+			if m.Session.ProbeResources == nil {
+				m.Session.ProbeResources = make(map[string][]resource.Resource)
 			}
-			m.ProbeResources[tc.canonShort] = []resource.Resource{
+			m.Session.ProbeResources[tc.canonShort] = []resource.Resource{
 				{ID: rid, Name: "probe-" + tc.canonShort, Status: "running"},
 			}
 
@@ -238,7 +238,7 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 				TypeGen:      0,
 			})
 
-			probeSlice, ok := m.ProbeResources[tc.canonShort]
+			probeSlice, ok := m.Session.ProbeResources[tc.canonShort]
 			if !ok || len(probeSlice) == 0 {
 				t.Fatalf("ProbeResources[%q] is empty after EnrichmentCheckedMsg (fold path must update ProbeResources before cleanup)", tc.canonShort)
 			}
@@ -314,7 +314,7 @@ func TestFold_RepeatedEnrichmentReplacesWave2(t *testing.T) {
 			}
 
 			m := newShimModel()
-			m.ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
+			m.Session.ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
 				Resources: []resource.Resource{
 					{ID: rid, Name: "test-" + tc.canonShort, Status: "impaired"},
 				},
@@ -336,7 +336,7 @@ func TestFold_RepeatedEnrichmentReplacesWave2(t *testing.T) {
 				TypeGen:      0,
 			})
 
-			entry, ok := m.ResourceCache[tc.canonShort]
+			entry, ok := m.Session.ResourceCache[tc.canonShort]
 			if !ok || len(entry.Resources) == 0 {
 				t.Fatalf("ResourceCache[%q] is empty", tc.canonShort)
 			}
@@ -424,7 +424,7 @@ func TestFold_EmptyEnrichmentClearsWave2(t *testing.T) {
 			}
 
 			m := newShimModel()
-			m.ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
+			m.Session.ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
 				Resources: []resource.Resource{
 					{ID: rid, Name: "test-" + tc.canonShort, Status: "impaired"},
 				},
@@ -440,7 +440,7 @@ func TestFold_EmptyEnrichmentClearsWave2(t *testing.T) {
 
 			// Verify wave2 was set before clearing.
 			{
-				entry := m.ResourceCache[tc.canonShort]
+				entry := m.Session.ResourceCache[tc.canonShort]
 				if entry == nil || len(entry.Resources) == 0 {
 					t.Fatalf("ResourceCache[%q] empty after initial enrichment", tc.canonShort)
 				}
@@ -464,7 +464,7 @@ func TestFold_EmptyEnrichmentClearsWave2(t *testing.T) {
 				TypeGen:      0,
 			})
 
-			entry, ok := m.ResourceCache[tc.canonShort]
+			entry, ok := m.Session.ResourceCache[tc.canonShort]
 			if !ok || len(entry.Resources) == 0 {
 				t.Fatalf("ResourceCache[%q] is empty after empty EnrichmentCheckedMsg", tc.canonShort)
 			}
@@ -526,7 +526,7 @@ func TestFold_EnrichmentFindingsFieldDeleted(t *testing.T) {
 //
 // The pre-fix bug (PR #310 CodeRabbit finding A):
 //
-//	handleRefresh calls delete(m.ResourceCache[rt]) BEFORE applyEnrichment(rt, nil).
+//	handleRefresh calls delete(m.Session.ResourceCache[rt]) BEFORE applyEnrichment(rt, nil).
 //	applyEnrichment walks ResourceCache[rt] to find rows to clear — but the entry
 //	was just deleted, so it finds nothing. The ResourceListModel was constructed
 //	from entry.Resources when NavigateMsg was handled; the rl's internal slice
@@ -560,7 +560,7 @@ func TestFold_CtrlROnList_ClearsActiveRowFindings(t *testing.T) {
 
 	// Step 1: seed ResourceCache so NavigateMsg gets a cache hit and creates
 	// a ResourceListModel holding this slice.
-	m.ResourceCache["ec2"] = &session.ResourceCacheEntry{
+	m.Session.ResourceCache["ec2"] = &session.ResourceCacheEntry{
 		Resources: []resource.Resource{
 			{ID: rid, Name: "test-ec2", Status: "running"},
 		},
@@ -602,7 +602,7 @@ func TestFold_CtrlROnList_ClearsActiveRowFindings(t *testing.T) {
 
 	// Assertion: after Ctrl+R, no wave2 entry should remain on the rows
 	// visible in the active ResourceListModel. The fix requires applyEnrichment
-	// to run BEFORE delete(m.ResourceCache[rt]), so that rl's internal slice
+	// to run BEFORE delete(m.Session.ResourceCache[rt]), so that rl's internal slice
 	// has its wave2 findings cleared before the cache entry is removed.
 	postResources := m.ActiveListResources()
 	if len(postResources) == 0 {
@@ -614,7 +614,7 @@ func TestFold_CtrlROnList_ClearsActiveRowFindings(t *testing.T) {
 			if f.Source == wantSource {
 				t.Errorf(
 					"resource %q still has stale wave2 finding after Ctrl+R: Source=%q Phrase=%q; "+
-						"fix: call applyEnrichment(rt, nil) BEFORE delete(m.ResourceCache[rt]) in handleRefresh",
+						"fix: call applyEnrichment(rt, nil) BEFORE delete(m.Session.ResourceCache[rt]) in handleRefresh",
 					r.ID, f.Source, f.Phrase,
 				)
 			}
@@ -631,7 +631,7 @@ func TestFold_CtrlROnList_ClearsActiveRowFindings(t *testing.T) {
 // The pre-fix bug (PR #310 CodeRabbit finding B):
 //
 //	handleRefresh on the main-menu path resets side maps (ProbeResources,
-//	EnrichmentRan, etc.) but never touches m.ResourceCache. Rows in ResourceCache
+//	EnrichmentRan, etc.) but never touches m.Session.ResourceCache. Rows in ResourceCache
 //	retain stale r.Findings from the previous enrichment wave. When the user
 //	navigates back to a list, they see stale wave2 markers until a fresh
 //	EnrichmentCheckedMsg arrives and overwrites them.
@@ -664,12 +664,12 @@ func TestFold_MainMenuCtrlR_ClearsAllCachedWave2(t *testing.T) {
 	m = shimApplyMsg(m, messages.ClientsReadyMsg{Clients: nil})
 
 	// Step 1: seed ResourceCache for ec2 and s3 with running resources.
-	m.ResourceCache[ec2Short] = &session.ResourceCacheEntry{
+	m.Session.ResourceCache[ec2Short] = &session.ResourceCacheEntry{
 		Resources: []resource.Resource{
 			{ID: ec2ID, Name: "test-ec2", Status: "running"},
 		},
 	}
-	m.ResourceCache[s3Short] = &session.ResourceCacheEntry{
+	m.Session.ResourceCache[s3Short] = &session.ResourceCacheEntry{
 		Resources: []resource.Resource{
 			{ID: s3ID, Name: "test-bucket", Status: "running"},
 		},
@@ -698,7 +698,7 @@ func TestFold_MainMenuCtrlR_ClearsAllCachedWave2(t *testing.T) {
 		{ec2Short, ec2ID, "wave2:" + ec2Short},
 		{s3Short, s3ID, "wave2:" + s3Short},
 	} {
-		entry, ok := m.ResourceCache[tc.short]
+		entry, ok := m.Session.ResourceCache[tc.short]
 		if !ok || len(entry.Resources) == 0 {
 			t.Fatalf("pre-Ctrl+R: ResourceCache[%q] empty — enrichment not wired", tc.short)
 		}
@@ -728,7 +728,7 @@ func TestFold_MainMenuCtrlR_ClearsAllCachedWave2(t *testing.T) {
 		{ec2Short, "wave2:" + ec2Short},
 		{s3Short, "wave2:" + s3Short},
 	} {
-		entry, ok := m.ResourceCache[tc.short]
+		entry, ok := m.Session.ResourceCache[tc.short]
 		if !ok {
 			// Cache entry deleted on Ctrl+R is also acceptable — no stale wave2.
 			continue
@@ -824,7 +824,7 @@ func TestFold_AttentionDetailsCarryAcrossEntryPoints(t *testing.T) {
 
 			// Verify entry-point wave1 was set (shim site #4 must be wired for this to hold).
 			{
-				entry := m.ResourceCache[tc.canonShort]
+				entry := m.Session.ResourceCache[tc.canonShort]
 				if entry == nil || len(entry.Resources) == 0 {
 					t.Fatalf("ResourceCache[%q] empty after RelatedCheckResultMsg — site 4 shim not wired", tc.canonShort)
 				}
@@ -841,7 +841,7 @@ func TestFold_AttentionDetailsCarryAcrossEntryPoints(t *testing.T) {
 				TypeGen:      0,
 			})
 
-			entry, ok := m.ResourceCache[tc.canonShort]
+			entry, ok := m.Session.ResourceCache[tc.canonShort]
 			if !ok || len(entry.Resources) == 0 {
 				t.Fatalf("ResourceCache[%q] is empty after EnrichmentCheckedMsg", tc.canonShort)
 			}

--- a/tests/unit/phase03_shim_wireups_test.go
+++ b/tests/unit/phase03_shim_wireups_test.go
@@ -32,7 +32,7 @@
 //	   scaffolding. Covered by grep-audit.
 //
 //	#7 app_enrich.go — EnrichDetailResultMsg updates only the active DetailModel's
-//	   internal m.res field, not m.ResourceCache. That field is unexported and
+//	   internal m.res field, not m.Session.ResourceCache. That field is unexported and
 //	   inaccessible from this external test package. The wire-up will be verified
 //	   by the coder's grep-audit (exactly 7 sites).
 //
@@ -55,7 +55,7 @@
 //	   are missed. Pre-fix: only wave1 finding returned. Post-fix: 2 findings.
 //
 //	TestShim_NavigateAliasHitsCanonicalCache:
-//	   handleNavigate does m.ResourceCache[msg.ResourceType] — alias misses canonical
+//	   handleNavigate does m.Session.ResourceCache[msg.ResourceType] — alias misses canonical
 //	   cache key, bypasses deriveFindingsForType, leaving Findings empty. Pre-fix:
 //	   empty. Post-fix: Findings populated.
 //
@@ -100,11 +100,11 @@ func newShimModel() tui.Model {
 }
 
 // TestShim_ProbeResourcesPopulatesFindings verifies that when
-// AvailabilityCheckedMsg is handled the retained resources in m.ProbeResources
+// AvailabilityCheckedMsg is handled the retained resources in m.Session.ProbeResources
 // have their Findings field populated by DeriveFindings.
 //
 // Wire-up site: app_handlers_availability.go (~line 215), the
-// m.ProbeResources[msg.ResourceType] = msg.Resources assignment.
+// m.Session.ProbeResources[msg.ResourceType] = msg.Resources assignment.
 //
 // Table-driven: every row exercises a distinct resource type to ensure no
 // type is special-cased and aliases are handled correctly.
@@ -152,7 +152,7 @@ func TestShim_ProbeResourcesPopulatesFindings(t *testing.T) {
 			})
 
 			// The cache lookup must use the canonical short name, NOT the alias.
-			probeSlice, ok := m.ProbeResources[tc.canonShort]
+			probeSlice, ok := m.Session.ProbeResources[tc.canonShort]
 			if !ok || len(probeSlice) == 0 {
 				t.Fatalf("ProbeResources[%q] is empty — handler did not retain resources (alias=%q)", tc.canonShort, effective)
 			}
@@ -183,7 +183,7 @@ func TestShim_ProbeResourcesPopulatesFindings(t *testing.T) {
 
 // TestShim_EnrichmentCheckedBridgesWave2Findings is the critical Wave-2 bridge test.
 //
-// The test pre-seeds m.ResourceCache[tc.canonShort] with a resource that has
+// The test pre-seeds m.Session.ResourceCache[tc.canonShort] with a resource that has
 // tc.status, sends EnrichmentCheckedMsg (using alias if present), and asserts
 // the first finding is populated correctly.
 //
@@ -222,7 +222,7 @@ func TestShim_EnrichmentCheckedBridgesWave2Findings(t *testing.T) {
 			}
 
 			// Seed the cache under the canonical short name.
-			m.ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
+			m.Session.ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
 				Resources: []resource.Resource{res},
 			}
 
@@ -236,7 +236,7 @@ func TestShim_EnrichmentCheckedBridgesWave2Findings(t *testing.T) {
 				TypeGen:      0,
 			})
 
-			entry, ok := m.ResourceCache[tc.canonShort]
+			entry, ok := m.Session.ResourceCache[tc.canonShort]
 			if !ok || len(entry.Resources) == 0 {
 				t.Fatalf("ResourceCache[%q] is empty after EnrichmentCheckedMsg", tc.canonShort)
 			}
@@ -266,10 +266,10 @@ func TestShim_EnrichmentCheckedBridgesWave2Findings(t *testing.T) {
 }
 
 // TestShim_CachedPagesPopulatesFindings verifies that when RelatedCheckResultMsg
-// carries a CachedPages entry, the resources written to m.ResourceCache have
+// carries a CachedPages entry, the resources written to m.Session.ResourceCache have
 // their Findings field populated by DeriveFindings.
 //
-// Wire-up site: app.go (~line 489), the m.ResourceCache[shortName] = ... assignment
+// Wire-up site: app.go (~line 489), the m.Session.ResourceCache[shortName] = ... assignment
 // inside the CachedPages loop.
 //
 // Table-driven: aliased rows (rds-aliased, redis-aliased) are expected to fail
@@ -323,7 +323,7 @@ func TestShim_CachedPagesPopulatesFindings(t *testing.T) {
 			})
 
 			// After handling, the cache must be stored under the canonical key.
-			entry, ok := m.ResourceCache[tc.canonShort]
+			entry, ok := m.Session.ResourceCache[tc.canonShort]
 			if !ok || len(entry.Resources) == 0 {
 				t.Fatalf("ResourceCache[%q] is empty — CachedPages was not written (alias=%q)", tc.canonShort, effective)
 			}
@@ -353,10 +353,10 @@ func TestShim_CachedPagesPopulatesFindings(t *testing.T) {
 }
 
 // TestShim_LazyAddedPopulatesFindings verifies that when RelatedCheckResultMsg
-// carries a LazyAddedResources entry, the resources merged into m.LazyResourceCache
+// carries a LazyAddedResources entry, the resources merged into m.Session.LazyResourceCache
 // have their Findings field populated by DeriveFindings.
 //
-// Wire-up site: app.go (~line 517), the m.LazyResourceCache[shortName] = existing
+// Wire-up site: app.go (~line 517), the m.Session.LazyResourceCache[shortName] = existing
 // assignment inside the LazyAddedResources loop.
 //
 // Table-driven: aliased rows (rds-aliased, redis-aliased) are expected to fail
@@ -407,7 +407,7 @@ func TestShim_LazyAddedPopulatesFindings(t *testing.T) {
 			})
 
 			// The lazy cache must be stored under the canonical short name.
-			lazySlice, ok := m.LazyResourceCache[tc.canonShort]
+			lazySlice, ok := m.Session.LazyResourceCache[tc.canonShort]
 			if !ok || len(lazySlice) == 0 {
 				t.Fatalf("LazyResourceCache[%q] is empty — LazyAddedResources was not written (alias=%q)", tc.canonShort, effective)
 			}
@@ -489,7 +489,7 @@ func TestShim_DeriveHelpersResolveAlias(t *testing.T) {
 	// Set EnrichTotal > 1 so the "all enrichment done" branch (EnrichChecked >= EnrichTotal)
 	// does not fire after processing this single message, which would nil out ProbeResources
 	// before we can inspect it.
-	m.EnrichTotal = 2
+	m.Session.EnrichTotal = 2
 	m = shimApplyMsg(m, messages.EnrichmentCheckedMsg{
 		ResourceType: "dbi",
 		Findings: map[string]resource.EnrichmentFinding{
@@ -499,7 +499,7 @@ func TestShim_DeriveHelpersResolveAlias(t *testing.T) {
 		TypeGen: 0,
 	})
 
-	probeSlice, ok := m.ProbeResources["dbi"]
+	probeSlice, ok := m.Session.ProbeResources["dbi"]
 	if !ok || len(probeSlice) == 0 {
 		t.Fatal("ProbeResources[\"dbi\"] is empty after AvailabilityCheckedMsg with alias \"rds\"")
 	}
@@ -589,7 +589,7 @@ func TestShim_DeriveHelpersResolveAlias_SingleResource(t *testing.T) {
 	// Set EnrichTotal > 1 so the "all enrichment done" branch (EnrichChecked >= EnrichTotal)
 	// does not fire after processing this single message, which would nil out ProbeResources
 	// before we can inspect it.
-	m.EnrichTotal = 2
+	m.Session.EnrichTotal = 2
 	m = shimApplyMsg(m, messages.EnrichmentCheckedMsg{
 		ResourceType: "rds", // alias — exercises alias normalization in handleEnrichmentChecked
 		Findings: map[string]resource.EnrichmentFinding{
@@ -599,7 +599,7 @@ func TestShim_DeriveHelpersResolveAlias_SingleResource(t *testing.T) {
 		TypeGen: 0,
 	})
 
-	probeSlice, ok := m.ProbeResources["dbi"]
+	probeSlice, ok := m.Session.ProbeResources["dbi"]
 	if !ok || len(probeSlice) == 0 {
 		t.Fatal("ProbeResources[\"dbi\"] is empty after AvailabilityCheckedMsg with alias \"rds\"")
 	}
@@ -679,16 +679,16 @@ func TestShim_DeriveHelpersResolveAlias_SingleResource(t *testing.T) {
 // ──────────────────────────────────────────────────────────────────────────
 
 // TestShim_NavigateAliasHitsCanonicalCache verifies that handleNavigate resolves
-// an alias to the canonical ShortName before looking up m.ResourceCache.
+// an alias to the canonical ShortName before looking up m.Session.ResourceCache.
 //
-// Bug: app_handlers_navigate.go:49 does m.ResourceCache[msg.ResourceType] —
+// Bug: app_handlers_navigate.go:49 does m.Session.ResourceCache[msg.ResourceType] —
 // when msg.ResourceType is "rds" (alias) but the cache is keyed under "dbi"
 // (canonical), the lookup misses. deriveFindingsForType is never called on the
 // cached resources, so Findings remain empty.
 //
-// Setup: seed m.ResourceCache["dbi"] with one resource (Status="impaired").
+// Setup: seed m.Session.ResourceCache["dbi"] with one resource (Status="impaired").
 // Drive NavigateMsg{Target: TargetResourceList, ResourceType: "rds"}.
-// Post-fix: m.ResourceCache["dbi"].Resources[0].Findings is populated.
+// Post-fix: m.Session.ResourceCache["dbi"].Resources[0].Findings is populated.
 // Pre-fix: Findings is empty (cache entry found only after canonical lookup is wired).
 func TestShim_NavigateAliasHitsCanonicalCache(t *testing.T) {
 	m := newShimModel()
@@ -701,7 +701,7 @@ func TestShim_NavigateAliasHitsCanonicalCache(t *testing.T) {
 	}
 
 	// Seed the cache under the canonical key "dbi".
-	m.ResourceCache["dbi"] = &session.ResourceCacheEntry{
+	m.Session.ResourceCache["dbi"] = &session.ResourceCacheEntry{
 		Resources: []resource.Resource{res},
 	}
 
@@ -713,7 +713,7 @@ func TestShim_NavigateAliasHitsCanonicalCache(t *testing.T) {
 	})
 
 	// The cache under "dbi" must now have Findings populated.
-	entry, ok := m.ResourceCache["dbi"]
+	entry, ok := m.Session.ResourceCache["dbi"]
 	if !ok || len(entry.Resources) == 0 {
 		t.Fatal("ResourceCache[\"dbi\"] is empty after NavigateMsg — unexpected state")
 	}
@@ -793,10 +793,10 @@ func TestShim_ResourcesLoadedPopulatesFindings(t *testing.T) {
 			// an alias). The canonical test: check both canonical and alias keys to
 			// find where the entry landed, then assert Findings.
 			var entry *session.ResourceCacheEntry
-			if e, ok := m.ResourceCache[tc.canonShort]; ok {
+			if e, ok := m.Session.ResourceCache[tc.canonShort]; ok {
 				entry = e
 			} else if tc.alias != "" {
-				if e, ok := m.ResourceCache[effective]; ok {
+				if e, ok := m.Session.ResourceCache[effective]; ok {
 					entry = e
 				}
 			}

--- a/tests/unit/qa_prefetch_pagination_seed_test.go
+++ b/tests/unit/qa_prefetch_pagination_seed_test.go
@@ -58,7 +58,7 @@ func TestPrefetchPaginationSeed_PreservesNextToken(t *testing.T) {
 		Gen:            0,
 	})
 
-	entry, ok := m.ResourceCache[targetType]
+	entry, ok := m.Session.ResourceCache[targetType]
 	if !ok {
 		t.Fatalf("expected ResourceCache entry for %q after prefetch seed; got nil", targetType)
 	}
@@ -102,7 +102,7 @@ func TestPrefetchPaginationSeed_FallbackWhenPaginationOmitted(t *testing.T) {
 		Gen: 0,
 	})
 
-	entry, ok := m.ResourceCache[targetType]
+	entry, ok := m.Session.ResourceCache[targetType]
 	if !ok {
 		t.Fatalf("expected ResourceCache entry for %q after fallback prefetch seed; got nil", targetType)
 	}


### PR DESCRIPTION
## Summary

- Convert embedded `*session.Session` to named exported field `Session *session.Session` in `tui.Model`
- Shrink `internal/tui/app.go` from 1046 → 420 lines by extracting large inline handlers
- 5 large Update() cases extracted: `handleRelatedCheckResult`, `handleResourcesLoaded`, `handleLoadResources`, `handleEnrichDetailResult`, `handleRelatedNavigate`
- Stack/view helpers moved to `app_screens.go`; header helpers moved to `app_flash.go`; new `app_accessors.go` for `EnrichmentGen`/`ActiveDetailResource`/`ActiveListResources`
- All promoted field refs updated: `m.ResourceCache` → `m.Session.ResourceCache`, `m.LazyResourceCache` → `m.Session.LazyResourceCache`, etc. across 10 files

## Files changed

- `internal/tui/app.go` — 1046 → 420 lines
- `internal/tui/app_accessors.go` — new file
- `internal/tui/app_screens.go` — received `handleWindowSize`, stack helpers, `updateActiveView`, `cacheTopLevelResourceList`
- `internal/tui/app_flash.go` — received `headerRight`, `accountBadge`, `identityRoleName`, `identityToViewData`
- `internal/tui/runtime_adapter.go` — received `applyIntents`, `tasksToCmd`, `coreUpdate`, `handleEnrichDetailResult`
- `internal/tui/runtime_adapter_related.go` — received `handleRelatedCheckResult`
- `internal/tui/fetch_adapter.go` — received `handleLoadResources`, `handleResourcesLoaded`
- `internal/session/session.go` — doc comment updated (embedding → named field)
- Tests updated: `phase03_fold_test.go`, `phase03_shim_wireups_test.go`, `qa_prefetch_pagination_seed_test.go`, `probe_enrichment_cache_test.go`

## Test plan

- [x] `go test ./tests/unit/` — pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `govulncheck ./...` — no vulnerabilities
- [x] `go fix -inline -diff ./...` — no unfixed directives
- [x] `go build ./...` — clean

Closes AS-155

🤖 Generated with [Claude Code](https://claude.com/claude-code)