### PR TITLE
feat(phase-05-pr-05a-h3): port 6 handler bodies to runtime.Core (AS-324)

### DIFF
--- a/internal/runtime/handlers.go
+++ b/internal/runtime/handlers.go
@@ -1,78 +1,131 @@
+// handlers.go — shell-level handler bodies ported from internal/tui in
+// Phase-05 PR-05a-h3 (AS-315b / AS-324).
+//
+// Each ported handler is a (c *Core) Handle* method that consumes a typed
+// runtime event, applies session-scoped state changes, and returns
+// ([]UIIntent, []TaskRequest) so the platform-agnostic core stays free of
+// Bubble Tea / Lipgloss / Bubbles types. The TUI adapter wraps each handler
+// in a thin (≤12-line) (tea.Model, tea.Cmd) shim that translates the
+// adapter's messages.* into the runtime event, calls the Core method, and
+// translates the returned intents and tasks back into adapter-visible side
+// effects.
+//
+// What lives here (this PR):
+//
+//	HandleFlash          — flash gen bump + history; schedules ClearFlash tick.
+//	HandleClearFlash     — flash auto-clear honouring the session-owned gen.
+//	HandleAPIError       — AWS error classification + flash with [code] message.
+//	HandleClientsReady   — clients/identity wiring + post-connect refresh / boot.
+//	HandleProfileSelected— rotate, rollback latch, request reconnect.
+//	HandleRegionSelected — mirror of HandleProfileSelected for region.
+//
+// What stays in the TUI adapter (out of scope):
+//
+//   - handleKeyMsg (keyboard dispatch) — owns key.Matches semantics on
+//     adapter-owned tea types.
+//   - handleProfilesLoaded / handleValueRevealed / handleEnterChildView /
+//     handleThemeSelected — push concrete views onto the adapter view stack,
+//     which requires the screen-builder registry that lands in a successor PR.
 package runtime
 
 import (
-	"errors"
+	"fmt"
 	"time"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
-	"github.com/k2m30/a9s/v3/internal/tui/messages"
 )
 
-// errWrongClientsType is returned by HandleClientsReady when ev.Clients is
-// non-nil but is not *awsclient.ServiceClients — an impossible branch in
-// production that is guarded here so the adapter's APIError path classifies it.
-var errWrongClientsType = errors.New("internal: ClientsReadyEvent.Clients has unexpected concrete type")
+// Flash auto-clear durations. apiErrorFlashDuration is the longer 5 s window
+// for AWS errors; flashDuration is the default 2 s window for status flashes.
+const (
+	flashDuration         = 2 * time.Second
+	apiErrorFlashDuration = 5 * time.Second
+)
 
-// FlashEvent asks the core to display a transient flash message.
+// FlashEvent is the adapter-translated form of messages.FlashMsg used by
+// HandleFlash. NewGen is the flash generation the adapter has already
+// bumped to on its flashState before calling into the Core; the handler
+// echoes it back via FlashTickPayload.Gen so the scheduled ClearFlashMsg
+// references the same gen the active flash carries.
 type FlashEvent struct {
 	Text    string
 	IsError bool
 	NewGen  int
 }
 
-// ClearFlashEvent asks the core to clear the current flash if the gen matches.
+// ClearFlashEvent is the adapter-translated form of messages.ClearFlashMsg.
+// Gen is the gen the original tea.Tick carried; CurrentGen is the gen the
+// adapter has now. The handler treats them as stale when they disagree.
+// IsError lets the handler emit SetErrorHintIntent when the cleared flash
+// was an error flash (mirrors the adapter's flashState.isError check).
 type ClearFlashEvent struct {
 	Gen        int
 	CurrentGen int
 	IsError    bool
 }
 
-// APIErrorEvent carries an AWS API error to be displayed and logged.
+// APIErrorEvent is the adapter-translated form of messages.APIErrorMsg.
+// NewGen is the flash generation the adapter has already bumped to before
+// calling into the Core; the handler echoes it back via the FlashTickPayload.
 type APIErrorEvent struct {
 	Err    error
 	NewGen int
 }
 
-// ClientsReadyEvent is dispatched by the adapter after an AWS connect attempt
-// completes (success or failure).
+// ClientsReadyEvent mirrors the fields of messages.ClientsReadyMsg the
+// runtime needs to make its dispatch decision. The concrete *ServiceClients
+// is kept as any so this file stays free of any tui-only dependency on the
+// message type.
+//
+// StackDepth and HasActiveRL are renderer-shape inputs the adapter computes
+// from its view stack. StackDepth == 1 means only the main menu is on
+// screen; HasActiveRL is true when the active view is a ResourceListModel.
+// The runtime uses these to decide whether to emit the one-shot -c
+// navigation and the post-switch refresh.
 type ClientsReadyEvent struct {
-	Gen         int
-	NewGen      int
+	Clients     any
 	Err         error
-	Clients     any // *awsclient.ServiceClients or nil
 	Region      string
-	HasActiveRL bool
+	Gen         int
 	StackDepth  int
+	HasActiveRL bool
+	NewGen      int
 }
 
-// ProfileSelectedEvent is dispatched when the user confirms a profile switch.
+// ProfileSelectedEvent / RegionSelectedEvent mirror the corresponding
+// messages.*Msg shapes. NewGen is the flash generation the adapter has
+// already bumped to (used by the "Switching to …" flash tick).
 type ProfileSelectedEvent struct {
 	Profile string
 	NewGen  int
 }
 
-// RegionSelectedEvent is dispatched when the user confirms a region switch.
 type RegionSelectedEvent struct {
 	Region string
 	NewGen int
 }
 
-// HandleFlash processes a FlashEvent and returns the resulting intents and tasks.
+// HandleFlash bumps the flash generation, appends an error-history entry
+// when the flash carries an error, and schedules the auto-clear tick at
+// the default 2 s window.
 func (c *Core) HandleFlash(ev FlashEvent) ([]UIIntent, []TaskRequest) {
 	intents := []UIIntent{FlashIntent{Text: ev.Text, IsError: ev.IsError}}
 	if ev.IsError {
-		intents = append(intents, AppendErrorHistoryIntent{Time: time.Now(), Message: ev.Text})
+		intents = append(intents, AppendErrorHistoryIntent{
+			Time:    time.Now(),
+			Message: ev.Text,
+		})
 	}
-	tasks := []TaskRequest{
-		{
-			Key:     TaskKey{Kind: TaskKindFlashTick},
-			Payload: FlashTickPayload{Gen: ev.NewGen, Duration: 2 * time.Second},
-		},
-	}
+	tasks := []TaskRequest{{
+		Key:     TaskKey{Kind: TaskKindFlashTick},
+		Payload: FlashTickPayload{Gen: ev.NewGen, Duration: flashDuration},
+	}}
 	return intents, tasks
 }
 
-// HandleClearFlash processes a ClearFlashEvent. Stale gens are discarded.
+// HandleClearFlash clears the flash when the carried gen matches the
+// adapter's current gen, and surfaces the persistent error hint after an
+// error flash. Stale gens (rapid re-flash) are silently dropped.
 func (c *Core) HandleClearFlash(ev ClearFlashEvent) ([]UIIntent, []TaskRequest) {
 	if ev.Gen != ev.CurrentGen {
 		return nil, nil
@@ -84,152 +137,239 @@ func (c *Core) HandleClearFlash(ev ClearFlashEvent) ([]UIIntent, []TaskRequest) 
 	return intents, nil
 }
 
-// HandleAPIError processes an APIErrorEvent, always emitting three intents and
-// one 5-second flash tick task.
+// HandleAPIError classifies the AWS error, builds a "[code] message" flash
+// text, records the error to history, clears the active list's loading
+// indicator, and schedules the longer 5 s clear tick used for AWS errors.
 func (c *Core) HandleAPIError(ev APIErrorEvent) ([]UIIntent, []TaskRequest) {
+	code, message, _ := awsclient.ClassifyAWSError(ev.Err)
+	var text string
+	if code != "" && code != "Unknown" {
+		text = fmt.Sprintf("[%s] %s", code, message)
+	} else {
+		text = ev.Err.Error()
+	}
 	intents := []UIIntent{
-		FlashIntent{Text: ev.Err.Error(), IsError: true},
-		AppendErrorHistoryIntent{Time: time.Now(), Message: ev.Err.Error()},
+		FlashIntent{Text: text, IsError: true},
+		AppendErrorHistoryIntent{Time: time.Now(), Message: text},
 		ClearActiveListLoadingIntent{},
 	}
-	tasks := []TaskRequest{
-		{
-			Key:     TaskKey{Kind: TaskKindFlashTick},
-			Payload: FlashTickPayload{Gen: ev.NewGen, Duration: 5 * time.Second},
-		},
-	}
+	tasks := []TaskRequest{{
+		Key:     TaskKey{Kind: TaskKindFlashTick},
+		Payload: FlashTickPayload{Gen: ev.NewGen, Duration: apiErrorFlashDuration},
+	}}
 	return intents, tasks
 }
 
-// HandleClientsReady processes the result of an AWS connect attempt. Stale gens
-// (ev.Gen != session.ConnectGen) are discarded.
+// HandleClientsReady wires fresh AWS clients into the session, clears the
+// rollback latch, fires identity + availability bootstrap tasks, and — on
+// failure — rolls back to the previous stable profile/region. A
+// PendingRefresh in the success path triggers a list re-fetch with a
+// "Connected. Refreshing..." flash.
+//
+// Stale results (Gen != session.ConnectGen) are dropped: the user switched
+// profile/region again while this connect was in flight.
 func (c *Core) HandleClientsReady(ev ClientsReadyEvent) ([]UIIntent, []TaskRequest) {
 	if ev.Gen != c.session.ConnectGen {
 		return nil, nil
 	}
 
 	if ev.Err != nil {
-		// Failure path — roll back to previous profile/region if available.
-		if c.session.HasPrevState {
-			c.session.Profile = c.session.PrevProfile
-			c.session.Region = c.session.PrevRegion
-		}
-		c.session.HasPrevState = false
-		c.session.PrevProfile = ""
-		c.session.PrevRegion = ""
-		c.session.PendingRefresh = false
-		c.session.ConnectGen = ev.NewGen
-
-		intents := []UIIntent{
-			FlashIntent{Text: ev.Err.Error(), IsError: true},
-			AppendErrorHistoryIntent{Time: time.Now(), Message: ev.Err.Error()},
-		}
-		tasks := []TaskRequest{
-			{
-				Key:     TaskKey{Kind: TaskKindFlashTick},
-				Payload: FlashTickPayload{Gen: ev.NewGen, Duration: 5 * time.Second},
-			},
-		}
-
-		// If we still have existing clients, re-bootstrap identity + cache.
-		if c.session.Clients != nil {
-			tasks = append(tasks, TaskRequest{Key: TaskKey{Kind: TaskKindFetchIdentity}, Payload: FetchIdentityPayload{}})
-			if c.session.NoCache {
-				tasks = append(tasks, TaskRequest{Key: TaskKey{Kind: TaskKindDemoPrefetchCounts}, Payload: DemoPrefetchCountsPayload{}})
-			} else {
-				tasks = append(tasks, TaskRequest{Key: TaskKey{Kind: TaskKindLoadAvailCache}, Payload: LoadAvailCachePayload{}})
-			}
-		}
-
-		return intents, tasks
+		return c.handleClientsReadyFailure(ev)
 	}
 
-	// Success path — install clients.
-	if ev.Clients == nil && c.session.Clients == nil && c.session.PreSuppliedClients != nil {
-		c.session.Clients = c.session.PreSuppliedClients
-	} else if sc, ok := ev.Clients.(*awsclient.ServiceClients); ok {
-		c.session.Clients = sc
-	} else if ev.Clients != nil {
-		// Wrong concrete type — route through APIError task.
-		c.session.HasPrevState = false
-		c.session.PrevProfile = ""
-		c.session.PrevRegion = ""
-		c.session.ConnectGen = ev.NewGen
-		typeErr := errWrongClientsType
-		return []UIIntent{
-				FlashIntent{Text: typeErr.Error(), IsError: true},
-				AppendErrorHistoryIntent{Time: time.Now(), Message: typeErr.Error()},
-			}, []TaskRequest{
-				{Key: TaskKey{Kind: TaskKindEmitAPIError}, Payload: EmitAPIErrorPayload{Err: typeErr}},
-			}
+	return c.handleClientsReadySuccess(ev)
+}
+
+// handleClientsReadyFailure rolls Profile / Region back to the captured
+// rollback target, emits the error flash + history entry, schedules the
+// 5 s clear tick, and — when there are still valid clients (rollback to
+// the old session) — refires identity and availability tasks against the
+// retained transport so the post-rollback UI is consistent.
+func (c *Core) handleClientsReadyFailure(ev ClientsReadyEvent) ([]UIIntent, []TaskRequest) {
+	s := c.session
+	if s.HasPrevState {
+		s.Profile = s.PrevProfile
+		s.Region = s.PrevRegion
 	}
+	s.HasPrevState = false
+	s.PrevProfile = ""
+	s.PrevRegion = ""
+	s.PendingRefresh = false
 
-	c.session.HasPrevState = false
-	c.session.PrevProfile = ""
-	c.session.PrevRegion = ""
-	c.session.ConnectGen = ev.NewGen
+	errText := ev.Err.Error()
+	intents := []UIIntent{
+		FlashIntent{Text: errText, IsError: true},
+		AppendErrorHistoryIntent{Time: time.Now(), Message: errText},
+	}
+	tasks := []TaskRequest{{
+		Key:     TaskKey{Kind: TaskKindFlashTick},
+		Payload: FlashTickPayload{Gen: ev.NewGen, Duration: apiErrorFlashDuration},
+	}}
 
-	var intents []UIIntent
-	var tasks []TaskRequest
+	if s.Clients != nil {
+		// P3 invariant: Session.Rotate() (run earlier on the switch attempt
+		// that just failed) installed fresh IAMPolicies / IdentityStore /
+		// RuleSets on the session. The retained transport still points at
+		// the pre-rotate (now-discarded) stores, so Pattern-C related
+		// checks (Glue tags, EBS Backup) and IAM lazy-add would read
+		// sticky state until the next successful reconnect. Rewire on
+		// rollback so the retained transport sees the post-rotate stores.
+		s.Clients.SetIAMPolicies(s.IAMPolicies)
+		s.Clients.SetIdentityStore(s.IdentityStore)
+		s.Clients.SetRuleSets(s.RuleSets)
 
-	// Handle -c CLI flag navigation.
-	if c.session.Command != "" {
-		if ev.StackDepth == 1 {
+		s.IdentityFetching = true
+		tasks = append(tasks, TaskRequest{
+			Key:     TaskKey{Kind: TaskKindFetchIdentity},
+			Payload: FetchIdentityPayload{},
+		})
+		if s.NoCache {
 			tasks = append(tasks, TaskRequest{
-				Key: TaskKey{Kind: TaskKindEmitNavigate},
-				Payload: EmitNavigatePayload{
-					Target:       messages.TargetResourceList,
-					ResourceType: c.session.Command,
-				},
+				Key:     TaskKey{Kind: TaskKindDemoPrefetchCounts},
+				Payload: DemoPrefetchCountsPayload{},
+			})
+		} else {
+			tasks = append(tasks, TaskRequest{
+				Key:     TaskKey{Kind: TaskKindLoadAvailCache},
+				Payload: LoadAvailCachePayload{},
 			})
 		}
-		c.session.Command = ""
-	}
-
-	if c.session.NoCache {
-		tasks = append(tasks, TaskRequest{Key: TaskKey{Kind: TaskKindDemoPrefetchCounts}, Payload: DemoPrefetchCountsPayload{}})
-		if c.session.PendingRefresh {
-			if ev.HasActiveRL {
-				intents = append(intents, RefreshActiveListIntent{}, FlashIntent{Text: "Connected. Refreshing..."})
-			}
-			c.session.PendingRefresh = false
-		}
-		return intents, tasks
-	}
-
-	// Live AWS path.
-	tasks = append(tasks,
-		TaskRequest{Key: TaskKey{Kind: TaskKindFetchIdentity}, Payload: FetchIdentityPayload{}},
-		TaskRequest{Key: TaskKey{Kind: TaskKindLoadAvailCache}, Payload: LoadAvailCachePayload{}},
-	)
-	if c.session.PendingRefresh {
-		if ev.HasActiveRL {
-			intents = append(intents, RefreshActiveListIntent{}, FlashIntent{Text: "Connected. Refreshing..."})
-		}
-		c.session.PendingRefresh = false
 	}
 	return intents, tasks
 }
 
-// HandleProfileSelected processes a profile selector confirmation. Captures
-// rollback state, rotates the session, and dispatches a connect task.
-func (c *Core) HandleProfileSelected(ev ProfileSelectedEvent) ([]UIIntent, []TaskRequest) {
-	hadPrev := c.session.HasPrevState
-	prevProf := c.session.PrevProfile
-	prevReg := c.session.PrevRegion
-	if !hadPrev {
-		prevProf = c.session.Profile
-		prevReg = c.session.Region
+// handleClientsReadySuccess installs the new clients (or falls back to the
+// pre-supplied demo transport when ev.Clients is nil), defaults Profile /
+// Region when empty, dispatches the one-shot -c navigation, and fires the
+// identity + availability tasks (plus a refresh-list flash + intent when
+// PendingRefresh is set and the active view is a ResourceListModel).
+func (c *Core) handleClientsReadySuccess(ev ClientsReadyEvent) ([]UIIntent, []TaskRequest) {
+	s := c.session
+
+	// Install the new transport.
+	if ev.Clients == nil {
+		if s.Clients == nil && s.PreSuppliedClients != nil {
+			s.PreSuppliedClients.SetIAMPolicies(s.IAMPolicies)
+			s.PreSuppliedClients.SetIdentityStore(s.IdentityStore)
+			s.PreSuppliedClients.SetRuleSets(s.RuleSets)
+			s.Clients = s.PreSuppliedClients
+		}
+	} else if clients, ok := ev.Clients.(*awsclient.ServiceClients); ok {
+		clients.SetIAMPolicies(s.IAMPolicies)
+		clients.SetIdentityStore(s.IdentityStore)
+		clients.SetRuleSets(s.RuleSets)
+		s.Clients = clients
+	} else {
+		// Wrong concrete type — surface as APIErrorMsg via the adapter so
+		// the existing classification flow handles it.
+		wrongType := fmt.Errorf("internal: unexpected ClientsReadyMsg.Clients type %T", ev.Clients)
+		return nil, []TaskRequest{{
+			Key:     TaskKey{Kind: TaskKindEmitAPIError},
+			Payload: EmitAPIErrorPayload{Err: wrongType},
+		}}
 	}
 
-	c.session.Rotate()
+	s.HasPrevState = false
+	s.PrevProfile = ""
+	s.PrevRegion = ""
 
-	c.session.HasPrevState = true
-	c.session.PrevProfile = prevProf
-	c.session.PrevRegion = prevReg
-	c.session.Profile = ev.Profile
-	c.session.Region = ""
-	c.session.PendingRefresh = true
+	var tasks []TaskRequest
+
+	// One-shot -c navigation: only fire when we have an unconsumed Command
+	// AND the active view is still the main menu (Stack depth 1).
+	if s.Command != "" {
+		if ev.StackDepth == 1 {
+			tasks = append(tasks, TaskRequest{
+				Key: TaskKey{Kind: TaskKindEmitNavigate},
+				Payload: EmitNavigatePayload{
+					Target:       NavigateTargetResourceList,
+					ResourceType: s.Command,
+				},
+			})
+		}
+		s.Command = ""
+	}
+
+	if s.Profile == "" {
+		s.Profile = "default"
+	}
+	if s.Region == "" {
+		if ev.Region != "" {
+			s.Region = ev.Region
+		} else {
+			configPath := awsclient.DefaultConfigPath()
+			s.Region = awsclient.GetDefaultRegion(configPath, s.Profile)
+		}
+	}
+
+	// Demo / no-cache: synchronous prefetch instead of the async probe
+	// pipeline. Identity fetch is skipped in this mode (synthetic creds).
+	if s.NoCache {
+		tasks = append(tasks, TaskRequest{
+			Key:     TaskKey{Kind: TaskKindDemoPrefetchCounts},
+			Payload: DemoPrefetchCountsPayload{},
+		})
+		intents, refreshTasks := c.maybeRefreshIntents(ev)
+		tasks = append(tasks, refreshTasks...)
+		return intents, tasks
+	}
+
+	// Live AWS path: fetch identity + load disk cache.
+	s.IdentityFetching = true
+	tasks = append(tasks, TaskRequest{
+		Key:     TaskKey{Kind: TaskKindFetchIdentity},
+		Payload: FetchIdentityPayload{},
+	})
+	tasks = append(tasks, TaskRequest{
+		Key:     TaskKey{Kind: TaskKindLoadAvailCache},
+		Payload: LoadAvailCachePayload{},
+	})
+
+	intents, refreshTasks := c.maybeRefreshIntents(ev)
+	tasks = append(tasks, refreshTasks...)
+	return intents, tasks
+}
+
+// maybeRefreshIntents returns the refresh intents + flash when a pending
+// post-switch refresh should fire (PendingRefresh is set AND an active
+// resource list exists). Clears PendingRefresh so it does not re-fire on
+// the next ClientsReadyMsg.
+func (c *Core) maybeRefreshIntents(ev ClientsReadyEvent) ([]UIIntent, []TaskRequest) {
+	if !c.session.PendingRefresh {
+		return nil, nil
+	}
+	c.session.PendingRefresh = false
+	if !ev.HasActiveRL {
+		return nil, nil
+	}
+	return []UIIntent{
+		FlashIntent{Text: "Connected. Refreshing..."},
+		RefreshActiveListIntent{},
+	}, nil
+}
+
+// HandleProfileSelected captures the pre-switch profile/region as the
+// rollback target (only on first switch — rapid A→B→C keeps A), rotates
+// the session, sets the new profile, clears region so the new profile's
+// default region resolves, asks the adapter to clear main-menu
+// availability and pop the selector, and schedules the new connect.
+func (c *Core) HandleProfileSelected(ev ProfileSelectedEvent) ([]UIIntent, []TaskRequest) {
+	s := c.session
+	hadPrev := s.HasPrevState
+	prevProf := s.PrevProfile
+	prevReg := s.PrevRegion
+	if !hadPrev {
+		hadPrev = true
+		prevProf = s.Profile
+		prevReg = s.Region
+	}
+	s.Rotate()
+	s.HasPrevState = hadPrev
+	s.PrevProfile = prevProf
+	s.PrevRegion = prevReg
+	s.Profile = ev.Profile
+	s.Region = ""
+	s.PendingRefresh = true
 
 	intents := []UIIntent{
 		MenuClearAvailabilityIntent{},
@@ -239,36 +379,34 @@ func (c *Core) HandleProfileSelected(ev ProfileSelectedEvent) ([]UIIntent, []Tas
 	tasks := []TaskRequest{
 		{
 			Key:     TaskKey{Kind: TaskKindConnect},
-			Payload: ConnectPayload{Profile: ev.Profile, Region: "", Gen: c.session.ConnectGen},
+			Payload: ConnectPayload{Profile: ev.Profile, Region: "", Gen: s.ConnectGen},
 		},
 		{
 			Key:     TaskKey{Kind: TaskKindFlashTick},
-			Payload: FlashTickPayload{Gen: ev.NewGen, Duration: 2 * time.Second},
+			Payload: FlashTickPayload{Gen: ev.NewGen, Duration: flashDuration},
 		},
 	}
 	return intents, tasks
 }
 
-// HandleRegionSelected processes a region selector confirmation. Mirrors
-// HandleProfileSelected but preserves the current profile.
+// HandleRegionSelected mirrors HandleProfileSelected for the region switch.
+// Profile is preserved on the new connect; only the region changes.
 func (c *Core) HandleRegionSelected(ev RegionSelectedEvent) ([]UIIntent, []TaskRequest) {
-	hadPrev := c.session.HasPrevState
-	prevProf := c.session.PrevProfile
-	prevReg := c.session.PrevRegion
+	s := c.session
+	hadPrev := s.HasPrevState
+	prevProf := s.PrevProfile
+	prevReg := s.PrevRegion
 	if !hadPrev {
-		prevProf = c.session.Profile
-		prevReg = c.session.Region
+		hadPrev = true
+		prevProf = s.Profile
+		prevReg = s.Region
 	}
-
-	capturedProfile := c.session.Profile
-
-	c.session.Rotate()
-
-	c.session.HasPrevState = true
-	c.session.PrevProfile = prevProf
-	c.session.PrevRegion = prevReg
-	c.session.Region = ev.Region
-	c.session.PendingRefresh = true
+	s.Rotate()
+	s.HasPrevState = hadPrev
+	s.PrevProfile = prevProf
+	s.PrevRegion = prevReg
+	s.Region = ev.Region
+	s.PendingRefresh = true
 
 	intents := []UIIntent{
 		MenuClearAvailabilityIntent{},
@@ -278,11 +416,11 @@ func (c *Core) HandleRegionSelected(ev RegionSelectedEvent) ([]UIIntent, []TaskR
 	tasks := []TaskRequest{
 		{
 			Key:     TaskKey{Kind: TaskKindConnect},
-			Payload: ConnectPayload{Profile: capturedProfile, Region: ev.Region, Gen: c.session.ConnectGen},
+			Payload: ConnectPayload{Profile: s.Profile, Region: ev.Region, Gen: s.ConnectGen},
 		},
 		{
 			Key:     TaskKey{Kind: TaskKindFlashTick},
-			Payload: FlashTickPayload{Gen: ev.NewGen, Duration: 2 * time.Second},
+			Payload: FlashTickPayload{Gen: ev.NewGen, Duration: flashDuration},
 		},
 	}
 	return intents, tasks

--- a/internal/runtime/handlers_test.go
+++ b/internal/runtime/handlers_test.go
@@ -1009,5 +1009,79 @@ func TestHandleClientsReady_Failure_NilClients_NoBootstrapTasks(t *testing.T) {
 	}
 }
 
+// TestHandleClientsReady_Failure_RewiresPostRotateStores guards the Stage 5
+// P3 regression caught on PR #360: after Session.Rotate() installs fresh
+// per-session stores (PolicyStore / IdentityStore / RuleSetStore), the
+// failure path on the resulting ClientsReadyMsg must rewire the retained
+// transport with those post-rotate stores. Otherwise Pattern-C related
+// checkers (Glue tags, EBS Backup) and IAM lazy-add silently read the
+// pre-rotate (now-discarded) stores until the next successful reconnect.
+func TestHandleClientsReady_Failure_RewiresPostRotateStores(t *testing.T) {
+	c := newCore()
+	s := c.session
+
+	// Pre-rotate transport: holds the "old" per-session stores.
+	preRotateIAM := session.NewPolicyStore()
+	preRotateID := session.NewIdentityStore()
+	preRotateRS := session.NewRuleSetStore()
+	sc := &awsclient.ServiceClients{}
+	sc.SetIAMPolicies(preRotateIAM)
+	sc.SetIdentityStore(preRotateID)
+	sc.SetRuleSets(preRotateRS)
+	s.Clients = sc
+
+	// session.New() already installed fresh "post-rotate" stores on
+	// s.IAMPolicies / s.IdentityStore / s.RuleSets — capture them for
+	// comparison. They MUST be distinct from the pre-rotate stores wired
+	// onto sc above (otherwise this test cannot detect the regression).
+	postRotateIAM := s.IAMPolicies
+	postRotateID := s.IdentityStore
+	postRotateRS := s.RuleSets
+	if postRotateIAM == preRotateIAM || postRotateID == preRotateID || postRotateRS == preRotateRS {
+		t.Fatal("test setup error: pre- and post-rotate stores must be distinct references")
+	}
+
+	s.ConnectGen = 1
+	c.HandleClientsReady(ClientsReadyEvent{ //nolint:ineffassign,staticcheck // crash-verification
+		Gen: 1, NewGen: 2,
+		Err: errors.New("connect failed"),
+	})
+
+	if sc.IAMPolicies() != postRotateIAM {
+		t.Error("failure path must rewire retained Clients with post-rotate IAMPolicies (P3 invariant)")
+	}
+	if sc.IdentityStore() != postRotateID {
+		t.Error("failure path must rewire retained Clients with post-rotate IdentityStore (P3 invariant)")
+	}
+	if sc.RuleSets() != postRotateRS {
+		t.Error("failure path must rewire retained Clients with post-rotate RuleSets (P3 invariant)")
+	}
+}
+
+// TestHandleClientsReady_StaleGen_ReturnsEmpty guards the Stage 5 invariant
+// caught on PR #360: when the Core sees a stale ConnectGen on a
+// ClientsReadyMsg, it returns (nil, nil). The TUI adapter relies on this
+// to gate its flash.gen bump (it must not bump on stale dispatches —
+// doing so would invalidate ClearFlashMsg already in flight for the
+// current flash, leaving an active flash stuck on screen). This test
+// pins the Core side of that contract; the adapter side is the
+// `len(intents) > 0 || len(tasks) > 0` guard in app_session.go.
+func TestHandleClientsReady_StaleGen_ReturnsEmpty(t *testing.T) {
+	c := newCore()
+	c.session.ConnectGen = 5
+
+	intents, tasks := c.HandleClientsReady(ClientsReadyEvent{
+		Gen: 3, NewGen: 99, // stale Gen
+		Err: errors.New("ignored — stale"),
+	})
+
+	if len(intents) != 0 {
+		t.Errorf("stale Gen must return empty intents, got %d", len(intents))
+	}
+	if len(tasks) != 0 {
+		t.Errorf("stale Gen must return empty tasks, got %d", len(tasks))
+	}
+}
+
 // Sentinel to ensure the time import is used (AppendErrorHistoryIntent carries time.Time).
 var _ = time.Now

--- a/internal/runtime/handlers_test.go
+++ b/internal/runtime/handlers_test.go
@@ -523,6 +523,55 @@ func TestHandleClientsReady_Success_InstallsClients(t *testing.T) {
 	}
 }
 
+// TestHandleClientsReady_Success_NoPendingRefresh_NoFlashWork pins the
+// Core contract the TUI adapter's `hasFlashWork` gate relies on: when
+// PendingRefresh=false, the success path emits NO FlashIntent in intents
+// and NO FlashTickPayload in tasks, so the adapter must not advance
+// m.flash.gen and must not invalidate any in-flight ClearFlashMsg for
+// the current flash. (CXR/Architect Stage 5 R3 regression.)
+func TestHandleClientsReady_Success_NoPendingRefresh_NoFlashWork(t *testing.T) {
+	c := newCore()
+	s := c.session
+	s.ConnectGen = 1
+	s.PendingRefresh = false
+
+	intents, tasks := c.HandleClientsReady(ClientsReadyEvent{
+		Gen: 1, NewGen: 2,
+		Clients:     &awsclient.ServiceClients{},
+		HasActiveRL: true, // even with an active list, no flash work when PendingRefresh=false
+	})
+
+	if _, ok := findFlashIntent(intents); ok {
+		t.Error("success-no-pending-refresh must not emit FlashIntent — bumping flash.gen on this path would silently invalidate any in-flight ClearFlashMsg for the current flash")
+	}
+	for _, ts := range tasks {
+		if _, ok := ts.Payload.(FlashTickPayload); ok {
+			t.Error("success-no-pending-refresh must not emit FlashTickPayload — bumping flash.gen on this path would silently invalidate any in-flight ClearFlashMsg for the current flash")
+		}
+	}
+}
+
+// TestHandleClientsReady_StaleGen_NoFlashWork pins the symmetric Core
+// contract for the stale path: stale Gen returns (nil, nil), so the
+// adapter's hasFlashWork gate correctly leaves m.flash.gen alone.
+func TestHandleClientsReady_StaleGen_NoFlashWork(t *testing.T) {
+	c := newCore()
+	c.session.ConnectGen = 5
+
+	intents, tasks := c.HandleClientsReady(ClientsReadyEvent{
+		Gen: 3, NewGen: 6, // ev.Gen != session.ConnectGen
+	})
+
+	if _, ok := findFlashIntent(intents); ok {
+		t.Error("stale gen must not emit FlashIntent")
+	}
+	for _, ts := range tasks {
+		if _, ok := ts.Payload.(FlashTickPayload); ok {
+			t.Error("stale gen must not emit FlashTickPayload")
+		}
+	}
+}
+
 // TestHandleClientsReady_Success_PendingRefreshWithActiveRL: PendingRefresh=true
 // AND HasActiveRL=true → RefreshActiveListIntent + "Connected. Refreshing..."
 // flash, PendingRefresh cleared.

--- a/internal/runtime/handlers_test.go
+++ b/internal/runtime/handlers_test.go
@@ -14,7 +14,6 @@ import (
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/session"
-	"github.com/k2m30/a9s/v3/internal/tui/messages"
 )
 
 // ---- helpers ---------------------------------------------------------------
@@ -638,8 +637,8 @@ func TestHandleClientsReady_Success_Command_StackDepth1(t *testing.T) {
 	if !ok {
 		t.Fatal("expected TaskKindEmitNavigate task when Command set and StackDepth==1")
 	}
-	if nav.Target != messages.TargetResourceList {
-		t.Errorf("EmitNavigatePayload.Target = %v, want TargetResourceList", nav.Target)
+	if nav.Target != NavigateTargetResourceList {
+		t.Errorf("EmitNavigatePayload.Target = %v, want NavigateTargetResourceList", nav.Target)
 	}
 	if nav.ResourceType != "ec2" {
 		t.Errorf("EmitNavigatePayload.ResourceType = %q, want %q", nav.ResourceType, "ec2")

--- a/internal/runtime/tasks.go
+++ b/internal/runtime/tasks.go
@@ -3,8 +3,6 @@ package runtime
 import (
 	"context"
 	"time"
-
-	"github.com/k2m30/a9s/v3/internal/tui/messages"
 )
 
 // TaskKind names a family of background tasks ("enrich", "related",
@@ -184,10 +182,10 @@ func (FlashTickPayload) isTaskPayload() {}
 
 // EmitNavigatePayload carries the one-shot navigation the adapter must
 // dispatch as messages.NavigateMsg on first successful connect, derived
-// from the -c / Command field on the session. Target is the typed
-// ViewTarget the renderer uses for its dispatch.
+// from the -c / Command field on the session. Target is the runtime-owned
+// NavigateTarget (translated to messages.ViewTarget by the adapter).
 type EmitNavigatePayload struct {
-	Target       messages.ViewTarget
+	Target       NavigateTarget
 	ResourceType string
 }
 

--- a/internal/tui/app_accessors.go
+++ b/internal/tui/app_accessors.go
@@ -20,6 +20,15 @@ func (m Model) EnrichmentGen() int {
 	return m.Session.EnrichmentGen
 }
 
+// FlashGen returns the current tui-adapter flash generation counter.
+// Test-only accessor for verifying handleClientsReady's `hasFlashWork` gate:
+// non-flash success paths and stale-gen paths must NOT advance this counter,
+// otherwise an in-flight ClearFlashMsg for the current flash gets silently
+// invalidated. (CXR/Architect Stage 5 R3+R4 finding regression coverage.)
+func (m Model) FlashGen() int {
+	return m.flash.gen
+}
+
 // ActiveDetailResource is an exported test-only accessor for the top-of-stack
 // DetailModel resource — production code does not call it.
 // Returns ok=false when the active view is not a DetailModel.

--- a/internal/tui/app_flash.go
+++ b/internal/tui/app_flash.go
@@ -2,66 +2,51 @@ package tui
 
 // app_flash.go — flash-message lifecycle and API-error surface, owned by the
 // TUI adapter. These handlers were split out of internal/tui/app_handlers.go
-// in Phase-05 PR-05a-h1 (AS-147). They drive tea.Tick auto-clear timers and
-// mutate tui-Model flash/errorHistory state that has not yet migrated to
-// session.Session; that migration is a follow-up PR.
+// in Phase-05 PR-05a-h1 (AS-147), and their handler bodies were ported to
+// runtime.Core in PR-05a-h3 (AS-324). The functions below are thin
+// (≤12-line) adapters: they pre-bump the tui-side flashState.gen counter
+// (which the Core echoes back via FlashTickPayload.Gen), translate the
+// messages.* into the runtime.*Event, call the Core method, apply the
+// returned intents, and translate the returned tasks into tea.Cmds.
 
 import (
-	"fmt"
-	"time"
-
 	tea "charm.land/bubbletea/v2"
 
-	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/runtime"
 	"github.com/k2m30/a9s/v3/internal/tui/messages"
-	"github.com/k2m30/a9s/v3/internal/tui/views"
 )
 
-// apiErrorFlashDuration controls how long API error messages stay visible.
-// Longer than regular flash (2s) because error messages are more important.
-const apiErrorFlashDuration = 5 * time.Second
-
-// handleFlash sets the flash message and schedules its auto-clear.
+// handleFlash bumps the flash gen, then defers to runtime.Core.HandleFlash
+// for the state computation. Auto-clear tick is dispatched via the
+// returned FlashTickPayload.
 func (m Model) handleFlash(msg messages.FlashMsg) (tea.Model, tea.Cmd) {
-	newGen := m.flash.gen + 1
-	m.flash = flashState{text: msg.Text, isError: msg.IsError, active: true, gen: newGen}
-	if msg.IsError {
-		m.errorHistory = append(m.errorHistory, errorEntry{time: time.Now(), message: msg.Text})
-	}
-	gen := m.flash.gen
-	return m, tea.Tick(2*time.Second, func(_ time.Time) tea.Msg {
-		return messages.ClearFlashMsg{Gen: gen}
+	m.flash.gen++
+	intents, tasks := m.core.HandleFlash(runtime.FlashEvent{
+		Text: msg.Text, IsError: msg.IsError, NewGen: m.flash.gen,
 	})
+	cmd := m.dispatchHandlerResult(intents, tasks)
+	return m, cmd
 }
 
-// handleClearFlash clears the flash if the generation matches (not stale).
+// handleClearFlash defers to runtime.Core.HandleClearFlash, which honours
+// the gen guard and emits the SetErrorHintIntent when the cleared flash
+// was an error flash.
 func (m Model) handleClearFlash(msg messages.ClearFlashMsg) (tea.Model, tea.Cmd) {
-	if msg.Gen == m.flash.gen {
-		if m.flash.isError {
-			m.showErrorHint = true
-		}
-		m.flash.active = false
-	}
-	return m, nil
+	intents, tasks := m.core.HandleClearFlash(runtime.ClearFlashEvent{
+		Gen: msg.Gen, CurrentGen: m.flash.gen, IsError: m.flash.isError,
+	})
+	cmd := m.dispatchHandlerResult(intents, tasks)
+	return m, cmd
 }
 
-// handleAPIError shows a flash error and clears loading state on the resource list.
+// handleAPIError bumps the flash gen and defers to runtime.Core.HandleAPIError
+// for the classification + flash text computation. The active resource
+// list's loading spinner is cleared via ClearActiveListLoadingIntent.
 func (m Model) handleAPIError(msg messages.APIErrorMsg) (tea.Model, tea.Cmd) {
-	code, message, _ := awsclient.ClassifyAWSError(msg.Err)
-	var flashText string
-	if code != "" && code != "Unknown" {
-		flashText = fmt.Sprintf("[%s] %s", code, message)
-	} else {
-		flashText = msg.Err.Error()
-	}
-	newGen := m.flash.gen + 1
-	m.flash = flashState{text: flashText, isError: true, active: true, gen: newGen}
-	m.errorHistory = append(m.errorHistory, errorEntry{time: time.Now(), message: flashText})
-	if rl, ok := m.activeView().(*views.ResourceListModel); ok {
-		rl.ClearLoading()
-	}
-	gen := m.flash.gen
-	return m, tea.Tick(apiErrorFlashDuration, func(_ time.Time) tea.Msg {
-		return messages.ClearFlashMsg{Gen: gen}
+	m.flash.gen++
+	intents, tasks := m.core.HandleAPIError(runtime.APIErrorEvent{
+		Err: msg.Err, NewGen: m.flash.gen,
 	})
+	cmd := m.dispatchHandlerResult(intents, tasks)
+	return m, cmd
 }

--- a/internal/tui/app_session.go
+++ b/internal/tui/app_session.go
@@ -2,241 +2,75 @@ package tui
 
 // app_session.go — AWS-session lifecycle handlers: clients-ready bootstrap,
 // profile/region/theme selectors, and the profile-list loader. Split out of
-// internal/tui/app_handlers.go in Phase-05 PR-05a-h1 (AS-147). These handlers
-// mutate session.Session fields (Profile, Region, Identity, Clients, ConnectGen,
-// PendingRefresh, HasPrevState, PrevProfile, PrevRegion, PreSuppliedClients,
-// Command, NoCache — migrated to Session in AS-315a / PR-05a-h2) plus
-// tui-Model UI-shell fields (activeTheme, headerCacheKey). Handler bodies
-// move to *Core methods returning ([]UIIntent, []TaskRequest) in AS-315b /
-// PR-05a-h3.
+// internal/tui/app_handlers.go in Phase-05 PR-05a-h1 (AS-147). The three
+// session-driven handlers (handleClientsReady, handleProfileSelected,
+// handleRegionSelected) were ported to runtime.Core in PR-05a-h3 (AS-324)
+// and are ≤12-line adapters here that pre-bump the flash gen, translate
+// the messages.* into the runtime.*Event, call the Core method, apply
+// returned intents, and translate returned tasks into tea.Cmds.
+//
+// handleThemeSelected and handleProfilesLoaded stay in the TUI adapter
+// for now — they push concrete view structs onto the adapter view stack,
+// which requires the screen-builder registry that lands in a successor PR.
 
 import (
-	"fmt"
 	"os"
-	"time"
 
 	tea "charm.land/bubbletea/v2"
 
-	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/config"
+	"github.com/k2m30/a9s/v3/internal/runtime"
 	"github.com/k2m30/a9s/v3/internal/tui/messages"
 	"github.com/k2m30/a9s/v3/internal/tui/styles"
 	"github.com/k2m30/a9s/v3/internal/tui/views"
 )
 
-// handleClientsReady stores the new AWS clients and optionally triggers a
-// pending refresh (after profile/region switch).
+// handleClientsReady defers to runtime.Core.HandleClientsReady for the
+// connect-lifecycle decision and translates the returned intents/tasks
+// back into Bubble Tea side effects. The flash gen bump is committed
+// only when Core actually returns a non-stale result — a stale Gen
+// causes Core to return (nil, nil), and bumping flash.gen anyway would
+// silently invalidate any ClearFlashMsg already in flight for the
+// current flash (CR/CXR Stage 5 finding).
 func (m Model) handleClientsReady(msg messages.ClientsReadyMsg) (tea.Model, tea.Cmd) {
-	// Ignore stale results from a superseded connect (rapid profile/region switch)
-	if msg.Gen != m.Session.ConnectGen {
-		return m, nil
+	_, hasRL := m.activeView().(*views.ResourceListModel)
+	intents, tasks := m.core.HandleClientsReady(runtime.ClientsReadyEvent{
+		Clients: msg.Clients, Err: msg.Err, Region: msg.Region, Gen: msg.Gen,
+		StackDepth: len(m.stack), HasActiveRL: hasRL, NewGen: m.flash.gen + 1,
+	})
+	if len(intents) > 0 || len(tasks) > 0 {
+		m.flash.gen++
 	}
-
-	if msg.Err != nil {
-		// Rollback profile/region to previous stable values on connect failure
-		if m.Session.HasPrevState {
-			m.Session.Profile = m.Session.PrevProfile
-			m.Session.Region = m.Session.PrevRegion
-		}
-		m.Session.HasPrevState = false
-		m.Session.PrevProfile = ""
-		m.Session.PrevRegion = ""
-		m.Session.PendingRefresh = false
-		newGen := m.flash.gen + 1
-		m.flash = flashState{text: msg.Err.Error(), isError: true, active: true, gen: newGen}
-		m.errorHistory = append(m.errorHistory, errorEntry{time: time.Now(), message: msg.Err.Error()})
-		gen := m.flash.gen
-		clearFlash := tea.Tick(apiErrorFlashDuration, func(_ time.Time) tea.Msg {
-			return messages.ClearFlashMsg{Gen: gen}
-		})
-
-		// The switch attempt cleared identity, resource cache, and availability.
-		// Restore them using the still-valid old clients.
-		//
-		// IMPORTANT: Session.Rotate already swapped in fresh PolicyStore /
-		// IdentityStore on m, so the retained transport clients (m.Session.Clients)
-		// still point at the PRE-rotate stores. Without rewiring here,
-		// Pattern-C related checks (Glue tags, EBS Backup) and IAM lazy-add
-		// would read sticky state from the now-discarded old stores — the
-		// header's identity reload could succeed against the new fresh
-		// stores while related-panel rows stayed broken until the next
-		// successful reconnect. Rewire on rollback too. (P3 finding.)
-		var cmds []tea.Cmd
-		cmds = append(cmds, clearFlash)
-		if m.Session.Clients != nil {
-			m.Session.Clients.SetIAMPolicies(m.Session.IAMPolicies)
-			m.Session.Clients.SetIdentityStore(m.Session.IdentityStore)
-			m.Session.Clients.SetRuleSets(m.Session.RuleSets)
-			m.Session.IdentityFetching = true
-			cmds = append(cmds, m.fetchIdentity())
-			if m.Session.NoCache {
-				cmds = append(cmds, m.demoPrefetchCounts())
-			} else {
-				cmds = append(cmds, m.loadAvailabilityCache())
-			}
-		}
-		return m, tea.Batch(cmds...)
-	}
-	if msg.Clients == nil {
-		if m.Session.Clients == nil && m.Session.PreSuppliedClients != nil {
-			// Fall back to pre-supplied clients (demo path) when msg carries no clients.
-			// Wire per-session capability stores into the transport layer.
-			m.Session.PreSuppliedClients.SetIAMPolicies(m.Session.IAMPolicies)
-			m.Session.PreSuppliedClients.SetIdentityStore(m.Session.IdentityStore)
-			m.Session.PreSuppliedClients.SetRuleSets(m.Session.RuleSets)
-			m.Session.Clients = m.Session.PreSuppliedClients
-		}
-	} else if clients, ok := msg.Clients.(*awsclient.ServiceClients); ok {
-		// Per-session stores: SES rule sets, IAM policies, and identity all
-		// live on m.{RuleSets,IAMPolicies,IdentityStore} after PR-02b/c/d. The
-		// legacy ClearAllSESRuleSetCaches global-clear is gone — fresh
-		// session = fresh store, wired here via thread-safe setters.
-		clients.SetIAMPolicies(m.Session.IAMPolicies)
-		clients.SetIdentityStore(m.Session.IdentityStore)
-		clients.SetRuleSets(m.Session.RuleSets)
-		m.Session.Clients = clients
-	} else {
-		wrongTypeErr := fmt.Errorf("internal: unexpected ClientsReadyMsg.Clients type %T", msg.Clients)
-		return m, func() tea.Msg {
-			return messages.APIErrorMsg{Err: wrongTypeErr}
-		}
-	}
-	m.Session.HasPrevState = false
-	m.Session.PrevProfile = ""
-	m.Session.PrevRegion = ""
-
-	// Emit a one-shot NavigateMsg if the -c flag set an initial command. Only
-	// fire while the app is still at the main menu (stack depth 1). If the
-	// initial connection was slow and the user already navigated elsewhere,
-	// skip the auto-navigation to avoid pushing a view on top of whatever
-	// the user is doing. Cleared after first use so that subsequent
-	// ClientsReadyMsg (profile/region switch) don't re-navigate.
-	var navigateCmd tea.Cmd
-	if m.Session.Command != "" {
-		if len(m.stack) == 1 {
-			target := m.Session.Command
-			navigateCmd = func() tea.Msg {
-				return messages.NavigateMsg{
-					Target:       messages.TargetResourceList,
-					ResourceType: target,
-				}
-			}
-		}
-		m.Session.Command = "" // always clear, even if skipped, to prevent stale re-navigation
-	}
-
-	if m.Session.Profile == "" {
-		m.Session.Profile = "default"
-	}
-	if m.Session.Region == "" {
-		if msg.Region != "" {
-			m.Session.Region = msg.Region
-		} else {
-			configPath := awsclient.DefaultConfigPath()
-			m.Session.Region = awsclient.GetDefaultRegion(configPath, m.Session.Profile)
-		}
-	}
-	// In demo/no-cache mode, prefetch all counts synchronously in one cmd so the
-	// main menu shows counts immediately without the async probe pipeline.
-	// Skip identity fetch in demo mode — the profile/region are synthetic.
-	if m.Session.NoCache {
-		availCmd := m.demoPrefetchCounts()
-		if m.Session.PendingRefresh {
-			m.Session.PendingRefresh = false
-			if rl, ok := m.activeView().(*views.ResourceListModel); ok {
-				m.flash = flashState{text: "Connected. Refreshing...", active: true}
-				cmd := m.refreshResourceList(*rl)
-				return m, tea.Batch(cmd, availCmd, navigateCmd)
-			}
-		}
-		return m, tea.Batch(availCmd, navigateCmd)
-	}
-
-	// Fetch identity on every clients-ready event
-	m.Session.IdentityFetching = true
-	identityCmd := m.fetchIdentity()
-
-	// Load disk cache which then fires background probes for expired/missing entries.
-	availCmd := m.loadAvailabilityCache()
-
-	if m.Session.PendingRefresh {
-		m.Session.PendingRefresh = false
-		if rl, ok := m.activeView().(*views.ResourceListModel); ok {
-			m.flash = flashState{text: "Connected. Refreshing...", active: true}
-			cmd := m.refreshResourceList(*rl)
-			return m, tea.Batch(cmd, identityCmd, availCmd, navigateCmd)
-		}
-	}
-	return m, tea.Batch(identityCmd, availCmd, navigateCmd)
+	cmd := m.dispatchHandlerResult(intents, tasks)
+	return m, cmd
 }
 
-// handleProfileSelected switches the AWS profile, pops the profile selector,
-// and reconnects.
+// handleProfileSelected defers to runtime.Core.HandleProfileSelected for
+// the Session.Rotate + rollback-latch + reconnect-request sequence.
 func (m Model) handleProfileSelected(msg messages.ProfileSelectedMsg) (tea.Model, tea.Cmd) {
-	// Capture rollback state BEFORE Rotate (which now clears HasPrevState/
-	// PrevProfile/PrevRegion). Only save prev on first switch; rapid A→B→C
-	// keeps A as rollback target.
-	hadPrev := m.Session.HasPrevState
-	prevProf := m.Session.PrevProfile
-	prevReg := m.Session.PrevRegion
-	if !hadPrev {
-		hadPrev = true
-		prevProf = m.Session.Profile
-		prevReg = m.Session.Region
-	}
-	m.Session.Rotate() // bumps ConnectGen; clears Identity/IdentityFetching/PendingRefresh/HasPrevState/...
-	m.Session.HasPrevState = hadPrev
-	m.Session.PrevProfile = prevProf
-	m.Session.PrevRegion = prevReg
-	m.Session.Profile = msg.Profile
-	m.Session.Region = "" // clear so handleClientsReady resolves the new profile's default region
-	if menu, ok := m.stack[0].(*views.MainMenuModel); ok {
-		menu.ClearAvailability()
-	}
-	m.Session.PendingRefresh = true
-	if _, ok := m.activeView().(*views.SelectorModel); ok {
-		m.popView()
-	}
-	flashCmd := func() tea.Msg {
-		return messages.FlashMsg{Text: "Switching to " + msg.Profile + "..."}
-	}
-	return m, tea.Batch(flashCmd, m.connectAWS(msg.Profile, "", m.Session.ConnectGen))
+	m.flash.gen++
+	intents, tasks := m.core.HandleProfileSelected(runtime.ProfileSelectedEvent{
+		Profile: msg.Profile, NewGen: m.flash.gen,
+	})
+	cmd := m.dispatchHandlerResult(intents, tasks)
+	return m, cmd
 }
 
-// handleRegionSelected switches the AWS region, pops the region selector,
-// and reconnects.
+// handleRegionSelected defers to runtime.Core.HandleRegionSelected for
+// the Session.Rotate + rollback-latch + reconnect-request sequence.
 func (m Model) handleRegionSelected(msg messages.RegionSelectedMsg) (tea.Model, tea.Cmd) {
-	// Capture rollback state BEFORE Rotate (which now clears HasPrevState/
-	// PrevProfile/PrevRegion). Only save prev on first switch; rapid switches
-	// keep original as rollback target.
-	hadPrev := m.Session.HasPrevState
-	prevProf := m.Session.PrevProfile
-	prevReg := m.Session.PrevRegion
-	if !hadPrev {
-		hadPrev = true
-		prevProf = m.Session.Profile
-		prevReg = m.Session.Region
-	}
-	m.Session.Rotate() // bumps ConnectGen; clears Identity/IdentityFetching/PendingRefresh/HasPrevState/...
-	m.Session.HasPrevState = hadPrev
-	m.Session.PrevProfile = prevProf
-	m.Session.PrevRegion = prevReg
-	m.Session.Region = msg.Region
-	if menu, ok := m.stack[0].(*views.MainMenuModel); ok {
-		menu.ClearAvailability()
-	}
-	m.Session.PendingRefresh = true
-	if _, ok := m.activeView().(*views.SelectorModel); ok {
-		m.popView()
-	}
-	flashCmd := func() tea.Msg {
-		return messages.FlashMsg{Text: "Switching to " + msg.Region + "..."}
-	}
-	return m, tea.Batch(flashCmd, m.connectAWS(m.Session.Profile, msg.Region, m.Session.ConnectGen))
+	m.flash.gen++
+	intents, tasks := m.core.HandleRegionSelected(runtime.RegionSelectedEvent{
+		Region: msg.Region, NewGen: m.flash.gen,
+	})
+	cmd := m.dispatchHandlerResult(intents, tasks)
+	return m, cmd
 }
 
 // handleThemeSelected applies the selected theme, invalidates style caches,
-// pops the selector, and persists the choice to config.yaml.
+// pops the selector, and persists the choice to config.yaml. Stays in the
+// TUI adapter pending the screen-builder registry that successor PRs need
+// to push the selector view from a Core method.
 func (m Model) handleThemeSelected(msg messages.ThemeSelectedMsg) (tea.Model, tea.Cmd) {
 	path, err := config.ThemePath(msg.Theme)
 	if err != nil {

--- a/internal/tui/app_session.go
+++ b/internal/tui/app_session.go
@@ -28,21 +28,42 @@ import (
 // handleClientsReady defers to runtime.Core.HandleClientsReady for the
 // connect-lifecycle decision and translates the returned intents/tasks
 // back into Bubble Tea side effects. The flash gen bump is committed
-// only when Core actually returns a non-stale result — a stale Gen
-// causes Core to return (nil, nil), and bumping flash.gen anyway would
-// silently invalidate any ClearFlashMsg already in flight for the
-// current flash (CR/CXR Stage 5 finding).
+// only when Core actually emits flash work (FlashIntent or
+// FlashTickPayload) — non-flash result branches (stale gen → nil/nil;
+// success-no-pending-refresh → FetchIdentity+LoadAvailCache only) must
+// leave flash.gen alone so that any ClearFlashMsg already in flight for
+// the current flash still matches and clears on schedule (CXR/Architect
+// Stage 5 R3 finding on the prior `len(intents)>0||len(tasks)>0` gate).
 func (m Model) handleClientsReady(msg messages.ClientsReadyMsg) (tea.Model, tea.Cmd) {
 	_, hasRL := m.activeView().(*views.ResourceListModel)
 	intents, tasks := m.core.HandleClientsReady(runtime.ClientsReadyEvent{
 		Clients: msg.Clients, Err: msg.Err, Region: msg.Region, Gen: msg.Gen,
 		StackDepth: len(m.stack), HasActiveRL: hasRL, NewGen: m.flash.gen + 1,
 	})
-	if len(intents) > 0 || len(tasks) > 0 {
+	if hasFlashWork(intents, tasks) {
 		m.flash.gen++
 	}
 	cmd := m.dispatchHandlerResult(intents, tasks)
 	return m, cmd
+}
+
+// hasFlashWork returns true when Core's result emits flash work — i.e.
+// a new flash (FlashIntent) is being set or an auto-clear tick
+// (FlashTickPayload) is being scheduled. Used by handleClientsReady to
+// gate the flash.gen bump so non-flash success paths do not invalidate
+// any in-flight ClearFlashMsg for the current flash.
+func hasFlashWork(intents []runtime.UIIntent, tasks []runtime.TaskRequest) bool {
+	for _, in := range intents {
+		if _, ok := in.(runtime.FlashIntent); ok {
+			return true
+		}
+	}
+	for _, t := range tasks {
+		if _, ok := t.Payload.(runtime.FlashTickPayload); ok {
+			return true
+		}
+	}
+	return false
 }
 
 // handleProfileSelected defers to runtime.Core.HandleProfileSelected for

--- a/internal/tui/runtime_adapter.go
+++ b/internal/tui/runtime_adapter.go
@@ -1,5 +1,5 @@
 // runtime_adapter.go is the Bubble Tea adapter glue for the platform-
-// agnostic runtime.Core (Phase 05 PR-05a-extract). It owns:
+// agnostic runtime.Core (Phase 05 PR-05a-extract / -h3). It owns:
 //
 //  1. handleEnrichDetail — a Model-receiver wrapper that replaces the
 //     deleted internal/tui/app_enrich.go entry point. It constructs a
@@ -8,10 +8,14 @@
 //     TaskRequests into tea.Cmd values. The existing app.go dispatch
 //     line (return m.handleEnrichDetail(msg)) is unchanged.
 //
-//  2. applyIntent — the stack walker that translates runtime.UIIntent
-//     into renderer-specific view mutations. Today's intent set is empty
-//     for the only migrated handler; the switch exists so per-handler
-//     PRs can add cases without touching app.go.
+//  2. applyIntent — the per-intent applier used by the 6 ported
+//     handlers (HandleFlash / HandleClearFlash / HandleAPIError /
+//     HandleClientsReady / HandleProfileSelected / HandleRegionSelected
+//     adapters in app_flash.go and app_session.go) AND any future
+//     handler that wires through this file. It mutates the *Model in
+//     place (errorHistory, flash state, showErrorHint, …) and returns
+//     a single tea.Cmd for intents that need follow-up work, such as
+//     RefreshActiveListIntent.
 //
 //  3. runtimeTasksToCmd / enrichDetailCmd — the TaskRequest-to-tea.Cmd
 //     translator. Tasks carry typed Payload values (runtime.TaskPayload
@@ -33,6 +37,7 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/runtime"
 	"github.com/k2m30/a9s/v3/internal/tui/messages"
+	"github.com/k2m30/a9s/v3/internal/tui/views"
 )
 
 // handleEnrichDetail replaces the entry point previously in
@@ -48,18 +53,70 @@ func (m Model) handleEnrichDetail(msg messages.EnrichDetailMsg) (tea.Model, tea.
 		ResourceType: msg.ResourceType,
 		Resource:     msg.Resource,
 	})
+	var cmds []tea.Cmd
 	for _, in := range intents {
-		m.applyIntent(in)
+		if c := m.applyIntent(in); c != nil {
+			cmds = append(cmds, c)
+		}
 	}
-	return m, m.runtimeTasksToCmd(tasks)
+	if tc := m.runtimeTasksToCmd(tasks); tc != nil {
+		cmds = append(cmds, tc)
+	}
+	switch len(cmds) {
+	case 0:
+		return m, nil
+	case 1:
+		return m, cmds[0]
+	default:
+		return m, tea.Batch(cmds...)
+	}
 }
 
-// applyIntent walks the view stack applying a runtime UIIntent.
-// Per-handler PRs add cases as their corresponding handler migrates.
+// applyIntent applies a single runtime UIIntent to the adapter-owned
+// Model state. Returns a tea.Cmd when the intent triggers follow-up
+// work (e.g. RefreshActiveListIntent), nil otherwise.
+//
+// FlashIntent is applied DIRECTLY here (set flashState text/isError/active)
+// rather than being dispatched back as messages.FlashMsg the way app.go's
+// multi-intent applyIntents path does. The per-handler adapters in
+// app_flash.go / app_session.go pre-bump m.flash.gen before invoking the
+// Core, so by the time we get here the gen is already in sync with the
+// FlashTickPayload the Core returned.
+//
 // Unknown intent types are silently dropped for forward compatibility.
-func (m *Model) applyIntent(_ runtime.UIIntent) {
-	// No intent variants are emitted by migrated handlers yet; the
-	// switch is a placeholder that PR-05a-h1..h8 successors extend.
+func (m *Model) applyIntent(intent runtime.UIIntent) tea.Cmd {
+	switch v := intent.(type) {
+	case runtime.FlashIntent:
+		m.flash.text = v.Text
+		m.flash.isError = v.IsError
+		m.flash.active = true
+	case runtime.ClearFlash:
+		m.flash.active = false
+	case runtime.SetErrorHintIntent:
+		m.showErrorHint = v.Show
+	case runtime.AppendErrorHistoryIntent:
+		m.errorHistory = append(m.errorHistory, errorEntry{
+			time:    v.Time,
+			message: v.Message,
+		})
+	case runtime.ClearActiveListLoadingIntent:
+		if rl, ok := m.activeView().(*views.ResourceListModel); ok {
+			rl.ClearLoading()
+		}
+	case runtime.MenuClearAvailabilityIntent:
+		if menu, ok := m.stack[0].(*views.MainMenuModel); ok {
+			menu.ClearAvailability()
+		}
+	case runtime.PopSelectorIntent:
+		if _, ok := m.activeView().(*views.SelectorModel); ok {
+			m.popView()
+		}
+	case runtime.RefreshActiveListIntent:
+		if rl, ok := m.activeView().(*views.ResourceListModel); ok {
+			return m.refreshResourceList(*rl)
+		}
+	}
+	return nil
 }
 
 // runtimeTasksToCmd translates a slice of runtime.TaskRequest values
@@ -67,10 +124,6 @@ func (m *Model) applyIntent(_ runtime.UIIntent) {
 // (a runtime.TaskPayload variant) whose concrete type tells the adapter
 // which closure builder to use. Unknown payload types are dropped for
 // forward-compat with newer runtime builds.
-//
-// Per-handler PRs (probes, related, fetchers, …) add their own
-// type-switch cases here as they migrate. The signature accepts only
-// the runtime's own TaskRequest slice — no side-channel parameters.
 func (m Model) runtimeTasksToCmd(tasks []runtime.TaskRequest) tea.Cmd {
 	if len(tasks) == 0 {
 		return nil
@@ -80,6 +133,20 @@ func (m Model) runtimeTasksToCmd(tasks []runtime.TaskRequest) tea.Cmd {
 		switch p := t.Payload.(type) {
 		case runtime.EnrichDetailPayload:
 			cmds = append(cmds, m.enrichDetailCmd(p))
+		case runtime.ConnectPayload:
+			cmds = append(cmds, m.connectAWS(p.Profile, p.Region, p.Gen))
+		case runtime.FetchIdentityPayload:
+			cmds = append(cmds, m.fetchIdentity())
+		case runtime.LoadAvailCachePayload:
+			cmds = append(cmds, m.loadAvailabilityCache())
+		case runtime.DemoPrefetchCountsPayload:
+			cmds = append(cmds, m.demoPrefetchCounts())
+		case runtime.FlashTickPayload:
+			cmds = append(cmds, flashTickCmd(p))
+		case runtime.EmitNavigatePayload:
+			cmds = append(cmds, emitNavigateCmd(p))
+		case runtime.EmitAPIErrorPayload:
+			cmds = append(cmds, emitAPIErrorCmd(p))
 		}
 	}
 	switch len(cmds) {
@@ -97,12 +164,6 @@ func (m Model) runtimeTasksToCmd(tasks []runtime.TaskRequest) tea.Cmd {
 // resource type and resource directly from the typed payload — no
 // Scope parsing, no side-channel resource argument.
 //
-// The runtime guarantees that an enricher is registered for
-// p.ResourceType (it would not have emitted this TaskRequest otherwise).
-// The adapter does not re-check this invariant. If somehow violated, the
-// nil-deref panic on enricher(...) is the correct surfacing — silent
-// no-op would mask a runtime/registry bug.
-//
 // EnrichGen is captured from the embedded Session at dispatch time to
 // preserve stale-result-rejection semantics: the result handler in
 // app.go compares msg.Generation against m.Session.EnrichGen on receipt.
@@ -110,6 +171,7 @@ func (m Model) runtimeTasksToCmd(tasks []runtime.TaskRequest) tea.Cmd {
 // migrated to the runtime core.
 func (m Model) enrichDetailCmd(p runtime.EnrichDetailPayload) tea.Cmd {
 	enricher := resource.GetDetailEnricher(p.ResourceType)
+
 	gen := m.Session.EnrichGen             // session-owned, promoted via embedded *Session
 	policyDocs := m.Session.PolicyDocCache // session-owned, promoted via embedded *Session
 	clients := m.Session.Clients
@@ -131,5 +193,70 @@ func (m Model) enrichDetailCmd(p runtime.EnrichDetailPayload) tea.Cmd {
 			Err:          err,
 			Generation:   gen,
 		}
+	}
+}
+
+// flashTickCmd schedules the auto-clear ClearFlashMsg dispatch using the
+// gen and duration carried by FlashTickPayload. The Core method that
+// emitted this payload already echoed back the gen the adapter pre-bumped
+// before invocation; equality on receipt rejects ticks superseded by a
+// newer flash.
+func flashTickCmd(p runtime.FlashTickPayload) tea.Cmd {
+	gen, dur := p.Gen, p.Duration
+	return tea.Tick(dur, func(_ time.Time) tea.Msg {
+		return messages.ClearFlashMsg{Gen: gen}
+	})
+}
+
+// emitNavigateCmd dispatches the one-shot NavigateMsg carried by
+// EmitNavigatePayload. Used by HandleClientsReady for the -c CLI flag's
+// initial-list navigation on first successful connect. Translates the
+// runtime-owned NavigateTarget to the adapter-owned messages.ViewTarget.
+func emitNavigateCmd(p runtime.EmitNavigatePayload) tea.Cmd {
+	var target messages.ViewTarget
+	switch p.Target {
+	case runtime.NavigateTargetResourceList:
+		target = messages.TargetResourceList
+	default:
+		target = messages.TargetMainMenu
+	}
+	rt := p.ResourceType
+	return func() tea.Msg {
+		return messages.NavigateMsg{Target: target, ResourceType: rt}
+	}
+}
+
+// emitAPIErrorCmd dispatches the APIErrorMsg carried by EmitAPIErrorPayload.
+// Used by HandleClientsReady's "wrong concrete type on Clients" branch to
+// route the error through HandleAPIError's classification flow.
+func emitAPIErrorCmd(p runtime.EmitAPIErrorPayload) tea.Cmd {
+	err := p.Err
+	return func() tea.Msg {
+		return messages.APIErrorMsg{Err: err}
+	}
+}
+
+// dispatchHandlerResult is the shared adapter-side glue used by every
+// ≤12-line handler in app_flash.go / app_session.go: it applies the
+// returned UIIntents (in order, via applyIntent) and translates the
+// returned TaskRequests into tea.Cmd values, batching everything into a
+// single tea.Cmd.
+func (m *Model) dispatchHandlerResult(intents []runtime.UIIntent, tasks []runtime.TaskRequest) tea.Cmd {
+	var cmds []tea.Cmd
+	for _, in := range intents {
+		if c := m.applyIntent(in); c != nil {
+			cmds = append(cmds, c)
+		}
+	}
+	if tc := m.runtimeTasksToCmd(tasks); tc != nil {
+		cmds = append(cmds, tc)
+	}
+	switch len(cmds) {
+	case 0:
+		return nil
+	case 1:
+		return cmds[0]
+	default:
+		return tea.Batch(cmds...)
 	}
 }

--- a/tests/unit/qa_clients_ready_flash_gen_test.go
+++ b/tests/unit/qa_clients_ready_flash_gen_test.go
@@ -1,0 +1,85 @@
+// qa_clients_ready_flash_gen_test.go — adapter-level regression for the
+// `handleClientsReady` flash.gen gate, covering the CXR/Architect Stage 5
+// R3+R4 finding on `internal/tui/app_session.go`.
+//
+// The R2 rework introduced a broad gate (`len(intents) > 0 ||
+// len(tasks) > 0`) that bumped `m.flash.gen` on any non-stale Core result.
+// That silently invalidated any in-flight `ClearFlashMsg` for the current
+// flash because the normal success path returns non-flash tasks
+// (`FetchIdentity`, `LoadAvailCache`) even when no FlashIntent or
+// FlashTickPayload is emitted.
+//
+// R3 narrowed the gate to `hasFlashWork(intents, tasks)`. These tests
+// exercise the adapter directly (via `m.Update(ClientsReadyMsg)`) and
+// fail if the gate is reverted to anything broader than "FlashIntent in
+// intents OR FlashTickPayload in tasks".
+package unit
+
+import (
+	"testing"
+
+	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/tui/messages"
+)
+
+// TestHandleClientsReady_SuccessNoPendingRefresh_FlashGenUnchanged
+// exercises the regression that the R3 fix addresses: a non-stale
+// ClientsReadyMsg success path with `PendingRefresh=false` triggers
+// `FetchIdentity` + `LoadAvailCache` tasks but no flash work — the
+// adapter must not advance `m.flash.gen` because any in-flight
+// `ClearFlashMsg` for the current flash would otherwise stop matching.
+//
+// Reverting `internal/tui/app_session.go` to the prior broad gate
+// (`len(intents) > 0 || len(tasks) > 0`) makes this test fail because
+// the success path emits two non-flash tasks.
+func TestHandleClientsReady_SuccessNoPendingRefresh_FlashGenUnchanged(t *testing.T) {
+	m := newRootSizedModel()
+
+	// Establish a non-zero baseline flash.gen via a normal FlashMsg.
+	m, _ = rootApplyMsg(m, messages.FlashMsg{Text: "first flash"})
+	genBefore := m.FlashGen()
+	if genBefore == 0 {
+		t.Fatalf("baseline flash.gen should be >0 after FlashMsg, got %d", genBefore)
+	}
+
+	// Dispatch a non-stale success ClientsReadyMsg. PendingRefresh stays
+	// false (the session default), so Core returns only FetchIdentity +
+	// LoadAvailCache tasks with no FlashIntent / FlashTickPayload.
+	m, _ = rootApplyMsg(m, messages.ClientsReadyMsg{
+		Clients: &awsclient.ServiceClients{},
+		Region:  "us-east-1",
+		Gen:     m.Session.ConnectGen, // matches session → non-stale
+	})
+
+	if got := m.FlashGen(); got != genBefore {
+		t.Errorf("handleClientsReady advanced flash.gen on success-no-pending-refresh path: was %d, now %d — broad-gate regression would silently invalidate any in-flight ClearFlashMsg for the current flash", genBefore, got)
+	}
+}
+
+// TestHandleClientsReady_StaleGen_FlashGenUnchanged pins the symmetric
+// stale-gen invariant: when `msg.Gen` does not match the session's
+// `ConnectGen`, Core returns (nil, nil) and the adapter must leave
+// `flash.gen` alone. The broad gate would also pass this test, but
+// keeping the assertion makes the invariant explicit at the adapter
+// level so future changes that only tweak the success path cannot
+// inadvertently regress the stale path.
+func TestHandleClientsReady_StaleGen_FlashGenUnchanged(t *testing.T) {
+	m := newRootSizedModel()
+
+	m, _ = rootApplyMsg(m, messages.FlashMsg{Text: "first flash"})
+	genBefore := m.FlashGen()
+	if genBefore == 0 {
+		t.Fatalf("baseline flash.gen should be >0 after FlashMsg, got %d", genBefore)
+	}
+
+	// Dispatch with Gen far ahead of ConnectGen so the stale guard fires.
+	m, _ = rootApplyMsg(m, messages.ClientsReadyMsg{
+		Clients: &awsclient.ServiceClients{},
+		Region:  "us-east-1",
+		Gen:     m.Session.ConnectGen + 5,
+	})
+
+	if got := m.FlashGen(); got != genBefore {
+		t.Errorf("handleClientsReady advanced flash.gen on stale-gen path: was %d, now %d", genBefore, got)
+	}
+}


### PR DESCRIPTION
## Summary

Phase-05 PR-05a-h3 ports 6 of the 10 shell-level handler bodies from `internal/tui` to platform-agnostic `(c *Core) Handle*` methods in `internal/runtime/handlers.go`. Closes the `(AS-324)` deliverable in the AS-315 program.

### Handlers ported (6)

| Handler | New Core method |
|---|---|
| `handleFlash` | `HandleFlash(FlashEvent) ([]UIIntent, []TaskRequest)` |
| `handleClearFlash` | `HandleClearFlash(ClearFlashEvent)` |
| `handleAPIError` | `HandleAPIError(APIErrorEvent)` |
| `handleClientsReady` | `HandleClientsReady(ClientsReadyEvent)` (success / failure helpers private) |
| `handleProfileSelected` | `HandleProfileSelected(ProfileSelectedEvent)` |
| `handleRegionSelected` | `HandleRegionSelected(RegionSelectedEvent)` |

The 4 view-stack handlers (`handleProfilesLoaded`, `handleValueRevealed`, `handleEnterChildView`, `handleThemeSelected`) and `handleKeyMsg` stay in `internal/tui` per `docs/refactor/05-boundary.md` §"5a-extract" — they need `PushScreen` / `PopScreen` adapter dispatch via the screen-builder registry that lands in a successor PR.

### New runtime types

- **6 UIIntent variants** in `intent.go`: `SetErrorHintIntent`, `AppendErrorHistoryIntent`, `ClearActiveListLoadingIntent`, `MenuClearAvailabilityIntent`, `PopSelectorIntent`, `RefreshActiveListIntent`.
- **7 TaskKind + Payload variants** in `tasks.go`: `Connect` / `FetchIdentity` / `LoadAvailCache` / `DemoPrefetchCounts` / `FlashTick` / `EmitNavigate` / `EmitAPIError`.

### TUI-side adapter shape

Each of the 6 tui-side handlers shrinks to a ≤9-line adapter that pre-bumps `m.flash.gen`, translates `messages.*` → `runtime.*Event`, calls the Core method, and dispatches the returned `[]UIIntent` + `[]TaskRequest` via the new `dispatchHandlerResult` helper. New `applyIntent` cases in `internal/tui/runtime_adapter.go` apply each intent directly to `*Model` state; new payload cases in `runtimeTasksToCmd` wrap the existing `connectAWS` / `fetchIdentity` / `loadAvailabilityCache` / `demoPrefetchCounts` / flash-tick / one-shot `NavigateMsg` / `APIErrorMsg` emissions as `tea.Cmd`.

## Acceptance verification

```bash
$ rg 'func \(c \*Core\) Handle' internal/runtime/handlers.go | wc -l
6
$ go list -f '{{.Imports}}' github.com/k2m30/a9s/v3/internal/runtime | grep -E 'bubbletea|lipgloss|bubbles'
(no output)
$ for h in handleFlash handleClearFlash handleAPIError handleClientsReady handleProfileSelected handleRegionSelected; do
    for f in internal/tui/app_flash.go internal/tui/app_session.go; do
      c=$(awk "/^func \\(m Model\\) ${h}\\(/,/^}/" "$f" | wc -l)
      [ "$c" -gt 0 ] && echo "$h: $c lines"
    done
  done
handleFlash: 7 lines
handleClearFlash: 6 lines
handleAPIError: 7 lines
handleClientsReady: 9 lines
handleProfileSelected: 7 lines
handleRegionSelected: 7 lines
$ rg 'func Test.*Handle(Flash|ClearFlash|APIError|ClientsReady|ProfileSelected|RegionSelected)' internal/runtime/handlers_test.go | wc -l
32
```

All tui adapter bodies are ≤9 lines (target ≤12).

## Local gate

```
go build ./...                              PASS
go test ./internal/runtime/ -count=1        PASS (32 new tests)
go test ./tests/unit/ -count=1              PASS (13.5s)
go test ./tests/unit/ -run 'Golden|Scenario' PASS
golangci-lint run ./...                     0 issues
govulncheck ./...                           No vulnerabilities found
go fix -inline -diff ./...                  (no output)
```

Sub-gates that the pod cannot run locally:
- `make test-race` — needs CGO / gcc not present in the Stage-6 pod (per pod bootstrap reference).
- `make mdlint` — `markdownlint-cli2` not installed in this pod; PR is code-only, no `.md` changes.
- `tests/integration/` Visual scenarios — pre-existing failures on `origin/main` (AS-350), unchanged by this PR.

CI will run the full gate.

## Test plan

- [x] All 6 Core methods compile under the BT-free runtime boundary
- [x] 32 unit tests in `internal/runtime/handlers_test.go` cover all 6 handlers, stale-gen guards, rollback semantics, NoCache/Demo branches, and the StackDepth + Command + PendingRefresh interactions
- [x] tui-side adapter line counts all ≤9 (target ≤12)
- [x] Existing TUI flash dispatch path (`applyIntents` in app.go) preserved for handlers that delegate via `FlashIntent` → `FlashMsg` dispatch
- [x] `verify-readonly` passes
- [x] `lint`, `security`, `gofix`, `snapshot` all green

## Cross-references

- Parent: AS-315
- Predecessors merged: AS-149 (PR #355), AS-323 (PR #356)
- Spec: `docs/refactor/05-pr-05a-h2.md` §"PR-05a-h3 (AS-315b)"
- Contract: `docs/refactor/05-boundary.md` §"5a-extract"

🤖 Generated with [Claude Code](https://claude.com/claude-code)