### PR TITLE
feat(phase-05-pr-05a-gens): unify generation counters into domain.Gen (AS-73)

### DIFF
--- a/internal/domain/gen.go
+++ b/internal/domain/gen.go
@@ -1,0 +1,39 @@
+package domain
+
+// Gen is the program-wide generation-counter type used by async-result
+// staleness guards. Every session-rotation counter (ConnectGen,
+// AvailabilityGen, EnrichmentGen, RelatedGen, EnrichGen, per-type
+// EnrichmentTypeGen) and every message field that carries one of those
+// values (Gen, TypeGen, NewGen, CurrentGen, Generation) uses this single
+// type — there is one generation-counter type across the program.
+//
+// A handler captures the current session Gen at dispatch time and stamps
+// it onto an outgoing async tea.Cmd. When the async result returns, the
+// handler compares the carried Gen against the live session Gen; a
+// mismatch means the user switched profile/region (or triggered a
+// refresh) while the work was in flight, so the result is stale and
+// must be dropped.
+//
+// Thread-safety contract: Gen is read and written exclusively on the
+// Bubble Tea Update goroutine — Session.Rotate(), refresh handlers, and
+// per-handler stamp/check sites all run there. Async tea.Cmd closures
+// capture a Gen by value at dispatch time and never mutate the live
+// session Gen from a goroutine; the captured value is compared inside
+// the handler when the result arrives. Because the Bubble Tea runtime
+// serializes Update, no atomic operations are required.
+//
+// Zero value: a freshly-constructed Session sets every Gen to 1 (via
+// session.New). The zero value 0 is reserved for "pre-guard dispatch"
+// sentinels — handlers that see a message with Gen == 0 accept it
+// unconditionally so synthetic test messages and early-return paths
+// don't require a live session to round-trip a gen.
+type Gen uint64
+
+// Bump increments the generation in place and returns the new value.
+// Use from Session.Rotate and refresh handlers; the returned value is
+// the new "current" Gen that subsequent dispatches will stamp onto
+// outgoing tea.Cmds.
+func (g *Gen) Bump() Gen {
+	*g++
+	return *g
+}

--- a/internal/runtime/handlers.go
+++ b/internal/runtime/handlers.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 )
 
 // Flash auto-clear durations. apiErrorFlashDuration is the longer 5 s window
@@ -50,7 +51,7 @@ const (
 type FlashEvent struct {
 	Text    string
 	IsError bool
-	NewGen  int
+	NewGen  domain.Gen
 }
 
 // ClearFlashEvent is the adapter-translated form of messages.ClearFlashMsg.
@@ -59,8 +60,8 @@ type FlashEvent struct {
 // IsError lets the handler emit SetErrorHintIntent when the cleared flash
 // was an error flash (mirrors the adapter's flashState.isError check).
 type ClearFlashEvent struct {
-	Gen        int
-	CurrentGen int
+	Gen        domain.Gen
+	CurrentGen domain.Gen
 	IsError    bool
 }
 
@@ -69,7 +70,7 @@ type ClearFlashEvent struct {
 // calling into the Core; the handler echoes it back via the FlashTickPayload.
 type APIErrorEvent struct {
 	Err    error
-	NewGen int
+	NewGen domain.Gen
 }
 
 // ClientsReadyEvent mirrors the fields of messages.ClientsReadyMsg the
@@ -86,10 +87,10 @@ type ClientsReadyEvent struct {
 	Clients     any
 	Err         error
 	Region      string
-	Gen         int
+	Gen         domain.Gen
 	StackDepth  int
 	HasActiveRL bool
-	NewGen      int
+	NewGen      domain.Gen
 }
 
 // ProfileSelectedEvent / RegionSelectedEvent mirror the corresponding
@@ -97,12 +98,12 @@ type ClientsReadyEvent struct {
 // already bumped to (used by the "Switching to …" flash tick).
 type ProfileSelectedEvent struct {
 	Profile string
-	NewGen  int
+	NewGen  domain.Gen
 }
 
 type RegionSelectedEvent struct {
 	Region string
-	NewGen int
+	NewGen domain.Gen
 }
 
 // HandleFlash bumps the flash generation, appends an error-history entry

--- a/internal/runtime/tasks.go
+++ b/internal/runtime/tasks.go
@@ -3,6 +3,8 @@ package runtime
 import (
 	"context"
 	"time"
+
+	"github.com/k2m30/a9s/v3/internal/domain"
 )
 
 // TaskKind names a family of background tasks ("enrich", "related",
@@ -144,7 +146,7 @@ type TaskRequest struct {
 type ConnectPayload struct {
 	Profile string
 	Region  string
-	Gen     int
+	Gen     domain.Gen
 }
 
 func (ConnectPayload) isTaskPayload() {}
@@ -174,7 +176,7 @@ func (DemoPrefetchCountsPayload) isTaskPayload() {}
 // reference. The runtime owns the gen (computed at dispatch time) so the
 // stale-clear guard works the same as it did before extraction.
 type FlashTickPayload struct {
-	Gen      int
+	Gen      domain.Gen
 	Duration time.Duration
 }
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -25,6 +25,7 @@ package session
 
 import (
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -72,7 +73,7 @@ type Session struct {
 	// every profile/region switch so a slow pre-switch ClientsReadyMsg arriving
 	// after the user has switched again is rejected by the gen guard.
 	// Rotate() bumps this; handlers MUST NOT bump it manually.
-	ConnectGen int
+	ConnectGen domain.Gen
 
 	// PendingRefresh marks that a successful ClientsReady should re-fetch the
 	// active resource list (set by profile/region switch handlers). Cleared by
@@ -98,7 +99,7 @@ type Session struct {
 	NoCache bool
 
 	// Wave 1 availability scan.
-	AvailabilityGen int      // bumped on profile/region switch to cancel stale probes
+	AvailabilityGen domain.Gen // bumped on profile/region switch to cancel stale probes
 	AvailQueue      []string // resource short names remaining to probe
 	AvailChecked    int      // number probed so far in current gen
 	AvailTotal      int      // total types to probe in current gen
@@ -107,7 +108,7 @@ type Session struct {
 	ProbeResources map[string][]resource.Resource // retained first-page resources from Wave 1
 	ProbeTruncated map[string]bool                // per-type truncation signal from Wave 1 probe
 	EnrichQueue    []string                       // resource types pending Wave 2 enrichment
-	EnrichmentGen  int                            // session-wide gen counter for Wave 2
+	EnrichmentGen  domain.Gen                     // session-wide gen counter for Wave 2
 	EnrichChecked  int                            // number of enrichment probes completed in current gen
 	EnrichTotal    int                            // total enrichment probes to run in current gen
 
@@ -117,7 +118,7 @@ type Session struct {
 	// region switch handlers. The remaining maps stay here because they do not
 	// need to persist across a Rotate().
 	EnrichmentRan          map[string]bool
-	EnrichmentTypeGen      map[string]int
+	EnrichmentTypeGen      map[string]domain.Gen
 	EnrichmentTruncatedIDs map[string]map[string]bool
 
 	// Session-scoped caches + stale-result guards.
@@ -128,8 +129,8 @@ type Session struct {
 	// keys) do not pollute the scope-filtered main-menu list.
 	LazyResourceCache map[string][]resource.Resource
 	RelatedCache      *RelatedCacheLRU
-	RelatedGen        uint64 // bumped on refresh/profile/region switch
-	EnrichGen         uint64 // bumped on refresh/profile/region switch (detail-enrichment only)
+	RelatedGen        domain.Gen // bumped on refresh/profile/region switch
+	EnrichGen         domain.Gen // bumped on refresh/profile/region switch (detail-enrichment only)
 	EnrichResKey      string // "resourceType:resourceID" of last detail-enrichment dispatch
 
 	// Feature-specific session caches. These used to hang off *ServiceClients
@@ -171,7 +172,7 @@ func New() *Session {
 	return &Session{
 		ProbeResources:         nil, // initialized lazily on first probe retention
 		EnrichmentRan:          make(map[string]bool),
-		EnrichmentTypeGen:      make(map[string]int),
+		EnrichmentTypeGen:      make(map[string]domain.Gen),
 		EnrichmentTruncatedIDs: make(map[string]map[string]bool),
 		ResourceCache:          make(map[string]*ResourceCacheEntry),
 		LazyResourceCache:      make(map[string][]resource.Resource),
@@ -197,11 +198,11 @@ func New() *Session {
 // — this method touches only Session-owned fields.
 func (s *Session) Rotate() {
 	s.RelatedCache.Clear()
-	s.RelatedGen++
-	s.EnrichGen++
-	s.AvailabilityGen++
-	s.EnrichmentGen++
-	s.ConnectGen++
+	s.RelatedGen.Bump()
+	s.EnrichGen.Bump()
+	s.AvailabilityGen.Bump()
+	s.EnrichmentGen.Bump()
+	s.ConnectGen.Bump()
 
 	// Session-identity / rollback-latch / fetch-latch fields. Profile/Region/
 	// Clients/PreSuppliedClients/Command/NoCache are deliberately NOT cleared
@@ -227,7 +228,7 @@ func (s *Session) Rotate() {
 	s.ResourceCache = make(map[string]*ResourceCacheEntry)
 	s.LazyResourceCache = make(map[string][]resource.Resource)
 	s.EnrichmentRan = make(map[string]bool)
-	s.EnrichmentTypeGen = make(map[string]int)
+	s.EnrichmentTypeGen = make(map[string]domain.Gen)
 	s.EnrichmentTruncatedIDs = make(map[string]map[string]bool)
 
 	// Feature caches: swap the PolicyDocumentCache for a fresh instance so

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -12,6 +12,7 @@ import (
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/config"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/runtime"
 	"github.com/k2m30/a9s/v3/internal/session"
@@ -39,7 +40,7 @@ type flashState struct {
 	text    string
 	isError bool
 	active  bool
-	gen     int // generation counter to avoid stale clears
+	gen     domain.Gen // generation counter to avoid stale clears
 }
 
 // errorEntry records a single error for the session error log.

--- a/internal/tui/app_accessors.go
+++ b/internal/tui/app_accessors.go
@@ -6,6 +6,7 @@
 package tui
 
 import (
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/tui/views"
 )
@@ -16,7 +17,7 @@ import (
 //
 // Note: the method name shadows the promoted Session.EnrichmentGen field.
 // All write sites MUST use m.Session.EnrichmentGen explicitly.
-func (m Model) EnrichmentGen() int {
+func (m Model) EnrichmentGen() domain.Gen {
 	return m.Session.EnrichmentGen
 }
 
@@ -25,7 +26,7 @@ func (m Model) EnrichmentGen() int {
 // non-flash success paths and stale-gen paths must NOT advance this counter,
 // otherwise an in-flight ClearFlashMsg for the current flash gets silently
 // invalidated. (CXR/Architect Stage 5 R3+R4 finding regression coverage.)
-func (m Model) FlashGen() int {
+func (m Model) FlashGen() domain.Gen {
 	return m.flash.gen
 }
 

--- a/internal/tui/fetch_adapter.go
+++ b/internal/tui/fetch_adapter.go
@@ -10,6 +10,7 @@ package tui
 import (
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/runtime"
 	"github.com/k2m30/a9s/v3/internal/tui/messages"
 )
@@ -156,7 +157,7 @@ func (m *Model) fetchRevealValue(resourceType, resourceID string) tea.Cmd {
 // ClientsReadyMsg. gen is a monotonic counter incremented on each
 // profile/region switch; stale ClientsReadyMsg values carrying an old gen are
 // discarded by handleClientsReady.
-func (m *Model) connectAWS(profile, region string, gen int) tea.Cmd {
+func (m *Model) connectAWS(profile, region string, gen domain.Gen) tea.Cmd {
 	ctx := m.appCtx
 	return func() tea.Msg {
 		result, err := m.core.ConnectAWS(ctx, profile, region)

--- a/internal/tui/messages/messages.go
+++ b/internal/tui/messages/messages.go
@@ -1,6 +1,7 @@
 package messages
 
 import (
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -44,7 +45,7 @@ type ResourcesLoadedMsg struct {
 	// applies the list update unconditionally, then — after its existing
 	// write-through block — checks this field; if it matches the current
 	// per-type gen, it seeds probeResources and dispatches probeEnrichment.
-	TypeGen int
+	TypeGen domain.Gen
 	// Err is non-nil when the paginated fetcher returned a partial-success
 	// composite error: SOME resources made it back AND something failed
 	// (e.g. one inline-group-policy enumeration call timed out). The handler
@@ -79,7 +80,7 @@ type FlashMsg struct {
 
 // ClearFlashMsg is sent after the flash auto-clear timer expires.
 type ClearFlashMsg struct {
-	Gen int // only clear if this matches current flash generation
+	Gen domain.Gen // only clear if this matches current flash generation
 }
 
 // ProfileSelectedMsg is sent when the user confirms a profile selection.
@@ -123,7 +124,7 @@ type ClientsReadyMsg struct {
 	Clients any
 	Err     error
 	Region  string // resolved region from AWS config (set on success)
-	Gen     int    // connect generation — ignore if != current connectGen
+	Gen     domain.Gen // connect generation — ignore if != current connectGen
 }
 
 // EnterChildViewMsg signals that the user has triggered a child view navigation.
@@ -160,7 +161,7 @@ type RelatedCheckResultMsg struct {
 	SourceResourceID string // ID of the source resource (for cache keying)
 	DefDisplayName   string // unique def.DisplayName — disambiguates multiple defs sharing a TargetType (e.g. ct-events self-pivots)
 	Result           resource.RelatedCheckResult
-	Generation       uint64 // dispatch generation — discard if != Model.RelatedGen
+	Generation       domain.Gen // dispatch generation — discard if != Model.RelatedGen
 	// CachedPages contains full top-level resource pages fetched from AWS on a
 	// cold cache miss, keyed by target resource short name. Non-nil only when
 	// the NeedsTargetCache prefetch executed a live fetch (i.e., target was
@@ -228,7 +229,7 @@ type AvailabilityPrefetchedMsg struct {
 	IssueTruncated map[string]bool                      // shortName -> true if issue count is lower bound
 	Resources      map[string][]resource.Resource       // shortName -> retained first-page resources for Wave 2
 	Pagination     map[string]*resource.PaginationMeta  // shortName -> full pagination meta (NextToken, etc.) for cache seeding
-	Gen            int                                  // availabilityGen captured at dispatch — stale if != current
+	Gen            domain.Gen                           // availabilityGen captured at dispatch — stale if != current
 	// PrefetchErr is the composite error aggregating per-type fetch failures
 	// during the synchronous availability prefetch. Non-nil when any paginated
 	// fetcher errored; the app handler surfaces it as a FlashMsg so operators
@@ -243,7 +244,7 @@ type AvailabilityCheckedMsg struct {
 	Count        int                 // number of resources found
 	Truncated    bool                // true if count is from a truncated first page
 	Err          error               // non-nil means "couldn't check" -- treat as unknown, don't grey out
-	Gen          int                 // generation counter -- ignore if != current availabilityGen
+	Gen          domain.Gen          // generation counter -- ignore if != current availabilityGen
 	Issues    int                 // count of IsIssueRowColor() resources (red/yellow only)
 	Resources []resource.Resource // Populated on success AND on partial-success (Err non-nil but partial results present)
 }
@@ -267,8 +268,8 @@ type EnrichmentCheckedMsg struct {
 	// enricher could not fully inspect them (per-resource API error or page cap).
 	TruncatedIDs map[string]bool
 	Err          error // enrichment error (nil on success)
-	Gen          int   // session-wide generation counter (stale probe protection; profile/region switch)
-	TypeGen      int   // per-type generation counter; bumped on every rerun for that type. Stale
+	Gen          domain.Gen // session-wide generation counter (stale probe protection; profile/region switch)
+	TypeGen      domain.Gen // per-type generation counter; bumped on every rerun for that type. Stale
 	// results whose TypeGen doesn't match the current per-type gen are discarded.
 }
 
@@ -300,5 +301,5 @@ type EnrichDetailResultMsg struct {
 	ResourceID   string
 	EnrichedRes  resource.Resource
 	Err          error
-	Generation   uint64
+	Generation   domain.Gen
 }

--- a/internal/tui/probe_adapter.go
+++ b/internal/tui/probe_adapter.go
@@ -12,6 +12,7 @@ import (
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/cache"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/tui/messages"
 	"github.com/k2m30/a9s/v3/internal/tui/views"
 )
@@ -62,7 +63,7 @@ func (m *Model) loadAvailabilityCache() tea.Cmd {
 
 // probeResourceAvailability returns a tea.Cmd that runs a Wave-1 availability
 // probe for shortName and converts the result to AvailabilityCheckedMsg.
-func (m *Model) probeResourceAvailability(shortName string, gen int) tea.Cmd {
+func (m *Model) probeResourceAvailability(shortName string, gen domain.Gen) tea.Cmd {
 	ctx, clients := m.appCtx, m.Session.Clients
 	return func() tea.Msg {
 		r := m.core.ProbeResourceAvailability(ctx, clients, shortName)
@@ -142,7 +143,7 @@ func (m *Model) demoPrefetchCounts() tea.Cmd {
 // dispatch probeEnrichment. APIErrorMsg and any other message pass through
 // unchanged.
 func (m *Model) refreshResourceListWithEnrichmentRerun(
-	rl views.ResourceListModel, tok int,
+	rl views.ResourceListModel, tok domain.Gen,
 ) tea.Cmd {
 	inner := m.refreshResourceList(rl)
 	return func() tea.Msg {
@@ -157,7 +158,7 @@ func (m *Model) refreshResourceListWithEnrichmentRerun(
 
 // probeEnrichment returns a tea.Cmd that runs the registered Wave-2 enricher
 // for shortName and converts the result to EnrichmentCheckedMsg.
-func (m *Model) probeEnrichment(shortName string, gen int) tea.Cmd {
+func (m *Model) probeEnrichment(shortName string, gen domain.Gen) tea.Cmd {
 	ctx, clients := m.appCtx, m.Session.Clients
 	typeGen := m.Session.EnrichmentTypeGen[shortName]
 	if awsclient.IssueEnricherRegistry[shortName].Fn == nil {

--- a/internal/tui/runtime_adapter_navigate.go
+++ b/internal/tui/runtime_adapter_navigate.go
@@ -30,6 +30,7 @@ import (
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/config"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/runtime"
 	"github.com/k2m30/a9s/v3/internal/session"
@@ -395,7 +396,7 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 		m.Session.AvailabilityGen++
 		m.Session.EnrichmentGen++
 		m.Session.EnrichmentRan = make(map[string]bool)
-		m.Session.EnrichmentTypeGen = make(map[string]int)
+		m.Session.EnrichmentTypeGen = make(map[string]domain.Gen)
 		m.Session.EnrichmentTruncatedIDs = make(map[string]map[string]bool)
 		// Clear stale Wave 2 from all cached rows before resetting ProbeResources.
 		// Without this, opening a cached list before the new enrichment completes

--- a/tests/unit/qa_enrichment_rerun_overlap_test.go
+++ b/tests/unit/qa_enrichment_rerun_overlap_test.go
@@ -29,6 +29,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/tui"
 	"github.com/k2m30/a9s/v3/internal/tui/messages"
@@ -90,7 +91,7 @@ func rerunEBSResources() []resource.Resource {
 //
 // sessionGen MUST be 0 for a freshly created model (enrichmentGen starts at 0).
 // typeGen MUST match the current per-type gen (0 initially, 1 after first Ctrl+R).
-func enrichmentCheckedWithFindings(sessionGen, typeGen int) messages.EnrichmentCheckedMsg {
+func enrichmentCheckedWithFindings(sessionGen, typeGen domain.Gen) messages.EnrichmentCheckedMsg {
 	return messages.EnrichmentCheckedMsg{
 		ResourceType: "ec2",
 		Issues:       1,


### PR DESCRIPTION
## Summary

Phase-05 PR-05a-gens: collapse the `int` / `uint64` salad of `availabilityGen` / `enrichmentGen` / `relatedGen` / `enrichGen` / `enrichmentTypeGen` into a single `domain.Gen` (`uint64`) type used everywhere.

This re-applies the AS-73 work that was force-push-dropped from PR #360 during the R3/R4 rework cycles (AS-176 force-push-drop pattern).

## Changes

- **NEW** `internal/domain/gen.go` — `type Gen uint64` plus `Bump()` method. Single source of truth for the program-wide generation-counter type.
- `internal/session/session.go` — `ConnectGen`, `AvailabilityGen`, `EnrichmentGen`, `RelatedGen`, `EnrichGen`, and `EnrichmentTypeGen` (map value) all migrate to `domain.Gen`. `Rotate()` uses `.Bump()`.
- `internal/tui/messages/messages.go` — every message-side `Gen` / `TypeGen` / `Generation` field migrates to `domain.Gen` (`ClearFlashMsg`, `ClientsReadyMsg`, `ResourcesLoadedMsg.TypeGen`, `RelatedCheckResultMsg.Generation`, `AvailabilityPrefetchedMsg.Gen`, `AvailabilityCheckedMsg.Gen`, `EnrichmentCheckedMsg.Gen` + `TypeGen`, `EnrichDetailResultMsg.Generation`).
- `internal/runtime/handlers.go` — `FlashEvent.NewGen`, `ClearFlashEvent.Gen`/`CurrentGen`, `APIErrorEvent.NewGen`, `ClientsReadyEvent.Gen`/`NewGen`, `ProfileSelectedEvent.NewGen`, `RegionSelectedEvent.NewGen` → `domain.Gen`.
- `internal/runtime/tasks.go` — `ConnectPayload.Gen`, `FlashTickPayload.Gen` → `domain.Gen`.
- `internal/tui/app.go` — `flashState.gen` → `domain.Gen`.
- `internal/tui/app_accessors.go` — `EnrichmentGen()` and `FlashGen()` return `domain.Gen`.
- `internal/tui/fetch_adapter.go`, `internal/tui/probe_adapter.go` — adapter signatures threading the gen value adopt `domain.Gen`.
- `internal/tui/runtime_adapter_navigate.go` — refresh handler initializes `make(map[string]domain.Gen)`.
- `tests/unit/qa_enrichment_rerun_overlap_test.go` — helper signature aligned with the new map value type.

## Conflict resolution (vs the original e93c6af)

This branch cherry-picked the original AS-73 commit on top of post-R3/R4 main, resolving 5 conflicts where the file structure had shifted:

- `internal/runtime/handlers.go` + `tasks.go` — runtime handlers consume typed runtime events now; no longer need `messages` import.
- `internal/tui/app.go` — accessor methods (`EnrichmentGen`, `ActiveDetailResource`, `ActiveListResources`) live in `internal/tui/app_accessors.go` after the R3/R4 split; duplicates dropped from `app.go` and the existing accessors in `app_accessors.go` migrated to `domain.Gen` (including new `FlashGen()` which was added in the rework).
- `internal/tui/probe_adapter.go` + `runtime_adapter_navigate.go` — rebased against `m.Session.Clients` / `m.Session.EnrichmentTypeGen` post-un-embed (AS-155); the un-embed was merged after the original e93c6af.

## Acceptance

```
$ rg '(availabilityGen|enrichmentGen|relatedGen|enrichGen|enrichmentTypeGen)\s+(int|uint64)' internal/
# -> zero hits

$ rg 'type\s+Gen\s+' internal/domain/
# -> internal/domain/gen.go:30:type Gen uint64
```

## Local verification

- `go build ./...` — clean
- `go test ./... -count=1` — green (all packages)
- `golangci-lint run ./...` — 0 issues
- `govulncheck ./...` — no vulnerabilities found
- `go fix -inline -diff ./...` — clean
- `verify-readonly`, `check-readme`, unit snapshot tests — all PASS

### Skipped locally (Stage 6 pod constraint, per `feedback_a9s_stage6_pod_bootstrap.md`)

- `make test-race` — pod lacks gcc/CGO; CI runs the race detector
- `make mdlint` — `markdownlint-cli2` not present in pod; no docs touched in this PR
- Integration snapshot tests `TestScenario_S3Visual` and `TestDemoScenarioHarness_ListFilterAndSort` fail **identically on `origin/main`** (verified via a clean worktree); pre-existing failures tracked under AS-350, not regressions from this PR.

## Risk

- Race detector will catch any latent gen-counter races flushed out by the unification — the 05-boundary spec explicitly calls this out as "Good — that's the point." Race detection delegated to CI.
- Behavior preserved: this is type-rename churn only. `Bump()` is `*g++` returning the new value; identical semantics to the pre-existing `++` sites it replaces.

## Cross-references

- Closes AS-73
- Depends on PR-05a-extract (`internal/runtime/` exists) — already merged
- Enables PR-05b (typed gen-stamping)
- Spec: [`docs/refactor/05-boundary.md`](docs/refactor/05-boundary.md) §"5a-gens"
- Origin: previously landed as `e93c6af` inside PR #360 bundle; dropped during R3/R4 rework.

## Test plan

- [x] `go build ./...` and `go test ./...` green locally
- [x] golangci-lint, govulncheck, gofix, verify-readonly, check-readme, unit snapshot all green locally
- [ ] CI: `make ready-to-push` (`test-race` + `mdlint` covered by CI; this is the canonical Stage 6 gate)
- [ ] Stage 5 review: CodeReviewer + CodexReviewer + Architect (size ≥ M)

🤖 Generated with [Claude Code](https://claude.com/claude-code)