### PR TITLE
refactor(tui): remove Session field from Model, route through core.Session() (AS-237)

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -52,18 +52,12 @@ type errorEntry struct {
 // Model is the root Bubble Tea model. It owns the view stack, header state,
 // AWS clients, and routes all messages to the active child view.
 //
-// The Model pairs a UI shell (view stack, header, input mode, flash, theme)
-// with a named Session *session.Session field that owns the in-memory
-// orchestration state tied to the active profile/region session (un-embedded
-// in PR-05a-final to make session ownership explicit at every call site).
-// Access sites use m.Session.ResourceCache, m.Session.ProbeResources,
-// m.Session.RelatedGen, m.Session.Profile, m.Session.Clients, etc. —
-// see internal/session/session.go for the ownership contract.
-// handleProfileSelected / handleRegionSelected call m.Session.Rotate() to
-// invalidate in-flight async results on switch.
+// Session state is owned exclusively by core via core.Session(). Call
+// m.core.Session() at each use site. See internal/session/session.go for the
+// ownership contract. handleProfileSelected / handleRegionSelected call
+// m.core.Session().Rotate() to invalidate in-flight async results on switch.
 type Model struct {
-	Session *session.Session // session-scoped orchestration state (incl. Profile, Region, Clients, Identity, ConnectGen, etc. after PR-05a-h2; un-embedded in PR-05a-final)
-	core    *runtime.Core    // platform-agnostic app core (shares same *session.Session)
+	core    *runtime.Core    // platform-agnostic app core
 
 	// --- UI shell state ---
 	width  int
@@ -108,13 +102,13 @@ type Option func(*Model)
 // WithProfile overrides the profile field on the session. Used in tests that need
 // a specific profile string without going through the live AWS bootstrap path.
 func WithProfile(profile string) Option {
-	return func(m *Model) { m.Session.Profile = profile }
+	return func(m *Model) { m.core.Session().Profile = profile }
 }
 
 // WithRegion overrides the region field on the session. Used in tests that need
 // a specific region string without going through the live AWS bootstrap path.
 func WithRegion(region string) Option {
-	return func(m *Model) { m.Session.Region = region }
+	return func(m *Model) { m.core.Session().Region = region }
 }
 
 // WithIsDemo marks the session as demo mode, which skips Wave 2 enrichment.
@@ -129,7 +123,7 @@ func WithIsDemo(demo bool) Option {
 // WithNoCache disables resource availability caching and background checks.
 func WithNoCache(disabled bool) Option {
 	return func(m *Model) {
-		m.Session.NoCache = disabled
+		m.core.Session().NoCache = disabled
 	}
 }
 
@@ -137,7 +131,7 @@ func WithNoCache(disabled bool) Option {
 // synthetic ClientsReadyMsg instead of initiating a live AWS connection.
 func WithClients(clients *awsclient.ServiceClients) Option {
 	return func(m *Model) {
-		m.Session.PreSuppliedClients = clients
+		m.core.Session().PreSuppliedClients = clients
 	}
 }
 
@@ -152,7 +146,7 @@ func WithActiveTheme(name string) Option {
 // directly on startup instead of the main menu. The caller is responsible for
 // resolving the input via resource.FindResourceType.
 func WithCommand(name string) Option {
-	return func(m *Model) { m.Session.Command = name }
+	return func(m *Model) { m.core.Session().Command = name }
 }
 
 // New constructs the initial Model.
@@ -177,7 +171,6 @@ func New(profile, region string, opts ...Option) Model {
 	sess.Profile = profile
 	sess.Region = region
 	m := Model{
-		Session:     sess,
 		core:        runtime.New(sess, resource.AllResourceTypes()),
 		keys:        k,
 		stack:       []views.View{&menu},
@@ -211,9 +204,9 @@ func (m Model) Cancel() {
 // When pre-supplied clients are present (demo mode or tests), emits a synthetic
 // ClientsReadyMsg immediately. Otherwise initiates the live AWS connection flow.
 func (m Model) Init() tea.Cmd {
-	if m.Session.PreSuppliedClients != nil {
+	if m.core.Session().PreSuppliedClients != nil {
 		preCmd := func() tea.Msg {
-			return messages.ClientsReady{Clients: m.Session.PreSuppliedClients}
+			return messages.ClientsReady{Clients: m.core.Session().PreSuppliedClients}
 		}
 		if m.configErr != nil {
 			return tea.Batch(preCmd, func() tea.Msg {
@@ -227,8 +220,8 @@ func (m Model) Init() tea.Cmd {
 	}
 	connectCmd := func() tea.Msg {
 		return messages.InitConnect{
-			Profile: m.Session.Profile,
-			Region:  m.Session.Region,
+			Profile: m.core.Session().Profile,
+			Region:  m.core.Session().Region,
 		}
 	}
 	if m.configErr != nil {
@@ -287,7 +280,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case messages.ClearFlash:
 		return m.handleClearFlash(msg)
 	case messages.InitConnect:
-		cmd := m.connectAWS(msg.Profile, msg.Region, m.Session.ConnectGen)
+		cmd := m.connectAWS(msg.Profile, msg.Region, m.core.Session().ConnectGen)
 		return m, cmd
 	case messages.ClientsReady:
 		return m.handleClientsReady(msg)
@@ -350,7 +343,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if rl.ParentContext() == nil && !rl.EscPops() {
 					rt := rl.ResourceType()
 					sortColIdx, sortAsc := rl.SortState()
-					updatedModel.Session.ResourceCache[rt] = &session.ResourceCacheEntry{
+					updatedModel.core.Session().ResourceCache[rt] = &session.ResourceCacheEntry{
 						Resources:     rl.AllResources(),
 						Pagination:    rl.PaginationState(),
 						FilterText:    rl.FilterText(),
@@ -365,8 +358,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// Active view is not a ResourceList for this type (e.g., detail or menu).
 				// Cache resources directly from the message so handleRelatedNavigate
 				// can find them when navigating to a related resource type.
-				if _, alreadyCached := updatedModel.Session.ResourceCache[msg.ResourceType]; !alreadyCached {
-					updatedModel.Session.ResourceCache[msg.ResourceType] = &session.ResourceCacheEntry{
+				if _, alreadyCached := updatedModel.core.Session().ResourceCache[msg.ResourceType]; !alreadyCached {
+					updatedModel.core.Session().ResourceCache[msg.ResourceType] = &session.ResourceCacheEntry{
 						Resources: msg.Resources,
 					}
 				}
@@ -381,16 +374,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// NOTE: This check runs regardless of which view is currently active —
 			// the user may have navigated away from the resource list before the
 			// fetch returned, but the rerun must still fire.
-			if msg.TypeGen != 0 && msg.TypeGen == updatedModel.Session.EnrichmentTypeGen[msg.ResourceType] {
-				if updatedModel.Session.ProbeResources == nil {
-					updatedModel.Session.ProbeResources = make(map[string][]resource.Resource)
+			if msg.TypeGen != 0 && msg.TypeGen == updatedModel.core.Session().EnrichmentTypeGen[msg.ResourceType] {
+				if updatedModel.core.Session().ProbeResources == nil {
+					updatedModel.core.Session().ProbeResources = make(map[string][]resource.Resource)
 				}
-				updatedModel.Session.ProbeResources[msg.ResourceType] = msg.Resources
-				if updatedModel.Session.ProbeTruncated == nil {
-					updatedModel.Session.ProbeTruncated = make(map[string]bool)
+				updatedModel.core.Session().ProbeResources[msg.ResourceType] = msg.Resources
+				if updatedModel.core.Session().ProbeTruncated == nil {
+					updatedModel.core.Session().ProbeTruncated = make(map[string]bool)
 				}
-				updatedModel.Session.ProbeTruncated[msg.ResourceType] = msg.Pagination != nil && msg.Pagination.IsTruncated
-				cmd = tea.Batch(cmd, updatedModel.probeEnrichment(msg.ResourceType, updatedModel.Session.EnrichmentGen))
+				updatedModel.core.Session().ProbeTruncated[msg.ResourceType] = msg.Pagination != nil && msg.Pagination.IsTruncated
+				cmd = tea.Batch(cmd, updatedModel.probeEnrichment(msg.ResourceType, updatedModel.core.Session().EnrichmentGen))
 			}
 			return updatedModel, cmd
 		}
@@ -410,7 +403,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case messages.EnrichDetail:
 		return m.handleEnrichDetail(msg)
 	case messages.EnrichDetailResult:
-		if messages.IsStale(msg, m.Session) {
+		if messages.IsStale(msg, m.core.Session()) {
 			return m, nil
 		}
 		// Surface enrichment errors as a flash message.
@@ -429,7 +422,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleRelatedCheckStarted(msg)
 	case messages.RelatedCheckResult:
 		// Discard results from a previous check generation (e.g., after Ctrl+R or
-		if messages.IsStale(msg, m.Session) {
+		if messages.IsStale(msg, m.core.Session()) {
 			return m, nil
 		}
 		// Accumulate in relatedCache so re-entering the same detail skips re-dispatch.
@@ -443,8 +436,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if sourceID != "" {
 			ck := session.RelatedCacheKey(msg.ResourceType, sourceID)
-			existing, _ := m.Session.RelatedCache.Get(ck)
-			m.Session.RelatedCache.Set(ck, append(existing, session.RelatedCacheResult{
+			existing, _ := m.core.Session().RelatedCache.Get(ck)
+			m.core.Session().RelatedCache.Set(ck, append(existing, session.RelatedCacheResult{
 				DefDisplayName: msg.DefDisplayName,
 				Result:         msg.Result,
 			}))
@@ -464,10 +457,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if td := resource.FindResourceType(aliasName); td != nil {
 				shortName = td.ShortName
 			}
-			if _, exists := m.Session.ResourceCache[shortName]; exists {
+			if _, exists := m.core.Session().ResourceCache[shortName]; exists {
 				continue
 			}
-			if _, lazyExists := m.Session.LazyResourceCache[shortName]; lazyExists {
+			if _, lazyExists := m.core.Session().LazyResourceCache[shortName]; lazyExists {
 				continue
 			}
 			// Site 4: derive findings before storing in ResourceCache so cached
@@ -480,7 +473,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if pagination == nil && entry.IsTruncated {
 				pagination = &resource.PaginationMeta{IsTruncated: true}
 			}
-			m.Session.ResourceCache[shortName] = &session.ResourceCacheEntry{
+			m.core.Session().ResourceCache[shortName] = &session.ResourceCacheEntry{
 				Resources:  entry.Resources,
 				Pagination: pagination,
 			}
@@ -505,7 +498,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Site 5: derive findings across the new slice before merging into
 			// LazyResourceCache (PR-03a-shim wire-up).
 			(&m).deriveFindingsForType(shortName, extra)
-			existing := m.Session.LazyResourceCache[shortName]
+			existing := m.core.Session().LazyResourceCache[shortName]
 			known := make(map[string]struct{}, len(existing))
 			for _, r := range existing {
 				known[r.ID] = struct{}{}
@@ -517,7 +510,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				known[r.ID] = struct{}{}
 				existing = append(existing, r)
 			}
-			m.Session.LazyResourceCache[shortName] = existing
+			m.core.Session().LazyResourceCache[shortName] = existing
 		}
 		// Surface FetchByIDs failures as a visible flash error. Partial results
 		// are already merged above; the flash informs the operator that some IDs
@@ -597,8 +590,8 @@ func (m Model) View() tea.View {
 
 	active := m.activeView()
 
-	headerProfile := m.Session.Profile
-	headerRegion := m.Session.Region
+	headerProfile := m.core.Session().Profile
+	headerRegion := m.core.Session().Region
 	if sel, ok := active.(*views.SelectorModel); ok {
 		if sel.Title() == "aws-regions" {
 			headerRegion = "..."
@@ -895,7 +888,7 @@ func (m *Model) cacheTopLevelResourceList(rl views.ResourceListModel) {
 	}
 	rt := rl.ResourceType()
 	sortColIdx, sortAsc := rl.SortState()
-	m.Session.ResourceCache[rt] = &session.ResourceCacheEntry{
+	m.core.Session().ResourceCache[rt] = &session.ResourceCacheEntry{
 		Resources:     rl.AllResources(),
 		Pagination:    rl.PaginationState(),
 		FilterText:    rl.FilterText(),
@@ -959,35 +952,35 @@ func (m Model) headerRight() string {
 
 // accountBadge returns the account alias (preferred) or account ID for the header.
 func (m Model) accountBadge() string {
-	if m.Session.Identity == nil {
+	if m.core.Session().Identity == nil {
 		return ""
 	}
-	if m.Session.Identity.AccountAlias != "" {
-		return m.Session.Identity.AccountAlias
+	if m.core.Session().Identity.AccountAlias != "" {
+		return m.core.Session().Identity.AccountAlias
 	}
-	return m.Session.Identity.AccountID
+	return m.core.Session().Identity.AccountID
 }
 
 // identityRoleName returns the identity name (role or user) for the header.
 func (m Model) identityRoleName() string {
-	if m.Session.Identity == nil {
+	if m.core.Session().Identity == nil {
 		return ""
 	}
-	return m.Session.Identity.IdentityName
+	return m.core.Session().Identity.IdentityName
 }
 
 // identityToViewData converts the cached CallerIdentity to a view-layer IdentityData.
 func (m Model) identityToViewData() views.IdentityData {
-	if m.Session.Identity == nil {
+	if m.core.Session().Identity == nil {
 		return views.IdentityData{}
 	}
 	return views.IdentityData{
-		AccountID:     m.Session.Identity.AccountID,
-		AccountAlias:  m.Session.Identity.AccountAlias,
-		ARN:           m.Session.Identity.Arn,
-		RoleName:      m.Session.Identity.RoleName,
-		UserName:      m.Session.Identity.UserName,
-		SessionName:   m.Session.Identity.SessionName,
-		IsAssumedRole: m.Session.Identity.IsAssumedRole,
+		AccountID:     m.core.Session().Identity.AccountID,
+		AccountAlias:  m.core.Session().Identity.AccountAlias,
+		ARN:           m.core.Session().Identity.Arn,
+		RoleName:      m.core.Session().Identity.RoleName,
+		UserName:      m.core.Session().Identity.UserName,
+		SessionName:   m.core.Session().Identity.SessionName,
+		IsAssumedRole: m.core.Session().Identity.IsAssumedRole,
 	}
 }

--- a/internal/tui/app_accessors.go
+++ b/internal/tui/app_accessors.go
@@ -8,24 +8,24 @@ package tui
 import (
 	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+	"github.com/k2m30/a9s/v3/internal/session"
 	"github.com/k2m30/a9s/v3/internal/tui/views"
 )
 
+// Session returns the underlying *session.Session owned by core.
+// Test-only accessor — production code uses m.core.Session() directly.
+func (m Model) Session() *session.Session {
+	return m.core.Session()
+}
+
 // EnrichmentGen returns the current session-wide enrichment generation counter.
-// This accessor is used by tests to capture the pre-switch gen value and verify
-// that post-switch messages carrying the old gen are correctly discarded.
-//
-// Note: the method name shadows the promoted Session.EnrichmentGen field.
-// All write sites MUST use m.Session.EnrichmentGen explicitly.
+// Test-only accessor.
 func (m Model) EnrichmentGen() domain.Gen {
-	return m.Session.EnrichmentGen
+	return m.core.Session().EnrichmentGen
 }
 
 // FlashGen returns the current tui-adapter flash generation counter.
-// Test-only accessor for verifying handleClientsReady's `hasFlashWork` gate:
-// non-flash success paths and stale-gen paths must NOT advance this counter,
-// otherwise an in-flight ClearFlashMsg for the current flash gets silently
-// invalidated. (CXR/Architect Stage 5 R3+R4 finding regression coverage.)
+// Test-only accessor.
 func (m Model) FlashGen() domain.Gen {
 	return m.flash.gen
 }

--- a/internal/tui/app_enrich_fold.go
+++ b/internal/tui/app_enrich_fold.go
@@ -47,13 +47,13 @@ func (m *Model) applyEnrichment(resourceType string, findings map[string]resourc
 		}
 	}
 
-	if entry, ok := m.Session.ResourceCache[canon]; ok {
+	if entry, ok := m.core.Session().ResourceCache[canon]; ok {
 		apply(entry.Resources)
 	}
-	if rows, ok := m.Session.LazyResourceCache[canon]; ok {
+	if rows, ok := m.core.Session().LazyResourceCache[canon]; ok {
 		apply(rows)
 	}
-	if rows, ok := m.Session.ProbeResources[canon]; ok {
+	if rows, ok := m.core.Session().ProbeResources[canon]; ok {
 		apply(rows)
 	}
 }
@@ -157,7 +157,7 @@ func stripWave2(findings []domain.Finding) []domain.Finding {
 // cache. Used by main-menu Ctrl+R to ensure the next list-open doesn't
 // rehydrate stale wave2 attention state via findingsFromRows.
 func clearAllWave2(m *Model) {
-	for _, entry := range m.Session.ResourceCache {
+	for _, entry := range m.core.Session().ResourceCache {
 		if entry == nil {
 			continue
 		}
@@ -166,13 +166,13 @@ func clearAllWave2(m *Model) {
 			entry.Resources[i].AttentionDetails = nil
 		}
 	}
-	for _, rows := range m.Session.LazyResourceCache {
+	for _, rows := range m.core.Session().LazyResourceCache {
 		for i := range rows {
 			rows[i].Findings = stripWave2(rows[i].Findings)
 			rows[i].AttentionDetails = nil
 		}
 	}
-	for _, rows := range m.Session.ProbeResources {
+	for _, rows := range m.core.Session().ProbeResources {
 		for i := range rows {
 			rows[i].Findings = stripWave2(rows[i].Findings)
 			rows[i].AttentionDetails = nil

--- a/internal/tui/app_input.go
+++ b/internal/tui/app_input.go
@@ -59,15 +59,15 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if _, ok := m.activeView().(*views.IdentityModel); ok {
 			return m.updateActiveView(msg)
 		}
-		id := views.NewIdentity(m.Session.Profile, m.Session.Region, m.keys)
-		if m.Session.Identity != nil {
+		id := views.NewIdentity(m.core.Session().Profile, m.core.Session().Region, m.keys)
+		if m.core.Session().Identity != nil {
 			data := m.identityToViewData()
 			id.SetIdentity(data)
 		}
 		id.SetSize(m.innerSize())
 		m.pushView(&id)
 		// Always re-fetch on i press
-		m.Session.IdentityFetching = true
+		m.core.Session().IdentityFetching = true
 		cmd := m.fetchIdentity()
 		return m, cmd
 	}

--- a/internal/tui/app_session.go
+++ b/internal/tui/app_session.go
@@ -145,7 +145,7 @@ func (m Model) handleThemeSelected(msg messages.ThemeSelected) (tea.Model, tea.C
 
 // handleProfilesLoaded pushes the profile selector view onto the stack.
 func (m Model) handleProfilesLoaded(msg profilesLoadedMsg) (tea.Model, tea.Cmd) {
-	p := views.NewProfile(msg.profiles, m.Session.Profile, m.keys)
+	p := views.NewProfile(msg.profiles, m.core.Session().Profile, m.keys)
 	p.SetSize(m.innerSize())
 	m.pushView(&p)
 	return m, nil

--- a/internal/tui/fetch_adapter.go
+++ b/internal/tui/fetch_adapter.go
@@ -24,7 +24,7 @@ type profilesLoadedMsg struct {
 // fetchResources returns a tea.Cmd that calls Core.FetchResources and
 // converts the result to ResourcesLoadedMsg or APIErrorMsg.
 func (m *Model) fetchResources(resourceType string) tea.Cmd {
-	ctx, clients := m.appCtx, m.Session.Clients
+	ctx, clients := m.appCtx, m.core.Session().Clients
 	return func() tea.Msg {
 		res, err := m.core.FetchResources(ctx, clients, resourceType)
 		// Partial-success contract: fetchers may return BOTH a non-empty
@@ -45,7 +45,7 @@ func (m *Model) fetchResources(resourceType string) tea.Cmd {
 
 // fetchResourcesFiltered returns a tea.Cmd for a server-side filtered fetch.
 func (m *Model) fetchResourcesFiltered(resourceType string, filter map[string]string) tea.Cmd {
-	ctx, clients := m.appCtx, m.Session.Clients
+	ctx, clients := m.appCtx, m.core.Session().Clients
 	return func() tea.Msg {
 		res, err := m.core.FetchResourcesFiltered(ctx, clients, resourceType, filter)
 		if err != nil && len(res.Resources) == 0 {
@@ -63,7 +63,7 @@ func (m *Model) fetchResourcesFiltered(resourceType string, filter map[string]st
 // fetchAMIDetail returns a tea.Cmd that fetches a single AMI by ID and
 // navigates to its detail view.
 func (m *Model) fetchAMIDetail(imageID string) tea.Cmd {
-	ctx, clients := m.appCtx, m.Session.Clients
+	ctx, clients := m.appCtx, m.core.Session().Clients
 	return func() tea.Msg {
 		res, err := m.core.FetchAMIDetail(ctx, clients, imageID)
 		if err != nil {
@@ -79,7 +79,7 @@ func (m *Model) fetchAMIDetail(imageID string) tea.Cmd {
 
 // fetchChildResources returns a tea.Cmd for paginated child resource loading.
 func (m *Model) fetchChildResources(childType string, parentCtx map[string]string) tea.Cmd {
-	ctx, clients := m.appCtx, m.Session.Clients
+	ctx, clients := m.appCtx, m.core.Session().Clients
 	return func() tea.Msg {
 		res, err := m.core.FetchChildResources(ctx, clients, childType, parentCtx)
 		if err != nil {
@@ -96,7 +96,7 @@ func (m *Model) fetchChildResources(childType string, parentCtx map[string]strin
 // fetchMoreResources returns a tea.Cmd that fetches the next page of a
 // paginated resource list using the continuation token from LoadMoreMsg.
 func (m *Model) fetchMoreResources(msg messages.LoadMore) tea.Cmd {
-	ctx, clients := m.appCtx, m.Session.Clients
+	ctx, clients := m.appCtx, m.core.Session().Clients
 	p := runtime.FetchMoreParams{
 		ResourceType: msg.ResourceType,
 		Token:        msg.ContinuationToken,
@@ -120,7 +120,7 @@ func (m *Model) fetchMoreResources(msg messages.LoadMore) tea.Cmd {
 
 // fetchIdentity returns a tea.Cmd that fetches the AWS caller identity.
 func (m *Model) fetchIdentity() tea.Cmd {
-	ctx, clients := m.appCtx, m.Session.Clients
+	ctx, clients := m.appCtx, m.core.Session().Clients
 	return func() tea.Msg {
 		identity, err := m.core.FetchIdentity(ctx, clients)
 		if err != nil {
@@ -143,7 +143,7 @@ func (m *Model) fetchProfiles() tea.Cmd {
 
 // fetchRevealValue returns a tea.Cmd that calls the registered reveal fetcher.
 func (m *Model) fetchRevealValue(resourceType, resourceID string) tea.Cmd {
-	ctx, clients := m.appCtx, m.Session.Clients
+	ctx, clients := m.appCtx, m.core.Session().Clients
 	return func() tea.Msg {
 		value, err := m.core.FetchRevealValue(ctx, clients, resourceType, resourceID)
 		if err != nil {

--- a/internal/tui/probe_adapter.go
+++ b/internal/tui/probe_adapter.go
@@ -20,8 +20,8 @@ import (
 // loadAvailabilityCache returns a tea.Cmd that reads the availability cache
 // from disk and converts the result to AvailabilityCacheLoadedMsg.
 func (m *Model) loadAvailabilityCache() tea.Cmd {
-	profile := m.Session.Profile
-	region := m.Session.Region
+	profile := m.core.Session().Profile
+	region := m.core.Session().Region
 	return func() tea.Msg {
 		cf, err := m.core.LoadAvailabilityCache(profile, region)
 		if err != nil || cf == nil {
@@ -64,7 +64,7 @@ func (m *Model) loadAvailabilityCache() tea.Cmd {
 // probeResourceAvailability returns a tea.Cmd that runs a Wave-1 availability
 // probe for shortName and converts the result to AvailabilityCheckedMsg.
 func (m *Model) probeResourceAvailability(shortName string, gen domain.Gen) tea.Cmd {
-	ctx, clients := m.appCtx, m.Session.Clients
+	ctx, clients := m.appCtx, m.core.Session().Clients
 	return func() tea.Msg {
 		r := m.core.ProbeResourceAvailability(ctx, clients, shortName)
 		return messages.AvailabilityChecked{
@@ -83,11 +83,11 @@ func (m *Model) probeResourceAvailability(shortName string, gen domain.Gen) tea.
 // saveAvailabilityCache returns a tea.Cmd that persists the current
 // availability state to disk. No-op when caching is disabled (noCache=true).
 func (m *Model) saveAvailabilityCache() tea.Cmd {
-	if m.Session.NoCache {
+	if m.core.Session().NoCache {
 		return nil
 	}
-	profile := m.Session.Profile
-	region := m.Session.Region
+	profile := m.core.Session().Profile
+	region := m.core.Session().Region
 
 	// Collect availability, truncation, and issue counts from main menu.
 	var entries map[string]int
@@ -118,8 +118,8 @@ func (m *Model) saveAvailabilityCache() tea.Cmd {
 // Used when pre-supplied clients are present and no-cache is active so the
 // main menu shows counts immediately without the async probe pipeline.
 func (m *Model) demoPrefetchCounts() tea.Cmd {
-	ctx, clients := m.appCtx, m.Session.Clients
-	gen := m.Session.AvailabilityGen
+	ctx, clients := m.appCtx, m.core.Session().Clients
+	gen := m.core.Session().AvailabilityGen
 	return func() tea.Msg {
 		r := m.core.DemoPrefetchCounts(ctx, clients)
 		return messages.AvailabilityPrefetched{
@@ -159,8 +159,8 @@ func (m *Model) refreshResourceListWithEnrichmentRerun(
 // probeEnrichment returns a tea.Cmd that runs the registered Wave-2 enricher
 // for shortName and converts the result to EnrichmentCheckedMsg.
 func (m *Model) probeEnrichment(shortName string, gen domain.Gen) tea.Cmd {
-	ctx, clients := m.appCtx, m.Session.Clients
-	typeGen := m.Session.EnrichmentTypeGen[shortName]
+	ctx, clients := m.appCtx, m.core.Session().Clients
+	typeGen := m.core.Session().EnrichmentTypeGen[shortName]
 	if awsclient.IssueEnricherRegistry[shortName].Fn == nil {
 		return nil
 	}

--- a/internal/tui/probe_enrichment_cache_test.go
+++ b/internal/tui/probe_enrichment_cache_test.go
@@ -1,20 +1,20 @@
 package tui
 
 // probe_enrichment_cache_test.go — pin that probeEnrichment passes a cache
-// snapshot containing m.Session.ProbeResources to the enricher closure, even when
-// m.Session.ResourceCache is empty.
+// snapshot containing m.core.Session().ProbeResources to the enricher closure, even when
+// m.core.Session().ResourceCache is empty.
 //
 // Codex review (2026-04-25): the cross-ref enricher (e.g. dbi-snap orphan
 // detection) cannot fire on the initial enrichment pass if the cache snapshot
-// is built from m.Session.ResourceCache alone, because that map is empty until the
+// is built from m.core.Session().ResourceCache alone, because that map is empty until the
 // user opens a list. ProbeResources holds the first-page rows retained by the
 // availability probe — it MUST be merged in. The fix is to call
 // m.buildResourceCacheSnapshot() (which merges all three sources) instead of
-// rolling an inline view of m.Session.ResourceCache only.
+// rolling an inline view of m.core.Session().ResourceCache only.
 //
 // This test exercises the bug shape directly: register a capture-only enricher
-// for a sentinel resource type, populate m.Session.ProbeResources["dbi"] with a sibling
-// row, leave m.Session.ResourceCache empty, dispatch probeEnrichment, and assert the
+// for a sentinel resource type, populate m.core.Session().ProbeResources["dbi"] with a sibling
+// row, leave m.core.Session().ResourceCache empty, dispatch probeEnrichment, and assert the
 // enricher saw "dbi" in its cache argument.
 
 import (
@@ -30,9 +30,9 @@ import (
 )
 
 // TestProbeEnrichment_CacheSnapshotMergesProbeResources pins the contract
-// that probeEnrichment's cache snapshot includes m.Session.ProbeResources, not just
-// m.Session.ResourceCache. Pre-fix this test FAILS because the inline snapshot at
-// app_probes.go:344-353 builds only from m.Session.ResourceCache.
+// that probeEnrichment's cache snapshot includes m.core.Session().ProbeResources, not just
+// m.core.Session().ResourceCache. Pre-fix this test FAILS because the inline snapshot at
+// app_probes.go:344-353 builds only from m.core.Session().ResourceCache.
 func TestProbeEnrichment_CacheSnapshotMergesProbeResources(t *testing.T) {
 	const sentinelType = "dbi-snap-probe-cache-pin"
 
@@ -63,19 +63,18 @@ func TestProbeEnrichment_CacheSnapshotMergesProbeResources(t *testing.T) {
 
 	// Construct a Model where ProbeResources has a sibling list ("dbi") but
 	// ResourceCache is empty — this models the initial-menu-enrichment state.
-	// ResourceCache / ProbeResources / EnrichmentTypeGen live on the embedded
-	// *session.Session; session.New() initialises the required maps. The
-	// runtime.Core is bound to the same session so the probe_adapter delegate
+	// ResourceCache / ProbeResources / EnrichmentTypeGen live on the session
+	// owned by core; session.New() initialises the required maps. The
+	// runtime.Core is bound to the session so the probe_adapter delegate
 	// (m.core.ProbeEnrichment) sees the seeded ProbeResources without a nil
 	// receiver panic.
 	sess := session.New()
 	sess.Clients = &awsclient.ServiceClients{} // non-nil so closure passes the nil-check
 	m := &Model{
-		Session: sess,
-		core:    runtime.New(sess, catalog.ResourceTypes),
-		appCtx:  context.Background(),
+		core:   runtime.New(sess, catalog.ResourceTypes),
+		appCtx: context.Background(),
 	}
-	m.Session.ProbeResources = map[string][]resource.Resource{
+	m.core.Session().ProbeResources = map[string][]resource.Resource{
 		"dbi": {
 			{ID: "prod-dbi-1", Name: "prod-dbi-1"},
 		},
@@ -102,8 +101,8 @@ func TestProbeEnrichment_CacheSnapshotMergesProbeResources(t *testing.T) {
 	dbiEntry, ok := seenCache["dbi"]
 	if !ok {
 		t.Errorf("cache snapshot missing %q — enricher cannot run cross-ref signals against ProbeResources-only siblings.\n"+
-			"This is the Codex P1 regression: probeEnrichment must merge m.Session.ProbeResources into the cache snapshot, "+
-			"not just m.Session.ResourceCache (which is empty until the user opens a list).", "dbi")
+			"This is the Codex P1 regression: probeEnrichment must merge m.core.Session().ProbeResources into the cache snapshot, "+
+			"not just m.core.Session().ResourceCache (which is empty until the user opens a list).", "dbi")
 	}
 	if len(dbiEntry.Resources) != 1 || dbiEntry.Resources[0].ID != "prod-dbi-1" {
 		t.Errorf("cache[dbi].Resources = %v, want exactly the ProbeResources sibling row", dbiEntry.Resources)

--- a/internal/tui/related_helpers.go
+++ b/internal/tui/related_helpers.go
@@ -45,5 +45,5 @@ func (m *Model) newRelatedList(rt resource.ResourceTypeDef, src resource.Resourc
 // buildResourceCacheSnapshot delegates to runtime.Core for the canonical
 // multi-cache merge (ResourceCache + LazyResourceCache + ProbeResources).
 func (m *Model) buildResourceCacheSnapshot() resource.ResourceCache {
-	return runtime.New(m.Session, resource.AllResourceTypes()).BuildResourceCacheSnapshot()
+	return runtime.New(m.core.Session(), resource.AllResourceTypes()).BuildResourceCacheSnapshot()
 }

--- a/internal/tui/runtime_adapter.go
+++ b/internal/tui/runtime_adapter.go
@@ -3,7 +3,7 @@
 //
 //  1. handleEnrichDetail — a Model-receiver wrapper that replaces the
 //     deleted internal/tui/app_enrich.go entry point. It constructs a
-//     transient runtime.Core bound to the Model's embedded Session,
+//     transient runtime.Core bound to the Model's session owned by core,
 //     calls core.HandleEnrichDetail, and translates the returned
 //     TaskRequests into tea.Cmd values. The existing app.go dispatch
 //     line (return m.handleEnrichDetail(msg)) is unchanged.
@@ -23,7 +23,7 @@
 //     fields without parsing TaskKey.Scope or accepting side-channel
 //     arguments. The closure builder stays in the adapter because it
 //     returns tea.Cmd and reads adapter-owned state (m.appCtx,
-//     m.Session.Clients, the embedded session's EnrichGen and PolicyDocCache)
+//     m.core.Session().Clients, the session owned by core's EnrichGen and PolicyDocCache)
 //     that has not yet migrated to the runtime core.
 package tui
 
@@ -48,7 +48,7 @@ import (
 // (HandleEnrichDetail), applies any returned UIIntents to the view stack,
 // then converts the returned TaskRequests into Bubble Tea commands.
 func (m Model) handleEnrichDetail(msg messages.EnrichDetail) (tea.Model, tea.Cmd) {
-	core := runtime.New(m.Session, resource.AllResourceTypes())
+	core := runtime.New(m.core.Session(), resource.AllResourceTypes())
 	intents, tasks := core.HandleEnrichDetail(runtime.EnrichDetailEvent{
 		ResourceType: msg.ResourceType,
 		Resource:     msg.Resource,
@@ -164,17 +164,17 @@ func (m Model) runtimeTasksToCmd(tasks []runtime.TaskRequest) tea.Cmd {
 // resource type and resource directly from the typed payload — no
 // Scope parsing, no side-channel resource argument.
 //
-// EnrichGen is captured from the embedded Session at dispatch time to
+// EnrichGen is captured from the session owned by core at dispatch time to
 // preserve stale-result-rejection semantics: the result handler in
-// app.go compares msg.Generation against m.Session.EnrichGen on receipt.
+// app.go compares msg.Generation against m.core.Session().EnrichGen on receipt.
 // PolicyDocCache and clients are adapter-owned state that has not yet
 // migrated to the runtime core.
 func (m Model) enrichDetailCmd(p runtime.EnrichDetailPayload) tea.Cmd {
 	enricher := resource.GetDetailEnricher(p.ResourceType)
 
-	gen := m.Session.EnrichGen             // session-owned, promoted via embedded *Session
-	policyDocs := m.Session.PolicyDocCache // session-owned, promoted via embedded *Session
-	clients := m.Session.Clients
+	gen := m.core.Session().EnrichGen             // session-owned, promoted via session owned by core
+	policyDocs := m.core.Session().PolicyDocCache // session-owned, promoted via session owned by core
+	clients := m.core.Session().Clients
 	appCtx := m.appCtx
 	dctx := &awsclient.DetailEnrichmentCtx{
 		Clients:    clients,

--- a/internal/tui/runtime_adapter_navigate.go
+++ b/internal/tui/runtime_adapter_navigate.go
@@ -12,10 +12,10 @@
 // handleCopy, handleRefresh / refreshResourceList, handleReveal,
 // handleIdentityLoaded, and handleIdentityError stay here as TUI-only
 // helpers because every line of their bodies depends on adapter state
-// (view stack, view-typed methods, flashState, m.Session.Identity, tea.Cmd
+// (view stack, view-typed methods, flashState, m.core.Session().Identity, tea.Cmd
 // returns). Their runtime-policy parts (cache-mutation gen bumps,
 // per-type enrichment-rerun bookkeeping) are reads/writes against the
-// embedded *Session — same data the runtime sees through c.session.
+// session owned by core — same data the runtime sees through c.session.
 package tui
 
 import (
@@ -125,7 +125,7 @@ func (m Model) handleNavigate(msg messages.Navigate) (tea.Model, tea.Cmd) {
 			issueTrunc = menu.GetIssueTruncated()[canon]
 		}
 		rl.SetEnrichmentState(issueCount, issueTrunc, findingsFromRows(entry.Resources))
-		rl.SetTruncatedIDs(m.Session.EnrichmentTruncatedIDs[canon])
+		rl.SetTruncatedIDs(m.core.Session().EnrichmentTruncatedIDs[canon])
 		m.pushView(&rl)
 		return m, nil
 
@@ -152,7 +152,7 @@ func (m Model) handleNavigate(msg messages.Navigate) (tea.Model, tea.Cmd) {
 			issueTrunc = menu.GetIssueTruncated()[canon]
 		}
 		rl.SetEnrichmentState(issueCount, issueTrunc, nil)
-		rl.SetTruncatedIDs(m.Session.EnrichmentTruncatedIDs[canon])
+		rl.SetTruncatedIDs(m.core.Session().EnrichmentTruncatedIDs[canon])
 		rl, initCmd := rl.Init()
 		m.pushView(&rl)
 		fetchCmd := navigateTasksToCmd(m, msg, result, tasks)
@@ -179,7 +179,7 @@ func (m Model) handleNavigate(msg messages.Navigate) (tea.Model, tea.Cmd) {
 		}
 		if result.DispatchRelated && d.NeedsRelatedCheck() {
 			ck := session.RelatedCacheKey(result.ResolvedType, result.Resource.ID)
-			if cached, ok := m.Session.RelatedCache.Get(ck); ok && len(cached) > 0 {
+			if cached, ok := m.core.Session().RelatedCache.Get(ck); ok && len(cached) > 0 {
 				d.ApplyRelatedResults(session.RelatedCacheReplay(result.ResolvedType, cached))
 			} else {
 				res := *result.Resource
@@ -238,7 +238,7 @@ func (m Model) handleNavigate(msg messages.Navigate) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case runtime.NavigateKindFetchProfiles:
-		if m.Session.PreSuppliedClients != nil {
+		if m.core.Session().PreSuppliedClients != nil {
 			return m, func() tea.Msg {
 				return messages.Flash{
 					Text:    "context switching is disabled in demo mode",
@@ -249,7 +249,7 @@ func (m Model) handleNavigate(msg messages.Navigate) (tea.Model, tea.Cmd) {
 		return m, navigateTasksToCmd(m, msg, result, tasks)
 
 	case runtime.NavigateKindPushRegion:
-		if m.Session.PreSuppliedClients != nil {
+		if m.core.Session().PreSuppliedClients != nil {
 			return m, func() tea.Msg {
 				return messages.Flash{
 					Text:    "region switching is disabled in demo mode",
@@ -262,7 +262,7 @@ func (m Model) handleNavigate(msg messages.Navigate) (tea.Model, tea.Cmd) {
 		for i, r := range regions {
 			regionCodes[i] = r.Code
 		}
-		rg := views.NewRegion(regionCodes, m.Session.Region, m.keys)
+		rg := views.NewRegion(regionCodes, m.core.Session().Region, m.keys)
 		rg.SetSize(m.innerSize())
 		m.pushView(&rg)
 		return m, nil
@@ -383,28 +383,28 @@ func (m Model) handleCopy() (tea.Model, tea.Cmd) {
 // view kind, MainMenuModel, ResourceListModel, DetailModel) and returns
 // tea.Cmd values. The runtime-owned mutations (gen bumps, cache deletes,
 // applyEnrichment, ProbeResources/ProbeTruncated reset, RuleSets swap) all
-// touch the embedded *Session — same data the runtime would mutate via
+// touch the session owned by core — same data the runtime would mutate via
 // c.session — so a future split into runtime-side helpers can land
 // without re-shaping the call sites here.
 func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 	// Main menu: restart availability checks (no-op in no-cache mode).
 	if _, ok := m.activeView().(*views.MainMenuModel); ok {
-		if m.Session.NoCache {
+		if m.core.Session().NoCache {
 			return m, nil
 		}
 		// Increment gen to cancel any in-flight probes and enrichment.
-		m.Session.AvailabilityGen++
-		m.Session.EnrichmentGen++
-		m.Session.EnrichmentRan = make(map[string]bool)
-		m.Session.EnrichmentTypeGen = make(map[string]domain.Gen)
-		m.Session.EnrichmentTruncatedIDs = make(map[string]map[string]bool)
+		m.core.Session().AvailabilityGen++
+		m.core.Session().EnrichmentGen++
+		m.core.Session().EnrichmentRan = make(map[string]bool)
+		m.core.Session().EnrichmentTypeGen = make(map[string]domain.Gen)
+		m.core.Session().EnrichmentTruncatedIDs = make(map[string]map[string]bool)
 		// Clear stale Wave 2 from all cached rows before resetting ProbeResources.
 		// Without this, opening a cached list before the new enrichment completes
 		// would show the previous run's attention state (PR #310 CodeRabbit
 		// finding B).
 		clearAllWave2(&m)
-		m.Session.ProbeResources = make(map[string][]resource.Resource)
-		m.Session.ProbeTruncated = make(map[string]bool)
+		m.core.Session().ProbeResources = make(map[string][]resource.Resource)
+		m.core.Session().ProbeTruncated = make(map[string]bool)
 		// Reset the menu's view-side state (availability, issue counts) in
 		// lockstep with the model-side maps above.
 		if menu, ok := m.stack[0].(*views.MainMenuModel); ok {
@@ -420,10 +420,10 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 		d.ResetRightColumn()
 		rt := d.ResourceType()
 		srcRes := d.SourceResource()
-		m.Session.RelatedCache.Delete(session.RelatedCacheKey(rt, srcRes.ID))
-		m.Session.RelatedGen++      // cancel in-flight results from previous batch
-		m.Session.EnrichGen++       // cancel in-flight enrichment from previous batch
-		m.Session.EnrichResKey = "" // force gen bump on next enrichment dispatch
+		m.core.Session().RelatedCache.Delete(session.RelatedCacheKey(rt, srcRes.ID))
+		m.core.Session().RelatedGen++      // cancel in-flight results from previous batch
+		m.core.Session().EnrichGen++       // cancel in-flight enrichment from previous batch
+		m.core.Session().EnrichResKey = "" // force gen bump on next enrichment dispatch
 		// Invalidate the SES v1 receipt rule set cache so Ctrl+R on a detail
 		// view picks up receipt-rule changes without requiring a profile/region
 		// switch. Swap (not Clear) so that any in-flight blocked
@@ -432,9 +432,9 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 		// sesActiveReceiptRuleSet captures its store reference at entry; we
 		// replace the slot here.
 		if rt == "ses" {
-			m.Session.RuleSets = session.NewRuleSetStore()
-			if m.Session.Clients != nil {
-				m.Session.Clients.SetRuleSets(m.Session.RuleSets)
+			m.core.Session().RuleSets = session.NewRuleSetStore()
+			if m.core.Session().Clients != nil {
+				m.core.Session().Clients.SetRuleSets(m.core.Session().RuleSets)
 			}
 		}
 		m.flash = flashState{text: "Refreshing...", isError: false, active: true}
@@ -476,13 +476,13 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 		(&m).applyEnrichment(rt, nil)
 	}
 
-	delete(m.Session.ResourceCache, rt) // clear cache for refreshed type only
+	delete(m.core.Session().ResourceCache, rt) // clear cache for refreshed type only
 	if rt == "ses" {
 		// Swap (see detail-view path above): protects against in-flight blocked
 		// DescribeActiveReceiptRuleSet fetchers re-poisoning the cache.
-		m.Session.RuleSets = session.NewRuleSetStore()
-		if m.Session.Clients != nil {
-			m.Session.Clients.SetRuleSets(m.Session.RuleSets)
+		m.core.Session().RuleSets = session.NewRuleSetStore()
+		if m.core.Session().Clients != nil {
+			m.core.Session().Clients.SetRuleSets(m.core.Session().RuleSets)
 		}
 	}
 	m.flash = flashState{text: "Refreshing...", isError: false, active: true}
@@ -493,12 +493,12 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 	// probeResources and dispatch probeEnrichment on success.
 	if rl.ParentContext() == nil && !rl.EscPops() {
 		if _, hasEnricher := awsclient.IssueEnricherRegistry[rt]; hasEnricher {
-			m.Session.EnrichmentTypeGen[rt]++
-			tok := m.Session.EnrichmentTypeGen[rt]
-			delete(m.Session.EnrichmentRan, rt)
+			m.core.Session().EnrichmentTypeGen[rt]++
+			tok := m.core.Session().EnrichmentTypeGen[rt]
+			delete(m.core.Session().EnrichmentRan, rt)
 			// Clear per-resource truncation markers too: if the refresh errors
 			// out, stale "?" prefixes must not persist across the rerun.
-			delete(m.Session.EnrichmentTruncatedIDs, rt)
+			delete(m.core.Session().EnrichmentTruncatedIDs, rt)
 			// Wave2 already stripped above (pre-fetch cleanup). Strip any rows
 			// that entered via ProbeResources/LazyResourceCache (those paths
 			// are NOT covered by the pre-fetch cleanup above, which only
@@ -560,12 +560,12 @@ func (m Model) handleReveal() (tea.Model, tea.Cmd) {
 }
 
 // handleIdentityLoaded caches the identity and updates the identity view if
-// active. Adapter-side because m.Session.Identity / m.Session.IdentityFetching live on the
+// active. Adapter-side because m.core.Session().Identity / m.core.Session().IdentityFetching live on the
 // TUI Model today.
 func (m Model) handleIdentityLoaded(msg messages.IdentityLoaded) (tea.Model, tea.Cmd) {
-	m.Session.IdentityFetching = false
+	m.core.Session().IdentityFetching = false
 	if id, ok := msg.Identity.(*awsclient.CallerIdentity); ok {
-		m.Session.Identity = id
+		m.core.Session().Identity = id
 	}
 	if idView, ok := m.activeView().(*views.IdentityModel); ok {
 		data := m.identityToViewData()
@@ -577,7 +577,7 @@ func (m Model) handleIdentityLoaded(msg messages.IdentityLoaded) (tea.Model, tea
 // handleIdentityError clears the fetching flag and updates the identity view
 // if active. Adapter-side for the same reason as handleIdentityLoaded.
 func (m Model) handleIdentityError(msg messages.IdentityError) (tea.Model, tea.Cmd) {
-	m.Session.IdentityFetching = false
+	m.core.Session().IdentityFetching = false
 	if idView, ok := m.activeView().(*views.IdentityModel); ok {
 		idView.SetError(msg.Err)
 	}

--- a/internal/tui/runtime_adapter_related.go
+++ b/internal/tui/runtime_adapter_related.go
@@ -16,7 +16,7 @@
 // It asks runtime.Core whether any RelatedDefs are registered for the source
 // type, and if so fans out one checker goroutine per def via relatedCheckCmd
 // (capped by runtime.MaxConcurrentProbes). The actual probe loop stays here in
-// the adapter because it depends on m.Session.Clients, m.appCtx, and tea.Cmd —
+// the adapter because it depends on m.core.Session().Clients, m.appCtx, and tea.Cmd —
 // platform glue that does not belong in internal/runtime.
 //
 // Decision-locus follow-up (PR-05b): a few branches in this adapter still walk
@@ -53,7 +53,7 @@ import (
 // (HandleRelatedNavigate), then builds the view and starts any required fetch
 // based on the returned NavigationResult and TaskRequests.
 func (m Model) handleRelatedNavigate(msg messages.RelatedNavigate) (tea.Model, tea.Cmd) {
-	core := runtime.New(m.Session, resource.AllResourceTypes())
+	core := runtime.New(m.core.Session(), resource.AllResourceTypes())
 	ev := runtime.RelatedNavigateEvent{
 		TargetType:     msg.TargetType,
 		SourceResource: msg.SourceResource,
@@ -82,7 +82,7 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigate) (tea.Model, t
 		if rt == nil {
 			// Fetcher-only type (registered paginated fetcher but no ResourceTypeDef).
 			if len(result.RelatedIDs) > 0 {
-				if lazyRows, hasLazy := m.Session.LazyResourceCache[msg.TargetType]; hasLazy {
+				if lazyRows, hasLazy := m.core.Session().LazyResourceCache[msg.TargetType]; hasLazy {
 					idSet := make(map[string]bool, len(result.RelatedIDs))
 					for _, id := range result.RelatedIDs {
 						idSet[id] = true
@@ -124,11 +124,11 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigate) (tea.Model, t
 		if result.TargetID != "" {
 			// Exact AMI navigation should fetch by image ID instead of falling
 			// back to the owned-AMI list, which misses public and third-party images.
-			// PR-05b: when m.Session.Clients moves into the runtime Core, the runtime will
+			// PR-05b: when m.core.Session().Clients moves into the runtime Core, the runtime will
 			// emit a typed FetchAMIDetail TaskRequest and this branch collapses
 			// into runtimeTasksToCmd; the adapter override stays for now because
 			// client selection is adapter-owned state.
-			if msg.TargetType == "ami" && m.Session.Clients != nil {
+			if msg.TargetType == "ami" && m.core.Session().Clients != nil {
 				cmd := m.fetchAMIDetail(result.TargetID)
 				return m, cmd
 			}
@@ -149,7 +149,7 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigate) (tea.Model, t
 
 		// RelatedIDs-based filtered list (multi or single cache miss).
 		if len(result.RelatedIDs) > 0 {
-			if entry, ok := m.Session.ResourceCache[msg.TargetType]; ok {
+			if entry, ok := m.core.Session().ResourceCache[msg.TargetType]; ok {
 				idSet := make(map[string]bool, len(result.RelatedIDs))
 				for _, id := range result.RelatedIDs {
 					idSet[id] = true
@@ -161,7 +161,7 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigate) (tea.Model, t
 					}
 				}
 				// Augment with lazy-cached resources. Prefer ResourceCache on ID collision.
-				if lazyRows, hasLazy := m.Session.LazyResourceCache[msg.TargetType]; hasLazy {
+				if lazyRows, hasLazy := m.core.Session().LazyResourceCache[msg.TargetType]; hasLazy {
 					found := make(map[string]struct{}, len(filtered))
 					for _, r := range filtered {
 						found[r.ID] = struct{}{}
@@ -248,7 +248,7 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigate) (tea.Model, t
 			// the runtime decision rather than a divergence. PR-05b will route the
 			// lazy-row slice through TaskRequest payload so the adapter no longer
 			// re-walks the cache.
-			if lazyRows, hasLazy := m.Session.LazyResourceCache[msg.TargetType]; hasLazy {
+			if lazyRows, hasLazy := m.core.Session().LazyResourceCache[msg.TargetType]; hasLazy {
 				idSet := make(map[string]bool, len(result.RelatedIDs))
 				for _, id := range result.RelatedIDs {
 					idSet[id] = true
@@ -321,11 +321,11 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigate) (tea.Model, t
 		}
 		var detailRes resource.Resource
 		var detailFound bool
-		if entry, ok := m.Session.ResourceCache[msg.TargetType]; ok {
+		if entry, ok := m.core.Session().ResourceCache[msg.TargetType]; ok {
 			detailRes, detailFound = resolveDetailResource(entry.Resources)
 		}
 		if !detailFound {
-			if lazyRows, ok := m.Session.LazyResourceCache[msg.TargetType]; ok {
+			if lazyRows, ok := m.core.Session().LazyResourceCache[msg.TargetType]; ok {
 				detailRes, detailFound = resolveDetailResource(lazyRows)
 			}
 		}
@@ -349,7 +349,7 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigate) (tea.Model, t
 			m.pushView(&detail)
 			if detail.NeedsRelatedCheck() {
 				ck := session.RelatedCacheKey(msg.TargetType, r.ID)
-				if cached, ok := m.Session.RelatedCache.Get(ck); ok && len(cached) > 0 {
+				if cached, ok := m.core.Session().RelatedCache.Get(ck); ok && len(cached) > 0 {
 					detail.ApplyRelatedResults(session.RelatedCacheReplay(msg.TargetType, cached))
 					return m, nil
 				}
@@ -437,10 +437,10 @@ func relatedNavigateTasksToCmd(m Model, targetType string, result runtime.Naviga
 		case runtime.KindFetchMore:
 			// Continuation token is runtime-owned and arrives as a structured
 			// payload (AS-270 / PR-05b). The adapter is a pure pass-through
-			// and no longer reads m.Session.ResourceCache here. A missing or
-			// wrong-typed payload is a runtime bug, not an adapter-recoverable
-			// state — drop the task to surface the regression instead of
-			// silently re-deriving.
+			// and no longer reads session cache here. A missing or wrong-typed
+			// payload is a runtime bug, not an adapter-recoverable state —
+			// drop the task to surface the regression instead of silently
+			// re-deriving.
 			payload, ok := t.Payload.(runtime.FetchMorePayload)
 			if !ok {
 				continue
@@ -469,7 +469,7 @@ func (m Model) handleRelatedCheckStarted(msg messages.RelatedCheckStarted) (tea.
 	if src.Type == "" {
 		src.Type = msg.ResourceType
 	}
-	core := runtime.New(m.Session, resource.AllResourceTypes())
+	core := runtime.New(m.core.Session(), resource.AllResourceTypes())
 	_, tasks := core.HandleRelatedCheckStarted(runtime.RelatedCheckStartedEvent{
 		ResourceType:   msg.ResourceType,
 		SourceResource: src,
@@ -489,10 +489,10 @@ func (m Model) relatedCheckCmd(res resource.Resource) tea.Cmd {
 	}
 
 	cache := m.buildResourceCacheSnapshot()
-	gen := m.Session.RelatedGen
+	gen := m.core.Session().RelatedGen
 
-	mainCacheKeys := make(map[string]struct{}, len(m.Session.ResourceCache))
-	for k := range m.Session.ResourceCache {
+	mainCacheKeys := make(map[string]struct{}, len(m.core.Session().ResourceCache))
+	for k := range m.core.Session().ResourceCache {
 		mainCacheKeys[k] = struct{}{}
 	}
 
@@ -530,7 +530,7 @@ func (m Model) relatedCheckCmd(res resource.Resource) tea.Cmd {
 			if def.NeedsTargetCache {
 				if _, inMainCache := mainCacheKeys[def.TargetType]; !inMainCache {
 					if pf := resource.GetPaginatedFetcher(def.TargetType); pf != nil {
-						if fr, err := pf(ctx, m.Session.Clients, ""); err == nil {
+						if fr, err := pf(ctx, m.core.Session().Clients, ""); err == nil {
 							isTrunc := fr.Pagination != nil && fr.Pagination.IsTruncated
 							if prev, hasPrev := localCache[def.TargetType]; hasPrev && prev.IsTruncated {
 								isTrunc = true
@@ -549,7 +549,7 @@ func (m Model) relatedCheckCmd(res resource.Resource) tea.Cmd {
 					}
 				}
 			}
-			result := def.Checker(ctx, m.Session.Clients, res, localCache)
+			result := def.Checker(ctx, m.core.Session().Clients, res, localCache)
 			result.TargetType = def.TargetType
 			var lazyAdded map[string][]resource.Resource
 			var lazyAddError error
@@ -557,7 +557,7 @@ func (m Model) relatedCheckCmd(res resource.Resource) tea.Cmd {
 				if ff := resource.GetFetchByIDs(def.TargetType); ff != nil {
 					missing := runtime.MissingFromCache(localCache, def.TargetType, result.ResourceIDs)
 					if len(missing) > 0 {
-						extra, fetchErr := ff(ctx, m.Session.Clients, missing)
+						extra, fetchErr := ff(ctx, m.core.Session().Clients, missing)
 						if fetchErr != nil {
 							lazyAddError = fetchErr
 						}

--- a/tests/unit/phase03_fold_test.go
+++ b/tests/unit/phase03_fold_test.go
@@ -13,7 +13,7 @@
 // ── Red-light expectations (before PR-03a-fold) ─────────────────────────────
 //
 //	Test 1/ProbeResources: fails because the handler's "all-enrichment-done"
-//	    cleanup (m.Session.EnrichChecked >= m.Session.EnrichTotal → m.Session.ProbeResources = nil) runs
+//	    cleanup (m.Session().EnrichChecked >= m.Session().EnrichTotal → m.Session().ProbeResources = nil) runs
 //	    before the test can inspect the cache. After fold, applyEnrichment
 //	    must run BEFORE cleanup AND tests seed EnrichTotal=2 to keep ProbeResources
 //	    alive for inspection. Without EnrichTotal=2, this subtest ALWAYS fails.
@@ -132,7 +132,7 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 		t.Run(tc.name+"/ResourceCache", func(t *testing.T) {
 			m := newShimModel()
 
-			m.Session.ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
+			m.Session().ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
 				Resources: []resource.Resource{
 					{ID: rid, Name: "test-" + tc.canonShort, Status: "running"},
 				},
@@ -145,7 +145,7 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 				TypeGen:      0,
 			})
 
-			entry, ok := m.Session.ResourceCache[tc.canonShort]
+			entry, ok := m.Session().ResourceCache[tc.canonShort]
 			if !ok || len(entry.Resources) == 0 {
 				t.Fatalf("ResourceCache[%q] is empty after EnrichmentCheckedMsg", tc.canonShort)
 			}
@@ -185,7 +185,7 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 		t.Run(tc.name+"/LazyResourceCache", func(t *testing.T) {
 			m := newShimModel()
 
-			m.Session.LazyResourceCache[tc.canonShort] = []resource.Resource{
+			m.Session().LazyResourceCache[tc.canonShort] = []resource.Resource{
 				{ID: rid, Name: "lazy-" + tc.canonShort, Status: "running"},
 			}
 
@@ -196,7 +196,7 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 				TypeGen:      0,
 			})
 
-			lazySlice, ok := m.Session.LazyResourceCache[tc.canonShort]
+			lazySlice, ok := m.Session().LazyResourceCache[tc.canonShort]
 			if !ok || len(lazySlice) == 0 {
 				t.Fatalf("LazyResourceCache[%q] is empty after EnrichmentCheckedMsg", tc.canonShort)
 			}
@@ -215,19 +215,19 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 			m := newShimModel()
 
 			// Prevent the "all enrichment done" cleanup path (app_handlers_availability.go:
-			// if m.Session.EnrichChecked >= m.Session.EnrichTotal { m.Session.ProbeResources = nil }).
+			// if m.Session().EnrichChecked >= m.Session().EnrichTotal { m.Session().ProbeResources = nil }).
 			// After EnrichChecked++ fires (0→1), we need 1 < EnrichTotal to avoid
 			// the cleanup so ProbeResources remains inspectable. Setting EnrichTotal=2
 			// simulates "one type still pending", keeping the cache alive.
-			m.Session.EnrichTotal = 2
+			m.Session().EnrichTotal = 2
 
 			// ProbeResources is initialized via AvailabilityCheckedMsg in real usage,
 			// but for the fold test we set it directly — the fold must walk ProbeResources
 			// just as it walks the other two caches.
-			if m.Session.ProbeResources == nil {
-				m.Session.ProbeResources = make(map[string][]resource.Resource)
+			if m.Session().ProbeResources == nil {
+				m.Session().ProbeResources = make(map[string][]resource.Resource)
 			}
-			m.Session.ProbeResources[tc.canonShort] = []resource.Resource{
+			m.Session().ProbeResources[tc.canonShort] = []resource.Resource{
 				{ID: rid, Name: "probe-" + tc.canonShort, Status: "running"},
 			}
 
@@ -238,7 +238,7 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 				TypeGen:      0,
 			})
 
-			probeSlice, ok := m.Session.ProbeResources[tc.canonShort]
+			probeSlice, ok := m.Session().ProbeResources[tc.canonShort]
 			if !ok || len(probeSlice) == 0 {
 				t.Fatalf("ProbeResources[%q] is empty after EnrichmentCheckedMsg (fold path must update ProbeResources before cleanup)", tc.canonShort)
 			}
@@ -314,7 +314,7 @@ func TestFold_RepeatedEnrichmentReplacesWave2(t *testing.T) {
 			}
 
 			m := newShimModel()
-			m.Session.ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
+			m.Session().ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
 				Resources: []resource.Resource{
 					{ID: rid, Name: "test-" + tc.canonShort, Status: "impaired"},
 				},
@@ -336,7 +336,7 @@ func TestFold_RepeatedEnrichmentReplacesWave2(t *testing.T) {
 				TypeGen:      0,
 			})
 
-			entry, ok := m.Session.ResourceCache[tc.canonShort]
+			entry, ok := m.Session().ResourceCache[tc.canonShort]
 			if !ok || len(entry.Resources) == 0 {
 				t.Fatalf("ResourceCache[%q] is empty", tc.canonShort)
 			}
@@ -424,7 +424,7 @@ func TestFold_EmptyEnrichmentClearsWave2(t *testing.T) {
 			}
 
 			m := newShimModel()
-			m.Session.ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
+			m.Session().ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
 				Resources: []resource.Resource{
 					{ID: rid, Name: "test-" + tc.canonShort, Status: "impaired"},
 				},
@@ -440,7 +440,7 @@ func TestFold_EmptyEnrichmentClearsWave2(t *testing.T) {
 
 			// Verify wave2 was set before clearing.
 			{
-				entry := m.Session.ResourceCache[tc.canonShort]
+				entry := m.Session().ResourceCache[tc.canonShort]
 				if entry == nil || len(entry.Resources) == 0 {
 					t.Fatalf("ResourceCache[%q] empty after initial enrichment", tc.canonShort)
 				}
@@ -464,7 +464,7 @@ func TestFold_EmptyEnrichmentClearsWave2(t *testing.T) {
 				TypeGen:      0,
 			})
 
-			entry, ok := m.Session.ResourceCache[tc.canonShort]
+			entry, ok := m.Session().ResourceCache[tc.canonShort]
 			if !ok || len(entry.Resources) == 0 {
 				t.Fatalf("ResourceCache[%q] is empty after empty EnrichmentCheckedMsg", tc.canonShort)
 			}
@@ -526,7 +526,7 @@ func TestFold_EnrichmentFindingsFieldDeleted(t *testing.T) {
 //
 // The pre-fix bug (PR #310 CodeRabbit finding A):
 //
-//	handleRefresh calls delete(m.Session.ResourceCache[rt]) BEFORE applyEnrichment(rt, nil).
+//	handleRefresh calls delete(m.Session().ResourceCache[rt]) BEFORE applyEnrichment(rt, nil).
 //	applyEnrichment walks ResourceCache[rt] to find rows to clear — but the entry
 //	was just deleted, so it finds nothing. The ResourceListModel was constructed
 //	from entry.Resources when NavigateMsg was handled; the rl's internal slice
@@ -560,7 +560,7 @@ func TestFold_CtrlROnList_ClearsActiveRowFindings(t *testing.T) {
 
 	// Step 1: seed ResourceCache so NavigateMsg gets a cache hit and creates
 	// a ResourceListModel holding this slice.
-	m.Session.ResourceCache["ec2"] = &session.ResourceCacheEntry{
+	m.Session().ResourceCache["ec2"] = &session.ResourceCacheEntry{
 		Resources: []resource.Resource{
 			{ID: rid, Name: "test-ec2", Status: "running"},
 		},
@@ -602,7 +602,7 @@ func TestFold_CtrlROnList_ClearsActiveRowFindings(t *testing.T) {
 
 	// Assertion: after Ctrl+R, no wave2 entry should remain on the rows
 	// visible in the active ResourceListModel. The fix requires applyEnrichment
-	// to run BEFORE delete(m.Session.ResourceCache[rt]), so that rl's internal slice
+	// to run BEFORE delete(m.Session().ResourceCache[rt]), so that rl's internal slice
 	// has its wave2 findings cleared before the cache entry is removed.
 	postResources := m.ActiveListResources()
 	if len(postResources) == 0 {
@@ -614,7 +614,7 @@ func TestFold_CtrlROnList_ClearsActiveRowFindings(t *testing.T) {
 			if f.Source == wantSource {
 				t.Errorf(
 					"resource %q still has stale wave2 finding after Ctrl+R: Source=%q Phrase=%q; "+
-						"fix: call applyEnrichment(rt, nil) BEFORE delete(m.Session.ResourceCache[rt]) in handleRefresh",
+						"fix: call applyEnrichment(rt, nil) BEFORE delete(m.Session().ResourceCache[rt]) in handleRefresh",
 					r.ID, f.Source, f.Phrase,
 				)
 			}
@@ -631,7 +631,7 @@ func TestFold_CtrlROnList_ClearsActiveRowFindings(t *testing.T) {
 // The pre-fix bug (PR #310 CodeRabbit finding B):
 //
 //	handleRefresh on the main-menu path resets side maps (ProbeResources,
-//	EnrichmentRan, etc.) but never touches m.Session.ResourceCache. Rows in ResourceCache
+//	EnrichmentRan, etc.) but never touches m.Session().ResourceCache. Rows in ResourceCache
 //	retain stale r.Findings from the previous enrichment wave. When the user
 //	navigates back to a list, they see stale wave2 markers until a fresh
 //	EnrichmentCheckedMsg arrives and overwrites them.
@@ -664,12 +664,12 @@ func TestFold_MainMenuCtrlR_ClearsAllCachedWave2(t *testing.T) {
 	m = shimApplyMsg(m, messages.ClientsReady{Clients: nil})
 
 	// Step 1: seed ResourceCache for ec2 and s3 with running resources.
-	m.Session.ResourceCache[ec2Short] = &session.ResourceCacheEntry{
+	m.Session().ResourceCache[ec2Short] = &session.ResourceCacheEntry{
 		Resources: []resource.Resource{
 			{ID: ec2ID, Name: "test-ec2", Status: "running"},
 		},
 	}
-	m.Session.ResourceCache[s3Short] = &session.ResourceCacheEntry{
+	m.Session().ResourceCache[s3Short] = &session.ResourceCacheEntry{
 		Resources: []resource.Resource{
 			{ID: s3ID, Name: "test-bucket", Status: "running"},
 		},
@@ -698,7 +698,7 @@ func TestFold_MainMenuCtrlR_ClearsAllCachedWave2(t *testing.T) {
 		{ec2Short, ec2ID, "wave2:" + ec2Short},
 		{s3Short, s3ID, "wave2:" + s3Short},
 	} {
-		entry, ok := m.Session.ResourceCache[tc.short]
+		entry, ok := m.Session().ResourceCache[tc.short]
 		if !ok || len(entry.Resources) == 0 {
 			t.Fatalf("pre-Ctrl+R: ResourceCache[%q] empty — enrichment not wired", tc.short)
 		}
@@ -728,7 +728,7 @@ func TestFold_MainMenuCtrlR_ClearsAllCachedWave2(t *testing.T) {
 		{ec2Short, "wave2:" + ec2Short},
 		{s3Short, "wave2:" + s3Short},
 	} {
-		entry, ok := m.Session.ResourceCache[tc.short]
+		entry, ok := m.Session().ResourceCache[tc.short]
 		if !ok {
 			// Cache entry deleted on Ctrl+R is also acceptable — no stale wave2.
 			continue
@@ -824,7 +824,7 @@ func TestFold_AttentionDetailsCarryAcrossEntryPoints(t *testing.T) {
 
 			// Verify entry-point wave1 was set (shim site #4 must be wired for this to hold).
 			{
-				entry := m.Session.ResourceCache[tc.canonShort]
+				entry := m.Session().ResourceCache[tc.canonShort]
 				if entry == nil || len(entry.Resources) == 0 {
 					t.Fatalf("ResourceCache[%q] empty after RelatedCheckResultMsg — site 4 shim not wired", tc.canonShort)
 				}
@@ -841,7 +841,7 @@ func TestFold_AttentionDetailsCarryAcrossEntryPoints(t *testing.T) {
 				TypeGen:      0,
 			})
 
-			entry, ok := m.Session.ResourceCache[tc.canonShort]
+			entry, ok := m.Session().ResourceCache[tc.canonShort]
 			if !ok || len(entry.Resources) == 0 {
 				t.Fatalf("ResourceCache[%q] is empty after EnrichmentCheckedMsg", tc.canonShort)
 			}

--- a/tests/unit/phase03_shim_wireups_test.go
+++ b/tests/unit/phase03_shim_wireups_test.go
@@ -32,7 +32,7 @@
 //	   scaffolding. Covered by grep-audit.
 //
 //	#7 app_enrich.go — EnrichDetailResultMsg updates only the active DetailModel's
-//	   internal m.res field, not m.Session.ResourceCache. That field is unexported and
+//	   internal m.res field, not m.Session().ResourceCache. That field is unexported and
 //	   inaccessible from this external test package. The wire-up will be verified
 //	   by the coder's grep-audit (exactly 7 sites).
 //
@@ -55,7 +55,7 @@
 //	   are missed. Pre-fix: only wave1 finding returned. Post-fix: 2 findings.
 //
 //	TestShim_NavigateAliasHitsCanonicalCache:
-//	   handleNavigate does m.Session.ResourceCache[msg.ResourceType] — alias misses canonical
+//	   handleNavigate does m.Session().ResourceCache[msg.ResourceType] — alias misses canonical
 //	   cache key, bypasses deriveFindingsForType, leaving Findings empty. Pre-fix:
 //	   empty. Post-fix: Findings populated.
 //
@@ -100,11 +100,11 @@ func newShimModel() tui.Model {
 }
 
 // TestShim_ProbeResourcesPopulatesFindings verifies that when
-// AvailabilityCheckedMsg is handled the retained resources in m.Session.ProbeResources
+// AvailabilityCheckedMsg is handled the retained resources in m.Session().ProbeResources
 // have their Findings field populated by DeriveFindings.
 //
 // Wire-up site: app_handlers_availability.go (~line 215), the
-// m.Session.ProbeResources[msg.ResourceType] = msg.Resources assignment.
+// m.Session().ProbeResources[msg.ResourceType] = msg.Resources assignment.
 //
 // Table-driven: every row exercises a distinct resource type to ensure no
 // type is special-cased and aliases are handled correctly.
@@ -152,7 +152,7 @@ func TestShim_ProbeResourcesPopulatesFindings(t *testing.T) {
 			})
 
 			// The cache lookup must use the canonical short name, NOT the alias.
-			probeSlice, ok := m.Session.ProbeResources[tc.canonShort]
+			probeSlice, ok := m.Session().ProbeResources[tc.canonShort]
 			if !ok || len(probeSlice) == 0 {
 				t.Fatalf("ProbeResources[%q] is empty — handler did not retain resources (alias=%q)", tc.canonShort, effective)
 			}
@@ -183,7 +183,7 @@ func TestShim_ProbeResourcesPopulatesFindings(t *testing.T) {
 
 // TestShim_EnrichmentCheckedBridgesWave2Findings is the critical Wave-2 bridge test.
 //
-// The test pre-seeds m.Session.ResourceCache[tc.canonShort] with a resource that has
+// The test pre-seeds m.Session().ResourceCache[tc.canonShort] with a resource that has
 // tc.status, sends EnrichmentCheckedMsg (using alias if present), and asserts
 // the first finding is populated correctly.
 //
@@ -222,7 +222,7 @@ func TestShim_EnrichmentCheckedBridgesWave2Findings(t *testing.T) {
 			}
 
 			// Seed the cache under the canonical short name.
-			m.Session.ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
+			m.Session().ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
 				Resources: []resource.Resource{res},
 			}
 
@@ -236,7 +236,7 @@ func TestShim_EnrichmentCheckedBridgesWave2Findings(t *testing.T) {
 				TypeGen:      0,
 			})
 
-			entry, ok := m.Session.ResourceCache[tc.canonShort]
+			entry, ok := m.Session().ResourceCache[tc.canonShort]
 			if !ok || len(entry.Resources) == 0 {
 				t.Fatalf("ResourceCache[%q] is empty after EnrichmentCheckedMsg", tc.canonShort)
 			}
@@ -266,10 +266,10 @@ func TestShim_EnrichmentCheckedBridgesWave2Findings(t *testing.T) {
 }
 
 // TestShim_CachedPagesPopulatesFindings verifies that when RelatedCheckResultMsg
-// carries a CachedPages entry, the resources written to m.Session.ResourceCache have
+// carries a CachedPages entry, the resources written to m.Session().ResourceCache have
 // their Findings field populated by DeriveFindings.
 //
-// Wire-up site: app.go (~line 489), the m.Session.ResourceCache[shortName] = ... assignment
+// Wire-up site: app.go (~line 489), the m.Session().ResourceCache[shortName] = ... assignment
 // inside the CachedPages loop.
 //
 // Table-driven: aliased rows (rds-aliased, redis-aliased) are expected to fail
@@ -323,7 +323,7 @@ func TestShim_CachedPagesPopulatesFindings(t *testing.T) {
 			})
 
 			// After handling, the cache must be stored under the canonical key.
-			entry, ok := m.Session.ResourceCache[tc.canonShort]
+			entry, ok := m.Session().ResourceCache[tc.canonShort]
 			if !ok || len(entry.Resources) == 0 {
 				t.Fatalf("ResourceCache[%q] is empty — CachedPages was not written (alias=%q)", tc.canonShort, effective)
 			}
@@ -353,10 +353,10 @@ func TestShim_CachedPagesPopulatesFindings(t *testing.T) {
 }
 
 // TestShim_LazyAddedPopulatesFindings verifies that when RelatedCheckResultMsg
-// carries a LazyAddedResources entry, the resources merged into m.Session.LazyResourceCache
+// carries a LazyAddedResources entry, the resources merged into m.Session().LazyResourceCache
 // have their Findings field populated by DeriveFindings.
 //
-// Wire-up site: app.go (~line 517), the m.Session.LazyResourceCache[shortName] = existing
+// Wire-up site: app.go (~line 517), the m.Session().LazyResourceCache[shortName] = existing
 // assignment inside the LazyAddedResources loop.
 //
 // Table-driven: aliased rows (rds-aliased, redis-aliased) are expected to fail
@@ -407,7 +407,7 @@ func TestShim_LazyAddedPopulatesFindings(t *testing.T) {
 			})
 
 			// The lazy cache must be stored under the canonical short name.
-			lazySlice, ok := m.Session.LazyResourceCache[tc.canonShort]
+			lazySlice, ok := m.Session().LazyResourceCache[tc.canonShort]
 			if !ok || len(lazySlice) == 0 {
 				t.Fatalf("LazyResourceCache[%q] is empty — LazyAddedResources was not written (alias=%q)", tc.canonShort, effective)
 			}
@@ -489,7 +489,7 @@ func TestShim_DeriveHelpersResolveAlias(t *testing.T) {
 	// Set EnrichTotal > 1 so the "all enrichment done" branch (EnrichChecked >= EnrichTotal)
 	// does not fire after processing this single message, which would nil out ProbeResources
 	// before we can inspect it.
-	m.Session.EnrichTotal = 2
+	m.Session().EnrichTotal = 2
 	m = shimApplyMsg(m, messages.EnrichmentChecked{
 		ResourceType: "dbi",
 		Findings: map[string]resource.EnrichmentFinding{
@@ -499,7 +499,7 @@ func TestShim_DeriveHelpersResolveAlias(t *testing.T) {
 		TypeGen: 0,
 	})
 
-	probeSlice, ok := m.Session.ProbeResources["dbi"]
+	probeSlice, ok := m.Session().ProbeResources["dbi"]
 	if !ok || len(probeSlice) == 0 {
 		t.Fatal("ProbeResources[\"dbi\"] is empty after AvailabilityCheckedMsg with alias \"rds\"")
 	}
@@ -589,7 +589,7 @@ func TestShim_DeriveHelpersResolveAlias_SingleResource(t *testing.T) {
 	// Set EnrichTotal > 1 so the "all enrichment done" branch (EnrichChecked >= EnrichTotal)
 	// does not fire after processing this single message, which would nil out ProbeResources
 	// before we can inspect it.
-	m.Session.EnrichTotal = 2
+	m.Session().EnrichTotal = 2
 	m = shimApplyMsg(m, messages.EnrichmentChecked{
 		ResourceType: "rds", // alias — exercises alias normalization in handleEnrichmentChecked
 		Findings: map[string]resource.EnrichmentFinding{
@@ -599,7 +599,7 @@ func TestShim_DeriveHelpersResolveAlias_SingleResource(t *testing.T) {
 		TypeGen: 0,
 	})
 
-	probeSlice, ok := m.Session.ProbeResources["dbi"]
+	probeSlice, ok := m.Session().ProbeResources["dbi"]
 	if !ok || len(probeSlice) == 0 {
 		t.Fatal("ProbeResources[\"dbi\"] is empty after AvailabilityCheckedMsg with alias \"rds\"")
 	}
@@ -679,16 +679,16 @@ func TestShim_DeriveHelpersResolveAlias_SingleResource(t *testing.T) {
 // ──────────────────────────────────────────────────────────────────────────
 
 // TestShim_NavigateAliasHitsCanonicalCache verifies that handleNavigate resolves
-// an alias to the canonical ShortName before looking up m.Session.ResourceCache.
+// an alias to the canonical ShortName before looking up m.Session().ResourceCache.
 //
-// Bug: app_handlers_navigate.go:49 does m.Session.ResourceCache[msg.ResourceType] —
+// Bug: app_handlers_navigate.go:49 does m.Session().ResourceCache[msg.ResourceType] —
 // when msg.ResourceType is "rds" (alias) but the cache is keyed under "dbi"
 // (canonical), the lookup misses. deriveFindingsForType is never called on the
 // cached resources, so Findings remain empty.
 //
-// Setup: seed m.Session.ResourceCache["dbi"] with one resource (Status="impaired").
+// Setup: seed m.Session().ResourceCache["dbi"] with one resource (Status="impaired").
 // Drive NavigateMsg{Target: TargetResourceList, ResourceType: "rds"}.
-// Post-fix: m.Session.ResourceCache["dbi"].Resources[0].Findings is populated.
+// Post-fix: m.Session().ResourceCache["dbi"].Resources[0].Findings is populated.
 // Pre-fix: Findings is empty (cache entry found only after canonical lookup is wired).
 func TestShim_NavigateAliasHitsCanonicalCache(t *testing.T) {
 	m := newShimModel()
@@ -701,7 +701,7 @@ func TestShim_NavigateAliasHitsCanonicalCache(t *testing.T) {
 	}
 
 	// Seed the cache under the canonical key "dbi".
-	m.Session.ResourceCache["dbi"] = &session.ResourceCacheEntry{
+	m.Session().ResourceCache["dbi"] = &session.ResourceCacheEntry{
 		Resources: []resource.Resource{res},
 	}
 
@@ -713,7 +713,7 @@ func TestShim_NavigateAliasHitsCanonicalCache(t *testing.T) {
 	})
 
 	// The cache under "dbi" must now have Findings populated.
-	entry, ok := m.Session.ResourceCache["dbi"]
+	entry, ok := m.Session().ResourceCache["dbi"]
 	if !ok || len(entry.Resources) == 0 {
 		t.Fatal("ResourceCache[\"dbi\"] is empty after NavigateMsg — unexpected state")
 	}
@@ -793,10 +793,10 @@ func TestShim_ResourcesLoadedPopulatesFindings(t *testing.T) {
 			// an alias). The canonical test: check both canonical and alias keys to
 			// find where the entry landed, then assert Findings.
 			var entry *session.ResourceCacheEntry
-			if e, ok := m.Session.ResourceCache[tc.canonShort]; ok {
+			if e, ok := m.Session().ResourceCache[tc.canonShort]; ok {
 				entry = e
 			} else if tc.alias != "" {
-				if e, ok := m.Session.ResourceCache[effective]; ok {
+				if e, ok := m.Session().ResourceCache[effective]; ok {
 					entry = e
 				}
 			}

--- a/tests/unit/qa_clients_ready_flash_gen_test.go
+++ b/tests/unit/qa_clients_ready_flash_gen_test.go
@@ -48,7 +48,7 @@ func TestHandleClientsReady_SuccessNoPendingRefresh_FlashGenUnchanged(t *testing
 	m, _ = rootApplyMsg(m, messages.ClientsReady{
 		Clients: &awsclient.ServiceClients{},
 		Region:  "us-east-1",
-		Gen:     m.Session.ConnectGen, // matches session → non-stale
+		Gen:     m.Session().ConnectGen, // matches session → non-stale
 	})
 
 	if got := m.FlashGen(); got != genBefore {
@@ -76,7 +76,7 @@ func TestHandleClientsReady_StaleGen_FlashGenUnchanged(t *testing.T) {
 	m, _ = rootApplyMsg(m, messages.ClientsReady{
 		Clients: &awsclient.ServiceClients{},
 		Region:  "us-east-1",
-		Gen:     m.Session.ConnectGen + 5,
+		Gen:     m.Session().ConnectGen + 5,
 	})
 
 	if got := m.FlashGen(); got != genBefore {

--- a/tests/unit/qa_prefetch_pagination_seed_test.go
+++ b/tests/unit/qa_prefetch_pagination_seed_test.go
@@ -58,7 +58,7 @@ func TestPrefetchPaginationSeed_PreservesNextToken(t *testing.T) {
 		Gen:            0,
 	})
 
-	entry, ok := m.Session.ResourceCache[targetType]
+	entry, ok := m.Session().ResourceCache[targetType]
 	if !ok {
 		t.Fatalf("expected ResourceCache entry for %q after prefetch seed; got nil", targetType)
 	}
@@ -102,7 +102,7 @@ func TestPrefetchPaginationSeed_FallbackWhenPaginationOmitted(t *testing.T) {
 		Gen: 0,
 	})
 
-	entry, ok := m.Session.ResourceCache[targetType]
+	entry, ok := m.Session().ResourceCache[targetType]
 	if !ok {
 		t.Fatalf("expected ResourceCache entry for %q after fallback prefetch seed; got nil", targetType)
 	}


### PR DESCRIPTION
## Summary

- Removes `Session *session.Session` named field from `tui.Model`
- All 11 tui files updated to use `m.core.Session().X` instead of `m.Session.X`
- Adds `Model.Session()` test-only accessor in `app_accessors.go` (returns `core.Session()`)
- 4 unit test files updated to use `m.Session().X` through the public accessor

## Acceptance criteria

- [x] `rg 'session.Session' internal/tui/app.go` — zero hits
- [x] `tui.Model` no longer has a `*session.Session` field
- [x] `go build ./...` passes
- [x] `go test ./tests/unit/` passes

Note: `go list -f '{{.Imports}}' .../internal/tui | grep internal/session` still returns a hit because `session.New()`, `session.ResourceCacheEntry`, `session.RelatedCacheKey` are still used as types/constructors in `app.go`. Removing these would require moving session construction into `runtime.Core` — a separate follow-up.

## Test plan

- [x] All unit tests pass (`go test ./tests/unit/`)
- [x] Build passes (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)