### PR TITLE
refactor(phase-05-pr-05b): KindFetchMore carries token via FetchMorePayload (AS-270)

### DIFF
--- a/internal/runtime/handlers_related.go
+++ b/internal/runtime/handlers_related.go
@@ -72,15 +72,21 @@ const (
 	KindFetchFiltered TaskKind = "fetch-filtered"
 
 	// KindFetchMore asks the adapter to fetch the next page of resources for
-	// the type named by TaskKey.Scope, using the continuation token it holds
-	// in the session cache.
-	//
-	// TODO(PR-05b): the continuation token is currently re-derived by the
-	// adapter from the session cache (see runtime_adapter_related.go). When
-	// PR-05b lands the typed cmd/event split it will travel as a structured
-	// payload on TaskRequest so the runtime is the single decision-maker.
+	// the type named by TaskKey.Scope. The continuation token rides on the
+	// TaskRequest as a FetchMorePayload so the runtime is the single decision-
+	// maker and the adapter is a pure mechanical translator (AS-270 / PR-05b).
 	KindFetchMore TaskKind = "fetch-more"
 )
+
+// FetchMorePayload carries the continuation token the adapter must use when
+// the runtime requests a KindFetchMore fetch. The runtime captures the token
+// from the session cache at dispatch time so the adapter no longer reaches
+// back into session state to re-derive it.
+type FetchMorePayload struct {
+	ContinuationToken string
+}
+
+func (FetchMorePayload) isTaskPayload() {}
 
 // HandleRelatedNavigate resolves the navigation kind using the session cache
 // and returns the decision plus any fetch tasks the adapter should start.
@@ -161,11 +167,14 @@ func relatedFetchTasks(s *session.Session, targetType string, relatedIDs []strin
 		return nil
 	}
 
-	// Some IDs are missing. If the cache has more pages, ask for more.
+	// Some IDs are missing. If the cache has more pages, ask for more and
+	// carry the continuation token as a structured payload (AS-270 / PR-05b)
+	// so the adapter is a pure pass-through.
 	if entry != nil && entry.Pagination != nil && entry.Pagination.IsTruncated {
 		return []TaskRequest{{
-			Key:   TaskKey{Kind: KindFetchMore, Scope: targetType},
-			Cache: CacheNone,
+			Key:     TaskKey{Kind: KindFetchMore, Scope: targetType},
+			Cache:   CacheNone,
+			Payload: FetchMorePayload{ContinuationToken: entry.Pagination.NextToken},
 		}}
 	}
 

--- a/internal/runtime/handlers_related_test.go
+++ b/internal/runtime/handlers_related_test.go
@@ -110,6 +110,63 @@ func TestRelatedFetchTasks_PartialCoverage_TruncatedCache_FetchMore(t *testing.T
 	if tasks[0].Key.Scope != "ec2" {
 		t.Errorf("Scope = %q, want %q", tasks[0].Key.Scope, "ec2")
 	}
+	// AS-270: continuation token must travel on the TaskRequest as a typed
+	// FetchMorePayload so the adapter is a pure pass-through.
+	payload, ok := tasks[0].Payload.(FetchMorePayload)
+	if !ok {
+		t.Fatalf("Payload = %T, want FetchMorePayload", tasks[0].Payload)
+	}
+	if payload.ContinuationToken != "tok-2" {
+		t.Errorf("ContinuationToken = %q, want %q", payload.ContinuationToken, "tok-2")
+	}
+}
+
+// TestRelatedFetchTasks_FetchMore_EmptyToken — pins that an empty NextToken
+// on a truncated cache entry still travels as a FetchMorePayload (with
+// ContinuationToken=""), rather than being silently dropped. The runtime is
+// the single decision-maker; payload absence would force the adapter to
+// re-derive state.
+func TestRelatedFetchTasks_FetchMore_EmptyToken(t *testing.T) {
+	s := newTestSession()
+	s.ResourceCache = map[string]*session.ResourceCacheEntry{
+		"ec2": {
+			Resources:  []resource.Resource{{ID: "i-1"}},
+			Pagination: &resource.PaginationMeta{IsTruncated: true, NextToken: ""},
+		},
+	}
+
+	tasks := relatedFetchTasks(s, "ec2", []string{"i-1", "i-missing"})
+	if len(tasks) != 1 || tasks[0].Key.Kind != KindFetchMore {
+		t.Fatalf("tasks = %+v, want one KindFetchMore task", tasks)
+	}
+	payload, ok := tasks[0].Payload.(FetchMorePayload)
+	if !ok {
+		t.Fatalf("Payload = %T, want FetchMorePayload", tasks[0].Payload)
+	}
+	if payload.ContinuationToken != "" {
+		t.Errorf("ContinuationToken = %q, want empty string", payload.ContinuationToken)
+	}
+}
+
+// TestRelatedFetchTasks_FetchResources_NoPayload — KindFetchResources tasks
+// do not carry a FetchMorePayload; assert Payload is nil so the adapter
+// branch for fetch-resources is never accidentally fed a continuation token.
+func TestRelatedFetchTasks_FetchResources_NoPayload(t *testing.T) {
+	s := newTestSession()
+	s.ResourceCache = map[string]*session.ResourceCacheEntry{
+		"ec2": {
+			Resources:  []resource.Resource{{ID: "i-1"}},
+			Pagination: &resource.PaginationMeta{IsTruncated: false},
+		},
+	}
+
+	tasks := relatedFetchTasks(s, "ec2", []string{"i-1", "i-missing"})
+	if len(tasks) != 1 || tasks[0].Key.Kind != KindFetchResources {
+		t.Fatalf("tasks = %+v, want one KindFetchResources task", tasks)
+	}
+	if tasks[0].Payload != nil {
+		t.Errorf("Payload = %+v, want nil — KindFetchResources must not carry FetchMorePayload", tasks[0].Payload)
+	}
 }
 
 func TestRelatedFetchTasks_FullMiss_FetchAll(t *testing.T) {

--- a/internal/tui/runtime_adapter_related.go
+++ b/internal/tui/runtime_adapter_related.go
@@ -23,11 +23,11 @@
 // the session cache directly to drive view construction (AMI exact-ID drill,
 // lazy-cache full-coverage shortcut, RelatedIDs partial-coverage pre-populated
 // list). The runtime emits the same task decisions in HandleRelatedNavigate /
-// relatedFetchTasks; when PR-05b lands the typed cmd/event split it will carry
-// enough payload (continuation tokens, lazy-cache slices, client selection)
-// for the adapter to be purely mechanical. Until then the adapter mirrors the
-// runtime's policy and trusts the emitted []TaskRequest rather than overriding
-// it.
+// relatedFetchTasks; the typed payload split lands these incrementally. AS-270
+// handed continuation tokens off via FetchMorePayload so KindFetchMore is a
+// pure pass-through; the remaining lazy-cache slices and client selection
+// branches will follow. Until then the adapter mirrors the runtime's policy
+// and trusts the emitted []TaskRequest rather than overriding it.
 package tui
 
 import (
@@ -435,17 +435,20 @@ func relatedNavigateTasksToCmd(m Model, targetType string, result runtime.Naviga
 		case runtime.KindFetchFiltered:
 			cmds = append(cmds, m.fetchResourcesFiltered(targetType, result.FetchFilter))
 		case runtime.KindFetchMore:
-			// PR-05b: KindFetchMore TaskRequest does not carry the continuation
-			// token yet; the adapter re-derives it from the session cache here.
-			// When PR-05b lands the typed cmd/event split, the token rides on a
-			// structured TaskRequest payload (e.g. FetchMoreRequest) and this
-			// branch becomes a direct param pass-through.
-			if entry, ok := m.Session.ResourceCache[targetType]; ok && entry.Pagination != nil {
-				cmds = append(cmds, m.fetchMoreResources(messages.LoadMore{
-					ResourceType:      targetType,
-					ContinuationToken: entry.Pagination.NextToken,
-				}))
+			// Continuation token is runtime-owned and arrives as a structured
+			// payload (AS-270 / PR-05b). The adapter is a pure pass-through
+			// and no longer reads m.Session.ResourceCache here. A missing or
+			// wrong-typed payload is a runtime bug, not an adapter-recoverable
+			// state — drop the task to surface the regression instead of
+			// silently re-deriving.
+			payload, ok := t.Payload.(runtime.FetchMorePayload)
+			if !ok {
+				continue
 			}
+			cmds = append(cmds, m.fetchMoreResources(messages.LoadMore{
+				ResourceType:      targetType,
+				ContinuationToken: payload.ContinuationToken,
+			}))
 		}
 	}
 	switch len(cmds) {

--- a/tests/unit/runtime_handlers_related_test.go
+++ b/tests/unit/runtime_handlers_related_test.go
@@ -214,12 +214,13 @@ func TestHandleRelatedNavigate_MultipleRelatedIDs_CacheMiss_FetchResources(t *te
 }
 
 // Case H — multiple RelatedIDs, partial coverage + truncated cache →
-// FilteredList with a single KindFetchMore task (continuation).
+// FilteredList with a single KindFetchMore task (continuation). AS-270:
+// the continuation token rides on the TaskRequest as a FetchMorePayload.
 func TestHandleRelatedNavigate_MultipleRelatedIDs_PartialCoverage_Truncated_FetchMore(t *testing.T) {
 	c, s := newRuntimeCore(t)
 	s.ResourceCache["ec2"] = &session.ResourceCacheEntry{
 		Resources:  []resource.Resource{{ID: "i-1"}},
-		Pagination: &domain.PaginationMeta{IsTruncated: true},
+		Pagination: &domain.PaginationMeta{IsTruncated: true, NextToken: "next-tok-xyz"},
 	}
 
 	result, tasks := c.HandleRelatedNavigate(runtime.RelatedNavigateEvent{
@@ -231,8 +232,9 @@ func TestHandleRelatedNavigate_MultipleRelatedIDs_PartialCoverage_Truncated_Fetc
 		t.Errorf("Kind = %v, want NavigationKindFilteredList", result.Kind)
 	}
 	wantTasks := []runtime.TaskRequest{{
-		Key:   runtime.TaskKey{Kind: runtime.KindFetchMore, Scope: "ec2"},
-		Cache: runtime.CacheNone,
+		Key:     runtime.TaskKey{Kind: runtime.KindFetchMore, Scope: "ec2"},
+		Cache:   runtime.CacheNone,
+		Payload: runtime.FetchMorePayload{ContinuationToken: "next-tok-xyz"},
 	}}
 	if !reflect.DeepEqual(tasks, wantTasks) {
 		t.Errorf("tasks = %+v, want %+v", tasks, wantTasks)


### PR DESCRIPTION
## Summary

- Resolves AS-270 by moving the continuation token off the cache-re-derivation
  path and onto a typed `runtime.FetchMorePayload` on the `TaskRequest`. The
  TUI adapter is now a pure pass-through for `KindFetchMore` and no longer
  reads `m.Session.ResourceCache` in its translator.
- Removes the `TODO(PR-05b)` at `internal/runtime/handlers_related.go:78` that
  was flagged by CodexReviewer on PR #349 and filed as a separate follow-up
  per CTO adjudication on AS-154.
- Drops the lingering "PR-05b: KindFetchMore TaskRequest does not carry the
  continuation token yet" comment block in `runtime_adapter_related.go`.

## How the token now flows

1. `runtime.relatedFetchTasks` reads `entry.Pagination.NextToken` from the
   session cache at dispatch time and emits a `TaskRequest` with
   `Payload: FetchMorePayload{ContinuationToken: <tok>}`.
2. The adapter's `relatedNavigateTasksToCmd` type-asserts the payload and
   feeds it straight into `m.fetchMoreResources(messages.LoadMore{...})`.
3. A missing or wrong-typed payload is treated as a runtime bug — the task is
   dropped to surface the regression rather than silently re-deriving from
   session state.

## Tests

New unit tests in `internal/runtime/handlers_related_test.go` cover:

- `TestRelatedFetchTasks_PartialCoverage_TruncatedCache_FetchMore` — extended
  to assert `Payload` is a `FetchMorePayload` carrying the expected token.
- `TestRelatedFetchTasks_FetchMore_EmptyToken` — empty `NextToken` still
  travels as a `FetchMorePayload` (not dropped, not nil).
- `TestRelatedFetchTasks_FetchResources_NoPayload` — `KindFetchResources`
  tasks must not carry a `FetchMorePayload`.

The existing `tests/unit/related_navigate_partial_cache_test.go` and
`app_related_token_test.go` cover the adapter end-to-end (truncated cache
with a missing related ID initiates a fetch with `Append=true`).

## Test plan

- [x] `go test ./internal/runtime/ -run TestRelatedFetchTasks -count=1`
- [x] `go test ./tests/unit/ -count=1`
- [x] `go build ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `govulncheck ./...` — no vulnerabilities
- [x] `go fix -inline -diff ./...` — no findings
- [x] `markdownlint-cli2` — 0 errors
- [x] `verify-readonly`, `check-readme`, unit `snapshot` targets — green
- [ ] `make test-race` and `integration` snapshot — blocked locally (pod
      lacks CGO; integration snapshots are pre-existing failures unrelated to
      this PR, tracked in AS-350). Will be exercised by CI on the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)