### PR TITLE
fix(integration): cache-enriched Resource in OpenDetailResource (AS-350, 12/14)

### DIFF
--- a/tests/integration/scripted_scenario_helpers_test.go
+++ b/tests/integration/scripted_scenario_helpers_test.go
@@ -233,6 +233,21 @@ func (s *fullIntegrationScenario) OpenList(resourceType string) {
 
 func (s *fullIntegrationScenario) OpenDetailResource(resourceType string, res resource.Resource) {
 	s.t.Helper()
+	// Real demo navigation passes the cached enriched row (the one the list
+	// view holds, which has already been mutated by applyEnrichment on
+	// EnrichmentChecked). Test helpers like selectDBIByID return a fresh
+	// fetch via the paginated fetcher — that copy never picked up Wave-2
+	// Findings or AttentionDetails, so the detail-view Attention section
+	// would render only Wave-1 entries. Swap in the cached row when one
+	// exists so detail rendering matches what `./a9s --demo` shows on screen.
+	if entry, ok := s.model.Session().ResourceCache[resourceType]; ok && entry != nil {
+		for i := range entry.Resources {
+			if entry.Resources[i].ID == res.ID {
+				res = entry.Resources[i]
+				break
+			}
+		}
+	}
 	s.beginAction("open detail %s %s", resourceType, res.ID)
 	copy := res
 	s.applyAndDrain(messages.Navigate{


### PR DESCRIPTION
## Summary

Test-harness fix: when scenarios open the detail view via `OpenDetailResource`, swap in the cached enriched Resource from `Session().ResourceCache` instead of the fresh-fetched copy the scenario passed in. Matches what `./a9s --demo` actually shows on screen.

Fixes 12 of the 14 pre-existing integration failures tracked in [AS-350](https://github.com/k2m30/a9s/issues?q=AS-350):

```
TestScenario_BackupVisual
TestScenario_DBCSnapVisual_DetailSurfacesAttention
TestScenario_DBCSnapVisual_FailedPlusManualOldStacks
TestScenario_DBCVisual
TestScenario_DBCVisual_DetailSurfacesAllIssues
TestScenario_DBCVisual_AttentionGlyphSurvivesColorCap
TestScenario_DBISnapVisual_DetailSurfacesAllIssues
TestScenario_DBIVisual
TestScenario_DBIVisual_DetailSurfacesAllIssues
TestScenario_DDBVisual
TestScenario_OpenSearchVisual
TestScenario_S3Visual
```

## Root cause

The scenarios call helpers like `selectDBIByID` which do a fresh `paginatedFetcher` call — that copy has only Wave-1 Findings. The detail-view Attention section renders from `r.Findings + r.AttentionDetails`, so Wave-2 phrases were silently absent.

In real demo use, list-view rows are the cached enriched rows (mutated by `applyEnrichment` on `EnrichmentChecked`), and `Navigate` carries that enriched copy when the user presses Enter — so the detail view sees both Wave-1 and Wave-2 in production. The harness was the only path bypassing this.

## Residual (out of scope here)

- `TestScenario_EFSVisual` — list-view status column shows `mount target down` instead of `mount target down (+1)`. Wave-2 finding lands in the cached row, but the Wave-1 entry isn't picked up as the (+1) suffix. Same code path AS-140's PR-branch is reworking (commits `103120f` / `ad7c2bd` / `18eeac2`); will fold there.
- `TestDemoScenarioHarness_ListFilterAndSort` — Phase-05 sort+filter state regression. Separate bug.

## Test plan

- [x] `go test -tags=integration ./tests/integration/ -count=1` — 12 previously-failing scenarios now pass; 2 residuals documented above.
- [x] `go test ./tests/unit/ -count=1` — clean.
- [x] No production code changed; integration test harness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)