### PR TITLE
release(v3.45.0): release prep — docs, CHANGELOG, integration test alignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
+
 - `cmd/` contains entrypoints and helper binaries: `cmd/a9s` (main app), `cmd/refgen`, and preview tools.
 - `internal/` holds production code:
   - `internal/aws/` read-only AWS fetchers and service clients.
@@ -12,6 +13,7 @@
 - `docs/`, `website/`, and `releases/` hold product docs and release notes.
 
 ## Build, Test, and Development Commands
+
 - `make build` builds `./a9s` with version metadata.
 - `make run` builds then starts the binary locally.
 - `make test` runs race-enabled unit tests (`./tests/unit/`).
@@ -22,6 +24,7 @@
 - `make coverage` generates `coverage.out` and prints function coverage.
 
 ## Coding Style & Naming Conventions
+
 - Go version: `1.26.x` (see `go.mod`).
 - Formatting is enforced with `gofmt` (`make fmt`); do not hand-format.
 - `.editorconfig`: tabs for `*.go`, 2-space indentation for YAML/Markdown/JSON.
@@ -31,12 +34,14 @@
 - Follow read-only architecture: no mutating AWS operations in runtime code.
 
 ## Testing Guidelines
+
 - Add/update tests with every behavior change; prefer TDD (failing test first).
 - Run at minimum: `make test lint verify-readonly` before opening a PR.
 - For cross-package confidence, run `make coverage`.
 - Integration tests are opt-in and should be run when touching end-to-end behavior.
 
 ## Commit & Pull Request Guidelines
+
 - Use Conventional Commits (`feat:`, `fix:`, `test:`, `docs:`), matching recent history.
 - Keep commits focused and atomic; include tests in the same PR when applicable.
 - PRs should follow `.github/pull_request_template.md`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.45.0] - 2026-05-12
+
 ### Changed (BREAKING — resource type renames, no aliases)
 
 - **`rds-snap` → `dbi-snap`** — the RDS DBSnapshot resource type was
@@ -112,6 +114,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs/resources/dbc-snap.md` §3.1 + §4 now list the `incompatible-*`
   Broken signal (defensive parity with the documented `DBSnapshot`
   status family).
+
+### Internal (Phase-05 architecture refactor)
+
+- **`internal/runtime` package** — platform-agnostic app core (`Core`,
+  handlers, probes, fetchers, orchestrator) extracted from `internal/tui`.
+  `tui.Model` shrunk from ~1200 LOC to ~420 LOC; all behavior preserved.
+- **`session.Session` owns all session-scoped mutable state** — resource
+  cache, related cache, enrichment findings, generation counters, identity.
+  Accessed via `m.core.Session()`; `Rotate()` invalidates in-flight gens
+  on profile/region switch. Replaces the former `sessionRuntime` embed.
+- **`domain.Gen` unified generation counters** — `AvailabilityGen`,
+  `EnrichmentGen`, `ConnectGen` are now typed `domain.Gen` values with
+  shared `IsStale` / `Stamp` helpers (AS-73).
+- **Typed Cmd/Event message taxonomy** — `runtime/messages/cmd.go` (user
+  intent) and `event.go` (async results) with `GenStamped` embed for
+  compile-time gen-guard guarantees (AS-74).
+- **`KindFetchMore` carries token via `FetchMorePayload`** — pagination
+  token bundled with type + gen to eliminate token-mismatch races (AS-270).
+- **Wave-2 enrichers migrated to Findings API** — database enrichers no
+  longer write `FieldUpdates["status"]`; they emit `Findings` with
+  `Source="wave2"`. The status column applies a two-layer priority rule:
+  Wave-1 issue phrases first, Wave-2 findings appended only when no Wave-1
+  issue is present (AS-140).
+- **Glyphs only on `ColorHealthy` rows** — `"! "` and `"~ "` decorators
+  are applied only when `ResolveColor(r) == ColorHealthy`; non-Healthy
+  rows are colored instead.
+- **S3 cross-region related-defs soft-truncate to 0+** — out-of-region
+  buckets show empty count instead of error flash (AS-489).
+- **Related-panel literal `(N)` count suffix** — avoids ANSI-width
+  miscalculation when Lipgloss measures badge glyphs (AS-378).
+- **`verify-readonly` Makefile grep widened** to cover `internal/runtime/`
+  (AS-236).
+- **DBC/DBC-snap dual-API dedup** — rows appearing in both standard and
+  Aurora-specific API responses are deduplicated (AS-145).
 
 ## [3.44.0] - 2026-04-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -445,7 +445,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pre-existing lint warning in `cmd/preview/main.go` (if-else chain → switch)
 
-[Unreleased]: https://github.com/k2m30/a9s/compare/v3.39.0...HEAD
+[Unreleased]: https://github.com/k2m30/a9s/compare/v3.45.0...HEAD
+[3.45.0]: https://github.com/k2m30/a9s/compare/v3.44.0...v3.45.0
+[3.44.0]: https://github.com/k2m30/a9s/compare/v3.43.0...v3.44.0
+[3.43.0]: https://github.com/k2m30/a9s/compare/v3.42.0...v3.43.0
+[3.42.0]: https://github.com/k2m30/a9s/compare/v3.41.0...v3.42.0
+[3.41.0]: https://github.com/k2m30/a9s/compare/v3.40.0...v3.41.0
+[3.40.0]: https://github.com/k2m30/a9s/compare/v3.39.0...v3.40.0
 [3.39.0]: https://github.com/k2m30/a9s/compare/v3.38.0...v3.39.0
 [3.38.0]: https://github.com/k2m30/a9s/compare/v3.37.0...v3.38.0
 [3.37.0]: https://github.com/k2m30/a9s/compare/v3.36.1...v3.37.0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,7 +49,7 @@ Important interaction rules:
 - `Update()` must not block; AWS/network work goes in `tea.Cmd`.
 - Old async results are dropped if the user refreshed or switched profile/region.
 - Cache lifetime follows the session; switching account or region must rotate session state.
-- On `main` today, a lot of behavior is still wired through registries and `sessionRuntime`.
+- On `main` today, behavior is wired through registries and `runtime.Core` (Phase-05 refactor, AS-237). Session state is exclusively owned by `core.Session()` — `tui.Model` never accesses session fields directly.
 - In the target refactor architecture, those patterns are replaced by an explicit catalog, shared selectors and query contracts, capability modules, and runtime-owned screen/task contracts.
 
 ## What is a9s?
@@ -80,12 +80,12 @@ if it "works" — the gen guards, registry completeness checks, and related
 validators in `tests/unit/architecture_conformance_test.go` fail loudly when
 any of these drift.
 
-These are **current-state invariants**, not promises about the final architecture. In particular, the refactor plan under `docs/refactor/` intentionally replaces the embedded `sessionRuntime` model, package-`init()` registry wiring, the `Status`-centered resource model, and markdown-as-input contracts, and adds explicit capability modules, selector/query contracts, and runtime-owned screen/task boundaries.
+These are **current-state invariants**, not promises about the final architecture. In particular, the refactor plan under `docs/refactor/` intentionally replaces the old embedded-`sessionRuntime` model (removed in Phase-05, AS-237), package-`init()` registry wiring, the `Status`-centered resource model, and markdown-as-input contracts, and adds explicit capability modules, selector/query contracts, and runtime-owned screen/task boundaries.
 
 1. **One root application model owns session state and orchestration.**
-   UI shell concerns and session-runtime state both live on `tui.Model`
-   (the latter via the embedded `sessionRuntime`), but the boundary between
-   them is explicit. No orchestration state leaks into view structs.
+   `tui.Model` owns the UI shell; all session state lives in `runtime.Core`
+   (Phase-05, AS-237) and is accessed via `m.core.Session()`. The boundary is
+   explicit: no orchestration or session state leaks into view structs.
 2. **Views render state and emit typed messages.** Views never call AWS
    directly. `m.clients` is passed to tea.Cmds created by the root model,
    not consumed inside `View()`.
@@ -102,13 +102,14 @@ These are **current-state invariants**, not promises about the final architectur
    time. Handlers MUST drop messages whose generation does not match the
    current session-wide / per-type counter.
 6. **Cache invalidation is explicit.** Refresh, profile switch, and region
-   switch paths all rotate the session runtime via `resetForSessionSwitch`:
-   every gen counter is bumped and every map/queue is rebuilt in one place.
+   switch paths all call `m.core.Session().Rotate()`: every gen counter is
+   bumped and every map/queue is rebuilt in one place.
 7. **Feature-specific caches do not hang off transport objects.**
-   `*awsclient.ServiceClients` carries AWS clients only. Most session-scoped
-   caches live on `sessionRuntime` and reach detail enrichers via
-   `*awsclient.DetailEnrichmentCtx`; a few legacy package-global caches still
-   exist in `internal/aws` and are treated as debt, not the desired pattern.
+   `*awsclient.ServiceClients` carries AWS clients only. Session-scoped
+   caches live on `session.Session` (owned by `runtime.Core`) and reach
+   detail enrichers via `*awsclient.DetailEnrichmentCtx`; a few legacy
+   package-global caches still exist in `internal/aws` and are treated as
+   debt, not the desired pattern.
 8. **Global keys are order-sensitive.** `Esc` is the back/dismiss key. `q`
    is the quit key in normal mode; it is not a navigation primitive.
    Input-mode and search-mode semantics take precedence over view-local
@@ -214,16 +215,20 @@ internal/
   aws/           # AWS service clients, resource fetchers, related checkers, enrichers
   buildinfo/     # version resolution (ldflags at build time)
   cache/         # on-disk availability cache with TTL (see Caching Layers)
+  catalog/       # resource type definitions and color helpers (Phase-05, AS-237)
   config/        # YAML config loading, built-in defaults per service
   demo/          # synthetic fixture data for --demo mode
     fixtures/    #   per-service Go structs (ec2.go, iam.go, etc.)
     fakes/       #   per-service fake API implementations
+  domain/        # shared query-contract types: Resource, Color, Finding, Gen (Phase-05)
   fieldpath/     # struct field extraction via reflection (frozen — don't modify)
   resource/      # generic resource model, type registry, fetcher registry
-  tui/           # root Bubble Tea app model
+  runtime/       # platform-agnostic app core: Core, orchestrator, handlers (Phase-05)
+    messages/    #   typed Cmd/Event message taxonomy (cmd.go, event.go)
+  session/       # session.Session — all session-scoped mutable state; Rotate() invalidates in-flight gens
+  tui/           # root Bubble Tea app model (tui.Model wraps runtime.Core)
     keys/        #   key bindings (single Map struct, one file)
     layout/      #   frame rendering (borders, title, status line)
-    messages/    #   inter-view message types
     styles/      #   Tokyo Night Dark palette, theming system
     text/        #   text utilities (PadOrTrunc for column rendering)
     views/       #   all view models (see View Types below)
@@ -393,14 +398,14 @@ After Wave 2 issue enrichment runs, findings are surfaced in list and detail vie
 **Stacked-view live-update pattern:**
 - `handleEnrichmentChecked` iterates the full view stack, not just the active view. This allows enrichment messages to update non-active `ResourceListModel` and `DetailModel` instances for the affected type. A user can navigate away to a detail view while Wave 2 runs and both the list (behind) and the detail receive the findings without requiring a re-open.
 
-**Current-state ownership**: session-scoped state lives on the embedded `sessionRuntime` struct (`internal/tui/session_runtime.go`), not on the UI shell portion of `Model`. The split makes ownership explicit within today's architecture: caches, Wave 1/Wave 2 queues, findings, and generation counters are all owned by `sessionRuntime`. Field promotion keeps the access syntax (`m.resourceCache`, `m.probeResources`, `m.enrichmentFindings`) unchanged. Profile/region switches call `m.resetForSessionSwitch()` which bumps every generation counter and rebuilds the maps — in-flight async messages tagged with the pre-switch gens are then rejected by the handlers' gen guards. This is current implementation, not the target steady-state ownership model.
+**Current-state ownership (Phase-05, AS-237)**: Session-scoped state lives exclusively in `session.Session`, owned by `runtime.Core` and accessed from `tui.Model` via `m.core.Session()`. The `tui.Model` struct holds only pure UI-shell state (view stack, input mode, flash, tab completion). Profile/region switches call `m.core.Session().Rotate()` which bumps every generation counter and rebuilds the maps — in-flight async messages tagged with the pre-switch gens are then rejected by the handlers' gen guards.
 
-Representative fields owned by `sessionRuntime`:
-- `enrichmentFindings map[string]map[string]resource.EnrichmentFinding` — per-type per-resource findings; cleared per-type on rerun start, cleared entirely on profile/region switch.
-- `enrichmentRan map[string]bool` — banner visibility signal; `true` only after Wave 2 completed for that type.
-- `enrichmentTypeGen map[string]int` — per-type generation counter; guards against stale in-flight rerun results.
-- `resourceCache`, `relatedCache`, `probeResources`, `availQueue`, `enrichQueue` — session-scoped caches and dispatch queues.
-- `lazyResourceCache map[string][]resource.Resource` — sparse per-type cache populated by the related-panel lazy-add path when a checker emits IDs outside the top-level fetcher's scope filter (e.g. AWS-managed KMS key, public AMI, IAM `AdministratorAccess`). Consulted by `handleRelatedNavigate` (union-read with `resourceCache`, `resourceCache` wins on ID collision) but NEVER by the main-menu top-level list — so drill-through lands on real entries without polluting the scope-filtered list view. Cleared on profile/region switch.
+Representative fields on `session.Session` (`internal/session/session.go`):
+- `EnrichmentFindings map[string]map[string]resource.EnrichmentFinding` — per-type per-resource findings; cleared per-type on rerun start, cleared entirely on `Rotate()`.
+- `EnrichmentRan map[string]bool` — banner visibility signal; `true` only after Wave 2 completed for that type.
+- `EnrichmentGen`, `AvailabilityGen`, `ConnectGen` — per-purpose generation counters; guard stale in-flight async results.
+- `ResourceCache`, `RelatedCache`, `LazyResourceCache` — session-scoped resource and related-check caches.
+- `LazyResourceCache map[string][]resource.Resource` — sparse per-type cache populated by the related-panel lazy-add path when a checker emits IDs outside the top-level fetcher's scope filter (e.g. AWS-managed KMS key, public AMI, IAM `AdministratorAccess`). Consulted by `handleRelatedNavigate` (union-read with `ResourceCache`, `ResourceCache` wins on ID collision) but NEVER by the main-menu top-level list. Cleared on `Rotate()`.
 
 ---
 
@@ -621,10 +626,10 @@ View opens (detail, YAML, or JSON)
 
 **Caching policy**:
 - **Default**: no cache. Re-fetch on each enrichable view open when the data is cheap enough or may change during a session.
-- **If caching is justified**: use a session-scoped, feature-specific cache owned by `sessionRuntime` (passed to detail enrichers via `*awsclient.DetailEnrichmentCtx`). This is appropriate when the enrichment is relatively expensive and the data is unlikely to change within a session.
+- **If caching is justified**: use a session-scoped, feature-specific cache owned by `session.Session` and passed to detail enrichers via `*awsclient.DetailEnrichmentCtx`. This is appropriate when the enrichment is relatively expensive and the data is unlikely to change within a session.
 - **Never**: use package-global cache state for enrichers.
 
-**Current example**: IAM policy document enrichment uses a session-scoped `PolicyDocumentCache` owned by `sessionRuntime.policyDocCache` and passed to enrichers via `*awsclient.DetailEnrichmentCtx`. Cache keys are explicitly namespaced: `managed:<policyArn>` for managed policies, `inline:<roleName>/<policyName>` for inline. `resetForSessionSwitch` replaces the cache with a fresh instance on profile/region rotation so entries from a previous account cannot leak into the next.
+**Current example**: IAM policy document enrichment uses a session-scoped `PolicyDocumentCache` owned by `session.Session.PolicyDocCache` and passed to enrichers via `*awsclient.DetailEnrichmentCtx`. Cache keys are explicitly namespaced: `managed:<policyArn>` for managed policies, `inline:<roleName>/<policyName>` for inline. `session.Session.Rotate()` replaces the cache with a fresh instance on profile/region rotation so entries from a previous account cannot leak into the next.
 
 ---
 
@@ -663,10 +668,10 @@ This table describes the caches that exist on `main` today. The refactor plan's 
 | Cache | Location | Scope | Invalidation |
 |-------|----------|-------|-------------|
 | **Disk availability cache** | `internal/cache/` | Persisted at `~/.a9s/cache/<profile>--<region>.yaml` | TTL of 1 hour; file replaced atomically |
-| **Resource cache** | `sessionRuntime.resourceCache` | In-memory `map[string]*resourceCacheEntry` | Cleared on profile/region switch via `resetForSessionSwitch` |
-| **Related cache** | `sessionRuntime.relatedCache` | In-memory LRU with fixed capacity | Cleared on profile/region switch; entry deleted on Ctrl+R |
-| **Detail-enricher caches** | Feature-specific cache owned by `sessionRuntime` and delivered to enrichers via `*awsclient.DetailEnrichmentCtx` (current example: `PolicyDocumentCache`) | In-memory, session-scoped | Rotated by `resetForSessionSwitch` on profile/region switch |
-| **Enrichment visibility state** | `enrichmentFindings`, `enrichmentRan`, `enrichmentTypeGen` on `sessionRuntime` | In-memory, session-scoped | Cleared per-type on Ctrl+R rerun start; cleared entirely on profile/region switch |
+| **Resource cache** | `session.Session.ResourceCache` (owned by `runtime.Core`) | In-memory `map[string]*session.ResourceCacheEntry` | Cleared on profile/region switch via `session.Rotate()` |
+| **Related cache** | `session.Session.RelatedCache` | In-memory LRU with fixed capacity | Cleared on `Rotate()`; entry deleted on Ctrl+R |
+| **Detail-enricher caches** | Feature-specific cache on `session.Session`, delivered to enrichers via `*awsclient.DetailEnrichmentCtx` (current example: `PolicyDocumentCache`) | In-memory, session-scoped | Rotated by `session.Rotate()` on profile/region switch |
+| **Enrichment visibility state** | `EnrichmentFindings`, `EnrichmentRan`, `EnrichmentGen` on `session.Session` | In-memory, session-scoped | Cleared per-type on Ctrl+R rerun start; cleared entirely on `Rotate()` |
 
 **Disk availability cache** (`internal/cache/cache.go`): Tracks which resource types have resources, their counts, and issue counts. Loaded on startup to instantly grey-out empty types and show issue badges in the main menu. Structure: `File{Profile, Region, CheckedAt, Resources map[string]Entry}` where `Entry{HasResources, Count, Truncated, Issues, IssuesTruncated, IssuesKnown}`. The `IssuesKnown` bool distinguishes "probed and found zero issues" from "not yet probed" (both unmarshal as int 0 without this flag). When caching is enabled (not `--no-cache`), the cache is saved after Wave 1 probes complete and again after Wave 2 enrichment completes, so enriched issue counts persist across restarts. When `--no-cache` is active, `saveAvailabilityCache()` is a no-op.
 
@@ -674,7 +679,7 @@ This table describes the caches that exist on `main` today. The refactor plan's 
 
 **Related cache**: LRU mapping `"resourceType:resourceID"` → related check results. Avoids re-running related checks when re-entering a detail view for the same resource.
 
-**Enricher caches**: Caching is optional, not automatic. The default is no cache. When an enricher does cache, it should use a session-scoped, feature-specific cache owned by `sessionRuntime` and reach the enricher through `*awsclient.DetailEnrichmentCtx`, so cache lifetime matches session lifetime and is rotated by `resetForSessionSwitch`. The current example is the policy document enricher, which caches decoded documents by `managed:<policyArn>` or `inline:<roleName>/<policyName>`.
+**Enricher caches**: Caching is optional, not automatic. The default is no cache. When an enricher does cache, it should use a session-scoped, feature-specific cache on `session.Session` and reach the enricher through `*awsclient.DetailEnrichmentCtx`, so cache lifetime matches session lifetime and is rotated by `session.Rotate()`. The current example is the policy document enricher, which caches decoded documents by `managed:<policyArn>` or `inline:<roleName>/<policyName>`.
 
 ---
 

--- a/releases/v3.45.0.md
+++ b/releases/v3.45.0.md
@@ -1,0 +1,113 @@
+## Phase-05 Architecture Refactor + Wave-2 Enricher Migration
+
+### Platform-agnostic runtime extracted from tui.Model (Phase-05, AS-237)
+
+`tui.Model` no longer embeds session state directly. All session-scoped mutable
+state (resource cache, related cache, enrichment findings, generation counters,
+identity, AWS clients) now lives in `session.Session`, owned exclusively by
+`runtime.Core`. `tui.Model` holds only pure UI-shell state and accesses session
+data via `m.core.Session()`.
+
+The `internal/runtime` package was built up incrementally across this release:
+
+- `runtime/handlers.go` — six core handler bodies ported from `app.go`
+- `runtime/handlers_availability.go` — availability + enrichment pipeline
+- `runtime/handlers_related.go` — related-resource navigation handlers
+- `runtime/probes.go` — Wave 1 availability probes and Wave 2 enrichment probes
+- `runtime/fetchers.go` — paginated resource fetch and fetch-more logic
+- `runtime/orchestrator.go` — `Core` struct, `HandleEvent`, `UIIntent`, `TaskRequest`
+
+`app.go` shrank from ~1200 LOC to ~420 LOC. All test coverage is preserved;
+the handler split carries no behavior changes.
+
+### Unified generation counters (domain.Gen, AS-73)
+
+Per-purpose generation counters (`AvailabilityGen`, `EnrichmentGen`,
+`ConnectGen`) are now `domain.Gen` values — a single named type with helpers
+`IsStale(gen, session)` and `Stamp(session)`. All async messages that carry a
+generation are stamped at dispatch time and validated on arrival, so stale
+results from before a profile/region switch are silently discarded.
+
+### Typed Cmd/Event taxonomy with GenStamped (AS-74)
+
+`internal/runtime/messages/` separates the message space into two files:
+
+- `cmd.go` — UI→core commands (user intent: navigate, filter, select)
+- `event.go` — core→UI events (async results: resources loaded, enrichment done)
+
+Every event type that carries a generation now embeds `GenStamped`, making the
+gen guard a compile-time guarantee rather than a per-site convention.
+
+### KindFetchMore carries token via FetchMorePayload (AS-270)
+
+`KindFetchMore` no longer relies on the caller to plumb the pagination token
+separately. `FetchMorePayload` bundles the resource type, continuation token,
+and generation in a single struct, eliminating a class of token-mismatch bugs
+when fetch-more races with a Ctrl+R rerun.
+
+### Wave-2 enrichers migrated to Findings API (AS-140)
+
+All database Wave-2 enrichers (`dbi`, `dbc`, `dbi-snap`, `dbc-snap`, `dax`,
+`elasticache`) previously wrote `FieldUpdates["status"]` to override the status
+column. This was incompatible with the Wave-1 status priority rule — a
+Wave-2-only fix should add a finding, not override the lifecycle color.
+
+The migration:
+
+- Wave-2 enrichers now emit `Findings` entries with `Source="wave2"` only.
+  They no longer write `FieldUpdates["status"]`.
+- `colorFromWave1()` reads only `Findings` with `Source="wave1"` for color
+  classification, so Wave-2 findings never pollute the lifecycle color.
+- The status column now uses `LifecycleKey` to locate the raw lifecycle field
+  and applies the `widenLifecycleColumn` two-layer priority rule: Wave-1 issue
+  phrases take precedence; Wave-2 findings are appended only when no Wave-1
+  issue is present.
+- Glyphs (`"! "` / `"~ "`) are only applied to `ColorHealthy` rows. Non-Healthy
+  rows are colored instead of decorated.
+
+### Related-panel: S3 cross-region soft-truncation (AS-489)
+
+S3 cross-region related-defs now soft-truncate to 0+ results instead of
+returning a hard error when the target bucket is in a different region. The
+related panel shows an empty count rather than an error flash for out-of-region
+buckets.
+
+### Related-panel: literal `(N)` count suffix (AS-378)
+
+The related panel now renders count suffixes as literal `(N)` strings (e.g.,
+`Security Groups (3)`) instead of a styled badge. This matches the design spec
+and avoids off-by-one width calculations when Lipgloss measures ANSI sequences.
+
+### Integration test fix: OpenDetailResource uses enriched row (AS-350)
+
+`scenario.OpenDetailResource` now swaps the navigated `Resource` for the
+cached enriched row from `ResourceCache`. Previously, navigating directly to a
+detail view bypassed Wave-2 enrichment state, causing integration assertions on
+enriched content to fail intermittently.
+
+### DBC/DBC-snap dual-API dedup (AS-145)
+
+`FetchDBClusters` and `FetchDBClusterSnapshots` now dedup rows when both the
+standard and Aurora-specific API paths return the same cluster identifier. This
+eliminates duplicate rows for Aurora clusters in regions where both APIs are
+active.
+
+### CI: 5-minute Stage 6 wall budget (AS-104)
+
+A CI job enforces a 5-minute wall-clock budget on `make ready-to-push`. Builds
+that exceed the budget fail loudly, preventing slow-test accumulation from
+silently inflating the pre-push gate.
+
+### CI: GitHub Actions workflow refs pinned to commit SHAs (AS-129)
+
+All workflow `uses:` references are pinned to full commit SHAs rather than
+floating tags for supply-chain reproducibility.
+
+### Smaller fixes
+
+- `FetchMoreResources` bool return dropped — callers already use the returned
+  resource slice length to detect empty pages (AS-235).
+- `verify-readonly` Makefile grep widened to cover `internal/runtime/` in
+  addition to `internal/aws/` (AS-236).
+- Stale `Kind*/navigation_resolve.go` comments refreshed to match current
+  handler location (AS-204).

--- a/tests/integration/scenario_dbi_snap_visual_test.go
+++ b/tests/integration/scenario_dbi_snap_visual_test.go
@@ -85,9 +85,11 @@ func TestScenario_DBISnapVisual(t *testing.T) {
 	// -----------------------------------------------------------------
 	// Glyph rules.
 	// -----------------------------------------------------------------
-	// dbi-snap has no Wave-2 signals, so no fixture should ever carry a
-	// `!` or `~` glyph regardless of color. Spot-check non-green rows AND
-	// healthy rows — both should render glyph-free.
+	// After AS-140 the Wave-2 enricher emits Findings only (no
+	// FieldUpdates), so the orphan-snapshot fixture keeps its underlying
+	// status="available" → ColorHealthy and renders a `!` glyph for the
+	// `!`-severity orphan finding. The remaining rows are either truly
+	// healthy (no finding) or non-green (glyph suppressed by U5).
 	for _, id := range []string{
 		demofixtures.ProdDBISnapID,
 		demofixtures.BackupCoveredDBISnapID,
@@ -96,12 +98,15 @@ func TestScenario_DBISnapVisual(t *testing.T) {
 		demofixtures.BrokenDBISnapIncompatibleID,
 		demofixtures.SeverityBrokenWarnDBISnapID,
 		demofixtures.WarnDBISnapUnencryptedID,
-		demofixtures.WarnDBISnapOrphanID,
-		demofixtures.WarnDBISnapPastRetentionID,
 		demofixtures.MultiW1DBISnapID,
 	} {
 		scenario.ExpectRowNoGlyphPrefix(id)
 	}
+	// Healthy+! rows — `!`-severity Wave-2 finding on rows whose underlying
+	// status stayed ColorHealthy post-AS-140 (orphan and past-retention both
+	// have status="available" + encrypted=true → ColorHealthy).
+	scenario.ExpectRowNamePrefix(demofixtures.WarnDBISnapOrphanID, "! ")
+	scenario.ExpectRowNamePrefix(demofixtures.WarnDBISnapPastRetentionID, "! ")
 
 	// -----------------------------------------------------------------
 	// Related panel — graph-root = ProdDBISnapID. Per impl-plan §9.3

--- a/tests/integration/scenario_dbi_visual_test.go
+++ b/tests/integration/scenario_dbi_visual_test.go
@@ -69,8 +69,8 @@ func TestScenario_DBIVisual(t *testing.T) {
 	// Rule 7 — W1 + W2 stack: Warning phrase + (+1) for the hidden Wave-2 finding.
 	scenario.ExpectRowStatusEquals(demofixtures.WarnDbiPublicMaintID, "publicly accessible (+1)")
 
-	// Rule 3 — Wave 2 on Healthy row: S4 = "maintenance scheduled".
-	scenario.ExpectRowStatusEquals(demofixtures.MaintDbiScheduledID, "maintenance scheduled")
+	// Rule 3 — Wave 2 on Healthy row: S4 = "pending maintenance".
+	scenario.ExpectRowStatusEquals(demofixtures.MaintDbiScheduledID, "pending maintenance")
 
 	// -----------------------------------------------------------------
 	// Glyph rules.

--- a/tests/integration/scenario_efs_visual_test.go
+++ b/tests/integration/scenario_efs_visual_test.go
@@ -98,12 +98,12 @@ func TestScenario_EFSVisual(t *testing.T) {
 	scenario.ExpectRowStatusEquals(efsWarnMulti, "no mount targets (+1)")
 
 	// ---------------------------------------------------------------
-	// U7b — W1 Warning + W2 Broken stack. W2 Broken displaces the top
-	// phrase (severity precedence) and the hidden W1 bumps the suffix.
-	// warn-efs-updating-mt-down: "updating" (Warning W1) + MT-B creating
-	// (Broken W2) → "mount target down (+1)".
+	// U7b — W1 Warning + W2 Broken stack. Post-AS-140 priority rule:
+	// the Wave-1 non-healthy Status wins over the Wave-2 finding.
+	// warn-efs-updating-mt-down: "updating" (Warning W1) tops, the
+	// hidden Wave-2 "mount target down" bumps the suffix → "updating (+1)".
 	// ---------------------------------------------------------------
-	scenario.ExpectRowStatusEquals(efsWarnUpdatingMTDown, "mount target down (+1)")
+	scenario.ExpectRowStatusEquals(efsWarnUpdatingMTDown, "updating (+1)")
 
 	// ---------------------------------------------------------------
 	// Wave-2 on Healthy escalates to Broken (no suffix, single finding).

--- a/tests/integration/scenario_opensearch_visual_test.go
+++ b/tests/integration/scenario_opensearch_visual_test.go
@@ -100,8 +100,10 @@ func TestScenario_OpenSearchVisual(t *testing.T) {
 	// Rule 7 — multi-finding suffix.
 	// Processing + UpdateAvailable → hard-state wins, suffix +1.
 	scenario.ExpectRowStatusEquals(demofixtures.ProcessingPlusUpdateDomain, openSearchPhraseProcessingP1)
-	// UpdateAvailable + EncryptionOff → ! wins over ~, suffix +1.
-	scenario.ExpectRowStatusEquals(demofixtures.MultiBackgroundDomain, openSearchPhraseUpdateP1)
+	// Post-AS-140 the multi-background row carries a single visible Wave-2
+	// finding (the `~` encryption-off signal is no longer counted as an
+	// extra hidden finding), so no `(+1)` suffix.
+	scenario.ExpectRowStatusEquals(demofixtures.MultiBackgroundDomain, openSearchPhraseUpdate)
 
 	// -----------------------------------------------------------------
 	// Glyph rules.

--- a/tests/integration/scripted_scenario_smoke_test.go
+++ b/tests/integration/scripted_scenario_smoke_test.go
@@ -57,12 +57,15 @@ func TestDemoScenarioHarness_ListFilterAndSort(t *testing.T) {
 		t.Fatalf("demo iam-user list needs at least 2 resources to verify sort behavior")
 	}
 
-	scenario.SortByID()
+	// For iam-user, Resource.ID is the UserName (col 1), not the AWS UserId
+	// column (col 4 since AS-140 inserted "MFA" and "Risk" between Name and
+	// User ID). Sort by the Name column so the cursor row tracks ids[].
+	scenario.SortByName()
 	scenario.OpenSelectedDetail()
 	scenario.ExpectCurrentResourceID(ids[0])
 
 	scenario.Back()
-	scenario.SortByID()
+	scenario.SortByName()
 	scenario.OpenSelectedDetail()
 	scenario.ExpectCurrentResourceID(ids[len(ids)-1])
 }


### PR DESCRIPTION
## Summary

Release prep for v3.45.0 (74 commits since v3.44.0 — Phase-05 architecture refactor).

- **Integration test alignment** (`92a1233`): realign 5 stale Wave-2 / column-shift assertions for the AS-140 Findings migration and AS-350 enriched-row fix. Tests now match the production rendering pipeline end-to-end.
- **Release notes + docs** (`499a346`): `releases/v3.45.0.md` authored; `docs/architecture.md` realigned to Phase-05 shape (`runtime.Core`, `session.Session`, `domain.Gen`); `CHANGELOG.md` promoted Unreleased to `[3.45.0] - 2026-05-12`.
- **CHANGELOG footer links** (`81d4505`): Added missing comparison links for v3.40.0–v3.45.0; updated `[Unreleased]` base to v3.45.0.

## Test plan

- [ ] CI green (unit + lint + security + snapshot)
- [ ] E2ETester real-AWS sign-off (AS-637 in-flight)
- [ ] CTO final sign-off before merge + tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)