### PR TITLE
[trivial-docs] docs(architecture): fix stale handler-file refs after Phase-05 migration (AS-661)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -355,8 +355,9 @@ This section documents the current Wave 2 implementation on `main`. The refactor
 **Architecture:**
 - `internal/aws/issue_enrichment.go` — Wave 2 infrastructure: `IssueEnricherRegistry` map, unexported `registerIssueEnricher` helper (panics on empty name, nil fn, duplicate short name), `NoOpIssueEnricher`, `IssueEnricher` struct, `IssueEnricherFunc` / `IssueEnricherResult` types, shared helpers, `EnrichmentCap` / `PerParentPageCap`.
 - `internal/aws/*_issue_enrichment.go` — per-type enricher registrations, including real enrichers and `NoOpIssueEnricher` placeholders for types whose Wave 2 column is currently "None". Each file's `init()` calls `registerIssueEnricher(<shortname>, <fn>, <priority>)` and — if the enricher writes `FieldUpdates` — `resource.RegisterIssueEnricherFieldKeys(<shortname>, [...])`.
-- `internal/tui/app_probes.go` — `buildEnrichQueue()`, `probeEnrichment()`
-- `internal/tui/app_handlers_availability.go` — `startEnrichment()`, `handleEnrichmentChecked()` with only-increase guard
+- `internal/runtime/probes.go` — `(*Core).BuildEnrichQueue()` (queue construction lives on `runtime.Core`).
+- `internal/tui/probe_adapter.go` — `(*Model).probeEnrichment()` — the TUI-side `tea.Cmd` wrapper that dispatches enrichers and emits `EnrichmentChecked` messages.
+- `internal/runtime/handlers_availability.go` — `(*Core).startEnrichment()` (builds the queue, returns probe tasks) and `(*Core).handleEnrichmentChecked()` (applies one Wave-2 result with the only-increase guard).
 
 **Flow:**
 
@@ -372,7 +373,7 @@ Wave 1 probes complete
 
 **Registry**: On `main`, Wave 2 capability is expressed through `IssueEnricherRegistry` entries, including `NoOpIssueEnricher` placeholders that make "no Wave 2 signal" explicit and testable. Some types with `NoOpIssueEnricher` still perform in-fetcher Wave 2 work — their fetchers already make per-resource Describe calls and populate health fields at fetch time (e.g., EKS `health_issues_count`, CloudTrail `is_logging`, OpenSearch `cluster_health`).
 
-**Priority order** (`buildEnrichQueue`): Batchable enrichers that make account-wide calls are dispatched first (e.g., RDS/DocDB maintenance, EC2 instance status). Per-resource enrichers (e.g., DynamoDB PITR, KMS rotation, S3 PAB) iterate over resource IDs/ARNs, capped at `EnrichmentCap` (50). The registry key for each enricher must match the `ShortName` Wave 1 uses to store probe resources — a mismatch silently skips the enricher.
+**Priority order** (`(*Core).BuildEnrichQueue`): Batchable enrichers that make account-wide calls are dispatched first (e.g., RDS/DocDB maintenance, EC2 instance status). Per-resource enrichers (e.g., DynamoDB PITR, KMS rotation, S3 PAB) iterate over resource IDs/ARNs, capped at `EnrichmentCap` (50). The registry key for each enricher must match the `ShortName` Wave 1 uses to store probe resources — a mismatch silently skips the enricher.
 
 **Resource identity**: Enrichers receive retained first-page resources from Wave 1 probes (`probeResources map[string][]resource.Resource`). Account-wide enrichers make a single API call covering all resources. Per-resource enrichers fan out to individual resources, capped at `EnrichmentCap` (50).
 
@@ -528,7 +529,7 @@ Key highlights:
 
 ### Global vs View-Local Key Resolution
 
-The root model's `handleKeyMsg` (`app_handlers.go`) resolves keys in a specific order. Input modes take priority over global keys, which means `q`, `?`, etc. are swallowed during typing:
+The root model's `handleKeyMsg` (`internal/tui/app_input.go`) resolves keys in a specific order. Input modes take priority over global keys, which means `q`, `?`, etc. are swallowed during typing:
 
 1. **`Ctrl+C`** — force quit (always global, never delegated)
 2. **Input modes** — if filter, command, or search input is active, **all keys route to that input handler** (including `q`, `/`, `?`). This is why `q` doesn't quit while typing a filter.


### PR DESCRIPTION
## Summary

Three path-location references in `docs/architecture.md` still pointed at `internal/tui/app_*.go` files that were removed during the Phase-05 runtime-core migration (AS-237). This restores the doc to source-of-truth status.

| Section | Before (gone) | After (current) |
| --- | --- | --- |
| Wave-2 architecture | `internal/tui/app_probes.go` — `buildEnrichQueue()`, `probeEnrichment()` | `internal/runtime/probes.go` — `(*Core).BuildEnrichQueue()` **and** `internal/tui/probe_adapter.go` — `(*Model).probeEnrichment()` |
| Wave-2 architecture | `internal/tui/app_handlers_availability.go` — `startEnrichment()`, `handleEnrichmentChecked()` | `internal/runtime/handlers_availability.go` — `(*Core).startEnrichment()` + `(*Core).handleEnrichmentChecked()` |
| Priority-order callout | `` `buildEnrichQueue` `` | `` `(*Core).BuildEnrichQueue` `` (now exported because it crosses the runtime↔tui seam) |
| Global vs view-local key resolution | `handleKeyMsg` (`app_handlers.go`) | `handleKeyMsg` (`internal/tui/app_input.go`) |

## Why this is doc-only

The functions exist and behave as documented; only their **home** moved during the Phase-05 split (runtime owns the Core methods; TUI owns the `tea.Cmd` adapter wrappers). No behavior, key bindings, or tests change.

## Out of scope (intentional)

A single code comment in `internal/aws/issue_enrichment.go:159` still says "dispatcher (internal/tui/app_probes.go probeEnrichment)" — same stale path, but it's in application code. CTO charter forbids editing application code, so this is filed as a follow-up issue rather than wedged into this docs PR.

## Verification

- `make mdlint` clean (`docs/**/*.md` — 0 errors)
- `grep -nE 'app_probes\.go|app_handlers_availability\.go|app_handlers\.go|\\bbuildEnrichQueue\\b' docs/architecture.md` → no matches
- Symbols cross-checked against current source (`internal/runtime/probes.go`, `internal/runtime/handlers_availability.go`, `internal/tui/probe_adapter.go`, `internal/tui/app_input.go`)

## Test plan

- [x] markdownlint clean
- [x] No remaining `app_probes.go` / `app_handlers_availability.go` / `app_handlers.go` references in architecture.md
- [x] Symbols cited in the doc are findable in the current source tree
- [ ] CodeReviewer + CodexReviewer Stage 5 (XS, docs-only — Architect not required)

Closes AS-661.

Co-Authored-By: Paperclip <noreply@paperclip.ing>