### PR TITLE
fix(views): drop ResourcesLoaded for non-matching type (AS-652)

### DIFF
--- a/internal/tui/views/resourcelist.go
+++ b/internal/tui/views/resourcelist.go
@@ -170,6 +170,27 @@ func (m ResourceListModel) Init() (ResourceListModel, tea.Cmd) {
 func (m ResourceListModel) Update(msg tea.Msg) (ResourceListModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case messages.ResourcesLoaded:
+		// Drop loads for a different active resource type. A late EC2 fetch
+		// returning after the user has opened S3 must not mutate the S3
+		// list or its loading state — let the root model route the message
+		// to its write-through cache (which keys by msg.ResourceType).
+		//
+		// Compare via the registry so the alias the fetcher carried (e.g.
+		// "rds") still matches the list's canonical ShortName ("dbi"). Empty
+		// ResourceType ("unstamped") falls through: production fetch results
+		// always stamp the type via internal/tui/fetch_adapter.go, so an
+		// empty type only appears in unit-test fixtures that synthesise a
+		// ResourcesLoaded without a ResourceType. AS-648-h2 will tighten
+		// this further by carrying a session generation alongside the type.
+		if msg.ResourceType != "" {
+			canon := msg.ResourceType
+			if td := resource.FindResourceType(msg.ResourceType); td != nil {
+				canon = td.ShortName
+			}
+			if canon != m.typeDef.ShortName {
+				return m, nil
+			}
+		}
 		m.loading = false
 		m.loadingMore = false
 		if msg.Append {

--- a/tests/unit/qa_architect_bugs_test.go
+++ b/tests/unit/qa_architect_bugs_test.go
@@ -32,7 +32,7 @@ func TestBug_S3_EnterOnFolder_NavigatesIntoPrefix(t *testing.T) {
 		msg := cmd()
 		m, _ = rootApplyMsg(m, msg)
 	}
-	// Load objects including a folder
+	// Load objects including a folder (child list type is s3_objects)
 	objects := []resource.Resource{
 		{ID: "enterprise/", Name: "enterprise/", Status: "folder", Fields: map[string]string{
 			"key": "enterprise/", "size": "", "last_modified": "", "storage_class": "",
@@ -41,7 +41,7 @@ func TestBug_S3_EnterOnFolder_NavigatesIntoPrefix(t *testing.T) {
 			"key": "readme.txt", "size": "1024", "last_modified": "2025-01-01", "storage_class": "STANDARD",
 		}},
 	}
-	m, _ = rootApplyMsg(m, messages.ResourcesLoaded{ResourceType: "s3", Resources: objects})
+	m, _ = rootApplyMsg(m, messages.ResourcesLoaded{ResourceType: "s3_objects", Resources: objects})
 	// Press Enter on the folder — should navigate into prefix, NOT show detail
 	_, cmd = rootApplyMsg(m, tea.KeyPressMsg{Code: tea.KeyEnter})
 	if cmd == nil {

--- a/tests/unit/qa_s3_test.go
+++ b/tests/unit/qa_s3_test.go
@@ -64,9 +64,9 @@ func s3LoadedObjectModel() tui.Model {
 		msg := cmd()
 		m, _ = rootApplyMsg(m, msg)
 	}
-	// Load objects
+	// Load objects (child list type is s3_objects)
 	m, _ = rootApplyMsg(m, messages.ResourcesLoaded{
-		ResourceType: "s3",
+		ResourceType: "s3_objects",
 		Resources:    fixtureS3Objects(),
 	})
 	return m
@@ -549,7 +549,7 @@ func TestQA_S3_B2_1_ObjectList_EmptyBucket(t *testing.T) {
 	m.SetSize(120, 20)
 	m, _ = m.Init()
 	m, _ = m.Update(messages.ResourcesLoaded{
-		ResourceType: "s3",
+		ResourceType: "s3_objects",
 		Resources:    []resource.Resource{},
 	})
 
@@ -1011,7 +1011,7 @@ func TestQA_S3_D2_1_FullFlowStack(t *testing.T) {
 		m, _ = rootApplyMsg(m, msg)
 	}
 	m, _ = rootApplyMsg(m, messages.ResourcesLoaded{
-		ResourceType: "s3",
+		ResourceType: "s3_objects",
 		Resources:    fixtureS3Objects(),
 	})
 
@@ -1248,7 +1248,7 @@ func TestQA_S3_ObjectList_HorizontalScroll(t *testing.T) {
 	m.SetSize(50, 20) // narrow width to trigger horizontal scroll
 	m, _ = m.Init()
 	m, _ = m.Update(messages.ResourcesLoaded{
-		ResourceType: "s3",
+		ResourceType: "s3_objects",
 		Resources:    fixtureS3Objects(),
 	})
 

--- a/tests/unit/resourcelist_mismatched_type_test.go
+++ b/tests/unit/resourcelist_mismatched_type_test.go
@@ -1,0 +1,84 @@
+package unit
+
+import (
+	"testing"
+
+	_ "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/resource"
+	"github.com/k2m30/a9s/v3/internal/runtime/messages"
+	"github.com/k2m30/a9s/v3/internal/tui/keys"
+	"github.com/k2m30/a9s/v3/internal/tui/views"
+)
+
+// AS-652 / AS-648-h1: a ResourcesLoaded message whose ResourceType differs
+// from the active list's typeDef.ShortName must be dropped — it must not
+// mutate m.allResources and must not flip loading state. A late EC2 fetch
+// returning after the user has opened S3 used to render EC2 rows in the S3
+// list.
+func TestResourceListModel_ResourcesLoaded_DropsMismatchedType(t *testing.T) {
+	k := keys.Default()
+	td := resource.ResourceTypeDef{
+		Name:      "S3 Buckets",
+		ShortName: "s3",
+		Columns: []resource.Column{
+			{Key: "id", Title: "Name", Width: 20},
+		},
+	}
+
+	m := views.NewResourceList(td, nil, k)
+	m.SetSize(80, 24)
+	m, _ = m.Init()
+
+	// Late, mismatched fetch result for ec2 arrives while this list is s3.
+	stale := messages.ResourcesLoaded{
+		ResourceType: "ec2",
+		Resources: []resource.Resource{
+			{ID: "i-0123", Name: "i-0123", Fields: map[string]string{"id": "i-0123"}},
+			{ID: "i-0456", Name: "i-0456", Fields: map[string]string{"id": "i-0456"}},
+		},
+	}
+
+	m, cmd := m.Update(stale)
+
+	if got := len(m.AllResources()); got != 0 {
+		t.Errorf("mismatched ResourcesLoaded must not mutate allResources: got %d rows, want 0", got)
+	}
+	if got := len(m.VisibleResources()); got != 0 {
+		t.Errorf("mismatched ResourcesLoaded must not populate visibleResources: got %d rows, want 0", got)
+	}
+	if cmd != nil {
+		t.Errorf("mismatched ResourcesLoaded must return nil cmd, got %T", cmd())
+	}
+}
+
+// AS-652 / AS-648-h1 (symmetric): a matching-type ResourcesLoaded still
+// populates m.allResources. Regression guard so the type-guard does not
+// over-fire and silently drop legitimate loads.
+func TestResourceListModel_ResourcesLoaded_AppliesMatchingType(t *testing.T) {
+	k := keys.Default()
+	td := resource.ResourceTypeDef{
+		Name:      "S3 Buckets",
+		ShortName: "s3",
+		Columns: []resource.Column{
+			{Key: "id", Title: "Name", Width: 20},
+		},
+	}
+
+	m := views.NewResourceList(td, nil, k)
+	m.SetSize(80, 24)
+	m, _ = m.Init()
+
+	fresh := messages.ResourcesLoaded{
+		ResourceType: "s3",
+		Resources: []resource.Resource{
+			{ID: "bucket-a", Name: "bucket-a", Fields: map[string]string{"id": "bucket-a"}},
+			{ID: "bucket-b", Name: "bucket-b", Fields: map[string]string{"id": "bucket-b"}},
+		},
+	}
+
+	m, _ = m.Update(fresh)
+
+	if got := len(m.AllResources()); got != 2 {
+		t.Errorf("matching-type ResourcesLoaded did not populate allResources: got %d rows, want 2", got)
+	}
+}

--- a/tests/unit/resourcelist_mismatched_type_test.go
+++ b/tests/unit/resourcelist_mismatched_type_test.go
@@ -1,6 +1,7 @@
 package unit
 
 import (
+	"strings"
 	"testing"
 
 	_ "github.com/k2m30/a9s/v3/internal/aws"
@@ -17,37 +18,60 @@ import (
 // list.
 func TestResourceListModel_ResourcesLoaded_DropsMismatchedType(t *testing.T) {
 	k := keys.Default()
-	td := resource.ResourceTypeDef{
-		Name:      "S3 Buckets",
-		ShortName: "s3",
-		Columns: []resource.Column{
-			{Key: "id", Title: "Name", Width: 20},
-		},
+
+	cases := []struct {
+		name          string // name of the active list
+		listShortName string // ShortName of the active list model
+		staleType     string // ResourceType on the stale message (alias or canonical)
+	}{
+		{"S3 list rejects EC2 rows", "s3", "ec2"},
+		{"EC2 list rejects S3 rows", "ec2", "s3"},
+		// "rds" is a registered alias for canonical ShortName "dbi".
+		// The fetcher stamps the alias on the wire; the guard must still drop it
+		// when the active list is for a different type.
+		{"S3 list rejects RDS alias rows", "s3", "rds"},
+		{"S3 list rejects RDS canonical rows", "s3", "dbi"},
+		{"Lambda list rejects EC2 rows", "lambda", "ec2"},
 	}
 
-	m := views.NewResourceList(td, nil, k)
-	m.SetSize(80, 24)
-	m, _ = m.Init()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			td := resource.ResourceTypeDef{
+				Name:      tc.listShortName,
+				ShortName: tc.listShortName,
+				Columns: []resource.Column{
+					{Key: "id", Title: "ID", Width: 20},
+				},
+			}
 
-	// Late, mismatched fetch result for ec2 arrives while this list is s3.
-	stale := messages.ResourcesLoaded{
-		ResourceType: "ec2",
-		Resources: []resource.Resource{
-			{ID: "i-0123", Name: "i-0123", Fields: map[string]string{"id": "i-0123"}},
-			{ID: "i-0456", Name: "i-0456", Fields: map[string]string{"id": "i-0456"}},
-		},
-	}
+			m := views.NewResourceList(td, nil, k)
+			m.SetSize(80, 24)
+			m, _ = m.Init()
 
-	m, cmd := m.Update(stale)
+			stale := messages.ResourcesLoaded{
+				ResourceType: tc.staleType,
+				Resources: []resource.Resource{
+					{ID: "x-0001", Name: "x-0001", Fields: map[string]string{"id": "x-0001"}},
+				},
+			}
 
-	if got := len(m.AllResources()); got != 0 {
-		t.Errorf("mismatched ResourcesLoaded must not mutate allResources: got %d rows, want 0", got)
-	}
-	if got := len(m.VisibleResources()); got != 0 {
-		t.Errorf("mismatched ResourcesLoaded must not populate visibleResources: got %d rows, want 0", got)
-	}
-	if cmd != nil {
-		t.Errorf("mismatched ResourcesLoaded must return nil cmd, got %T", cmd())
+			m, cmd := m.Update(stale)
+
+			if got := len(m.AllResources()); got != 0 {
+				t.Errorf("mismatched ResourcesLoaded must not mutate allResources: got %d rows, want 0", got)
+			}
+			if got := len(m.VisibleResources()); got != 0 {
+				t.Errorf("mismatched ResourcesLoaded must not populate visibleResources: got %d rows, want 0", got)
+			}
+			if cmd != nil {
+				t.Errorf("mismatched ResourcesLoaded must return nil cmd, got %T", cmd())
+			}
+			// Behavioral proxy: the stale resource ID must not appear in the
+			// rendered view (loading spinner is still shown instead of rows).
+			if view := m.View(); strings.Contains(view, "x-0001") {
+				t.Errorf("stale resource ID must not appear in View() after mismatched drop")
+			}
+		})
 	}
 }
 
@@ -56,29 +80,46 @@ func TestResourceListModel_ResourcesLoaded_DropsMismatchedType(t *testing.T) {
 // over-fire and silently drop legitimate loads.
 func TestResourceListModel_ResourcesLoaded_AppliesMatchingType(t *testing.T) {
 	k := keys.Default()
-	td := resource.ResourceTypeDef{
-		Name:      "S3 Buckets",
-		ShortName: "s3",
-		Columns: []resource.Column{
-			{Key: "id", Title: "Name", Width: 20},
-		},
+
+	cases := []struct {
+		name          string
+		listShortName string
+		msgType       string // may be an alias
+	}{
+		{"S3 exact match", "s3", "s3"},
+		{"EC2 exact match", "ec2", "ec2"},
+		// The fetcher stamps "rds" (alias) on the wire while the list holds
+		// canonical ShortName "dbi" — the alias-aware guard must not drop it.
+		{"RDS alias match (rds→dbi)", "dbi", "rds"},
 	}
 
-	m := views.NewResourceList(td, nil, k)
-	m.SetSize(80, 24)
-	m, _ = m.Init()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			td := resource.ResourceTypeDef{
+				Name:      tc.listShortName,
+				ShortName: tc.listShortName,
+				Columns: []resource.Column{
+					{Key: "id", Title: "ID", Width: 20},
+				},
+			}
 
-	fresh := messages.ResourcesLoaded{
-		ResourceType: "s3",
-		Resources: []resource.Resource{
-			{ID: "bucket-a", Name: "bucket-a", Fields: map[string]string{"id": "bucket-a"}},
-			{ID: "bucket-b", Name: "bucket-b", Fields: map[string]string{"id": "bucket-b"}},
-		},
-	}
+			m := views.NewResourceList(td, nil, k)
+			m.SetSize(80, 24)
+			m, _ = m.Init()
 
-	m, _ = m.Update(fresh)
+			fresh := messages.ResourcesLoaded{
+				ResourceType: tc.msgType,
+				Resources: []resource.Resource{
+					{ID: "res-a", Name: "res-a", Fields: map[string]string{"id": "res-a"}},
+					{ID: "res-b", Name: "res-b", Fields: map[string]string{"id": "res-b"}},
+				},
+			}
 
-	if got := len(m.AllResources()); got != 2 {
-		t.Errorf("matching-type ResourcesLoaded did not populate allResources: got %d rows, want 2", got)
+			m, _ = m.Update(fresh)
+
+			if got := len(m.AllResources()); got != 2 {
+				t.Errorf("matching-type ResourcesLoaded did not populate allResources: got %d rows, want 2", got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Fix **AS-648-h1 (P1)**: `ResourceListModel.Update` would absorb rows from a late `ResourcesLoaded` for a different resource type (e.g. an EC2 fetch returning after the user has opened S3). Guard `msg.ResourceType` against the list's `typeDef.ShortName` and drop the mismatch; the root write-through cache (keyed by `msg.ResourceType`) is unaffected.
- Add focused unit tests (drop path + matching-type regression guard) in `tests/unit/resourcelist_mismatched_type_test.go`.

## Deviations from architect's literal `!=` spec — documented inline

The issue spec ([AS-652](https://app.paperclip.dev/issues/AS-652)) gave a literal `if msg.ResourceType != m.typeDef.ShortName`. Implementing that verbatim breaks the build in two ways; both deviations are documented inline in the guard.

1. **Empty `ResourceType` falls through.** Production fetch results always stamp the type (verified in `internal/tui/fetch_adapter.go:37-42,88-92`). The empty case only appears in pre-existing unit-test fixtures (~340 callsites across the repo) that synthesise `ResourcesLoaded{Resources: …}` without a `ResourceType`. AS-648-h2 will tighten this further by carrying a session generation alongside the type.
2. **Alias-aware comparison via `resource.FindResourceType`.** Navigation canonicalises types (e.g. "rds" → "dbi" — see `internal/runtime/handlers_navigate.go:138-167`), so the list's `typeDef.ShortName` is canonical ("dbi"), but the fetcher carries the user-typed alias on the wire (`Scope: ev.ResourceType` for `KindFetchResources`). A literal `!=` would drop every production RDS list load. The guard resolves `msg.ResourceType` through the registry before comparing.

## Tests in `qa_s3_test.go` / `qa_architect_bugs_test.go` — stamp corrections

The alias-aware guard exposes a handful of pre-existing test bugs where child `s3_objects` lists were stamped `"s3"`. Production stamps `"s3_objects"` (child fetcher uses `childType`). Updated 5 stamps (no logic changes):

- `qa_s3_test.go:69` (`s3LoadedObjectModel` helper), `:552`, `:1014`, `:1251`
- `qa_architect_bugs_test.go:44`

## Acceptance criteria (from AS-652)

- [x] Stale `ResourcesLoaded{ResourceType: "ec2", …}` arriving while a list for `s3` is active does not mutate `m.allResources` and does not change loading state. (See `TestResourceListModel_ResourcesLoaded_DropsMismatchedType`.)
- [x] Matching-type messages still apply — `autoOpenSingleDetail`, append, `pendingFilter`, sort/filter rebuild paths unchanged. (See `TestResourceListModel_ResourcesLoaded_AppliesMatchingType` plus the rest of the unit suite that still drives `ResourcesLoaded` through `m.Update`.)
- [x] Root write-through caching path (cache keyed by `msg.ResourceType`) untouched.

## Out of scope

- Adding `Gen` stamping to `ResourcesLoaded` — that is **AS-648-h2**.
- Root write-through cache refactor.
- The other ~340 test callsites that omit `ResourceType` (they hit the empty-stamp fall-through; not bugs given the soft guard).

## Pre-push gate

Run in an isolated worktree because the shared pod workspace had concurrent WIP from another agent (AS-648-h2):

- `go build ./...` — green
- `go test ./tests/unit/ -count=1` — green (0 failures, was 6 before stamp fixes, 57 with strict spec)
- `golangci-lint run ./...` — `0 issues.`
- `govulncheck ./...` — `No vulnerabilities found.`
- `go fix -inline -diff ./...` — no output (no unfixed directives)

`make test-race` / `make mdlint` not runnable on this pod (gcc + markdownlint-cli2 not installed — known pod gap, CI will run them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)