### PR TITLE
fix(tui): skip probeEnrichment in demo mode (AS-658)

### DIFF
--- a/internal/tui/probe_adapter.go
+++ b/internal/tui/probe_adapter.go
@@ -158,7 +158,16 @@ func (m *Model) refreshResourceListWithEnrichmentRerun(
 
 // probeEnrichment returns a tea.Cmd that runs the registered Wave-2 enricher
 // for shortName and converts the result to EnrichmentCheckedMsg.
+//
+// In demo mode (`WithIsDemo(true)`) the contract is to skip Wave-2 enrichment
+// entirely — registered enrichers are AWS-keyed and would issue real API calls
+// against synthetic fakes / missing credentials. The early return here matches
+// the documented WithIsDemo behavior; the registry is not consulted so AWS-only
+// enricher contracts are not exercised in demo sessions (AS-658 / AS-648-h3).
 func (m *Model) probeEnrichment(shortName string, gen domain.Gen) tea.Cmd {
+	if m.isDemo {
+		return nil
+	}
 	ctx, clients := m.appCtx, m.core.Session().Clients
 	typeGen := m.core.Session().EnrichmentTypeGen[shortName]
 	if awsclient.IssueEnricherRegistry[shortName].Fn == nil {

--- a/internal/tui/probe_demo_guard_test.go
+++ b/internal/tui/probe_demo_guard_test.go
@@ -1,0 +1,100 @@
+package tui
+
+// probe_demo_guard_test.go — AS-658 / AS-648-h3 P2.
+//
+// Pins the contract that `Model.probeEnrichment` returns a nil tea.Cmd when the
+// Model is in demo mode (`WithIsDemo(true)`), so registered Wave-2 enrichers
+// are NOT invoked against synthetic fakes / missing AWS credentials during the
+// `./a9s --demo` startup prefetch or list refresh paths.
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/catalog"
+	"github.com/k2m30/a9s/v3/internal/resource"
+	"github.com/k2m30/a9s/v3/internal/runtime"
+	"github.com/k2m30/a9s/v3/internal/session"
+)
+
+// TestProbeEnrichment_DemoMode_ReturnsNilAndSkipsRegistry verifies that when
+// `m.isDemo == true`, probeEnrichment short-circuits to nil BEFORE consulting
+// `awsclient.IssueEnricherRegistry`. A sentinel enricher counts invocations of
+// its registry hit + closure; both must remain zero in demo mode.
+func TestProbeEnrichment_DemoMode_ReturnsNilAndSkipsRegistry(t *testing.T) {
+	const sentinelType = "dbi-snap-probe-demo-guard-pin"
+
+	var fnCalls int32
+	captureFn := func(_ context.Context, _ *awsclient.ServiceClients, _ []resource.Resource, _ resource.ResourceCache) (awsclient.IssueEnricherResult, error) {
+		atomic.AddInt32(&fnCalls, 1)
+		return awsclient.IssueEnricherResult{}, nil
+	}
+
+	prev, hadPrev := awsclient.IssueEnricherRegistry[sentinelType]
+	awsclient.IssueEnricherRegistry[sentinelType] = awsclient.IssueEnricher{Fn: captureFn, Priority: 100}
+	t.Cleanup(func() {
+		if hadPrev {
+			awsclient.IssueEnricherRegistry[sentinelType] = prev
+		} else {
+			delete(awsclient.IssueEnricherRegistry, sentinelType)
+		}
+	})
+
+	sess := session.New()
+	sess.Clients = &awsclient.ServiceClients{}
+	m := &Model{
+		core:   runtime.New(sess, catalog.ResourceTypes),
+		appCtx: context.Background(),
+		isDemo: true,
+	}
+
+	cmd := m.probeEnrichment(sentinelType, 1)
+	if cmd != nil {
+		t.Fatalf("probeEnrichment returned non-nil cmd in demo mode; want nil to skip Wave-2 enrichment")
+	}
+	if got := atomic.LoadInt32(&fnCalls); got != 0 {
+		t.Fatalf("enricher Fn was invoked %d time(s) in demo mode; want 0 (early return must precede registry lookup)", got)
+	}
+}
+
+// TestProbeEnrichment_NonDemoMode_ReturnsCmd verifies that the demo guard does
+// NOT affect production (non-demo) behavior: a registered enricher still
+// produces a non-nil tea.Cmd whose closure invokes the enricher Fn.
+func TestProbeEnrichment_NonDemoMode_ReturnsCmd(t *testing.T) {
+	const sentinelType = "dbi-snap-probe-demo-guard-prod-pin"
+
+	var fnCalls int32
+	captureFn := func(_ context.Context, _ *awsclient.ServiceClients, _ []resource.Resource, _ resource.ResourceCache) (awsclient.IssueEnricherResult, error) {
+		atomic.AddInt32(&fnCalls, 1)
+		return awsclient.IssueEnricherResult{}, nil
+	}
+
+	prev, hadPrev := awsclient.IssueEnricherRegistry[sentinelType]
+	awsclient.IssueEnricherRegistry[sentinelType] = awsclient.IssueEnricher{Fn: captureFn, Priority: 100}
+	t.Cleanup(func() {
+		if hadPrev {
+			awsclient.IssueEnricherRegistry[sentinelType] = prev
+		} else {
+			delete(awsclient.IssueEnricherRegistry, sentinelType)
+		}
+	})
+
+	sess := session.New()
+	sess.Clients = &awsclient.ServiceClients{}
+	m := &Model{
+		core:   runtime.New(sess, catalog.ResourceTypes),
+		appCtx: context.Background(),
+		isDemo: false,
+	}
+
+	cmd := m.probeEnrichment(sentinelType, 1)
+	if cmd == nil {
+		t.Fatalf("probeEnrichment returned nil cmd in non-demo mode with registered enricher; want a tea.Cmd")
+	}
+	_ = cmd()
+	if got := atomic.LoadInt32(&fnCalls); got != 1 {
+		t.Fatalf("enricher Fn invocations in non-demo mode = %d; want 1 (demo guard must not affect production path)", got)
+	}
+}


### PR DESCRIPTION
## Summary

AS-658 / AS-648-h3 P2 — `Model.probeEnrichment` ran the registered Wave-2 issue enrichers unconditionally. The `WithIsDemo(true)` contract is to skip Wave-2 entirely, but the dispatch never checked `m.isDemo`. Startup prefetch and Ctrl+R refresh in demo mode therefore invoked AWS-keyed enrichers against synthetic fakes / missing credentials.

- Add an early `return nil` at the top of `probeEnrichment` when `m.isDemo` is true, before the registry lookup.
- Two regression pins in `internal/tui/probe_demo_guard_test.go` cover demo (skip) and non-demo (unchanged) paths via a sentinel `IssueEnricherRegistry` entry with an atomic counter.

## Scope note

Issue whitelist named `tests/unit/probe_demo_guard_test.go`, but `probeEnrichment` is unexported. Tests are placed at `internal/tui/probe_demo_guard_test.go` (package `tui`) matching the existing `probe_enrichment_cache_test.go` precedent for the same method.

## Test plan

- [x] `TestProbeEnrichment_DemoMode_ReturnsNilAndSkipsRegistry` — sentinel enricher counter stays at 0 in demo mode.
- [x] `TestProbeEnrichment_NonDemoMode_ReturnsCmd` — sentinel enricher fires once in production mode.
- [x] `go test ./... -count=1 -timeout 180s` — all green.
- [x] `golangci-lint run ./...` — 0 issues.
- [x] `govulncheck ./internal/tui/...` — no vulnerabilities.
- [x] `go test ./tests/unit/ -run 'Golden|Scenario'` — snapshots green.
- [ ] `make test-race` — CGO unavailable in pod (known platform constraint AS-149); CI runs race.

## Acceptance criteria mapping

1. `./a9s --demo` startup does NOT invoke any `IssueEnricherRegistry[*].Fn` — pinned by `TestProbeEnrichment_DemoMode_ReturnsNilAndSkipsRegistry`.
2. Production (`isDemo == false`) behavior unchanged — pinned by `TestProbeEnrichment_NonDemoMode_ReturnsCmd`.
3. List refresh in demo mode does not crash on nil clients / missing AWS connectivity — guaranteed because `probeEnrichment` returns nil before touching `m.core.Session().Clients`.

Refs: AS-658, AS-648.

🤖 Generated with [Claude Code](https://claude.com/claude-code)