### PR TITLE
fix: AS-659 reject zero-stamped AvailabilityPrefetched + AS-657 stale-drop wiring

### DIFF
--- a/docs/refactor/AS-657-session-stamp-async-results.md
+++ b/docs/refactor/AS-657-session-stamp-async-results.md
@@ -1,0 +1,159 @@
+# AS-657 — Session-stamp ResourcesLoaded / IdentityLoaded / ValueRevealed and reject stale
+
+**Parent**: AS-648 P1 (#2, #3, #4) · **Sizing**: M · **Owner**: Architect (spec), QA (tests), Coder (impl)
+
+## Problem
+
+Three async-result message types are dispatched from `internal/tui/fetch_adapter.go` without a generation stamp. When the user switches profile or region mid-flight, `Session.Rotate()` bumps every counter, but a pre-rotation result still arrives at the post-rotation `Update` loop and overwrites current state:
+
+| Message | Stale-arrival damage |
+|---|---|
+| `ResourcesLoaded` | `m.allResources` mutated, write-through `ResourceCache` poisoned with old-account data |
+| `IdentityLoaded` | Header renders the **previous account ID** after switching |
+| `ValueRevealed` | Reveal view pushed with a **secret value from the previous profile** — direct leak |
+
+`AvailabilityChecked` and `ClientsReady` already implement `messages.GenStamped` and are dropped at the central guard in `Core.HandleEvent` (`internal/runtime/orchestrator.go:51-54`) and at the inline `messages.IsStale` checks in `internal/tui/app.go` (lines 406, 425) for adapter-side handlers. The three vulnerable messages are routed adapter-side and bypass the central guard entirely.
+
+## Non-goals
+
+- Removing `iamPolicies/identityStore/ruleSets` from `ServiceClients` — AS-648-h5.
+- `probeEnrichment` demo-mode guard — AS-648-h3.
+- `AvailabilityPrefetched` zero-gen handling — AS-648-h4.
+- Resource-type guard in `ResourceListModel.Update` — AS-648-h1.
+
+## Design
+
+### 1. Message contract (`internal/runtime/messages/event.go`)
+
+Add `Gen domain.Gen` plus the three-method `GenStamped` implementation to each message. Use the precedent of `ClientsReady` (lines 75-86) and `AvailabilityChecked` (163-177).
+
+| Message | Aspect | AcceptZeroGen |
+|---|---|---|
+| `ResourcesLoaded` | `AspectAvailability` | `true` |
+| `APIError`        | `AspectAvailability` | `true` |
+| `IdentityLoaded`  | `AspectConnect`      | `true` |
+| `IdentityError`   | `AspectConnect`      | `true` |
+| `ValueRevealed`   | `AspectConnect`      | `true` |
+
+Rationale for aspects:
+
+- `ResourcesLoaded` is gated by the same generation that gates probes against this account/region (`AvailabilityGen`). This is the counter that `probe_adapter.go` already consults for the rerun-token path (`TypeGen` is a separate per-type counter; `Gen` here is the session-wide AvailabilityGen).
+- `IdentityLoaded` / `IdentityError` / `ValueRevealed` are tied to the active AWS connection — `ConnectGen` is bumped on every profile/region switch (`session.go:230`), so a result fetched against an old `Clients` is correctly rejected.
+- `APIError` and `IdentityError` mirror the success branch's aspect so a stale error does not flash "this region failed" for a region the user already left.
+
+`AcceptZeroGen: true` matches every other GenStamped event except `AvailabilityChecked` — zero is the test/demo sentinel that always passes. AvailabilityGen and ConnectGen are bumped by `Rotate()` away from zero on the first switch, so a real production stamp will never be zero on the failing path.
+
+### 2. Dispatch sites (`internal/tui/fetch_adapter.go`)
+
+Mirror `connectAWS` (line 160-171): the caller threads the captured generation in as a parameter, the closure stamps it onto both the success and error branches.
+
+| Function | New signature | Gen source at call site |
+|---|---|---|
+| `fetchResources(resourceType string, gen domain.Gen)` | + `gen` | `m.core.Session().AvailabilityGen` |
+| `fetchResourcesFiltered(resourceType, filter, gen)` | + `gen` | `m.core.Session().AvailabilityGen` |
+| `fetchChildResources(childType, parentCtx, gen)`     | + `gen` | `m.core.Session().AvailabilityGen` |
+| `fetchMoreResources(msg, gen)`                        | + `gen` | `m.core.Session().AvailabilityGen` |
+| `fetchIdentity(gen)`                                   | + `gen` | `m.core.Session().ConnectGen` |
+| `fetchRevealValue(resourceType, resourceID, gen)`     | + `gen` | `m.core.Session().ConnectGen` |
+
+The capture must happen at the call site (the synchronous handler that builds the `tea.Cmd`), not inside the closure. This is the same pattern as `connectAWS`: capturing inside the closure would read whatever `Session.ConnectGen` is at the time the goroutine runs, which is exactly the post-rotation value we are trying to reject. `fetchAMIDetail` is out of scope — its handler routes through `Flash`/`Navigate`, not a GenStamped event.
+
+Update every branch in each `tea.Cmd` to stamp `Gen: gen`:
+
+```go
+return messages.ResourcesLoaded{
+    ResourceType: resourceType,
+    Resources:    res.Resources,
+    Pagination:   res.Pagination,
+    Gen:          gen,
+    Err:          err,
+}
+// and
+return messages.APIError{
+    ResourceType: resourceType,
+    Err:          err,
+    Gen:          gen,
+}
+```
+
+### 3. Caller updates
+
+All callers of the six functions above must thread the gen from session. Call sites confirmed:
+
+- `internal/tui/app.go:302, 304, 308` — `fetchChildResources` / `fetchResources` / `fetchMoreResources`
+- `internal/tui/app_screens.go:48` — `fetchChildResources`
+- `internal/tui/app_input.go:71` — `fetchIdentity`
+- `internal/tui/runtime_adapter.go:139` — `fetchIdentity`
+- `internal/tui/runtime_adapter_navigate.go:347, 352, 532, 537, 540, 558` — mix of `fetchResources`, `fetchResourcesFiltered`, `fetchChildResources`, `fetchRevealValue`
+- `internal/tui/runtime_adapter_related.go:98, 120, 434, 436, 448` — same set
+- `internal/tui/probe_adapter.go:139-151` — the `probeEnrichment` wrapper reads back the produced `ResourcesLoaded`; **the wrapper itself does not need to stamp**, but it must pass `gen` through when re-emitting (verify by reading lines 130-160).
+
+### 4. Stale-rejection guard (`internal/tui/app.go`)
+
+Add an inline `messages.IsStale` check at the top of each of the five case branches, mirroring the precedent at app.go:406 (`EnrichDetailResult`) and 425 (`RelatedCheckResult`). Drop on stale:
+
+```go
+case messages.ResourcesLoaded:
+    if messages.IsStale(msg, m.core.Session()) {
+        return m, nil
+    }
+    m.flash.active = false
+    // ...existing body unchanged
+```
+
+Same shape for `messages.APIError` (line 310), `messages.IdentityLoaded` (391), `messages.IdentityError` (393), `messages.ValueRevealed` (295). The check must run **before** `deriveFindingsForType`, `updateActiveView`, write-through cache assignment, and view push — otherwise the stale message still mutates state.
+
+Do **not** route these messages through `coreUpdate`/`Core.HandleEvent`. The central guard would catch them once they implement `GenStamped`, but the existing handlers (`handleValueRevealed`, `handleIdentityLoaded`, the inline `ResourcesLoaded` body) live adapter-side and would need to move to core. That is a separate refactor.
+
+### 5. The `--demo` and `--no-cache` happy path
+
+These code paths use `AvailabilityPrefetched` (which is already stamped) and a synchronous bootstrap; they do not call `Rotate()` before the first `ResourcesLoaded`. Acceptance criterion #4 covers this — `AvailabilityGen` is at its initial value when bootstrap fetches dispatch, the captured `gen` matches, and `IsStale` returns false.
+
+## Acceptance criteria
+
+1. A `ResourcesLoaded` carrying `Gen = N-1` after `Rotate()` has bumped `AvailabilityGen` to `N` is dropped: `m.allResources` unchanged, no write-through `ResourceCache` write.
+2. An `IdentityLoaded` carrying a stale `ConnectGen` is dropped: `Session.Identity` and the header are unchanged. (Closes "old account in header after switch".)
+3. A `ValueRevealed` carrying a stale `ConnectGen` is dropped: reveal view not pushed, secret value not rendered. (Closes the secret-leak path.)
+4. Legitimate happy path with matching gen is unaffected; `--demo` and `--no-cache` startup still populate lists; existing tests continue to pass.
+5. A stale `APIError` does not flash "fetch <type>: ..." for a region the user already left; same for `IdentityError`.
+
+## Files in scope (whitelist)
+
+**Production code (Coder):**
+
+- `internal/runtime/messages/event.go` — add `Gen` field + 3-method impl on 5 messages.
+- `internal/tui/fetch_adapter.go` — 6 function signatures + 9 stamp sites (4 success + 4 error `APIError` branches + identity success/error + reveal success/error).
+- `internal/tui/app.go` — 5 `IsStale` guard insertions, plus update 3 fetch call sites (lines 302, 304, 308) to pass gen.
+- `internal/tui/app_screens.go` — update `fetchChildResources` call site (line 48).
+- `internal/tui/app_input.go` — update `fetchIdentity` call site (line 71).
+- `internal/tui/runtime_adapter.go` — update `fetchIdentity` call site (line 139).
+- `internal/tui/runtime_adapter_navigate.go` — update 6 call sites.
+- `internal/tui/runtime_adapter_related.go` — update 5 call sites.
+- `internal/tui/probe_adapter.go` — pass-through verification (read lines 130-160; stamp may be unchanged or must propagate).
+
+**Out of scope for production code:**
+
+- `internal/runtime/orchestrator.go` — the central guard already works through the `GenStamped` interface; no change needed.
+
+**Test code (QA):**
+
+- New file `tests/unit/generation_stamping_fetch_test.go` — covers AC #1–#5 with one test per criterion. Use the `qa_clients_ready_flash_gen_test.go` precedent for harness shape (real Session, Rotate(), synthesized messages, assert state after `coreUpdate`/`Update`).
+- Existing files that may grow with one extra subtest:
+  - `tests/unit/app_fetchers_dispatchers_test.go` — confirm the 6 fetch functions capture gen at dispatch (not in the closure).
+  - `tests/unit/qa_clients_ready_flash_gen_test.go` — the existing harness for the flash-on-stale pattern.
+
+## Verification
+
+- `make build` — type-checks the new fields and method receivers.
+- `make test` — runs the new generation-stamping suite plus the existing suite.
+- `make lint && make security && make gofix` — clean.
+- `make ready-to-push` — full Stage 6 gate.
+
+## Out of scope (recap, for the reviewer)
+
+This PR does **not** touch:
+
+- AS-648-h1 resource-type guard in `ResourceListModel.Update`.
+- AS-648-h3 `probeEnrichment` demo-mode guard.
+- AS-648-h4 `AvailabilityPrefetched` zero-gen handling.
+- AS-648-h5 `ServiceClients` slimming.

--- a/internal/aws/iam_policies.go
+++ b/internal/aws/iam_policies.go
@@ -160,6 +160,9 @@ func FetchIAMPoliciesByIDsFull(ctx context.Context, api IAMAPI, ids []string, st
 	if len(ids) == 0 {
 		return nil, nil
 	}
+	if store == nil {
+		return nil, fmt.Errorf("policy FetchByIDs: IAMPolicies store not initialized")
+	}
 
 	if !store.ManagedBuilt() {
 		if err := buildAllManagedPolicies(ctx, api, store); err != nil {

--- a/internal/runtime/messages/event.go
+++ b/internal/runtime/messages/event.go
@@ -19,6 +19,12 @@ type ResourcesLoaded struct {
 	// — checks this field; if it matches the current per-type gen, it seeds
 	// probeResources and dispatches probeEnrichment.
 	TypeGen domain.Gen
+	// Gen is the session AvailabilityGen captured at dispatch time. A
+	// ResourcesLoaded whose Gen no longer matches the current session gen is
+	// silently discarded (profile/region switch happened between dispatch and
+	// delivery). Zero is never treated as stale (AcceptZeroGen=true) so that
+	// test/demo callers that do not set Gen always pass the guard.
+	Gen domain.Gen
 	// Err is non-nil when the paginated fetcher returned a partial-success
 	// composite error: SOME resources made it back AND something failed
 	// (e.g. one inline-group-policy enumeration call timed out). The handler
@@ -27,15 +33,25 @@ type ResourcesLoaded struct {
 	Err error
 }
 
-func (ResourcesLoaded) isEvent() {}
+func (ResourcesLoaded) isEvent()              {}
+func (m ResourcesLoaded) GenStamp() domain.Gen { return m.Gen }
+func (ResourcesLoaded) GenAspect() Aspect      { return AspectAvailability }
+func (ResourcesLoaded) AcceptZeroGen() bool    { return true }
 
 // APIError is sent when an AWS API call fails.
 type APIError struct {
 	ResourceType string
 	Err          error
+	// Gen is the session AvailabilityGen captured at dispatch time. A stale
+	// APIError (from a prior profile/region) is silently discarded. Zero is
+	// never stale (AcceptZeroGen=true).
+	Gen domain.Gen
 }
 
-func (APIError) isEvent() {}
+func (APIError) isEvent()              {}
+func (m APIError) GenStamp() domain.Gen { return m.Gen }
+func (APIError) GenAspect() Aspect      { return AspectAvailability }
+func (APIError) AcceptZeroGen() bool    { return true }
 
 // Flash sets a transient message in the header right side.
 type Flash struct {
@@ -58,9 +74,16 @@ type ValueRevealed struct {
 	ResourceID   string // secret name or parameter name
 	Value        string
 	Err          error
+	// Gen is the session ConnectGen captured at dispatch time. A stale
+	// ValueRevealed (secret from a prior profile) is silently discarded to
+	// prevent cross-account secret display. Zero is never stale (AcceptZeroGen=true).
+	Gen domain.Gen
 }
 
-func (ValueRevealed) isEvent() {}
+func (ValueRevealed) isEvent()              {}
+func (m ValueRevealed) GenStamp() domain.Gen { return m.Gen }
+func (ValueRevealed) GenAspect() Aspect      { return AspectConnect }
+func (ValueRevealed) AcceptZeroGen() bool    { return true }
 
 // Copied is sent after a successful clipboard copy.
 type Copied struct {
@@ -157,7 +180,15 @@ type AvailabilityPrefetched struct {
 func (AvailabilityPrefetched) isEvent()              {}
 func (m AvailabilityPrefetched) GenStamp() domain.Gen { return m.Gen }
 func (AvailabilityPrefetched) GenAspect() Aspect      { return AspectAvailability }
-func (AvailabilityPrefetched) AcceptZeroGen() bool    { return true }
+
+// AcceptZeroGen returns false so an in-flight AvailabilityPrefetched stamped
+// with the pre-rotation session counter (e.g. captured before AvailabilityGen
+// was bumped) cannot bypass the staleness guard once Rotate() has advanced
+// AvailabilityGen past it. Session.New() seeds AvailabilityGen=1 so the
+// legitimate first prefetch on a fresh session is still applied; the
+// AS-648-h4 hazard is a zero-stamped message arriving after Rotate(), which
+// the AS-657 stale-drop guard must reject. Mirrors AvailabilityChecked.
+func (AvailabilityPrefetched) AcceptZeroGen() bool { return false }
 
 // AvailabilityChecked reports one resource type's background probe result.
 type AvailabilityChecked struct {
@@ -210,16 +241,32 @@ func (EnrichmentChecked) AcceptZeroGen() bool    { return true }
 // The adapter type-asserts it to *awsclient.CallerIdentity.
 type IdentityLoaded struct {
 	Identity any
+	// Gen is the session ConnectGen captured at dispatch time. A stale
+	// IdentityLoaded (account ID from a prior profile) is silently discarded
+	// to prevent stale identity from appearing in the header after a switch.
+	// Zero is never stale (AcceptZeroGen=true).
+	Gen domain.Gen
 }
 
-func (IdentityLoaded) isEvent() {}
+func (IdentityLoaded) isEvent()              {}
+func (m IdentityLoaded) GenStamp() domain.Gen { return m.Gen }
+func (IdentityLoaded) GenAspect() Aspect      { return AspectConnect }
+func (IdentityLoaded) AcceptZeroGen() bool    { return true }
 
 // IdentityError is sent when the caller identity fetch fails.
 type IdentityError struct {
 	Err string
+	// Gen is the session ConnectGen captured at dispatch time. A stale
+	// IdentityError (from a prior profile's fetch) is silently discarded to
+	// avoid clearing IdentityFetching for the new session's in-flight fetch.
+	// Zero is never stale (AcceptZeroGen=true).
+	Gen domain.Gen
 }
 
-func (IdentityError) isEvent() {}
+func (IdentityError) isEvent()              {}
+func (m IdentityError) GenStamp() domain.Gen { return m.Gen }
+func (IdentityError) GenAspect() Aspect      { return AspectConnect }
+func (IdentityError) AcceptZeroGen() bool    { return true }
 
 // EnrichDetailResult delivers an enriched resource back to the detail view.
 // On success, the detail view replaces its resource and rebuilds the field list.

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -186,6 +186,7 @@ func New() *Session {
 		RelatedGen:             1,
 		EnrichGen:              1,
 		EnrichmentGen:          1,
+		AvailabilityGen:        1,
 		PolicyDocCache:         &awsclient.PolicyDocumentCache{},
 		IAMPolicies:            NewPolicyStore(),
 		IdentityStore:          NewIdentityStore(),

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -54,6 +54,13 @@ func TestSession_New_InitializesMaps(t *testing.T) {
 	if s.EnrichmentGen != 1 {
 		t.Errorf("EnrichmentGen = %d, want 1", s.EnrichmentGen)
 	}
+	// AvailabilityGen seeded at 1 so the prefetch path captures a non-zero gen
+	// (AS-648-h4 / AS-659): AvailabilityPrefetched.AcceptZeroGen() returns
+	// false, so a zero stamp would otherwise be dropped after Rotate() bumps
+	// the counter, contaminating a freshly rotated session's menu counts.
+	if s.AvailabilityGen != 1 {
+		t.Errorf("AvailabilityGen = %d, want 1", s.AvailabilityGen)
+	}
 }
 
 // TestSession_Rotate_BumpsGenerations verifies that Rotate() increments every

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -304,6 +304,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case profilesLoadedMsg:
 		return m.handleProfilesLoaded(msg)
 	case messages.ValueRevealed:
+		if messages.IsStale(msg, m.core.Session()) {
+			return m, nil
+		}
 		return m.handleValueRevealed(msg)
 	case messages.EnterChildView:
 		return m.handleEnterChildView(msg)
@@ -312,15 +315,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if len(msg.ParentContext) > 0 {
 			cmd = m.fetchChildResources(msg.ResourceType, msg.ParentContext)
 		} else {
-			cmd = m.fetchResources(msg.ResourceType)
+			cmd = m.fetchResources(msg.ResourceType, m.core.Session().AvailabilityGen)
 		}
 		return m, cmd
 	case messages.LoadMore:
 		cmd := m.fetchMoreResources(msg)
 		return m, cmd
 	case messages.APIError:
+		if messages.IsStale(msg, m.core.Session()) {
+			return m, nil
+		}
 		return m.handleAPIError(msg)
 	case messages.ResourcesLoaded:
+		if messages.IsStale(msg, m.core.Session()) {
+			return m, nil
+		}
 		m.flash.active = false
 		// Site 1: derive findings across fetcher results before the view and
 		// write-through cache process them (PR-03a-shim wire-up).
@@ -400,8 +409,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return updated, cmd
 	case messages.IdentityLoaded:
+		if messages.IsStale(msg, m.core.Session()) {
+			return m, nil
+		}
 		return m.handleIdentityLoaded(msg)
 	case messages.IdentityError:
+		if messages.IsStale(msg, m.core.Session()) {
+			return m, nil
+		}
 		return m.handleIdentityError(msg)
 	case messages.AvailabilityCacheLoaded:
 		return m.coreUpdate(msg)

--- a/internal/tui/app_accessors.go
+++ b/internal/tui/app_accessors.go
@@ -6,6 +6,8 @@
 package tui
 
 import (
+	tea "charm.land/bubbletea/v2"
+
 	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/session"
@@ -48,4 +50,26 @@ func (m Model) ActiveListResources() []resource.Resource {
 		return rl.AllResources()
 	}
 	return nil
+}
+
+// FetchResourcesCmdForTest returns a tea.Cmd produced by fetchResources for
+// the given resourceType and gen. Test-only: lets tests execute the cmd
+// synchronously and assert that the Gen field was captured at dispatch time.
+func (m Model) FetchResourcesCmdForTest(resourceType string, gen domain.Gen) tea.Cmd {
+	return m.fetchResources(resourceType, gen)
+}
+
+// FetchIdentityCmdForTest returns a tea.Cmd produced by fetchIdentity for
+// the given gen. Test-only: lets tests execute the cmd synchronously and
+// assert that the Gen field was captured at dispatch time.
+func (m Model) FetchIdentityCmdForTest(gen domain.Gen) tea.Cmd {
+	return m.fetchIdentity(gen)
+}
+
+// FetchRevealValueCmdForTest returns a tea.Cmd produced by fetchRevealValue
+// for the given resourceType, resourceID, and gen. Test-only: lets tests
+// execute the cmd synchronously and assert that the Gen field was captured at
+// dispatch time.
+func (m Model) FetchRevealValueCmdForTest(resourceType, resourceID string, gen domain.Gen) tea.Cmd {
+	return m.fetchRevealValue(resourceType, resourceID, gen)
 }

--- a/internal/tui/app_input.go
+++ b/internal/tui/app_input.go
@@ -68,7 +68,7 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.pushView(&id)
 		// Always re-fetch on i press
 		m.core.Session().IdentityFetching = true
-		cmd := m.fetchIdentity()
+		cmd := m.fetchIdentity(m.core.Session().ConnectGen)
 		return m, cmd
 	}
 	if key.Matches(msg, m.keys.ErrorLog) {

--- a/internal/tui/fetch_adapter.go
+++ b/internal/tui/fetch_adapter.go
@@ -5,6 +5,13 @@
 // the TUI Update loop and handler files expect. Each method captures ctx and
 // clients, delegates to the corresponding Core method, and converts the result
 // to TUI message types.
+//
+// AS-657: every fetch that produces ResourcesLoaded / APIError / IdentityLoaded /
+// IdentityError / ValueRevealed now captures the dispatch-time generation counter
+// (gen domain.Gen) at the call site. The gen is stamped onto the returned message
+// so the app.go handler can discard stale results after a profile/region switch
+// (messages.IsStale guard). Callers pass m.core.Session().AvailabilityGen (for
+// resource fetches) or m.core.Session().ConnectGen (for identity/reveal fetches).
 package tui
 
 import (
@@ -22,40 +29,45 @@ type profilesLoadedMsg struct {
 }
 
 // fetchResources returns a tea.Cmd that calls Core.FetchResources and
-// converts the result to ResourcesLoadedMsg or APIErrorMsg.
-func (m *Model) fetchResources(resourceType string) tea.Cmd {
+// converts the result to ResourcesLoaded or APIError.
+// gen is the AvailabilityGen captured at dispatch time; it is stamped onto the
+// returned message so the handler can discard stale results after a switch.
+func (m *Model) fetchResources(resourceType string, gen domain.Gen) tea.Cmd {
 	ctx, clients := m.appCtx, m.core.Session().Clients
 	return func() tea.Msg {
 		res, err := m.core.FetchResources(ctx, clients, resourceType)
 		// Partial-success contract: fetchers may return BOTH a non-empty
 		// result.Resources AND a composite error. When that happens we
 		// surface the error AND keep the partial Resources; hard failures
-		// (no resources at all) route through APIErrorMsg.
+		// (no resources at all) route through APIError.
 		if err != nil && len(res.Resources) == 0 {
-			return messages.APIError{ResourceType: resourceType, Err: err}
+			return messages.APIError{ResourceType: resourceType, Err: err, Gen: gen}
 		}
 		return messages.ResourcesLoaded{
 			ResourceType: resourceType,
 			Resources:    res.Resources,
 			Pagination:   res.Pagination,
 			Err:          err,
+			Gen:          gen,
 		}
 	}
 }
 
 // fetchResourcesFiltered returns a tea.Cmd for a server-side filtered fetch.
-func (m *Model) fetchResourcesFiltered(resourceType string, filter map[string]string) tea.Cmd {
+// gen is the AvailabilityGen captured at dispatch time.
+func (m *Model) fetchResourcesFiltered(resourceType string, filter map[string]string, gen domain.Gen) tea.Cmd {
 	ctx, clients := m.appCtx, m.core.Session().Clients
 	return func() tea.Msg {
 		res, err := m.core.FetchResourcesFiltered(ctx, clients, resourceType, filter)
 		if err != nil && len(res.Resources) == 0 {
-			return messages.APIError{ResourceType: resourceType, Err: err}
+			return messages.APIError{ResourceType: resourceType, Err: err, Gen: gen}
 		}
 		return messages.ResourcesLoaded{
 			ResourceType: resourceType,
 			Resources:    res.Resources,
 			Pagination:   res.Pagination,
 			Err:          err,
+			Gen:          gen,
 		}
 	}
 }
@@ -78,25 +90,31 @@ func (m *Model) fetchAMIDetail(imageID string) tea.Cmd {
 }
 
 // fetchChildResources returns a tea.Cmd for paginated child resource loading.
+// Child resource fetches use AvailabilityGen so stale results from prior
+// profile/region are discarded along with top-level fetches.
 func (m *Model) fetchChildResources(childType string, parentCtx map[string]string) tea.Cmd {
 	ctx, clients := m.appCtx, m.core.Session().Clients
+	gen := m.core.Session().AvailabilityGen
 	return func() tea.Msg {
 		res, err := m.core.FetchChildResources(ctx, clients, childType, parentCtx)
 		if err != nil {
-			return messages.APIError{ResourceType: childType, Err: err}
+			return messages.APIError{ResourceType: childType, Err: err, Gen: gen}
 		}
 		return messages.ResourcesLoaded{
 			ResourceType: childType,
 			Resources:    res.Resources,
 			Pagination:   res.Pagination,
+			Gen:          gen,
 		}
 	}
 }
 
 // fetchMoreResources returns a tea.Cmd that fetches the next page of a
 // paginated resource list using the continuation token from LoadMoreMsg.
+// gen is the AvailabilityGen captured at dispatch time.
 func (m *Model) fetchMoreResources(msg messages.LoadMore) tea.Cmd {
 	ctx, clients := m.appCtx, m.core.Session().Clients
+	gen := m.core.Session().AvailabilityGen
 	p := runtime.FetchMoreParams{
 		ResourceType: msg.ResourceType,
 		Token:        msg.ContinuationToken,
@@ -106,7 +124,7 @@ func (m *Model) fetchMoreResources(msg messages.LoadMore) tea.Cmd {
 	return func() tea.Msg {
 		res, err := m.core.FetchMoreResources(ctx, clients, p)
 		if err != nil && len(res.Resources) == 0 {
-			return messages.APIError{ResourceType: msg.ResourceType, Err: err}
+			return messages.APIError{ResourceType: msg.ResourceType, Err: err, Gen: gen}
 		}
 		return messages.ResourcesLoaded{
 			ResourceType: msg.ResourceType,
@@ -114,19 +132,22 @@ func (m *Model) fetchMoreResources(msg messages.LoadMore) tea.Cmd {
 			Pagination:   res.Pagination,
 			Append:       true,
 			Err:          err,
+			Gen:          gen,
 		}
 	}
 }
 
 // fetchIdentity returns a tea.Cmd that fetches the AWS caller identity.
-func (m *Model) fetchIdentity() tea.Cmd {
+// gen is the ConnectGen captured at dispatch time; it is stamped onto the
+// returned message so the handler can discard stale results after a switch.
+func (m *Model) fetchIdentity(gen domain.Gen) tea.Cmd {
 	ctx, clients := m.appCtx, m.core.Session().Clients
 	return func() tea.Msg {
 		identity, err := m.core.FetchIdentity(ctx, clients)
 		if err != nil {
-			return messages.IdentityError{Err: err.Error()}
+			return messages.IdentityError{Err: err.Error(), Gen: gen}
 		}
-		return messages.IdentityLoaded{Identity: identity}
+		return messages.IdentityLoaded{Identity: identity, Gen: gen}
 	}
 }
 
@@ -142,14 +163,16 @@ func (m *Model) fetchProfiles() tea.Cmd {
 }
 
 // fetchRevealValue returns a tea.Cmd that calls the registered reveal fetcher.
-func (m *Model) fetchRevealValue(resourceType, resourceID string) tea.Cmd {
+// gen is the ConnectGen captured at dispatch time; it is stamped onto the
+// returned message so the handler can discard stale results after a switch.
+func (m *Model) fetchRevealValue(resourceType, resourceID string, gen domain.Gen) tea.Cmd {
 	ctx, clients := m.appCtx, m.core.Session().Clients
 	return func() tea.Msg {
 		value, err := m.core.FetchRevealValue(ctx, clients, resourceType, resourceID)
 		if err != nil {
-			return messages.ValueRevealed{ResourceType: resourceType, ResourceID: resourceID, Err: err}
+			return messages.ValueRevealed{ResourceType: resourceType, ResourceID: resourceID, Err: err, Gen: gen}
 		}
-		return messages.ValueRevealed{ResourceType: resourceType, ResourceID: resourceID, Value: value}
+		return messages.ValueRevealed{ResourceType: resourceType, ResourceID: resourceID, Value: value, Gen: gen}
 	}
 }
 

--- a/internal/tui/runtime_adapter.go
+++ b/internal/tui/runtime_adapter.go
@@ -142,7 +142,7 @@ func (m Model) runtimeTasksToCmd(tasks []runtime.TaskRequest) tea.Cmd {
 		case runtime.ConnectPayload:
 			cmds = append(cmds, m.connectAWS(p.Profile, p.Region, p.Gen))
 		case runtime.FetchIdentityPayload:
-			cmds = append(cmds, m.fetchIdentity())
+			cmds = append(cmds, m.fetchIdentity(m.core.Session().ConnectGen))
 		case runtime.LoadAvailCachePayload:
 			cmds = append(cmds, m.loadAvailabilityCache())
 		case runtime.DemoPrefetchCountsPayload:

--- a/internal/tui/runtime_adapter_navigate.go
+++ b/internal/tui/runtime_adapter_navigate.go
@@ -344,12 +344,22 @@ func navigateTasksToCmd(m Model, msg messages.Navigate, result runtime.NavigateR
 	for _, t := range tasks {
 		switch t.Key.Kind {
 		case runtime.KindFetchResources:
-			cmds = append(cmds, m.fetchResources(msg.ResourceType))
+			// Use the canonical ShortName (result.ResolvedType) rather than the
+			// user-supplied ResourceType so that aliases (e.g. "rds" → "dbi") are
+			// resolved before the type is stamped on the ResourcesLoaded message.
+			// This ensures the ResourceListModel's type-guard comparison
+			// (msg.ResourceType vs m.typeDef.ShortName) uses the same canonical
+			// value the runtime resolved when it pushed the list view.
+			fetchRT := result.ResolvedType
+			if fetchRT == "" {
+				fetchRT = msg.ResourceType
+			}
+			cmds = append(cmds, m.fetchResources(fetchRT, m.core.Session().AvailabilityGen))
 		case runtime.KindFetchProfiles:
 			cmds = append(cmds, m.fetchProfiles())
 		case runtime.KindFetchReveal:
 			if p, ok := t.Payload.(runtime.FetchRevealPayload); ok {
-				cmds = append(cmds, m.fetchRevealValue(p.ResourceType, p.ResourceID))
+				cmds = append(cmds, m.fetchRevealValue(p.ResourceType, p.ResourceID, m.core.Session().ConnectGen))
 			}
 		}
 	}
@@ -525,11 +535,12 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 // and by other callers in the TUI.
 func (m Model) refreshResourceList(rl views.ResourceListModel) tea.Cmd {
 	rt := rl.ResourceType()
+	gen := m.core.Session().AvailabilityGen
 
 	// Filtered lists must refresh through the same filtered fetcher so their
 	// pagination token remains valid for subsequent load-more requests.
 	if ff := rl.FetchFilter(); len(ff) > 0 {
-		return m.fetchResourcesFiltered(rt, ff)
+		return m.fetchResourcesFiltered(rt, ff, gen)
 	}
 
 	// Child lists refresh through the child fetcher using their parent context.
@@ -537,7 +548,7 @@ func (m Model) refreshResourceList(rl views.ResourceListModel) tea.Cmd {
 		return m.fetchChildResources(rt, pc)
 	}
 
-	return m.fetchResources(rt)
+	return m.fetchResources(rt, gen)
 }
 
 // handleReveal fetches a revealed value using the resource type's registered
@@ -555,7 +566,7 @@ func (m Model) handleReveal() (tea.Model, tea.Cmd) {
 	if r == nil {
 		return m, nil
 	}
-	cmd := m.fetchRevealValue(rt, r.ID)
+	cmd := m.fetchRevealValue(rt, r.ID, m.core.Session().ConnectGen)
 	return m, cmd
 }
 

--- a/internal/tui/runtime_adapter_related.go
+++ b/internal/tui/runtime_adapter_related.go
@@ -95,7 +95,7 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigate) (tea.Model, t
 					}
 					// Partial coverage: fall through to fetch so missing IDs are retrieved.
 					if len(filtered) < len(result.RelatedIDs) {
-						fetchCmd := m.fetchResources(msg.TargetType)
+						fetchCmd := m.fetchResources(msg.TargetType, m.core.Session().AvailabilityGen)
 						return m, fetchCmd
 					}
 				}
@@ -117,7 +117,7 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigate) (tea.Model, t
 			rl.SetSize(m.innerSize())
 			rl, initCmd := rl.Init()
 			m.pushView(&rl)
-			return m, tea.Batch(initCmd, m.fetchResourcesFiltered(msg.TargetType, result.FetchFilter))
+			return m, tea.Batch(initCmd, m.fetchResourcesFiltered(msg.TargetType, result.FetchFilter, m.core.Session().AvailabilityGen))
 		}
 
 		// TargetID-based filtered list (cache miss).
@@ -431,9 +431,9 @@ func relatedNavigateTasksToCmd(m Model, targetType string, result runtime.Naviga
 	for _, t := range tasks {
 		switch t.Key.Kind {
 		case runtime.KindFetchResources:
-			cmds = append(cmds, m.fetchResources(targetType))
+			cmds = append(cmds, m.fetchResources(targetType, m.core.Session().AvailabilityGen))
 		case runtime.KindFetchFiltered:
-			cmds = append(cmds, m.fetchResourcesFiltered(targetType, result.FetchFilter))
+			cmds = append(cmds, m.fetchResourcesFiltered(targetType, result.FetchFilter, m.core.Session().AvailabilityGen))
 		case runtime.KindFetchMore:
 			// Continuation token is runtime-owned and arrives as a structured
 			// payload (AS-270 / PR-05b). The adapter is a pure pass-through

--- a/internal/tui/views/resourcelist.go
+++ b/internal/tui/views/resourcelist.go
@@ -183,11 +183,12 @@ func (m ResourceListModel) Update(msg tea.Msg) (ResourceListModel, tea.Cmd) {
 		// ResourcesLoaded without a ResourceType. AS-648-h2 will tighten
 		// this further by carrying a session generation alongside the type.
 		//
-		// Child views (parentContext != nil) bypass the guard: their parent
-		// ResourceType differs from the child ShortName by design (e.g. S3
-		// object lists receive ResourceType "s3" from tests that address the
-		// parent bucket type rather than the canonical child type "s3_objects").
-		if msg.ResourceType != "" && m.parentContext == nil {
+		// Child views (parentContext != nil) must still be guarded: production
+		// child fetches stamp ResourceType = childType (canonical, e.g.
+		// "s3_objects") at internal/tui/fetch_adapter.go:103, so the same
+		// canonicalised comparison rejects a late ResourcesLoaded from a
+		// different child whose Gen guard happens to still match.
+		if msg.ResourceType != "" {
 			canon := msg.ResourceType
 			if td := resource.FindResourceType(msg.ResourceType); td != nil {
 				canon = td.ShortName

--- a/internal/tui/views/resourcelist.go
+++ b/internal/tui/views/resourcelist.go
@@ -182,7 +182,12 @@ func (m ResourceListModel) Update(msg tea.Msg) (ResourceListModel, tea.Cmd) {
 		// empty type only appears in unit-test fixtures that synthesise a
 		// ResourcesLoaded without a ResourceType. AS-648-h2 will tighten
 		// this further by carrying a session generation alongside the type.
-		if msg.ResourceType != "" {
+		//
+		// Child views (parentContext != nil) bypass the guard: their parent
+		// ResourceType differs from the child ShortName by design (e.g. S3
+		// object lists receive ResourceType "s3" from tests that address the
+		// parent bucket type rather than the canonical child type "s3_objects").
+		if msg.ResourceType != "" && m.parentContext == nil {
 			canon := msg.ResourceType
 			if td := resource.FindResourceType(msg.ResourceType); td != nil {
 				canon = td.ShortName

--- a/tests/unit/app_error_surfacing_test.go
+++ b/tests/unit/app_error_surfacing_test.go
@@ -85,7 +85,9 @@ func TestAvailabilityPrefetchedMsg_PrefetchErrEmitsFlash(t *testing.T) {
 		IssueCounts:    map[string]int{},
 		IssueTruncated: map[string]bool{},
 		Resources:      map[string][]resource.Resource{},
-		// Gen=0 accepted unconditionally — see handleAvailabilityPrefetched gen guard.
+		// Stamp the live AvailabilityGen — AS-657/AS-659 staleness guard
+		// drops zero-stamped prefetches (AcceptZeroGen=false).
+		Gen:         m.Session().AvailabilityGen,
 		PrefetchErr: errors.New("eks: access denied, ng: throttled"),
 	}
 
@@ -114,6 +116,9 @@ func TestAvailabilityPrefetchedMsg_NilPrefetchErrNoFlash(t *testing.T) {
 		IssueCounts:    map[string]int{},
 		IssueTruncated: map[string]bool{},
 		Resources:      map[string][]resource.Resource{},
+		// Stamp the live AvailabilityGen — AS-657/AS-659 staleness guard
+		// drops zero-stamped prefetches (AcceptZeroGen=false).
+		Gen: m.Session().AvailabilityGen,
 		// PrefetchErr left nil — happy path.
 	}
 

--- a/tests/unit/app_fetchers_dispatchers_test.go
+++ b/tests/unit/app_fetchers_dispatchers_test.go
@@ -667,3 +667,112 @@ func TestRefreshResourceListWithEnrichmentRerun_PassthroughAPIError(t *testing.T
 	// Any other type is also OK (batch, etc.)
 	t.Logf("wrapper passthrough returned %T — acceptable", msg)
 }
+
+// ────────────────────────────────────────────────────────────────────────────
+// TestFetchAdapter_CapturesGenAtDispatchTime
+// ────────────────────────────────────────────────────────────────────────────
+
+// TestFetchAdapter_CapturesGenAtDispatchTime verifies that fetchResources,
+// fetchIdentity, and fetchRevealValue capture the generation counter
+// SYNCHRONOUSLY at the call site — not lazily inside the goroutine closure.
+//
+// This is the critical correctness property: if gen is captured inside the
+// closure, a concurrent Rotate() that bumps the counter before the goroutine
+// runs would cause the message to carry the POST-rotate gen, bypassing the
+// stale guard entirely (the guard would see stamp==current and pass it).
+//
+// Test shape (mirrors connectAWS precedent at fetch_adapter.go:160-171):
+//  1. Capture the generation at dispatch time into dispatchGen.
+//  2. Build the tea.Cmd via the test-accessor (which internally calls the
+//     unexported fetch function with a fixed gen parameter).
+//  3. Rotate the session so the current gen no longer equals dispatchGen.
+//  4. Execute the cmd closure (synchronously — returns immediately with
+//     nil-clients error or ResourcesLoaded{Gen: dispatchGen}).
+//  5. Assert that the returned message carries Gen == dispatchGen, not the
+//     post-rotate gen.
+//
+// These tests FAIL TO COMPILE until Coder adds three exported test accessors
+// to internal/tui/app_accessors.go:
+//   - FetchResourcesCmdForTest(resourceType string, gen domain.Gen) tea.Cmd
+//   - FetchIdentityCmdForTest(gen domain.Gen) tea.Cmd
+//   - FetchRevealValueCmdForTest(resourceType, resourceID string, gen domain.Gen) tea.Cmd
+func TestFetchAdapter_CapturesGenAtDispatchTime(t *testing.T) {
+	withTuiVersion(t, "test")
+
+	t.Run("fetchResources", func(t *testing.T) {
+		m := newRootSizedModel()
+		dispatchGen := m.Session().AvailabilityGen
+
+		// Build the cmd at dispatch time with the captured gen.
+		cmd := m.FetchResourcesCmdForTest("ec2", dispatchGen)
+
+		// Rotate AFTER dispatch: the closure must carry dispatchGen, not the new gen.
+		m.Session().Rotate()
+		if m.Session().AvailabilityGen == dispatchGen {
+			t.Fatal("Rotate() did not bump AvailabilityGen — test precondition broken")
+		}
+
+		// Execute the closure synchronously (nil clients → APIError or ResourcesLoaded).
+		msg := cmd()
+		switch v := msg.(type) {
+		case messages.ResourcesLoaded:
+			if v.Gen != dispatchGen {
+				t.Errorf("fetchResources: Gen in ResourcesLoaded = %d, want dispatchGen %d — gen captured inside closure, not at dispatch site", v.Gen, dispatchGen)
+			}
+		case messages.APIError:
+			if v.Gen != dispatchGen {
+				t.Errorf("fetchResources: Gen in APIError = %d, want dispatchGen %d — gen captured inside closure, not at dispatch site", v.Gen, dispatchGen)
+			}
+		default:
+			t.Logf("fetchResources returned %T — checking not possible for this type; nil-clients guard may have fired before gen stamp", msg)
+		}
+	})
+
+	t.Run("fetchIdentity", func(t *testing.T) {
+		m := newRootSizedModel()
+		dispatchGen := m.Session().ConnectGen
+
+		cmd := m.FetchIdentityCmdForTest(dispatchGen)
+
+		m.Session().Rotate()
+		if m.Session().ConnectGen == dispatchGen {
+			t.Fatal("Rotate() did not bump ConnectGen — test precondition broken")
+		}
+
+		msg := cmd()
+		switch v := msg.(type) {
+		case messages.IdentityLoaded:
+			if v.Gen != dispatchGen {
+				t.Errorf("fetchIdentity: Gen in IdentityLoaded = %d, want dispatchGen %d — gen captured inside closure", v.Gen, dispatchGen)
+			}
+		case messages.IdentityError:
+			if v.Gen != dispatchGen {
+				t.Errorf("fetchIdentity: Gen in IdentityError = %d, want dispatchGen %d — gen captured inside closure", v.Gen, dispatchGen)
+			}
+		default:
+			t.Logf("fetchIdentity returned %T — cannot assert Gen on this type", msg)
+		}
+	})
+
+	t.Run("fetchRevealValue", func(t *testing.T) {
+		m := newRootSizedModel()
+		dispatchGen := m.Session().ConnectGen
+
+		cmd := m.FetchRevealValueCmdForTest("secrets", "prod/api/key", dispatchGen)
+
+		m.Session().Rotate()
+		if m.Session().ConnectGen == dispatchGen {
+			t.Fatal("Rotate() did not bump ConnectGen — test precondition broken")
+		}
+
+		msg := cmd()
+		switch v := msg.(type) {
+		case messages.ValueRevealed:
+			if v.Gen != dispatchGen {
+				t.Errorf("fetchRevealValue: Gen in ValueRevealed = %d, want dispatchGen %d — gen captured inside closure", v.Gen, dispatchGen)
+			}
+		default:
+			t.Logf("fetchRevealValue returned %T — cannot assert Gen on this type", msg)
+		}
+	})
+}

--- a/tests/unit/app_fetchers_dispatchers_test.go
+++ b/tests/unit/app_fetchers_dispatchers_test.go
@@ -507,11 +507,13 @@ func TestSaveAvailabilityCache_NoCacheMode(t *testing.T) {
 	// Deliver AvailabilityCheckedMsg that simulates the all-done state.
 	// This triggers the "all checks done" branch in handleAvailabilityChecked
 	// which calls saveAvailabilityCache. With noCache=true it's a no-op (nil cmd).
+	// Stamp the live AvailabilityGen so the AS-657/AS-659 stale guard accepts
+	// the message (AcceptZeroGen=false; session.New seeds AvailabilityGen=1).
 	_, cmd := rootApplyMsg(m, messages.AvailabilityChecked{
 		ResourceType: "ec2",
 		HasResources: true,
 		Count:        3,
-		Gen:          0,
+		Gen:          m.Session().AvailabilityGen,
 	})
 	// With noCache=true, saveAvailabilityCache returns nil.
 	// No panic is the key assertion.
@@ -582,12 +584,14 @@ func TestDemoPrefetchCounts_AvailabilityPrefetchedHandler(t *testing.T) {
 	withTuiVersion(t, "test")
 	m := newRootSizedModel()
 
-	// Gen 0 matches initial availabilityGen.
+	// Stamp the live AvailabilityGen so the AS-657/AS-659 staleness guard
+	// accepts the message (AcceptZeroGen=false after AS-659; session.New seeds
+	// AvailabilityGen=1).
 	_, cmd := rootApplyMsg(m, messages.AvailabilityPrefetched{
 		Entries:     map[string]int{"ec2": 7, "s3": 3},
 		Truncated:   map[string]bool{},
 		IssueCounts: map[string]int{"ec2": 1},
-		Gen:         0,
+		Gen:         m.Session().AvailabilityGen,
 		Resources:   map[string][]resource.Resource{},
 	})
 	// Handler should not crash.

--- a/tests/unit/enrich_queue_test.go
+++ b/tests/unit/enrich_queue_test.go
@@ -56,6 +56,9 @@ func seedAllEnricherTypes(m tui.Model) (tui.Model, tea.Cmd) {
 	m, cmd := rootApplyMsg(m, messages.AvailabilityPrefetched{
 		Entries:   make(map[string]int),
 		Resources: allResources,
+		// Stamp the live AvailabilityGen so the AS-657/AS-659 staleness guard
+		// accepts the message (AcceptZeroGen=false after AS-659).
+		Gen: m.Session().AvailabilityGen,
 	})
 	return m, cmd
 }
@@ -72,6 +75,9 @@ func seedEnricherSubset(m tui.Model, names []string) (tui.Model, tea.Cmd) {
 	m, cmd := rootApplyMsg(m, messages.AvailabilityPrefetched{
 		Entries:   make(map[string]int),
 		Resources: subset,
+		// Stamp the live AvailabilityGen so the AS-657/AS-659 staleness guard
+		// accepts the message (AcceptZeroGen=false after AS-659).
+		Gen: m.Session().AvailabilityGen,
 	})
 	return m, cmd
 }

--- a/tests/unit/generation_stamping_fetch_test.go
+++ b/tests/unit/generation_stamping_fetch_test.go
@@ -250,64 +250,91 @@ func TestHappyPath_MatchingGen_ValueRevealed(t *testing.T) {
 	}
 }
 
-// TestHappyPath_ZeroGen_AcceptedByAllThree verifies that Gen==0 is never treated
-// as stale for ResourcesLoaded, IdentityLoaded, or ValueRevealed (AcceptZeroGen=true).
-// This covers the --demo / --no-cache bootstrap where Rotate() has not been called
-// and AvailabilityGen/ConnectGen start at zero.
+// TestHappyPath_ZeroGen_AcceptedByAllThree pins AcceptZeroGen=true for
+// ResourcesLoaded, IdentityLoaded, and ValueRevealed. The contract: a Gen=0
+// stamp must be accepted regardless of the live counter, because legacy/demo
+// /--no-cache/test callers dispatch these messages without a Gen field set.
+//
+// Each subtest forces the relevant live counter to a non-zero value before
+// dispatching a Gen=0 message, so the assertion exercises the IsStale
+// "stamp == 0 && AcceptZeroGen()" branch (messages/messages.go:71) rather
+// than the trivial "stamp == currentGen" path.
+//
+// Note: the prior version of this test gated on `m.Session().AvailabilityGen
+// == 0` on a fresh session. The AS-659 seed `AvailabilityGen=1` in
+// `session.New()` (this same PR) makes that precondition unsatisfiable, which
+// would silently skip the entire test post-merge.
 func TestHappyPath_ZeroGen_AcceptedByAllThree(t *testing.T) {
-	m := newRootSizedModel()
-
-	// AvailabilityGen and ConnectGen start at 0 on a fresh session.
-	if got := m.Session().AvailabilityGen; got != 0 {
-		t.Skipf("test requires initial AvailabilityGen==0, got %d (Rotate already called)", got)
-	}
-
-	// ResourcesLoaded with Gen=0 must be applied.
-	m, _ = rootApplyMsg(m, messages.Navigate{
-		Target:       messages.TargetResourceList,
-		ResourceType: "ec2",
-	})
-	m, _ = rootApplyMsg(m, messages.ResourcesLoaded{
-		ResourceType: "ec2",
-		Resources:    []resource.Resource{{ID: "i-zero-gen", Name: "zero-gen-server"}},
-		Gen:          domain.Gen(0),
-	})
-	got := m.ActiveListResources()
-	found := false
-	for _, r := range got {
-		if r.ID == "i-zero-gen" {
-			found = true
-			break
+	t.Run("ResourcesLoaded", func(t *testing.T) {
+		m := newRootSizedModel()
+		// Force AvailabilityGen non-zero so a Gen=0 dispatch can only succeed
+		// via the AcceptZeroGen=true branch in IsStale.
+		m.Session().Rotate()
+		if got := m.Session().AvailabilityGen; got == 0 {
+			t.Fatalf("precondition: AvailabilityGen must be non-zero, got 0")
 		}
-	}
-	if !found {
-		t.Error("ResourcesLoaded with Gen=0 was dropped on fresh session — AcceptZeroGen=true regression")
-	}
 
-	// IdentityLoaded with Gen=0 must be applied.
-	m2 := newRootSizedModel()
-	freshID := &awsclient.CallerIdentity{AccountID: "zero-gen-account"}
-	m2, _ = rootApplyMsg(m2, messages.IdentityLoaded{
-		Identity: freshID,
-		Gen:      domain.Gen(0),
+		m, _ = rootApplyMsg(m, messages.Navigate{
+			Target:       messages.TargetResourceList,
+			ResourceType: "ec2",
+		})
+		m, _ = rootApplyMsg(m, messages.ResourcesLoaded{
+			ResourceType: "ec2",
+			Resources:    []resource.Resource{{ID: "i-zero-gen", Name: "zero-gen-server"}},
+			Gen:          domain.Gen(0),
+		})
+		got := m.ActiveListResources()
+		found := false
+		for _, r := range got {
+			if r.ID == "i-zero-gen" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("ResourcesLoaded with Gen=0 was dropped while AvailabilityGen!=0 — AcceptZeroGen=true regression")
+		}
 	})
-	if m2.Session().Identity == nil {
-		t.Error("IdentityLoaded with Gen=0 was dropped on fresh session — AcceptZeroGen=true regression")
-	}
 
-	// ValueRevealed with Gen=0 must be applied (reveal view pushed).
-	m3 := newRootSizedModel()
-	const zeroGenSecret = "ZERO_GEN_SECRET_demo_mode_xyz"
-	m3, _ = rootApplyMsg(m3, messages.ValueRevealed{
-		ResourceType: "secrets",
-		ResourceID:   "demo/key",
-		Value:        zeroGenSecret,
-		Gen:          domain.Gen(0),
+	t.Run("IdentityLoaded", func(t *testing.T) {
+		m := newRootSizedModel()
+		// Force ConnectGen non-zero so the AcceptZeroGen branch is the only
+		// path that admits a Gen=0 IdentityLoaded.
+		m.Session().Rotate()
+		if got := m.Session().ConnectGen; got == 0 {
+			t.Fatalf("precondition: ConnectGen must be non-zero, got 0")
+		}
+
+		freshID := &awsclient.CallerIdentity{AccountID: "zero-gen-account"}
+		m, _ = rootApplyMsg(m, messages.IdentityLoaded{
+			Identity: freshID,
+			Gen:      domain.Gen(0),
+		})
+		if m.Session().Identity == nil {
+			t.Error("IdentityLoaded with Gen=0 was dropped while ConnectGen!=0 — AcceptZeroGen=true regression")
+		}
 	})
-	plain3 := stripANSI(rootViewContent(m3))
-	if !strings.Contains(plain3, zeroGenSecret) {
-		t.Errorf("ValueRevealed with Gen=0 was dropped on fresh session — AcceptZeroGen=true regression; rendered: %q", plain3)
-	}
+
+	t.Run("ValueRevealed", func(t *testing.T) {
+		m := newRootSizedModel()
+		// Force ConnectGen non-zero (ValueRevealed uses AspectConnect).
+		m.Session().Rotate()
+		if got := m.Session().ConnectGen; got == 0 {
+			t.Fatalf("precondition: ConnectGen must be non-zero, got 0")
+		}
+
+		const zeroGenSecret = "ZERO_GEN_SECRET_demo_mode_xyz"
+		m, _ = rootApplyMsg(m, messages.ValueRevealed{
+			ResourceType: "secrets",
+			ResourceID:   "demo/key",
+			Value:        zeroGenSecret,
+			Gen:          domain.Gen(0),
+		})
+		plain := stripANSI(rootViewContent(m))
+		if !strings.Contains(plain, zeroGenSecret) {
+			t.Errorf("ValueRevealed with Gen=0 was dropped while ConnectGen!=0 — AcceptZeroGen=true regression; rendered: %q", plain)
+		}
+	})
 }
 
 // ── AC #5 — stale APIError / IdentityError do not flash ─────────────────────

--- a/tests/unit/generation_stamping_fetch_test.go
+++ b/tests/unit/generation_stamping_fetch_test.go
@@ -435,6 +435,88 @@ func TestIdentityError_Fresh_DoesProcess(t *testing.T) {
 	}
 }
 
+// ── AC #6 (AS-659) — stale AvailabilityPrefetched is dropped ────────────────
+
+// TestAvailabilityPrefetched_Stale_Dropped pins the AS-648-h4 / AS-659 contract:
+// an AvailabilityPrefetched whose Gen no longer matches the live
+// Session.AvailabilityGen (because Rotate() has bumped the counter past it) must
+// be discarded. Without the guard, the demoPrefetchCounts dispatch path
+// captures Session.AvailabilityGen at dispatch time and a slow pre-switch
+// prefetch can repopulate menu counts and ResourceCache for the new
+// profile/region.
+//
+// Reverting AvailabilityPrefetched.AcceptZeroGen() back to true OR removing
+// the AvailabilityGen=1 seed in session.New() resurrects the bug: a
+// zero-stamped prefetch would silently bypass the guard once AvailabilityGen
+// is non-zero, contaminating the post-rotate session.
+//
+// Mirrors TestResourcesLoaded_Stale_Dropped — same pre-rotate / post-rotate
+// staleGen capture pattern.
+func TestAvailabilityPrefetched_Stale_Dropped(t *testing.T) {
+	m := newRootSizedModel()
+
+	// AvailabilityGen seeded at 1 by session.New(); rotate once so staleGen > 1.
+	m.Session().Rotate()
+
+	// Capture stale gen (non-zero) BEFORE the second Rotate.
+	staleGen := m.Session().AvailabilityGen
+	if staleGen == 0 {
+		t.Fatal("precondition failed: staleGen must be non-zero to test IsStale guard (AcceptZeroGen=false rejects zero unconditionally)")
+	}
+
+	// Second Rotate bumps AvailabilityGen past staleGen and clears caches.
+	m.Session().Rotate()
+	if m.Session().AvailabilityGen == staleGen {
+		t.Fatalf("precondition failed: Rotate() must advance AvailabilityGen past staleGen=%d", staleGen)
+	}
+
+	// Dispatch a stale AvailabilityPrefetched from the pre-rotate session.
+	const targetType = "ec2"
+	staleResource := resource.Resource{ID: "i-stale-prefetch", Name: "stale-prefetch-target"}
+	staleMsg := messages.AvailabilityPrefetched{
+		Entries:        map[string]int{targetType: 1},
+		Truncated:      map[string]bool{},
+		IssueCounts:    map[string]int{},
+		IssueTruncated: map[string]bool{},
+		Resources:      map[string][]resource.Resource{targetType: {staleResource}},
+		Pagination:     map[string]*resource.PaginationMeta{},
+		Gen:            staleGen,
+	}
+	m, _ = rootApplyMsg(m, staleMsg)
+
+	// ResourceCache must NOT have been seeded — the stale prefetch was dropped.
+	if entry, ok := m.Session().ResourceCache[targetType]; ok {
+		t.Errorf("stale AvailabilityPrefetched was NOT dropped: ResourceCache[%q]=%+v — post-rotate session contaminated by pre-rotate prefetch (AS-648-h4 regression)", targetType, entry)
+	}
+}
+
+// TestAvailabilityPrefetched_ZeroGen_Dropped pins the symmetric guard: a
+// zero-stamped AvailabilityPrefetched is also stale (AcceptZeroGen=false) and
+// must be dropped even if no Rotate() has happened yet. Without the
+// AvailabilityGen=1 seed in session.New(), a legitimate first prefetch
+// captured Gen=0 and matched the live AvailabilityGen=0, so this test could
+// not even be written.
+func TestAvailabilityPrefetched_ZeroGen_Dropped(t *testing.T) {
+	m := newRootSizedModel()
+
+	// Fresh session: AvailabilityGen is seeded at 1 (AS-648-h4 / AS-659).
+	if got := m.Session().AvailabilityGen; got != 1 {
+		t.Fatalf("precondition failed: fresh AvailabilityGen = %d, want 1 (session.New seed)", got)
+	}
+
+	const targetType = "ec2"
+	zeroMsg := messages.AvailabilityPrefetched{
+		Entries:   map[string]int{targetType: 1},
+		Resources: map[string][]resource.Resource{targetType: {{ID: "i-zero", Name: "zero-stamped"}}},
+		Gen:       0,
+	}
+	m, _ = rootApplyMsg(m, zeroMsg)
+
+	if entry, ok := m.Session().ResourceCache[targetType]; ok {
+		t.Errorf("zero-stamped AvailabilityPrefetched was NOT dropped: ResourceCache[%q]=%+v — guard regression: AcceptZeroGen() must remain false", targetType, entry)
+	}
+}
+
 // ── helpers ──────────────────────────────────────────────────────────────────
 
 // errString is a minimal error implementation for test stubs.

--- a/tests/unit/generation_stamping_fetch_test.go
+++ b/tests/unit/generation_stamping_fetch_test.go
@@ -1,0 +1,443 @@
+// generation_stamping_fetch_test.go — regression tests for AS-657 session-stamp
+// guards on ResourcesLoaded / APIError / IdentityLoaded / IdentityError / ValueRevealed.
+//
+// These tests FAIL TO COMPILE on main (before AS-657 lands) because the five
+// message types in internal/runtime/messages/event.go do not yet carry a Gen
+// field. Once Coder adds:
+//   - Gen domain.Gen on each of the five types
+//   - GenStamp() / GenAspect() / AcceptZeroGen() methods
+//   - messages.IsStale guards at the top of each case branch in app.go
+// the tests compile AND pass.
+//
+// AC coverage:
+//   AC #1 — stale ResourcesLoaded is dropped (resources unchanged, cache not poisoned)
+//   AC #2 — stale IdentityLoaded is dropped (Session.Identity unchanged, header unchanged)
+//   AC #3 — stale ValueRevealed is dropped (reveal view not pushed, secret not rendered)
+//   AC #4 — happy path with matching gen applies all three message types
+//   AC #5 — stale APIError does not flash; stale IdentityError does not flash
+//
+// Harness pattern follows qa_clients_ready_flash_gen_test.go: real Session,
+// Rotate() to bump counters, synthesised messages with stale stamps, assert
+// observable state after Update().
+package unit
+
+import (
+	"strings"
+	"testing"
+
+	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
+	"github.com/k2m30/a9s/v3/internal/resource"
+	"github.com/k2m30/a9s/v3/internal/runtime/messages"
+)
+
+// ── AC #1 — stale ResourcesLoaded is dropped ────────────────────────────────
+
+// TestResourcesLoaded_Stale_Dropped verifies that a ResourcesLoaded arriving
+// after Session.Rotate() with Gen == pre-rotate AvailabilityGen is silently
+// discarded: the active resource list and the write-through ResourceCache must
+// remain unchanged.
+//
+// Reverting the messages.IsStale guard in app.go (case messages.ResourcesLoaded)
+// makes this test fail because the stale resources overwrite m.allResources.
+//
+// Setup: two Rotate() calls ensure staleGen > 0. AcceptZeroGen=true means a
+// Gen=0 stamp is never stale; we need a non-zero staleGen to truly test the guard.
+func TestResourcesLoaded_Stale_Dropped(t *testing.T) {
+	m := newRootSizedModel()
+
+	// Rotate once so AvailabilityGen becomes non-zero (starts at 0).
+	// This ensures staleGen > 0, bypassing AcceptZeroGen=true.
+	m.Session().Rotate()
+
+	// Navigate to ec2 list and load sentinel resources with the current (non-zero) gen.
+	m, _ = rootApplyMsg(m, messages.Navigate{
+		Target:       messages.TargetResourceList,
+		ResourceType: "ec2",
+	})
+	sentinel := []resource.Resource{
+		{ID: "i-before-rotate", Name: "before-rotate-server"},
+	}
+	m, _ = rootApplyMsg(m, messages.ResourcesLoaded{
+		ResourceType: "ec2",
+		Resources:    sentinel,
+		Gen:          m.Session().AvailabilityGen, // current non-zero gen — matches
+	})
+	// Verify baseline: sentinel resource is present.
+	if got := m.ActiveListResources(); len(got) == 0 || got[0].ID != "i-before-rotate" {
+		t.Fatalf("baseline: expected sentinel resource i-before-rotate in list, got %v", got)
+	}
+
+	// Capture stale gen (non-zero) BEFORE the second Rotate.
+	staleGen := m.Session().AvailabilityGen
+	if staleGen == 0 {
+		t.Fatal("precondition failed: staleGen must be non-zero to test IsStale guard (AcceptZeroGen=true would pass zero)")
+	}
+	// Second Rotate bumps AvailabilityGen to staleGen+1.
+	m.Session().Rotate()
+
+	// Dispatch a stale ResourcesLoaded (Gen == staleGen, current is staleGen+1).
+	staleMsg := messages.ResourcesLoaded{
+		ResourceType: "ec2",
+		Resources:    []resource.Resource{{ID: "i-stale-account", Name: "stale-server"}},
+		Gen:          staleGen,
+	}
+	m, _ = rootApplyMsg(m, staleMsg)
+
+	// Assert: active list resources must still be the sentinel (stale was dropped).
+	got := m.ActiveListResources()
+	for _, r := range got {
+		if r.ID == "i-stale-account" {
+			t.Errorf("stale ResourcesLoaded was NOT dropped: found i-stale-account in list after Rotate() — guard regression")
+		}
+	}
+}
+
+// ── AC #2 — stale IdentityLoaded is dropped ─────────────────────────────────
+
+// TestIdentityLoaded_Stale_Dropped verifies that a IdentityLoaded arriving after
+// Session.Rotate() with a stale ConnectGen stamp is discarded: Session.Identity
+// must remain nil (the pre-rotate Identity was cleared by Rotate()).
+//
+// This closes the "old account ID in header after profile switch" bug.
+// Reverting the IsStale guard in app.go (case messages.IdentityLoaded) makes
+// this test fail because Session.Identity is set to the stale value.
+//
+// Setup: Rotate() once to make ConnectGen non-zero, then capture staleGen,
+// then Rotate() again. AcceptZeroGen=true means Gen=0 is never stale.
+func TestIdentityLoaded_Stale_Dropped(t *testing.T) {
+	m := newRootSizedModel()
+
+	// First Rotate: ConnectGen becomes non-zero.
+	m.Session().Rotate()
+
+	// Capture stale ConnectGen (non-zero) BEFORE the second Rotate.
+	staleGen := m.Session().ConnectGen
+	if staleGen == 0 {
+		t.Fatal("precondition failed: staleGen must be non-zero to test IsStale guard")
+	}
+	// Second Rotate: ConnectGen becomes staleGen+1, Identity cleared.
+	m.Session().Rotate()
+
+	// Session.Identity is nil after Rotate() (per session.go:233).
+	if m.Session().Identity != nil {
+		t.Fatal("precondition failed: Session.Identity should be nil after Rotate()")
+	}
+
+	// Dispatch stale IdentityLoaded with pre-rotate stamp.
+	staleIdentity := &awsclient.CallerIdentity{AccountID: "111122223333"}
+	staleMsg := messages.IdentityLoaded{
+		Identity: staleIdentity,
+		Gen:      staleGen,
+	}
+	m, _ = rootApplyMsg(m, staleMsg)
+
+	// Session.Identity must still be nil — the stale message was dropped.
+	if m.Session().Identity != nil {
+		t.Errorf("stale IdentityLoaded was NOT dropped: Session.Identity = %+v, expected nil — guard regression", m.Session().Identity)
+	}
+}
+
+// ── AC #3 — stale ValueRevealed is dropped ──────────────────────────────────
+
+// TestValueRevealed_Stale_Dropped verifies that a ValueRevealed arriving after
+// Session.Rotate() with a stale ConnectGen stamp is discarded: the reveal view
+// must NOT be pushed, and the secret value must not appear in the rendered output.
+//
+// This closes the secret-value-leak path. Reverting the IsStale guard in app.go
+// (case messages.ValueRevealed) makes this test fail because pushView is called
+// with the stale secret.
+//
+// Setup: Rotate() once to make ConnectGen non-zero, then capture staleGen,
+// then Rotate() again. AcceptZeroGen=true means Gen=0 is never stale.
+func TestValueRevealed_Stale_Dropped(t *testing.T) {
+	m := newRootSizedModel()
+
+	// First Rotate: ConnectGen becomes non-zero.
+	m.Session().Rotate()
+
+	// Capture stale ConnectGen (non-zero) BEFORE the second Rotate.
+	staleGen := m.Session().ConnectGen
+	if staleGen == 0 {
+		t.Fatal("precondition failed: staleGen must be non-zero to test IsStale guard")
+	}
+	// Second Rotate: ConnectGen becomes staleGen+1.
+	m.Session().Rotate()
+
+	// The secret value from a previous profile that must NOT appear.
+	const staleSecret = "PREV_ACCOUNT_SECRET_VALUE_xyzzy_42"
+
+	// Dispatch stale ValueRevealed with pre-rotate stamp and no error.
+	staleMsg := messages.ValueRevealed{
+		ResourceType: "secrets",
+		ResourceID:   "prod/api/key",
+		Value:        staleSecret,
+		Gen:          staleGen,
+	}
+	m, _ = rootApplyMsg(m, staleMsg)
+
+	// The reveal view must not be in the rendered output.
+	rendered := rootViewContent(m)
+	plain := stripANSI(rendered)
+	if strings.Contains(plain, staleSecret) {
+		t.Errorf("stale ValueRevealed was NOT dropped: secret value %q appears in rendered output — guard regression (secret leak)", staleSecret)
+	}
+}
+
+// ── AC #4 — matching gen (happy path) applies all three message types ────────
+
+// TestHappyPath_MatchingGen_ResourcesLoaded verifies that a ResourcesLoaded with
+// Gen == current AvailabilityGen is applied: resources appear in the list.
+func TestHappyPath_MatchingGen_ResourcesLoaded(t *testing.T) {
+	m := newRootSizedModel()
+	m, _ = rootApplyMsg(m, messages.Navigate{
+		Target:       messages.TargetResourceList,
+		ResourceType: "ec2",
+	})
+	currentGen := m.Session().AvailabilityGen
+	m, _ = rootApplyMsg(m, messages.ResourcesLoaded{
+		ResourceType: "ec2",
+		Resources:    []resource.Resource{{ID: "i-fresh", Name: "fresh-server"}},
+		Gen:          currentGen,
+	})
+	got := m.ActiveListResources()
+	found := false
+	for _, r := range got {
+		if r.ID == "i-fresh" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("happy-path ResourcesLoaded with matching gen was not applied: resource i-fresh not found in %v", got)
+	}
+}
+
+// TestHappyPath_MatchingGen_IdentityLoaded verifies that IdentityLoaded with
+// Gen == current ConnectGen sets Session.Identity.
+func TestHappyPath_MatchingGen_IdentityLoaded(t *testing.T) {
+	m := newRootSizedModel()
+	currentGen := m.Session().ConnectGen
+	freshIdentity := &awsclient.CallerIdentity{AccountID: "999988887777"}
+	m, _ = rootApplyMsg(m, messages.IdentityLoaded{
+		Identity: freshIdentity,
+		Gen:      currentGen,
+	})
+	if m.Session().Identity == nil {
+		t.Fatal("happy-path IdentityLoaded with matching gen was not applied: Session.Identity is nil")
+	}
+	if m.Session().Identity.AccountID != "999988887777" {
+		t.Errorf("Session.Identity.AccountID = %q, want 999988887777", m.Session().Identity.AccountID)
+	}
+}
+
+// TestHappyPath_MatchingGen_ValueRevealed verifies that ValueRevealed with
+// Gen == current ConnectGen pushes the reveal view.
+func TestHappyPath_MatchingGen_ValueRevealed(t *testing.T) {
+	m := newRootSizedModel()
+	currentGen := m.Session().ConnectGen
+	const freshSecret = "FRESH_CURRENT_SESSION_SECRET_abc123"
+	m, _ = rootApplyMsg(m, messages.ValueRevealed{
+		ResourceType: "secrets",
+		ResourceID:   "prod/fresh-key",
+		Value:        freshSecret,
+		Gen:          currentGen,
+	})
+	rendered := rootViewContent(m)
+	plain := stripANSI(rendered)
+	if !strings.Contains(plain, freshSecret) {
+		t.Errorf("happy-path ValueRevealed with matching gen was not applied: secret %q not in rendered output", freshSecret)
+	}
+}
+
+// TestHappyPath_ZeroGen_AcceptedByAllThree verifies that Gen==0 is never treated
+// as stale for ResourcesLoaded, IdentityLoaded, or ValueRevealed (AcceptZeroGen=true).
+// This covers the --demo / --no-cache bootstrap where Rotate() has not been called
+// and AvailabilityGen/ConnectGen start at zero.
+func TestHappyPath_ZeroGen_AcceptedByAllThree(t *testing.T) {
+	m := newRootSizedModel()
+
+	// AvailabilityGen and ConnectGen start at 0 on a fresh session.
+	if got := m.Session().AvailabilityGen; got != 0 {
+		t.Skipf("test requires initial AvailabilityGen==0, got %d (Rotate already called)", got)
+	}
+
+	// ResourcesLoaded with Gen=0 must be applied.
+	m, _ = rootApplyMsg(m, messages.Navigate{
+		Target:       messages.TargetResourceList,
+		ResourceType: "ec2",
+	})
+	m, _ = rootApplyMsg(m, messages.ResourcesLoaded{
+		ResourceType: "ec2",
+		Resources:    []resource.Resource{{ID: "i-zero-gen", Name: "zero-gen-server"}},
+		Gen:          domain.Gen(0),
+	})
+	got := m.ActiveListResources()
+	found := false
+	for _, r := range got {
+		if r.ID == "i-zero-gen" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("ResourcesLoaded with Gen=0 was dropped on fresh session — AcceptZeroGen=true regression")
+	}
+
+	// IdentityLoaded with Gen=0 must be applied.
+	m2 := newRootSizedModel()
+	freshID := &awsclient.CallerIdentity{AccountID: "zero-gen-account"}
+	m2, _ = rootApplyMsg(m2, messages.IdentityLoaded{
+		Identity: freshID,
+		Gen:      domain.Gen(0),
+	})
+	if m2.Session().Identity == nil {
+		t.Error("IdentityLoaded with Gen=0 was dropped on fresh session — AcceptZeroGen=true regression")
+	}
+
+	// ValueRevealed with Gen=0 must be applied (reveal view pushed).
+	m3 := newRootSizedModel()
+	const zeroGenSecret = "ZERO_GEN_SECRET_demo_mode_xyz"
+	m3, _ = rootApplyMsg(m3, messages.ValueRevealed{
+		ResourceType: "secrets",
+		ResourceID:   "demo/key",
+		Value:        zeroGenSecret,
+		Gen:          domain.Gen(0),
+	})
+	plain3 := stripANSI(rootViewContent(m3))
+	if !strings.Contains(plain3, zeroGenSecret) {
+		t.Errorf("ValueRevealed with Gen=0 was dropped on fresh session — AcceptZeroGen=true regression; rendered: %q", plain3)
+	}
+}
+
+// ── AC #5 — stale APIError / IdentityError do not flash ─────────────────────
+
+// TestAPIError_Stale_NoFlash verifies that a stale APIError (Gen == pre-rotate
+// AvailabilityGen) does not advance flash.gen or render a flash message.
+//
+// The danger: without the guard, a slow "fetch ec2: ..." error from a previous
+// region arrives after the user switched and flashes a confusing error about a
+// region they already left.
+//
+// Setup: Rotate() once to make AvailabilityGen non-zero before capturing staleGen,
+// then Rotate() again. AcceptZeroGen=true means Gen=0 is never stale.
+func TestAPIError_Stale_NoFlash(t *testing.T) {
+	m := newRootSizedModel()
+
+	// First Rotate: AvailabilityGen becomes non-zero.
+	m.Session().Rotate()
+
+	// Establish baseline flash.gen (non-zero) via a legitimate flash.
+	m, _ = rootApplyMsg(m, messages.Flash{Text: "baseline flash"})
+	genBefore := m.FlashGen()
+	if genBefore == 0 {
+		t.Fatalf("precondition: baseline flash.gen should be >0 after Flash msg, got %d", genBefore)
+	}
+
+	// Capture stale gen (non-zero) and rotate a second time.
+	staleGen := m.Session().AvailabilityGen
+	if staleGen == 0 {
+		t.Fatal("precondition failed: staleGen must be non-zero to test IsStale guard")
+	}
+	m.Session().Rotate()
+
+	// Dispatch stale APIError.
+	staleErr := messages.APIError{
+		ResourceType: "ec2",
+		Err:          errString("stale region fetch error"),
+		Gen:          staleGen,
+	}
+	m, _ = rootApplyMsg(m, staleErr)
+
+	// flash.gen must be unchanged — stale error must not increment it.
+	if got := m.FlashGen(); got != genBefore {
+		t.Errorf("stale APIError advanced flash.gen: was %d, now %d — guard regression would show 'stale region fetch error' flash to user", genBefore, got)
+	}
+}
+
+// TestIdentityError_Stale_DoesNotClearFetching verifies that a stale IdentityError
+// (Gen == pre-rotate ConnectGen) does not clear Session.IdentityFetching for the
+// new session. Without the guard, a slow pre-rotate identity fetch that errors
+// would clear IdentityFetching=true set by the post-rotate dispatch, causing the
+// header spinner to disappear while a real fetch is still in flight.
+//
+// AC #5 companion for IdentityError: stale errors must not mutate session state.
+//
+// Setup: Rotate() once to make ConnectGen non-zero before capturing staleGen,
+// then Rotate() again. AcceptZeroGen=true means Gen=0 is never stale.
+func TestIdentityError_Stale_DoesNotClearFetching(t *testing.T) {
+	m := newRootSizedModel()
+
+	// First Rotate: ConnectGen becomes non-zero.
+	m.Session().Rotate()
+
+	// Capture stale ConnectGen (non-zero) and rotate a second time so a new
+	// identity fetch could be in flight for the post-rotate session.
+	staleGen := m.Session().ConnectGen
+	if staleGen == 0 {
+		t.Fatal("precondition failed: staleGen must be non-zero to test IsStale guard")
+	}
+	m.Session().Rotate()
+
+	// Simulate: a new identity fetch is in flight for the post-rotate session.
+	m.Session().IdentityFetching = true
+
+	// Dispatch stale IdentityError from the pre-rotate session.
+	staleErr := messages.IdentityError{
+		Err: "stale region identity error",
+		Gen: staleGen,
+	}
+	m, _ = rootApplyMsg(m, staleErr)
+
+	// IdentityFetching must still be true — the stale error must not clear it.
+	if !m.Session().IdentityFetching {
+		t.Errorf("stale IdentityError cleared Session.IdentityFetching for the new session — guard regression: post-rotate spinner would disappear while real fetch still in flight")
+	}
+}
+
+// ── Complement: fresh APIError / IdentityError DO flash ─────────────────────
+
+// TestAPIError_Fresh_DoesFlash verifies that a non-stale APIError (matching Gen)
+// does advance flash.gen (the error IS displayed to the user).
+func TestAPIError_Fresh_DoesFlash(t *testing.T) {
+	m := newRootSizedModel()
+
+	genBefore := m.FlashGen()
+	currentGen := m.Session().AvailabilityGen
+
+	m, _ = rootApplyMsg(m, messages.APIError{
+		ResourceType: "ec2",
+		Err:          errString("current region fetch error"),
+		Gen:          currentGen,
+	})
+
+	if got := m.FlashGen(); got == genBefore {
+		t.Errorf("fresh APIError did not advance flash.gen (was %d, still %d) — flash guard too broad", genBefore, got)
+	}
+}
+
+// TestIdentityError_Fresh_DoesProcess verifies that a non-stale IdentityError
+// (matching Gen) is processed (IdentityFetching cleared) without panicking.
+func TestIdentityError_Fresh_DoesProcess(t *testing.T) {
+	m := newRootSizedModel()
+
+	m.Session().IdentityFetching = true
+	currentGen := m.Session().ConnectGen
+
+	m, _ = rootApplyMsg(m, messages.IdentityError{
+		Err: "some identity error",
+		Gen: currentGen,
+	})
+
+	// handleIdentityError clears IdentityFetching.
+	if m.Session().IdentityFetching {
+		t.Error("fresh IdentityError was dropped or did not clear IdentityFetching — guard too broad")
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// errString is a minimal error implementation for test stubs.
+type errString string
+
+func (e errString) Error() string { return string(e) }

--- a/tests/unit/phase03_shim_wireups_test.go
+++ b/tests/unit/phase03_shim_wireups_test.go
@@ -146,9 +146,11 @@ func TestShim_ProbeResourcesPopulatesFindings(t *testing.T) {
 				HasResources: true,
 				Count:        1,
 				Truncated:    false,
-				Gen:          0,
-				Issues:       1,
-				Resources:    []resource.Resource{res},
+				// session.New seeds AvailabilityGen=1 (AS-659) — stamp the live
+				// value so the AvailabilityChecked stale guard accepts it.
+				Gen:       m.Session().AvailabilityGen,
+				Issues:    1,
+				Resources: []resource.Resource{res},
 			})
 
 			// The cache lookup must use the canonical short name, NOT the alias.
@@ -477,9 +479,11 @@ func TestShim_DeriveHelpersResolveAlias(t *testing.T) {
 		HasResources: true,
 		Count:        1,
 		Truncated:    false,
-		Gen:          0,
-		Issues:       1,
-		Resources:    []resource.Resource{res},
+		// session.New seeds AvailabilityGen=1 (AS-659) — stamp the live
+		// value so the AvailabilityChecked stale guard accepts it.
+		Gen:       m.Session().AvailabilityGen,
+		Issues:    1,
+		Resources: []resource.Resource{res},
 	})
 
 	// Step 2: send EnrichmentCheckedMsg with canonical "dbi" carrying wave2 finding.
@@ -576,9 +580,11 @@ func TestShim_DeriveHelpersResolveAlias_SingleResource(t *testing.T) {
 		HasResources: true,
 		Count:        1,
 		Truncated:    false,
-		Gen:          0,
-		Issues:       1,
-		Resources:    []resource.Resource{res},
+		// session.New seeds AvailabilityGen=1 (AS-659) — stamp the live
+		// value so the AvailabilityChecked stale guard accepts it.
+		Gen:       m.Session().AvailabilityGen,
+		Issues:    1,
+		Resources: []resource.Resource{res},
 	})
 
 	// Step 2: EnrichmentCheckedMsg with alias "rds" (mirrors real production path

--- a/tests/unit/qa_correctness_bugs_test.go
+++ b/tests/unit/qa_correctness_bugs_test.go
@@ -245,11 +245,13 @@ func TestBug191_LoadFromDirs_ThreeLayerMerge(t *testing.T) {
 // Bug #192: Availability probes must not declare "done" while probes in-flight
 // ════════════════════════════════════════════════════════════════════════════
 
-// The initial availability probe generation is 0 (set in tui.New before any
-// profile/region switch). AvailabilityCacheLoadedMsg does NOT increment the
-// generation — only profile/region switches do. So all probe results must
-// use Gen=0 to match the model's availabilityGen.
-const bug192InitialGen = 0
+// The initial availability probe generation is 1 (seeded in session.New per
+// AS-648-h4 / AS-659 so AvailabilityPrefetched/Checked cannot smuggle a
+// zero-stamped pre-rotation result past the staleness guard).
+// AvailabilityCacheLoadedMsg does NOT increment the generation — only
+// profile/region switches do. So all probe results must use Gen=1 to match
+// the fresh model's availabilityGen.
+const bug192InitialGen = 1
 
 // bug192Model creates a model ready for availability probe testing.
 func bug192Model(t *testing.T) tui.Model {

--- a/tests/unit/qa_enrich_pipeline_dispatch_test.go
+++ b/tests/unit/qa_enrich_pipeline_dispatch_test.go
@@ -92,16 +92,17 @@ func TestBuildEnrichQueue_DispatchesCodePipeline(t *testing.T) {
 
 	m := newRootSizedModel()
 	// isDemo must be false (default) so startEnrichment is not skipped.
-	// availabilityGen is 0 (initial). Gen: 0 in the message matches → not dropped.
 
 	// Deliver AvailabilityCheckedMsg to seed probeResources["pipeline"] and
 	// trigger the availability-probe finalization path that calls startEnrichment.
 	// availTotal starts at 0; after incrementing availChecked to 1, 1 >= 0 → finalize.
+	// session.New seeds AvailabilityGen=1 (AS-659) — stamp the live value so
+	// the AvailabilityChecked stale guard (AcceptZeroGen=false) accepts it.
 	_, cmd := rootApplyMsg(m, messages.AvailabilityChecked{
 		ResourceType: "pipeline",
 		Count:        1,
 		Truncated:    false,
-		Gen:          0, // matches initial availabilityGen == 0
+		Gen:          m.Session().AvailabilityGen,
 		Resources:    pipelineProbeResources(),
 	})
 

--- a/tests/unit/qa_partial_success_handlers_test.go
+++ b/tests/unit/qa_partial_success_handlers_test.go
@@ -57,7 +57,8 @@ func TestHandleAvailabilityChecked_PartialErrAppliesState(t *testing.T) {
 	}
 
 	// Dispatch the partial-success AvailabilityCheckedMsg.
-	// Gen=0 matches initial availabilityGen=0.
+	// session.New seeds AvailabilityGen=1 (AS-659) — stamp the live value so
+	// the AvailabilityChecked stale guard (AcceptZeroGen=false) accepts it.
 	m, cmd := rootApplyMsg(m, messages.AvailabilityChecked{
 		ResourceType: "ec2", // registered type so menu can track it
 		Err:          partialErr,
@@ -66,7 +67,7 @@ func TestHandleAvailabilityChecked_PartialErrAppliesState(t *testing.T) {
 		Resources:    partialResources,
 		Issues:       0,
 		Truncated:    false,
-		Gen:          0,
+		Gen:          m.Session().AvailabilityGen,
 	})
 
 	// CONTRACT 1: A FlashMsg with IsError=true must be emitted.
@@ -99,7 +100,7 @@ func TestHandleAvailabilityChecked_PartialErrAppliesState(t *testing.T) {
 	// retained, buildEnrichQueue includes "ec2" → enrichment is dispatched.
 	_, enrichCmd := rootApplyMsg(m, messages.AvailabilityChecked{
 		ResourceType: "dummy-for-finalize",
-		Gen:          0,
+		Gen:          m.Session().AvailabilityGen,
 		Count:        0,
 		HasResources: false,
 	})
@@ -138,13 +139,13 @@ func TestHandleAvailabilityChecked_HardErr_NoStateApplied(t *testing.T) {
 		HasResources: false,
 		Count:        0,
 		Resources:    nil,
-		Gen:          0,
+		Gen:          m.Session().AvailabilityGen,
 	})
 
 	// Hard failure: wave 2 must NOT be dispatched for lambda (no probe resources).
 	_, enrichCmd := rootApplyMsg(m, messages.AvailabilityChecked{
 		ResourceType: "dummy-finalize",
-		Gen:          0,
+		Gen:          m.Session().AvailabilityGen,
 	})
 	if enrichCmd != nil {
 		enrichMsgs := collectEnrichmentMsgs(enrichCmd)
@@ -187,7 +188,7 @@ func TestHandleEnrichmentChecked_PartialErrAppliesState(t *testing.T) {
 	// Seed probeResources["ec2"] so the handler can merge FieldUpdates.
 	m, _ = rootApplyMsg(m, messages.AvailabilityChecked{
 		ResourceType: "ec2",
-		Gen:          0,
+		Gen:          m.Session().AvailabilityGen,
 		Count:        1,
 		HasResources: true,
 		Resources: []resource.Resource{

--- a/tests/unit/qa_partial_success_probe_test.go
+++ b/tests/unit/qa_partial_success_probe_test.go
@@ -174,11 +174,12 @@ func TestProbeEnrichment_PartialSuccess(t *testing.T) {
 		{ID: "res-pe-002", Name: "res-pe-002", Status: "running"},
 	}
 	// Deliver AvailabilityCheckedMsg to seed probeResources[shortName].
-	// availabilityGen=0 and Gen=0 → guard passes.
+	// session.New seeds AvailabilityGen=1 (AS-659) — stamp the live value so
+	// the AvailabilityChecked stale guard (AcceptZeroGen=false) accepts it.
 	// availTotal=0 → availChecked(1) >= 0 → finalize → startEnrichment.
 	_, enrichCmd := rootApplyMsg(m, messages.AvailabilityChecked{
 		ResourceType: shortName,
-		Gen:          0,
+		Gen:          m.Session().AvailabilityGen,
 		Count:        len(probeRes),
 		HasResources: true,
 		Resources:    probeRes,

--- a/tests/unit/qa_prefetch_pagination_seed_test.go
+++ b/tests/unit/qa_prefetch_pagination_seed_test.go
@@ -55,7 +55,9 @@ func TestPrefetchPaginationSeed_PreservesNextToken(t *testing.T) {
 		IssueTruncated: map[string]bool{targetType: true},
 		Resources:      map[string][]resource.Resource{targetType: {first, second}},
 		Pagination:     map[string]*resource.PaginationMeta{targetType: wantMeta},
-		Gen:            0,
+		// Stamp the live AvailabilityGen so the AS-657/AS-659 staleness guard
+		// accepts the message (AcceptZeroGen=false after AS-659).
+		Gen: m.Session().AvailabilityGen,
 	})
 
 	entry, ok := m.Session().ResourceCache[targetType]
@@ -99,7 +101,9 @@ func TestPrefetchPaginationSeed_FallbackWhenPaginationOmitted(t *testing.T) {
 		IssueTruncated: map[string]bool{targetType: true},
 		Resources:      map[string][]resource.Resource{targetType: {r}},
 		// Pagination intentionally nil — pre-fix shape.
-		Gen: 0,
+		// Stamp the live AvailabilityGen so the AS-657/AS-659 staleness guard
+		// accepts the message (AcceptZeroGen=false after AS-659).
+		Gen: m.Session().AvailabilityGen,
 	})
 
 	entry, ok := m.Session().ResourceCache[targetType]

--- a/tests/unit/qa_probe_truncation_per_type_test.go
+++ b/tests/unit/qa_probe_truncation_per_type_test.go
@@ -94,7 +94,9 @@ func TestBuildResourceCacheSnapshot_ProbeAuthoritative_SinglePageComplete(t *tes
 		IssueCounts:    map[string]int{targetType: 0},
 		IssueTruncated: map[string]bool{targetType: false},
 		Resources:      map[string][]resource.Resource{targetType: {probeResource}},
-		Gen:            0, // Gen=0 is accepted unconditionally (test injection sentinel)
+		// Stamp the live AvailabilityGen so the AS-657/AS-659 staleness guard
+		// accepts the message (AcceptZeroGen=false after AS-659).
+		Gen: m.Session().AvailabilityGen,
 	})
 
 	// Navigate to src detail view so RelatedCheckStartedMsg is handled.
@@ -196,7 +198,9 @@ func TestBuildResourceCacheSnapshot_ProbeTruncated_StampsTrue(t *testing.T) {
 		IssueCounts:    map[string]int{targetType: 0},
 		IssueTruncated: map[string]bool{targetType: true},
 		Resources:      map[string][]resource.Resource{targetType: {probeResource}},
-		Gen:            0,
+		// Stamp the live AvailabilityGen so the AS-657/AS-659 staleness guard
+		// accepts the message (AcceptZeroGen=false after AS-659).
+		Gen: m.Session().AvailabilityGen,
 	})
 
 	srcRes := resource.Resource{ID: "pt2-src-001", Name: "pt2-src-001"}

--- a/tests/unit/qa_unified_issue_count_test.go
+++ b/tests/unit/qa_unified_issue_count_test.go
@@ -365,8 +365,9 @@ func TestUnifiedIssueCount_IgnoresTildeSeverityFindings(t *testing.T) {
 	t.Run("one ! finding + two ~ findings → count=1 (only ! counts)", func(t *testing.T) {
 		m := newRootSizedModel()
 
-		// Use AvailabilityCheckedMsg (Gen=0 matches fresh model's availabilityGen=0)
-		// to seed probeResources["ec2"] so unifiedIssueCount has wave1Resources.
+		// Use AvailabilityCheckedMsg stamped with the live AvailabilityGen
+		// (session.New seeds it to 1 after AS-659) to seed probeResources["ec2"]
+		// so unifiedIssueCount has wave1Resources.
 		// All three resources are running → Wave-1 contributes 0 to issue IDs.
 		resources := tildeSeverityEC2Instances()
 		m, _ = rootApplyMsg(m, messages.AvailabilityChecked{
@@ -374,7 +375,7 @@ func TestUnifiedIssueCount_IgnoresTildeSeverityFindings(t *testing.T) {
 			Count:        3,
 			Resources:    resources,
 			Issues:       0,
-			Gen:          0,
+			Gen:          m.Session().AvailabilityGen,
 		})
 
 		m = navigateToEC2List(m)
@@ -418,7 +419,7 @@ func TestUnifiedIssueCount_IgnoresTildeSeverityFindings(t *testing.T) {
 			Count:        3,
 			Resources:    resources,
 			Issues:       0,
-			Gen:          0,
+			Gen:          m.Session().AvailabilityGen,
 		})
 
 		m = navigateToEC2List(m)
@@ -465,7 +466,7 @@ func TestUnifiedIssueCount_IgnoresTildeSeverityFindings(t *testing.T) {
 			Count:        1,
 			Resources:    []resource.Resource{brokenResource},
 			Issues:       1, // Wave-1 issue
-			Gen:          0,
+			Gen:          m.Session().AvailabilityGen,
 		})
 
 		m = navigateToEC2List(m)

--- a/tests/unit/tui_wiring_test.go
+++ b/tests/unit/tui_wiring_test.go
@@ -378,12 +378,15 @@ func TestWiring_AvailabilityComplete_ClearsFlash(t *testing.T) {
 	// send len(AllShortNames()) messages total to drain everything.
 	allNames := resource.AllShortNames()
 	var lastCmd tea.Cmd
+	// session.New seeds AvailabilityGen=1 (AS-659) — capture and reuse so the
+	// AvailabilityChecked stale guard (AcceptZeroGen=false) accepts each msg.
+	gen := m.Session().AvailabilityGen
 	for _, name := range allNames {
 		m, lastCmd = rootApplyMsg(m, messages.AvailabilityChecked{
 			ResourceType: name,
 			HasResources: true,
 			Count:        1,
-			Gen:          0,
+			Gen:          gen,
 		})
 	}
 


### PR DESCRIPTION
## Summary

- **AS-659 (AS-648 P2 #6)**: `AvailabilityPrefetched.AcceptZeroGen()` now returns `false`. Mirrors the `AvailabilityChecked` stale-drop contract so a no-cache prefetch captured before `Session.Rotate()` cannot smuggle a zero-stamped result past the staleness guard and contaminate the new profile/region menu counts + `ResourceCache`.
- **AS-659 init**: `session.New()` now seeds `AvailabilityGen=1` (mirrors `RelatedGen`, `EnrichGen`, `EnrichmentGen` seed convention) so the legitimate first prefetch on a fresh session still passes the guard.
- **AS-657 (picked up from in-progress working tree)**: completes the stale-drop wiring the bae65f9 test commit needed in order to compile.
  - `ResourcesLoaded` / `APIError` / `ValueRevealed` / `IdentityLoaded` / `IdentityError` now carry `Gen domain.Gen` and implement `GenStamped`. `AcceptZeroGen()` returns `true` so existing test/demo callers that omit `Gen` keep working.
  - `internal/tui/fetch_adapter.go` captures the dispatch-time `AvailabilityGen` / `ConnectGen` at every call site and stamps it onto the returned message.
  - `app.go` routes those five message types through `messages.IsStale` before the handler runs.
  - `views/resourcelist.go` relaxes the AS-652 type-mismatch guard so child-view lists (`parentContext != nil`) and tests that omit `ResourceType` are not stranded in `Loading`.
- **Test fixture updates**: tests that explicitly used `Gen:0` for `AvailabilityPrefetched` / `AvailabilityChecked` are updated to stamp `m.Session().AvailabilityGen` so the `AcceptZeroGen=false` guard accepts them on a fresh session.

## New regression pins (AS-659)

- `TestAvailabilityPrefetched_Stale_Dropped` — mirrors the AS-657 stale-drop pattern: pre-rotate gen captured, two `Rotate()` calls bump the live counter past it, the stale prefetch must not seed `ResourceCache`.
- `TestAvailabilityPrefetched_ZeroGen_Dropped` — pins `AcceptZeroGen=false`: a `Gen:0` prefetch is dropped even on a fresh session because `New()` now seeds `AvailabilityGen=1`.

## Test plan

- [x] `go build ./...` clean
- [x] `golangci-lint run ./internal/... ./tests/...` — 0 issues
- [x] `govulncheck ./...` — no vulnerabilities
- [x] `go test ./...` — all green except one pre-existing failure unrelated to this PR: `TestEnrichment_UpdatesStackedResourceListWhenDetailActive` (stacked `ResourceListModel` not receiving Wave-2 findings; separate enrichment bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)