### PR TITLE
docs(comment): cite probe_adapter.go after Phase-05 dispatcher move (AS-662)

### DIFF
--- a/internal/aws/issue_enrichment.go
+++ b/internal/aws/issue_enrichment.go
@@ -156,8 +156,9 @@ type IssueEnricherResult struct {
 // (internal/resource/enricher.go) which enriches a single resource for detail views.
 //
 // Cache invariant — read-only shallow snapshot:
-// The dispatcher (internal/tui/app_probes.go probeEnrichment) builds the cache
-// once at dispatch time via m.buildResourceCacheSnapshot() and passes the
+// The TUI dispatcher (internal/tui/probe_adapter.go probeEnrichment tea.Cmd wrapper)
+// invokes (*Core).ProbeEnrichment, which builds the cache once at dispatch time via
+// (*Core).BuildResourceCacheSnapshot in internal/runtime/probes.go and passes the
 // resulting map by value. The map and its ResourceCacheEntry structs are
 // freshly allocated, but the .Resources slice header is COPIED — its backing
 // array is shared with the live m.resourceCache / m.probeResources / m.lazyResourceCache


### PR DESCRIPTION
## Summary

Follow-up to AS-661 / PR #378. The Wave-2 cache-invariant comment in `internal/aws/issue_enrichment.go` still referenced the removed `internal/tui/app_probes.go` path. The dispatcher was split during the Phase-05 runtime-core migration (AS-237):

- `(*Core).ProbeEnrichment` in `internal/runtime/probes.go` is the function that builds the `ResourceCache` snapshot at dispatch time (via `(*Core).BuildResourceCacheSnapshot`).
- `(*Model).probeEnrichment` in `internal/tui/probe_adapter.go` is the `tea.Cmd` wrapper that invokes the runtime function.

Comment-only edit; no Go semantics affected.

## Diff

```diff
-// The dispatcher (internal/tui/app_probes.go probeEnrichment) builds the cache
-// once at dispatch time via m.buildResourceCacheSnapshot() and passes the
+// The TUI dispatcher (internal/tui/probe_adapter.go probeEnrichment tea.Cmd wrapper)
+// invokes (*Core).ProbeEnrichment, which builds the cache once at dispatch time via
+// (*Core).BuildResourceCacheSnapshot in internal/runtime/probes.go and passes the
```

## Test plan

- [x] `go build ./...` — clean
- [x] `golangci-lint run ./...` — `0 issues`
- [x] Per issue body: size XS (≤5 LOC, single file, comment-only) — skips `ready-to-push`. One reviewer (CodeReviewer self-verdict on the implementing surface) is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)