### PR TITLE
feat(as-726): catalog-authoritative cutover for messaging types (PR-04i)

### DIFF
--- a/docs/refactor/AS-726-pr04i-messaging.md
+++ b/docs/refactor/AS-726-pr04i-messaging.md
@@ -1,0 +1,469 @@
+# AS-726 — PR-04i — Catalog population, messaging category
+
+Stage 2 spec. Sole owner: Architect. Status when written: in_progress.
+Parent program: [AS-651](../../AS/issues/AS-651). Prereq: AS-718 (PR-04a) — done.
+Sibling refactor docs: `04-catalog.md` (Phase 04 master plan), `AS-660-session-store-relocation.md` (per-PR spec precedent).
+
+## Problem statement
+
+Phase 04 makes `internal/catalog` the single source of truth for resource-type metadata
+(`var ResourceTypes`) and the registry world (`Register*` in `internal/resource`,
+`registerIssueEnricher` in `internal/aws/issue_enrichment.go`) is supposed to disappear.
+Commit `6afe866` (phase-04-pr04f-m bundle) populated `internal/catalog/types_messaging.go`
+with identity, columns, children, color, CloudTrailKey, and lifecycle metadata for the
+nine messaging top-level types — but did NOT migrate the behavior wiring (Fetcher, Wave 2
+enricher, Related defs, Navigable fields, FieldKeys). Those 24 `init()` calls still run
+in `internal/aws/*.go` and still register into the legacy `internal/resource` maps. The
+runtime then hits the catalog first via wrappers, falls through to the legacy map for
+every messaging type, and works — but the legacy registrations remain authoritative
+and the catalog rows are partial.
+
+AS-726 finishes the cutover for the messaging category: messaging types' behavior wiring
+lives on the catalog row, the legacy registrations for those types vanish, NoOp-only
+enrichment files (`sns_sub_issue_enrichment.go`, `kinesis_issue_enrichment.go`) are deleted,
+and the demo path + tests still pass.
+
+## Scope (in)
+
+Top-level messaging types (9 entries already in `messagingTypes`):
+
+`sqs`, `sns`, `sns-sub`, `eb-rule`, `kinesis`, `msk`, `sfn`, `ses`, plus
+the child-view stubs implied by their `Children:` slices:
+`sns_subscriptions`, `eb_rule_targets`, `sfn_executions`, `sfn_execution_history`.
+
+Service files touched (29 in `internal/aws/`):
+
+```
+internal/aws/sqs.go
+internal/aws/sqs_related.go
+internal/aws/sqs_issue_enrichment.go
+internal/aws/sns.go
+internal/aws/sns_related.go
+internal/aws/sns_issue_enrichment.go
+internal/aws/sns_sub.go
+internal/aws/sns_sub_by_topic.go
+internal/aws/sns_sub_related.go
+internal/aws/sns_sub_issue_enrichment.go     [DELETE]
+internal/aws/eb_rule.go
+internal/aws/eb_rule_related.go
+internal/aws/eb_rule_targets.go
+internal/aws/eb_rule_issue_enrichment.go
+internal/aws/kinesis.go
+internal/aws/kinesis_related.go
+internal/aws/kinesis_issue_enrichment.go     [DELETE]
+internal/aws/msk.go
+internal/aws/msk_related.go
+internal/aws/msk_issue_enrichment.go
+internal/aws/sfn.go
+internal/aws/sfn_executions.go
+internal/aws/sfn_execution_history.go
+internal/aws/sfn_issue_enrichment.go
+internal/aws/ses.go
+internal/aws/ses_issue_enrichment.go
+```
+
+Out of scope for messaging (NOT touched by this PR):
+
+- `internal/aws/eb_related.go`, `internal/aws/eb_issue_enrichment.go` — these wire the
+  Elastic Beanstalk (`eb`) top-level type, which lives in the COMPUTE category. They will
+  be migrated by the compute follow-up PR.
+- Compute / containers / databases / networking / monitoring / secrets / dns_cdn /
+  security / cicd / data / backup categories' init()s. Those are sibling cutovers under
+  AS-651, not AS-726.
+- `internal/ui/styles/severity.go` and the `Color` field on `ResourceTypeDef`. AS-718
+  was supposed to add `internal/ui/styles/severity.go` (CodexReviewer NEEDS CHANGES on
+  AS-718 still records this as a deferred fix) but did not. Color→severity inline
+  migration is therefore impossible to land in AS-726 — the destination infra does not
+  exist. The messaging `Color` helpers stay inline in `internal/catalog/types_messaging.go`
+  (where commit `6afe866` already placed them). This is a deviation from the issue
+  description's step 7; see "Acceptance deviations" below.
+
+## Scope (out — deferred to follow-ups)
+
+- **Import-direction flip (`internal/catalog` → `internal/aws`).** The literal exit
+  criterion 3 ("Zero `init()` in messaging service files") implies catalog struct literals
+  reference fetcher/enricher function values defined in `internal/aws/*.go` directly,
+  which requires `internal/catalog` to import `internal/aws`. Today, `internal/aws/issue_enrichment.go`
+  imports `internal/catalog`, so the reverse import would cycle. Breaking the
+  `aws→catalog` edge (move `IssueEnricher` type + `GetIssueEnricher` + `IssueEnricherRegistry`
+  to a leaf package, then point `internal/catalog` at it) is a cross-cutting structural
+  change that affects every category, not just messaging. AS-726 keeps the existing
+  direction and uses **mutator registration** (mirroring the existing
+  `catalog.RegisterProject` / `catalog.RegisterAugment` pattern) so messaging can finish
+  without holding up the program. Recommended follow-up: file AS-N28 (after AS-727 lands)
+  to flip direction and eliminate the mutator stubs.
+
+- **Child-type promotion.** `sns_subscriptions`, `eb_rule_targets`, `sfn_executions`,
+  `sfn_execution_history` are not first-class `catalog.ResourceTypes` entries today;
+  they live in `internal/resource/childTypes` and are wired by
+  `resource.RegisterChildType` + `resource.RegisterPaginatedChild`. The catalog has no
+  child slot. Promoting child types is a cross-cutting catalog-shape decision that should
+  be set once for the program. AS-726 keeps the four child-view init()s using a new
+  catalog-side child registrar (`catalog.RegisterChildView`) so the legacy
+  `internal/resource/childTypes` map can become empty for messaging-derived child
+  types, and the catalog accessor (`catalog.FindChild`) becomes authoritative for
+  messaging children. Compute's child views (e.g. `ecs_tasks`, `lambda_invocations`)
+  continue to use the legacy path; they get the same treatment in their own PRs.
+
+## Acceptance deviations from the issue description
+
+The issue description's exit criterion 3 reads "Zero `init()` in messaging service files".
+That bar is unreachable in AS-726 without the import-direction flip discussed above.
+The achievable bar in this PR — which still completes the messaging cutover — is:
+
+> Every `init()` in `internal/aws/<messaging-services>*.go` calls only `catalog.Register*`
+> (the new mutator API in `internal/catalog/catalog.go`), never `resource.Register*` or
+> the legacy `registerIssueEnricher`. Legacy registrations for messaging types are removed
+> from `internal/aws/issue_enrichment.go`'s `IssueEnricherRegistry` map by virtue of
+> those calls no longer executing. After AS-726 the messaging category is **catalog-authoritative**
+> for Fetcher / Wave 2 / Related / Navigable / FieldKeys / IssueEnricherFieldKeys /
+> Children, with no legacy fallback consulted.
+
+This deviation is necessary, narrow, and documented. The board/CTO can override by
+expanding scope to include the import-direction flip — but that turns AS-726 from M
+into XL and should be filed separately.
+
+## Design
+
+### 1. New catalog fields on `ResourceTypeDef`
+
+Add two fields to `internal/catalog/types.go`'s `ResourceTypeDef` struct, below the
+existing `Findings` section:
+
+```go
+// FieldKeys lists the Resource.Fields keys produced by the fetcher for this
+// resource type. Used by detail-field rendering and column-key assertions.
+// Migrated from internal/resource fieldKeyRegistry.
+FieldKeys []string
+
+// IssueEnricherFieldKeys lists additional Resource.Fields keys produced by
+// the Wave 2 enricher via IssueEnricherResult.FieldUpdates. Unioned with
+// FieldKeys by GetAllFieldKeys consumers. Migrated from
+// internal/resource issueEnricherFieldKeysRegistry.
+IssueEnricherFieldKeys []string
+```
+
+These are simple `[]string` slices populated either in the static
+`messagingTypes` literal (preferred when the values are short and obvious — e.g.
+`sqs` has six fetcher keys) or via the new mutator API (when wiring is needed because
+the legacy `init()` already constructs them, and minimal diff is desired).
+
+### 2. New catalog mutator API (`internal/catalog/catalog.go`)
+
+Mirror the existing `RegisterProject` / `RegisterAugment` pattern. Each mutator
+finds the catalog row by `ShortName` and sets one field. No-op when the row is missing.
+Idempotent. Panics only on duplicate non-nil overwrite (safety against double-register).
+
+```go
+// RegisterFetcher sets the Wave 1 paginated fetcher on the named catalog row.
+// Panics if the row already has a non-nil Fetcher (duplicate registration).
+func RegisterFetcher(shortName string, fn domain.PaginatedFetcher)
+
+// RegisterWave2 sets the Wave 2 enricher on the named catalog row. The value is
+// a concrete aws.IssueEnricher (stored as any to avoid an import cycle).
+// Panics if the row already has a non-nil Wave2.
+func RegisterWave2(shortName string, enr any)
+
+// RegisterRelated sets the related-resource defs on the named catalog row.
+// Panics if the row already has non-empty Related.
+func RegisterRelated(shortName string, defs []domain.RelatedDef)
+
+// RegisterNavigable sets the navigable-field defs on the named catalog row.
+// Panics if the row already has non-empty Navigable.
+func RegisterNavigable(shortName string, fields []domain.NavigableField)
+
+// RegisterFieldKeys sets the fetcher-produced FieldKeys on the named catalog row.
+// Panics on duplicate.
+func RegisterFieldKeys(shortName string, keys []string)
+
+// RegisterIssueEnricherFieldKeys appends Wave 2 field keys on the named catalog row.
+// Idempotent — duplicates are deduplicated. Multiple enrichers may target the same
+// type and union their keys here.
+func RegisterIssueEnricherFieldKeys(shortName string, keys []string)
+
+// RegisterChildView registers a child-view ResourceTypeDef into the catalog's
+// child registry, keyed by ShortName. Child views are NOT in the top-level
+// ResourceTypes slice — they live in a separate childTypes map. Panics on duplicate.
+func RegisterChildView(child ResourceTypeDef)
+
+// FindChild returns the child-view ResourceTypeDef registered under the given
+// ShortName, or nil if not in the catalog's child registry. Case-insensitive.
+func FindChild(shortName string) *ResourceTypeDef
+```
+
+Storage for child views: a new package-level map in `internal/catalog/catalog.go`:
+
+```go
+var childTypes = map[string]ResourceTypeDef{} //nolint:gochecknoglobals // catalog child registry
+```
+
+### 3. Catalog-backed accessor wrappers in `internal/resource/registry.go`
+
+Update three legacy accessors to consult catalog first, fall back to legacy registry:
+
+- `GetFieldKeys(shortName) []string` — read `catalog.Find(shortName).FieldKeys` first.
+- `GetIssueEnricherFieldKeys(shortName) []string` — read `catalog.Find(shortName).IssueEnricherFieldKeys` first.
+- `GetPaginatedChildFetcher(shortName)` — already a wrapper in PR-04a; ensure the catalog
+  child-fetcher path is wired. If `catalog.FindChild(shortName) != nil`, return its
+  `Fetcher` (it's a `domain.PaginatedFetcher`, callable with `parentCtx` via a thin
+  adapter — see implementation note below).
+- `GetChildType(shortName) *ResourceTypeDef` (currently legacy-only per CXR NEEDS CHANGES
+  on AS-718) — route to `catalog.FindChild(shortName)` first.
+
+The signature for child fetchers differs (parent context). Two options:
+
+- **A.** Add a separate `domain.PaginatedChildFetcher` field on the catalog's child
+  `ResourceTypeDef` (a child entry uses it; top-level entries leave it nil). This is the
+  cleanest if a single `ResourceTypeDef` struct must do double-duty for top-level and
+  child rows.
+- **B.** Define a new minimal struct `catalog.ChildTypeDef` with only the fields children
+  use (Name, ShortName, Columns, CopyField, Children, FieldKeys, ChildFetcher), and have
+  `RegisterChildView` / `FindChild` take that smaller struct.
+
+**Choose A.** The current `internal/resource/ResourceTypeDef` (where children are
+registered today) already double-duties. Mirroring that minimizes diff and lets a future
+PR fold child rows into the top-level `ResourceTypes` slice if desired.
+
+So: add a `ChildFetcher domain.PaginatedChildFetcher` field to `catalog.ResourceTypeDef`
+(child-only). For child rows, `Fetcher` stays nil. For top-level rows, `ChildFetcher`
+stays nil.
+
+### 4. Messaging service file rewiring
+
+For each of the 24 init()-bearing messaging files in scope, replace every
+`resource.Register*` / `registerIssueEnricher` call with the equivalent `catalog.Register*`
+call. Do not change function signatures or behavior — only the registration target.
+
+Example transformation for `internal/aws/sqs.go`:
+
+```go
+// Before
+func init() {
+    resource.RegisterFieldKeys("sqs", []string{"queue_name", "queue_url", "arn", "approx_messages", "approx_not_visible", "delay_seconds"})
+    resource.RegisterPaginated("sqs", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+        // ... unchanged body
+    })
+}
+
+// After
+func init() {
+    catalog.RegisterFieldKeys("sqs", []string{"queue_name", "queue_url", "arn", "approx_messages", "approx_not_visible", "delay_seconds"})
+    catalog.RegisterFetcher("sqs", func(ctx context.Context, clients any, continuationToken string) (domain.FetchResult, error) {
+        // ... unchanged body
+    })
+}
+```
+
+`resource.FetchResult` and `domain.FetchResult` are the same type (`resource.FetchResult = domain.FetchResult`
+alias — verify pre-flight; if not aliased, use the type the catalog mutator signature names).
+
+For combined init()s (sfn.go has fetcher + related + navigable in one init; ses.go has
+fetcher + related; sns_sub_by_topic.go has child fetcher + child type):
+
+```go
+// sfn.go after
+func init() {
+    catalog.RegisterFieldKeys("sfn", []string{"name", "type", "arn", "creation_date"})
+    catalog.RegisterFetcher("sfn", func(...) (domain.FetchResult, error) { ... })
+    catalog.RegisterRelated("sfn", []domain.RelatedDef{ ...same six entries... })
+    catalog.RegisterNavigable("sfn", []domain.NavigableField{{FieldPath: "RoleArn", TargetType: "role"}})
+}
+```
+
+For Wave 2 enrichers (`*_issue_enrichment.go`):
+
+```go
+// sqs_issue_enrichment.go after
+func init() {
+    catalog.RegisterWave2("sqs", IssueEnricher{Fn: EnrichSQSAttributes, Priority: 100})
+    catalog.RegisterIssueEnricherFieldKeys("sqs", []string{"dlq"})
+}
+```
+
+The `IssueEnricher` literal here is the existing `aws.IssueEnricher` type (defined in
+`internal/aws/issue_enrichment.go`). Stored on the catalog row as `any` because
+`internal/catalog` can't reference `aws.IssueEnricher`. `aws.GetIssueEnricher` already
+casts `any → IssueEnricher`; that path is unchanged.
+
+For NoOp-only files:
+
+```go
+// sns_sub_issue_enrichment.go — DELETE entire file
+// kinesis_issue_enrichment.go — DELETE entire file
+```
+
+Rationale: with catalog-routed lookup, `ct.Wave2 == nil` IS the "no Wave 2" signal.
+`aws.GetIssueEnricher` correctly returns `(IssueEnricher{}, false)` when the catalog
+row exists and `Wave2` is nil. Verify with a unit test (`TestNoOpWave2ReturnsAbsent`).
+
+For child views (`sns_sub_by_topic.go`, `eb_rule_targets.go`, `sfn_executions.go`,
+`sfn_execution_history.go`):
+
+```go
+// sns_sub_by_topic.go after
+func init() {
+    catalog.RegisterChildView(catalog.ResourceTypeDef{
+        Name:         "SNS Subscriptions",
+        ShortName:    "sns_subscriptions",
+        Columns:      resource.SnsSubscriptionColumns(),
+        CopyField:    "endpoint",
+        FieldKeys:    []string{"protocol", "endpoint", "confirmation_status", "owner", "subscription_arn", "topic_arn"},
+        ChildFetcher: func(ctx context.Context, clients any, parentCtx domain.ParentContext, continuationToken string) (domain.FetchResult, error) {
+            c, ok := clients.(*ServiceClients)
+            if !ok || c == nil { return domain.FetchResult{}, fmt.Errorf("AWS clients not initialized") }
+            return FetchSNSTopicSubscriptions(ctx, c.SNS, parentCtx["topic_arn"], continuationToken)
+        },
+    })
+}
+```
+
+`resource.SnsSubscriptionColumns()` is an existing helper returning `[]resource.Column`.
+If `resource.Column = domain.Column` aliases (verify), keep the call site as-is.
+Otherwise inline the column literal.
+
+### 5. Tests
+
+The catalog-backed accessor wrappers already exist; messaging-type lookups now go
+through them. Most tests are unaffected. The tests that must change:
+
+- `tests/unit/architecture_conformance_test.go` — already iterates `catalog.ResourceTypes`
+  (per PR-04a). Add assertions that for every messaging row: `Fetcher != nil`,
+  `Related != nil` (where the legacy init() registered any), `FieldKeys` matches the
+  pre-cutover legacy values.
+- Tests that directly poke `resource.RegisterPaginated` / `resource.RegisterRelated` /
+  `registerIssueEnricher` for messaging types and assert state — these need to switch
+  to `catalog.RegisterFetcher` / `catalog.RegisterRelated` / `catalog.RegisterWave2`. QA
+  must grep for these patterns and migrate.
+- `tests/unit/qa_*messaging*.go` (if any) and `tests/unit/qa_sqs_*.go`, `qa_sns_*.go`,
+  `qa_eb_rule_*.go`, `qa_kinesis_*.go`, `qa_msk_*.go`, `qa_sfn_*.go`, `qa_ses_*.go` —
+  any setup helpers that re-register types for isolation need the catalog mutator.
+
+A new test: `TestMessagingCatalogIsAuthoritative` in `tests/unit/architecture_conformance_test.go`:
+
+```go
+// Asserts each messaging type's behavior wiring is on the catalog row, not in the
+// legacy resource registry. Fails if a legacy fallback would be required.
+func TestMessagingCatalogIsAuthoritative(t *testing.T) {
+    messagingShortNames := []string{"sqs", "sns", "sns-sub", "eb-rule", "kinesis", "msk", "sfn", "ses"}
+    for _, sn := range messagingShortNames {
+        ct := catalog.Find(sn)
+        if ct == nil { t.Fatalf("catalog.Find(%q) returned nil", sn); continue }
+        if ct.Fetcher == nil { t.Errorf("%s: Fetcher missing on catalog row", sn) }
+        if len(ct.FieldKeys) == 0 { t.Errorf("%s: FieldKeys missing on catalog row", sn) }
+        // sqs, sns, sns-sub, eb-rule, kinesis, msk, sfn — all have Related
+        // ses — has Related
+    }
+}
+```
+
+### 6. `make generate` artifact refresh
+
+Run `make generate` after the rewiring. Expected diff: none. The generator reads
+`Findings` / `Related` / `Columns` / `Children` from `catalog.ResourceTypes`, which were
+already populated by `6afe866`. The new `FieldKeys` and `IssueEnricherFieldKeys` fields
+are not emitted to markdown (they're internal). Commit any diff; CI runs
+`make generate && git diff --exit-code`.
+
+If the generator's `Related` table for messaging types currently reads from a
+catalog-backed lookup that consults `ct.Related`, AND `ct.Related` is currently empty
+(because related was only in legacy), then BEFORE AS-726 the generated markdown for
+messaging Related tables was empty / fallback; AFTER AS-726 it is populated. Verify by
+running `make generate` on a pre-rewiring branch and comparing to post-rewiring. If a
+diff appears, commit it as part of this PR (markdown is `docs/related-resources.md`
++ per-resource files `docs/resources/<short>.md`).
+
+## Implementation order (Coder)
+
+1. Catalog field additions (`ResourceTypeDef.FieldKeys`, `IssueEnricherFieldKeys`,
+   `ChildFetcher`) — `internal/catalog/types.go`.
+2. Catalog mutator API (`RegisterFetcher`, `RegisterWave2`, `RegisterRelated`,
+   `RegisterNavigable`, `RegisterFieldKeys`, `RegisterIssueEnricherFieldKeys`,
+   `RegisterChildView`, `FindChild`) — `internal/catalog/catalog.go`.
+3. Catalog-backed accessor wiring (`resource.GetFieldKeys`,
+   `resource.GetIssueEnricherFieldKeys`, `resource.GetChildType`,
+   `resource.GetPaginatedChildFetcher`) — `internal/resource/registry.go`. Read catalog
+   first, legacy fallback retained for non-messaging types.
+4. Rewire 24 messaging service init()s to call `catalog.Register*` — list above.
+5. Delete `sns_sub_issue_enrichment.go` and `kinesis_issue_enrichment.go`.
+6. `make build`, `make test`, `make lint`, `make security`, `make gofix`, `make generate`,
+   verify clean.
+7. Self-check: `grep -n 'resource\.\(RegisterFieldKeys\|RegisterPaginated\|RegisterRelated\|RegisterDefaultNavFields\|RegisterPaginatedChild\|RegisterChildType\|RegisterIssueEnricherFieldKeys\)' internal/aws/sqs*.go internal/aws/sns*.go internal/aws/eb_rule*.go internal/aws/kinesis*.go internal/aws/msk*.go internal/aws/sfn*.go internal/aws/ses*.go` → zero hits.
+8. Self-check: `grep -n 'registerIssueEnricher(' internal/aws/sqs*.go internal/aws/sns*.go internal/aws/eb_rule*.go internal/aws/kinesis*.go internal/aws/msk*.go internal/aws/sfn*.go internal/aws/ses*.go` → zero hits.
+
+## Acceptance (concrete, machine-checkable)
+
+```bash
+# Catalog has the new mutators
+grep -E '^func RegisterFetcher\(|^func RegisterWave2\(|^func RegisterRelated\(|^func RegisterNavigable\(|^func RegisterFieldKeys\(|^func RegisterIssueEnricherFieldKeys\(|^func RegisterChildView\(|^func FindChild\(' internal/catalog/catalog.go
+# expected: 8 hits
+
+# No messaging-service file references the legacy registrar:
+grep -nE 'resource\.(RegisterFieldKeys|RegisterPaginated|RegisterRelated|RegisterDefaultNavFields|RegisterPaginatedChild|RegisterChildType|RegisterIssueEnricherFieldKeys)|registerIssueEnricher\(' \
+  internal/aws/sqs*.go internal/aws/sns*.go internal/aws/eb_rule*.go internal/aws/kinesis*.go internal/aws/msk*.go internal/aws/sfn*.go internal/aws/ses*.go
+# expected: zero hits
+
+# NoOp-only files are gone:
+ls internal/aws/sns_sub_issue_enrichment.go internal/aws/kinesis_issue_enrichment.go 2>&1
+# expected: No such file or directory (both)
+
+# Catalog and legacy registry stay in agreement on messaging behavior:
+make test
+# expected: pass — including the new TestMessagingCatalogIsAuthoritative
+
+# Demo path renders all messaging types correctly:
+./a9s --demo
+# expected: :sqs / :sns / :sns-sub / :eb-rule / :kinesis / :msk / :sfn / :ses each list and detail-render
+
+# Build / lint / vuln gates:
+make build && make lint && make security && make gofix
+# expected: clean
+
+# Generator artifact is current:
+make generate && git diff --exit-code
+# expected: no diff (or commit the generated diff in this PR)
+```
+
+## Sizing
+
+**M.** ≈ 600 LOC across ~30 files: catalog mutator API ~150 LOC, 24 init() rewrites
+~250 LOC mechanical, file deletions -10 LOC, accessor wrapper updates ~50 LOC,
+tests ~150 LOC. Borderline M/L, but mechanical surgery — no novel design beyond the
+mutator additions, which mirror existing `RegisterProject`/`RegisterAugment`.
+
+## Hand-offs
+
+Per CAE-1 the spec publication IS the dispatch trigger. Two child issues are filed in
+the same heartbeat as this spec:
+
+- **QA child** — failing tests on the feature branch that prove messaging is catalog-authoritative.
+- **Coder child** — implementation that makes those tests pass.
+
+QA tests are committed first to the feature branch (so the branch is red at commit
+time), Coder lands the implementation that turns it green.
+
+Reviewer chain (Stage 5): always-runs CodeReviewer + CodexReviewer, plus Architect
+re-read (size M-borderline-L), plus CTO final sign-off. No further confirmation gate.
+
+## Risk notes for reviewers
+
+- **Mutator panic on duplicate register.** During AS-726, if the same `init()` is
+  imported from two places (test transitive imports or a stray duplicate), the new
+  `catalog.Register*` will panic on duplicate non-nil overwrite. The legacy `Register*`
+  silently overwrote. This is a deliberate tightening; if it surfaces a real duplicate
+  (e.g., a test imports both `internal/aws` and a mock that also init()s), fix the test,
+  do not loosen the panic.
+- **Order of init() between catalog mutator definition and messaging service init()s.**
+  Go runs package-level var init before any same-package init() and runs imported
+  packages' init() before importer's init(). Messaging files in `internal/aws` import
+  `internal/catalog` (added by this PR). `internal/catalog/catalog.go`'s `ResourceTypes`
+  is a package-level var initialized via `allTypes()`, which is invoked at package init
+  time — BEFORE any `internal/aws/*.go` init() runs. Therefore `catalog.Find(shortName)`
+  in `catalog.Register*` will already see the messaging row when the mutator fires. Good.
+- **The `eb_*` (Elastic Beanstalk, compute) vs `eb-rule*` (EventBridge, messaging) split.**
+  Coder must not touch `eb_related.go` / `eb_issue_enrichment.go` — those are compute.
+  Files in scope are explicitly `eb_rule.go`, `eb_rule_related.go`, `eb_rule_targets.go`,
+  `eb_rule_issue_enrichment.go`. Self-check via the grep above which lists files explicitly.
+- **`internal/aws/issue_enrichment.go`'s `IssueEnricherRegistry` keeps non-messaging
+  entries.** Do not touch the registry map or `GetIssueEnricher`'s fallback branch.
+  Those serve the 11 other categories whose cutover follows in sibling PRs. PR-04n
+  deletes the fallback after every category is migrated.

--- a/internal/aws/eb_rule.go
+++ b/internal/aws/eb_rule.go
@@ -7,13 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
-	resource.RegisterFieldKeys("eb-rule", []string{"name", "state", "event_bus", "schedule", "description", "event_pattern"})
+	catalog.RegisterFieldKeys("eb-rule", []string{"name", "state", "event_bus", "schedule", "description", "event_pattern"})
 
-	resource.RegisterPaginated("eb-rule", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+	catalog.RegisterFetcher("eb-rule", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
 		c, ok := clients.(*ServiceClients)
 		if !ok || c == nil {
 			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")

--- a/internal/aws/eb_rule_issue_enrichment.go
+++ b/internal/aws/eb_rule_issue_enrichment.go
@@ -10,12 +10,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
 	eventbridgetypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
-	registerIssueEnricher("eb-rule", EnrichEventBridgeRuleTargets, 100)
-	resource.RegisterIssueEnricherFieldKeys("eb-rule", []string{"target_count"})
+	catalog.RegisterWave2("eb-rule", IssueEnricher{Fn: EnrichEventBridgeRuleTargets, Priority: 100})
+	catalog.RegisterIssueEnricherFieldKeys("eb-rule", []string{"target_count"})
 }
 
 // EnrichEventBridgeRuleTargets is a Wave 2 enricher for EventBridge rules.

--- a/internal/aws/eb_rule_related.go
+++ b/internal/aws/eb_rule_related.go
@@ -8,11 +8,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
 	eventbridgetypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
-	resource.RegisterRelated("eb-rule", []resource.RelatedDef{
+	catalog.RegisterRelated("eb-rule", []domain.RelatedDef{
 		{TargetType: "role", DisplayName: "IAM Role", Checker: checkEbRuleRole, NeedsTargetCache: false},
 		{TargetType: "kinesis", DisplayName: "Kinesis (targets)", Checker: checkEbRuleKinesis},
 		{TargetType: "lambda", DisplayName: "Lambda (targets)", Checker: checkEbRuleLambda},
@@ -23,7 +25,7 @@ func init() {
 	})
 
 	// eventbridgetypes.Rule: RoleArn (execution role for the rule target)
-	resource.RegisterDefaultNavFields("eb-rule", []resource.NavigableField{
+	catalog.RegisterNavigable("eb-rule", []domain.NavigableField{
 		{FieldPath: "RoleArn", TargetType: "role"},
 	})
 }

--- a/internal/aws/eb_rule_targets.go
+++ b/internal/aws/eb_rule_targets.go
@@ -8,27 +8,25 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
 	ebtypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
-	resource.RegisterFieldKeys("eb_rule_targets", []string{
-		"target_id", "target_arn", "role_arn", "resource_type_name", "input_summary",
-	})
-
-	resource.RegisterPaginatedChild("eb_rule_targets", func(ctx context.Context, clients any, parentCtx resource.ParentContext, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchEventBridgeRuleTargets(ctx, c.EventBridge, parentCtx, continuationToken)
-	})
-
-	resource.RegisterChildType(resource.ResourceTypeDef{
+	catalog.RegisterChildView(catalog.ResourceTypeDef{
 		Name:      "EB Rule Targets",
 		ShortName: "eb_rule_targets",
 		Columns:   resource.EbRuleTargetColumns(),
 		CopyField: "target_arn",
+		FieldKeys: []string{"target_id", "target_arn", "role_arn", "resource_type_name", "input_summary"},
+		ChildFetcher: func(ctx context.Context, clients any, parentCtx domain.ParentContext, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchEventBridgeRuleTargets(ctx, c.EventBridge, parentCtx, continuationToken)
+		},
 	})
 }
 

--- a/internal/aws/kinesis.go
+++ b/internal/aws/kinesis.go
@@ -8,14 +8,15 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	kinesistypes "github.com/aws/aws-sdk-go-v2/service/kinesis/types"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
-	resource.RegisterFieldKeys("kinesis", []string{"stream_name", "status", "stream_mode", "creation_time"})
+	catalog.RegisterFieldKeys("kinesis", []string{"stream_name", "status", "stream_mode", "creation_time"})
 
-	resource.RegisterPaginated("kinesis", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+	catalog.RegisterFetcher("kinesis", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
 		c, ok := clients.(*ServiceClients)
 		if !ok || c == nil {
 			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")

--- a/internal/aws/kinesis_issue_enrichment.go
+++ b/internal/aws/kinesis_issue_enrichment.go
@@ -1,6 +1,0 @@
-// kinesis_issue_enrichment.go — Wave 2 = None for the kinesis resource type.
-package aws
-
-func init() {
-	registerIssueEnricher("kinesis", NoOpIssueEnricher, 100)
-}

--- a/internal/aws/kinesis_related.go
+++ b/internal/aws/kinesis_related.go
@@ -12,11 +12,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
-	resource.RegisterRelated("kinesis", []resource.RelatedDef{
+	catalog.RegisterRelated("kinesis", []domain.RelatedDef{
 		{TargetType: "alarm", DisplayName: "CW Alarms", Checker: checkKinesisAlarms, NeedsTargetCache: true},
 		{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkKinesisLambda, NeedsTargetCache: true},
 		{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkKinesisCFN},

--- a/internal/aws/msk.go
+++ b/internal/aws/msk.go
@@ -8,14 +8,15 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/kafka"
 	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
-	resource.RegisterFieldKeys("msk", []string{"cluster_name", "cluster_type", "state", "version"})
+	catalog.RegisterFieldKeys("msk", []string{"cluster_name", "cluster_type", "state", "version"})
 
-	resource.RegisterPaginated("msk", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+	catalog.RegisterFetcher("msk", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
 		c, ok := clients.(*ServiceClients)
 		if !ok || c == nil {
 			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")

--- a/internal/aws/msk_issue_enrichment.go
+++ b/internal/aws/msk_issue_enrichment.go
@@ -10,11 +10,12 @@ import (
 	kafkasvc "github.com/aws/aws-sdk-go-v2/service/kafka"
 	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
-	registerIssueEnricher("msk", EnrichMSKCluster, 100)
+	catalog.RegisterWave2("msk", IssueEnricher{Fn: EnrichMSKCluster, Priority: 100})
 }
 
 // EnrichMSKCluster calls DescribeClusterV2 per provisioned MSK cluster (cap EnrichmentCap)

--- a/internal/aws/msk_related.go
+++ b/internal/aws/msk_related.go
@@ -12,11 +12,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/kafka"
 	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
-	resource.RegisterRelated("msk", []resource.RelatedDef{
+	catalog.RegisterRelated("msk", []domain.RelatedDef{
 		{TargetType: "alarm", DisplayName: "CW Alarms", Checker: checkMSKAlarms, NeedsTargetCache: true},
 		{TargetType: "sg", DisplayName: "Security Groups", Checker: checkMSKSG, NeedsTargetCache: false},
 		{TargetType: "kms", DisplayName: "KMS Key", Checker: checkMSKKMS},
@@ -30,7 +32,7 @@ func init() {
 	})
 
 	// kafkatypes.Cluster: Provisioned.EncryptionInfo.EncryptionAtRest.DataVolumeKMSKeyId → kms
-	resource.RegisterDefaultNavFields("msk", []resource.NavigableField{
+	catalog.RegisterNavigable("msk", []domain.NavigableField{
 		{FieldPath: "Provisioned.EncryptionInfo.EncryptionAtRest.DataVolumeKMSKeyId", TargetType: "kms"},
 	})
 }

--- a/internal/aws/ses.go
+++ b/internal/aws/ses.go
@@ -9,14 +9,15 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sesv2"
 	sesv2types "github.com/aws/aws-sdk-go-v2/service/sesv2/types"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
-	resource.RegisterFieldKeys("ses", []string{"identity_name", "identity_type", "verification_status", "sending_enabled", "status"})
+	catalog.RegisterFieldKeys("ses", []string{"identity_name", "identity_type", "verification_status", "sending_enabled", "status"})
 
-	resource.RegisterPaginated("ses", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+	catalog.RegisterFetcher("ses", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
 		c, ok := clients.(*ServiceClients)
 		if !ok || c == nil {
 			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
@@ -24,7 +25,7 @@ func init() {
 		return FetchSESIdentitiesPage(ctx, c.SESv2, continuationToken)
 	})
 
-	resource.RegisterRelated("ses", []resource.RelatedDef{
+	catalog.RegisterRelated("ses", []domain.RelatedDef{
 		{TargetType: "r53", DisplayName: "Route 53 (DNS)", Checker: checkSESR53, NeedsTargetCache: true},
 		{TargetType: "eb-rule", DisplayName: "EventBridge Rules", Checker: checkSESEbRule, NeedsTargetCache: true},
 		{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkSESLambda, NeedsTargetCache: false},

--- a/internal/aws/ses_issue_enrichment.go
+++ b/internal/aws/ses_issue_enrichment.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/sesv2"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
-	registerIssueEnricher("ses", EnrichSESAccount, 100)
-	resource.RegisterIssueEnricherFieldKeys("ses", []string{"status"})
+	catalog.RegisterWave2("ses", IssueEnricher{Fn: EnrichSESAccount, Priority: 100})
+	catalog.RegisterIssueEnricherFieldKeys("ses", []string{"status"})
 }
 
 // EnrichSESAccount calls sesv2:GetAccount once (account-wide) and replicates

--- a/internal/aws/sfn.go
+++ b/internal/aws/sfn.go
@@ -6,13 +6,15 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/sfn"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
-	resource.RegisterFieldKeys("sfn", []string{"name", "type", "arn", "creation_date"})
+	catalog.RegisterFieldKeys("sfn", []string{"name", "type", "arn", "creation_date"})
 
-	resource.RegisterPaginated("sfn", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+	catalog.RegisterFetcher("sfn", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
 		c, ok := clients.(*ServiceClients)
 		if !ok || c == nil {
 			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
@@ -20,7 +22,7 @@ func init() {
 		return FetchStepFunctionsPage(ctx, c.SFN, continuationToken)
 	})
 
-	resource.RegisterRelated("sfn", []resource.RelatedDef{
+	catalog.RegisterRelated("sfn", []domain.RelatedDef{
 		{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: checkSFNAlarm, NeedsTargetCache: false},
 		{TargetType: "logs", DisplayName: "Log Groups", Checker: checkSFNLogs, NeedsTargetCache: true},
 		{TargetType: "role", DisplayName: "IAM Role", Checker: checkSFNRole, NeedsTargetCache: false},
@@ -33,7 +35,7 @@ func init() {
 	// list RawStruct) lacks it — the navigable-field registration is an intent
 	// contract: "if the raw struct exposes RoleArn, treat it as a role navigation".
 	// It resolves only when enriched detail (DescribeStateMachine) is present.
-	resource.RegisterDefaultNavFields("sfn", []resource.NavigableField{
+	catalog.RegisterNavigable("sfn", []domain.NavigableField{
 		{FieldPath: "RoleArn", TargetType: "role"},
 	})
 }

--- a/internal/aws/sfn_execution_history.go
+++ b/internal/aws/sfn_execution_history.go
@@ -9,30 +9,30 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sfn"
 	sfntypes "github.com/aws/aws-sdk-go-v2/service/sfn/types"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 var camelSplitter = regexp.MustCompile("([a-z])([A-Z])")
 
 func init() {
-	resource.RegisterFieldKeys("sfn_execution_history", []string{
-		"timestamp", "event_type", "event_type_short",
-		"state_name", "event_detail", "event_id", "previous_event_id",
-	})
-
-	resource.RegisterPaginatedChild("sfn_execution_history", func(ctx context.Context, clients any, parentCtx resource.ParentContext, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchSFNExecutionHistory(ctx, c.SFN, parentCtx, continuationToken)
-	})
-
-	resource.RegisterChildType(resource.ResourceTypeDef{
+	catalog.RegisterChildView(catalog.ResourceTypeDef{
 		Name:      "SFN Execution History",
 		ShortName: "sfn_execution_history",
 		Columns:   resource.SFNExecutionHistoryColumns(),
 		CopyField: "event_detail",
+		FieldKeys: []string{
+			"timestamp", "event_type", "event_type_short",
+			"state_name", "event_detail", "event_id", "previous_event_id",
+		},
+		ChildFetcher: func(ctx context.Context, clients any, parentCtx domain.ParentContext, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchSFNExecutionHistory(ctx, c.SFN, parentCtx, continuationToken)
+		},
 	})
 }
 

--- a/internal/aws/sfn_executions.go
+++ b/internal/aws/sfn_executions.go
@@ -8,36 +8,36 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sfn"
 	sfntypes "github.com/aws/aws-sdk-go-v2/service/sfn/types"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
-	resource.RegisterFieldKeys("sfn_executions", []string{
-		"execution_arn", "name", "status", "start_date", "stop_date",
-		"duration", "state_machine_arn", "state_machine_alias_arn",
-		"state_machine_version_arn", "map_run_arn", "item_count",
-		"redrive_count", "redrive_date",
-	})
-
-	resource.RegisterPaginatedChild("sfn_executions", func(ctx context.Context, clients any, parentCtx resource.ParentContext, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchSFNExecutions(ctx, c.SFN, parentCtx, continuationToken)
-	})
-
-	resource.RegisterChildType(resource.ResourceTypeDef{
+	catalog.RegisterChildView(catalog.ResourceTypeDef{
 		Name:      "SFN Executions",
 		ShortName: "sfn_executions",
 		Columns:   resource.SFNExecutionColumns(),
 		CopyField: "execution_arn",
-		Children: []resource.ChildViewDef{{
+		FieldKeys: []string{
+			"execution_arn", "name", "status", "start_date", "stop_date",
+			"duration", "state_machine_arn", "state_machine_alias_arn",
+			"state_machine_version_arn", "map_run_arn", "item_count",
+			"redrive_count", "redrive_date",
+		},
+		Children: []domain.ChildViewDef{{
 			ChildType:      "sfn_execution_history",
 			Key:            "enter",
 			ContextKeys:    map[string]string{"execution_arn": "execution_arn", "execution_name": "Name"},
 			DisplayNameKey: "execution_name",
 		}},
+		ChildFetcher: func(ctx context.Context, clients any, parentCtx domain.ParentContext, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchSFNExecutions(ctx, c.SFN, parentCtx, continuationToken)
+		},
 	})
 }
 

--- a/internal/aws/sfn_issue_enrichment.go
+++ b/internal/aws/sfn_issue_enrichment.go
@@ -10,12 +10,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sfn"
 	sfntypes "github.com/aws/aws-sdk-go-v2/service/sfn/types"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
-	registerIssueEnricher("sfn", EnrichStepFunctionsStatus, 10)
-	resource.RegisterIssueEnricherFieldKeys("sfn", []string{"last_run"})
+	catalog.RegisterWave2("sfn", IssueEnricher{Fn: EnrichStepFunctionsStatus, Priority: 10})
+	catalog.RegisterIssueEnricherFieldKeys("sfn", []string{"last_run"})
 }
 
 // EnrichStepFunctionsStatus calls ListExecutions(max:1) for each state machine (1 per SFN, cap ~50).

--- a/internal/aws/sns.go
+++ b/internal/aws/sns.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
-	resource.RegisterFieldKeys("sns", []string{"topic_arn", "display_name"})
+	catalog.RegisterFieldKeys("sns", []string{"topic_arn", "display_name"})
 
-	resource.RegisterPaginated("sns", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+	catalog.RegisterFetcher("sns", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
 		c, ok := clients.(*ServiceClients)
 		if !ok || c == nil {
 			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")

--- a/internal/aws/sns_issue_enrichment.go
+++ b/internal/aws/sns_issue_enrichment.go
@@ -8,12 +8,13 @@ import (
 	snssvc "github.com/aws/aws-sdk-go-v2/service/sns"
 	snstypes "github.com/aws/aws-sdk-go-v2/service/sns/types"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
-	registerIssueEnricher("sns", EnrichSNSSubscriptions, 100)
-	resource.RegisterIssueEnricherFieldKeys("sns", []string{"subs_count"})
+	catalog.RegisterWave2("sns", IssueEnricher{Fn: EnrichSNSSubscriptions, Priority: 100})
+	catalog.RegisterIssueEnricherFieldKeys("sns", []string{"subs_count"})
 }
 
 // EnrichSNSSubscriptions calls ListSubscriptionsByTopic per topic (cap EnrichmentCap)

--- a/internal/aws/sns_related.go
+++ b/internal/aws/sns_related.go
@@ -9,6 +9,8 @@ import (
 	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -33,7 +35,7 @@ func snsGetTopicAttrs(ctx context.Context, clients any, topicARN string) map[str
 }
 
 func init() {
-	resource.RegisterRelated("sns", []resource.RelatedDef{
+	catalog.RegisterRelated("sns", []domain.RelatedDef{
 		{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: checkSNSAlarm, NeedsTargetCache: false},
 		{TargetType: "sns-sub", DisplayName: "Subscriptions", Checker: checkSNSSub, NeedsTargetCache: true},
 		{TargetType: "kms", DisplayName: "KMS Key", Checker: checkSNSKMS, NeedsTargetCache: false},

--- a/internal/aws/sns_sub.go
+++ b/internal/aws/sns_sub.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
-	resource.RegisterFieldKeys("sns-sub", []string{"topic_arn", "protocol", "endpoint", "subscription_arn"})
+	catalog.RegisterFieldKeys("sns-sub", []string{"topic_arn", "protocol", "endpoint", "subscription_arn"})
 
-	resource.RegisterPaginated("sns-sub", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+	catalog.RegisterFetcher("sns-sub", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
 		c, ok := clients.(*ServiceClients)
 		if !ok || c == nil {
 			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")

--- a/internal/aws/sns_sub_by_topic.go
+++ b/internal/aws/sns_sub_by_topic.go
@@ -7,28 +7,26 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 	snstypes "github.com/aws/aws-sdk-go-v2/service/sns/types"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
 	// Child view: SNS Topic Subscriptions
-	resource.RegisterFieldKeys("sns_subscriptions", []string{
-		"protocol", "endpoint", "confirmation_status", "owner", "subscription_arn", "topic_arn",
-	})
-
-	resource.RegisterPaginatedChild("sns_subscriptions", func(ctx context.Context, clients any, parentCtx resource.ParentContext, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchSNSTopicSubscriptions(ctx, c.SNS, parentCtx["topic_arn"], continuationToken)
-	})
-
-	resource.RegisterChildType(resource.ResourceTypeDef{
+	catalog.RegisterChildView(catalog.ResourceTypeDef{
 		Name:      "SNS Subscriptions",
 		ShortName: "sns_subscriptions",
 		Columns:   resource.SnsSubscriptionColumns(),
 		CopyField: "endpoint",
+		FieldKeys: []string{"protocol", "endpoint", "confirmation_status", "owner", "subscription_arn", "topic_arn"},
+		ChildFetcher: func(ctx context.Context, clients any, parentCtx domain.ParentContext, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchSNSTopicSubscriptions(ctx, c.SNS, parentCtx["topic_arn"], continuationToken)
+		},
 	})
 }
 

--- a/internal/aws/sns_sub_issue_enrichment.go
+++ b/internal/aws/sns_sub_issue_enrichment.go
@@ -1,6 +1,0 @@
-// sns_sub_issue_enrichment.go — Wave 2 = None for the sns-sub resource type.
-package aws
-
-func init() {
-	registerIssueEnricher("sns-sub", NoOpIssueEnricher, 100)
-}

--- a/internal/aws/sns_sub_related.go
+++ b/internal/aws/sns_sub_related.go
@@ -5,17 +5,19 @@ import (
 	"context"
 	"strings"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
-	resource.RegisterRelated("sns-sub", []resource.RelatedDef{
+	catalog.RegisterRelated("sns-sub", []domain.RelatedDef{
 		{TargetType: "sns", DisplayName: "SNS Topic", Checker: checkSNSSubTopic, NeedsTargetCache: true},
 		{TargetType: "lambda", DisplayName: "Lambda Function", Checker: checkSNSSubLambda, NeedsTargetCache: true},
 		{TargetType: "sqs", DisplayName: "SQS Queue", Checker: checkSNSSubSQS, NeedsTargetCache: true},
 	})
 
-	resource.RegisterDefaultNavFields("sns-sub", []resource.NavigableField{
+	catalog.RegisterNavigable("sns-sub", []domain.NavigableField{
 		{FieldPath: "TopicArn", TargetType: "sns"},
 	})
 }

--- a/internal/aws/sqs.go
+++ b/internal/aws/sqs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -21,9 +22,9 @@ type SQSQueueAttributesRow struct {
 }
 
 func init() {
-	resource.RegisterFieldKeys("sqs", []string{"queue_name", "queue_url", "arn", "approx_messages", "approx_not_visible", "delay_seconds"})
+	catalog.RegisterFieldKeys("sqs", []string{"queue_name", "queue_url", "arn", "approx_messages", "approx_not_visible", "delay_seconds"})
 
-	resource.RegisterPaginated("sqs", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+	catalog.RegisterFetcher("sqs", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
 		c, ok := clients.(*ServiceClients)
 		if !ok || c == nil {
 			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")

--- a/internal/aws/sqs_issue_enrichment.go
+++ b/internal/aws/sqs_issue_enrichment.go
@@ -9,12 +9,13 @@ import (
 	sqssvc "github.com/aws/aws-sdk-go-v2/service/sqs"
 	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
-	registerIssueEnricher("sqs", EnrichSQSAttributes, 100)
-	resource.RegisterIssueEnricherFieldKeys("sqs", []string{"dlq"})
+	catalog.RegisterWave2("sqs", IssueEnricher{Fn: EnrichSQSAttributes, Priority: 100})
+	catalog.RegisterIssueEnricherFieldKeys("sqs", []string{"dlq"})
 }
 
 // EnrichSQSAttributes calls GetQueueAttributes per queue (cap EnrichmentCap)

--- a/internal/aws/sqs_related.go
+++ b/internal/aws/sqs_related.go
@@ -10,11 +10,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 
+	"github.com/k2m30/a9s/v3/internal/catalog"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func init() {
-	resource.RegisterRelated("sqs", []resource.RelatedDef{
+	catalog.RegisterRelated("sqs", []domain.RelatedDef{
 		{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: checkSQSAlarm, NeedsTargetCache: true},
 		{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkSQSLambda, NeedsTargetCache: false},
 		{TargetType: "sqs", DisplayName: "Dead Letter Queues", Checker: checkSQSSQS, NeedsTargetCache: true},

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -1,6 +1,10 @@
 package catalog
 
-import "github.com/k2m30/a9s/v3/internal/domain"
+import (
+	"fmt"
+
+	"github.com/k2m30/a9s/v3/internal/domain"
+)
 
 // ResourceTypes is the declarative registry of all a9s resource types.
 // It is static — no init(), no Register* calls. Per-category PRs (04b–04m)
@@ -98,6 +102,165 @@ func RegisterAugment(shortName string, aug domain.Augmenter) {
 			return
 		}
 	}
+}
+
+// findIndex returns the index of the catalog row with ShortName matching name
+// (case-insensitive). Returns -1 when no row matches. Used by the Register*
+// mutators below.
+func findIndex(name string) int {
+	nameLower := toLower(name)
+	for i := range ResourceTypes {
+		if toLower(ResourceTypes[i].ShortName) == nameLower {
+			return i
+		}
+	}
+	return -1
+}
+
+// RegisterFetcher sets the Wave 1 paginated fetcher on the named catalog row.
+// Panics if the row already has a non-nil Fetcher (duplicate registration).
+// No-op when the row is missing — the legacy registry fallback continues to
+// own un-migrated types.
+func RegisterFetcher(shortName string, fn domain.PaginatedFetcher) {
+	i := findIndex(shortName)
+	if i < 0 {
+		return
+	}
+	if ResourceTypes[i].Fetcher != nil {
+		panic(fmt.Sprintf("catalog.RegisterFetcher(%q): duplicate registration — row already has a non-nil Fetcher", shortName))
+	}
+	ResourceTypes[i].Fetcher = fn
+}
+
+// RegisterWave2 sets the Wave 2 enricher on the named catalog row. The value
+// is a concrete aws.IssueEnricher stored as any to avoid an import cycle.
+// Panics if the row already has a non-nil Wave2. No-op when the row is
+// missing.
+func RegisterWave2(shortName string, enr any) {
+	i := findIndex(shortName)
+	if i < 0 {
+		return
+	}
+	if ResourceTypes[i].Wave2 != nil {
+		panic(fmt.Sprintf("catalog.RegisterWave2(%q): duplicate registration — row already has a non-nil Wave2", shortName))
+	}
+	ResourceTypes[i].Wave2 = enr
+}
+
+// RegisterRelated sets the related-resource defs on the named catalog row.
+// Panics if the row already has non-empty Related. No-op when the row is
+// missing.
+func RegisterRelated(shortName string, defs []domain.RelatedDef) {
+	i := findIndex(shortName)
+	if i < 0 {
+		return
+	}
+	if len(ResourceTypes[i].Related) > 0 {
+		panic(fmt.Sprintf("catalog.RegisterRelated(%q): duplicate registration — row already has non-empty Related", shortName))
+	}
+	ResourceTypes[i].Related = defs
+}
+
+// RegisterNavigable sets the navigable-field defs on the named catalog row.
+// Panics if the row already has non-empty Navigable. No-op when the row is
+// missing.
+func RegisterNavigable(shortName string, fields []domain.NavigableField) {
+	i := findIndex(shortName)
+	if i < 0 {
+		return
+	}
+	if len(ResourceTypes[i].Navigable) > 0 {
+		panic(fmt.Sprintf("catalog.RegisterNavigable(%q): duplicate registration — row already has non-empty Navigable", shortName))
+	}
+	ResourceTypes[i].Navigable = fields
+}
+
+// RegisterFieldKeys sets the fetcher-produced FieldKeys on the named catalog
+// row. Panics on duplicate (non-empty existing slice). No-op when the row is
+// missing.
+func RegisterFieldKeys(shortName string, keys []string) {
+	i := findIndex(shortName)
+	if i < 0 {
+		return
+	}
+	if len(ResourceTypes[i].FieldKeys) > 0 {
+		panic(fmt.Sprintf("catalog.RegisterFieldKeys(%q): duplicate registration — row already has non-empty FieldKeys", shortName))
+	}
+	ResourceTypes[i].FieldKeys = keys
+}
+
+// RegisterIssueEnricherFieldKeys appends Wave 2 field keys on the named
+// catalog row. Idempotent — duplicates are deduplicated. Multiple enrichers
+// may target the same type and union their keys here. Original order is
+// preserved; new (non-duplicate) keys are appended in input order. No-op
+// when the row is missing.
+func RegisterIssueEnricherFieldKeys(shortName string, keys []string) {
+	i := findIndex(shortName)
+	if i < 0 {
+		return
+	}
+	existing := ResourceTypes[i].IssueEnricherFieldKeys
+	seen := make(map[string]bool, len(existing))
+	for _, k := range existing {
+		seen[k] = true
+	}
+	for _, k := range keys {
+		if !seen[k] {
+			existing = append(existing, k)
+			seen[k] = true
+		}
+	}
+	ResourceTypes[i].IssueEnricherFieldKeys = existing
+}
+
+// childTypes holds catalog-registered child-view definitions keyed by
+// ShortName. Child views are NOT in the top-level ResourceTypes slice.
+// FindChild is the authoritative accessor.
+var childTypes = map[string]ResourceTypeDef{} //nolint:gochecknoglobals // catalog child registry
+
+// RegisterChildView registers a child-view ResourceTypeDef into the catalog's
+// child registry, keyed by ShortName. Panics on duplicate registration for
+// the same ShortName.
+func RegisterChildView(child ResourceTypeDef) {
+	key := toLower(child.ShortName)
+	if _, exists := childTypes[key]; exists {
+		panic(fmt.Sprintf("catalog.RegisterChildView(%q): duplicate registration", child.ShortName))
+	}
+	childTypes[key] = child
+}
+
+// FindChild returns the child-view ResourceTypeDef registered under the given
+// ShortName, or nil if not in the catalog's child registry. Case-insensitive.
+func FindChild(shortName string) *ResourceTypeDef {
+	key := toLower(shortName)
+	if c, ok := childTypes[key]; ok {
+		return &c
+	}
+	return nil
+}
+
+// AddForTest appends a synthetic ResourceTypeDef to the top-level
+// ResourceTypes slice. Test-only scaffolding for mutator tests; pair with
+// RemoveForTest in t.Cleanup. No-op for empty ShortName.
+func AddForTest(def ResourceTypeDef) {
+	if def.ShortName == "" {
+		return
+	}
+	ResourceTypes = append(ResourceTypes, def)
+}
+
+// RemoveForTest removes the catalog row whose ShortName matches shortName.
+// Pair with AddForTest. Also clears any matching entry in childTypes.
+// No-op when the shortName is not present.
+func RemoveForTest(shortName string) {
+	nameLower := toLower(shortName)
+	for i := range ResourceTypes {
+		if toLower(ResourceTypes[i].ShortName) == nameLower {
+			ResourceTypes = append(ResourceTypes[:i], ResourceTypes[i+1:]...)
+			break
+		}
+	}
+	delete(childTypes, nameLower)
 }
 
 // toLower is a minimal ASCII lower-case helper that avoids importing strings

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -117,6 +117,14 @@ func findIndex(name string) int {
 	return -1
 }
 
+// FindIndex returns the index of the catalog row with ShortName matching name
+// (case-insensitive), or -1 when no row matches. Used by callers that need to
+// mutate ResourceTypes[i] in place (e.g. resource.AppendRelated extending a
+// migrated row's Related slice).
+func FindIndex(name string) int {
+	return findIndex(name)
+}
+
 // RegisterFetcher sets the Wave 1 paginated fetcher on the named catalog row.
 // Panics if the row already has a non-nil Fetcher (duplicate registration).
 // No-op when the row is missing — the legacy registry fallback continues to

--- a/internal/catalog/types.go
+++ b/internal/catalog/types.go
@@ -107,6 +107,28 @@ type ResourceTypeDef struct {
 	// Findings is the declarative table of finding codes for this type.
 	// Graduated from Phase 03's per-enricher constants.
 	Findings []FindingDef
+
+	// ─── Field-key inventories (catalog-authoritative from PR-04i forward) ──
+
+	// FieldKeys lists the Resource.Fields keys produced by the fetcher for
+	// this resource type. Used by detail-field rendering and column-key
+	// assertions. Migrated from internal/resource fieldKeyRegistry.
+	FieldKeys []string
+
+	// IssueEnricherFieldKeys lists additional Resource.Fields keys produced
+	// by the Wave 2 enricher via IssueEnricherResult.FieldUpdates. Unioned
+	// with FieldKeys by GetAllFieldKeys consumers. Migrated from
+	// internal/resource issueEnricherFieldKeysRegistry. Catalog mutator
+	// RegisterIssueEnricherFieldKeys is idempotent and dedups entries.
+	IssueEnricherFieldKeys []string
+
+	// ─── Child-view-only fields ────────────────────────────────────────────
+
+	// ChildFetcher is the paginated fetcher for child-view rows. Populated
+	// only for entries registered via RegisterChildView (i.e. living in the
+	// catalog's child registry, not the top-level ResourceTypes slice).
+	// Top-level entries use Fetcher; child entries use ChildFetcher.
+	ChildFetcher domain.PaginatedChildFetcher
 }
 
 // ResolveColor classifies r using d.Color, defaulting to a generic

--- a/internal/resource/registry.go
+++ b/internal/resource/registry.go
@@ -34,11 +34,15 @@ func RegisterFieldKeys(shortName string, keys []string) {
 
 // GetFieldKeys returns the registered Fields keys for the given resource type,
 // or nil if none are registered.
-// Catalog-backed: consults catalog.Find(shortName).FieldKeys first; falls
-// through to the legacy map for un-migrated types. Fallback removed in PR-04n.
+// Catalog-backed: consults the catalog top-level row first, then the catalog
+// child registry (PR-04i child views); falls through to the legacy map for
+// un-migrated types. Fallback removed in PR-04n.
 func GetFieldKeys(shortName string) []string {
 	if ct := catalog.Find(shortName); ct != nil && len(ct.FieldKeys) > 0 {
 		return ct.FieldKeys
+	}
+	if c := catalog.FindChild(shortName); c != nil && len(c.FieldKeys) > 0 {
+		return c.FieldKeys
 	}
 	return fieldKeyRegistry[shortName]
 }

--- a/internal/resource/registry.go
+++ b/internal/resource/registry.go
@@ -34,7 +34,12 @@ func RegisterFieldKeys(shortName string, keys []string) {
 
 // GetFieldKeys returns the registered Fields keys for the given resource type,
 // or nil if none are registered.
+// Catalog-backed: consults catalog.Find(shortName).FieldKeys first; falls
+// through to the legacy map for un-migrated types. Fallback removed in PR-04n.
 func GetFieldKeys(shortName string) []string {
+	if ct := catalog.Find(shortName); ct != nil && len(ct.FieldKeys) > 0 {
+		return ct.FieldKeys
+	}
 	return fieldKeyRegistry[shortName]
 }
 
@@ -71,7 +76,13 @@ func RegisterIssueEnricherFieldKeys(shortName string, keys []string) {
 
 // GetIssueEnricherFieldKeys returns the accumulated Wave 2 issue-enricher
 // field keys for the given resource short name, or nil if none are registered.
+// Catalog-backed: consults catalog.Find(shortName).IssueEnricherFieldKeys
+// first; falls through to the legacy map for un-migrated types. Fallback
+// removed in PR-04n.
 func GetIssueEnricherFieldKeys(shortName string) []string {
+	if ct := catalog.Find(shortName); ct != nil && len(ct.IssueEnricherFieldKeys) > 0 {
+		return ct.IssueEnricherFieldKeys
+	}
 	return issueEnricherFieldKeysRegistry[shortName]
 }
 
@@ -172,7 +183,12 @@ func RegisterChildType(def ResourceTypeDef) {
 
 // GetChildType returns the child type definition for the given short name,
 // or nil if no child type is registered.
+// Catalog-backed: consults catalog.FindChild(shortName) first; falls through
+// to the legacy map for un-migrated child types. Fallback removed in PR-04n.
 func GetChildType(shortName string) *ResourceTypeDef {
+	if c := catalog.FindChild(shortName); c != nil {
+		return c
+	}
 	return childTypes[shortName]
 }
 
@@ -244,12 +260,13 @@ func RegisterPaginatedChild(shortName string, f PaginatedChildFetcher) {
 }
 
 // GetPaginatedChildFetcher returns the paginated child fetcher for the given short name.
-// Catalog-backed: checks the catalog first via the parent type's Children defs;
-// falls through to the legacy map. Fallback removed in PR-04n.
+// Catalog-backed: checks catalog.FindChild(shortName).ChildFetcher first;
+// falls through to the legacy map for un-migrated child types. Fallback
+// removed in PR-04n.
 func GetPaginatedChildFetcher(shortName string) PaginatedChildFetcher {
-	// Child fetchers are keyed by the child type's ShortName. The catalog stores
-	// them in the parent's Children []ChildViewDef; a separate per-child catalog
-	// lookup path is wired in per-category PRs (04b+). For now: legacy fallback.
+	if c := catalog.FindChild(shortName); c != nil && c.ChildFetcher != nil {
+		return c.ChildFetcher
+	}
 	return paginatedChildRegistry[shortName]
 }
 

--- a/internal/resource/related.go
+++ b/internal/resource/related.go
@@ -523,6 +523,20 @@ func BootstrapActiveNavFields() {
 	maps.Copy(snapshot, defaultNavFieldRegistry)
 	defaultNavFieldMu.RUnlock()
 
+	// Catalog-authoritative entries (PR-04i+) live on the catalog row's
+	// Navigable slice rather than defaultNavFieldRegistry. Include them in
+	// the snapshot so DetailModel — which reads GetActiveNavigableFields —
+	// still resolves navigability for migrated types.
+	for _, rt := range catalog.All() {
+		if len(rt.Navigable) == 0 {
+			continue
+		}
+		if _, exists := snapshot[rt.ShortName]; exists {
+			continue
+		}
+		snapshot[rt.ShortName] = rt.Navigable
+	}
+
 	navigableFieldMu.Lock()
 	defer navigableFieldMu.Unlock()
 	for k, v := range snapshot {

--- a/internal/resource/related.go
+++ b/internal/resource/related.go
@@ -316,11 +316,32 @@ func RegisterRelated(shortName string, defs []RelatedDef) {
 }
 
 // GetRelated returns the related definitions for the given resource short name.
-// Catalog-backed: checks the catalog first; falls through to the legacy map.
-// Fallback removed in PR-04n.
+// Catalog-backed: for migrated types (catalog.Find returns a row with non-empty
+// Related), unions the catalog's static defs with any AppendRelated additions
+// in the legacy map (e.g. the global ct-events append). For un-migrated types
+// the legacy map is the sole source. Fallback removed in PR-04n.
 func GetRelated(shortName string) []RelatedDef {
 	if ct := catalog.Find(shortName); ct != nil && len(ct.Related) > 0 {
-		return ct.Related
+		relatedRegistryMu.RLock()
+		extra := relatedRegistry[shortName]
+		relatedRegistryMu.RUnlock()
+		if len(extra) == 0 {
+			return ct.Related
+		}
+		seen := make(map[string]bool, len(ct.Related)+len(extra))
+		out := make([]RelatedDef, 0, len(ct.Related)+len(extra))
+		for _, d := range ct.Related {
+			seen[d.TargetType] = true
+			out = append(out, d)
+		}
+		for _, d := range extra {
+			if seen[d.TargetType] {
+				continue
+			}
+			seen[d.TargetType] = true
+			out = append(out, d)
+		}
+		return out
 	}
 	relatedRegistryMu.RLock()
 	defer relatedRegistryMu.RUnlock()

--- a/tests/unit/architecture_conformance_test.go
+++ b/tests/unit/architecture_conformance_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -38,20 +39,39 @@ func TestConformance_EveryResourceTypeHasPaginatedFetcher(t *testing.T) {
 }
 
 // TestConformance_EveryResourceTypeHasWave2Registration pins the Wave 2
-// allowlist contract: every registered top-level resource type must have an
-// entry in IssueEnricherRegistry, either a real issue enricher or
-// NoOpIssueEnricher. An unregistered type is a silent skip — it would never
-// participate in Wave 2 even when docs/attention-signals.md claims it should.
+// allowlist contract: every registered top-level resource type must have a
+// catalog row whose Wave 2 status is EXPLICIT.
+//
+// "Explicit" means one of:
+//   - catalog.Find(sn).Wave2 != nil — a real Wave 2 enricher is registered on the catalog row, OR
+//   - awsclient.IssueEnricherRegistry[sn] exists — legacy registration (real or NoOpIssueEnricher), OR
+//   - catalog.Find(sn) != nil AND its row is intentionally marked "no Wave 2" (Wave2 nil, no legacy entry).
+//
+// AS-726 PR-04i deletes the NoOp-only files for sns-sub and kinesis and routes
+// their "no Wave 2" signal through catalog Wave2 == nil. Pre-AS-726 the only
+// explicit signal was the IssueEnricherRegistry map. Post-AS-726 catalog
+// presence is the new explicit signal — silent skips happen only when neither
+// path knows about the shortName.
 func TestConformance_EveryResourceTypeHasWave2Registration(t *testing.T) {
 	for _, td := range resource.AllResourceTypes() {
-		if _, ok := awsclient.IssueEnricherRegistry[td.ShortName]; !ok {
-			t.Errorf(
-				"resource type %q is not in awsclient.IssueEnricherRegistry — "+
-					"register either a real IssueEnricherFunc or NoOpIssueEnricher "+
-					"so the Wave 2 contract is explicit (docs/attention-signals.md)",
-				td.ShortName,
-			)
+		_, legacyOK := awsclient.IssueEnricherRegistry[td.ShortName]
+		catalogRow := catalog.Find(td.ShortName)
+		if legacyOK {
+			continue
 		}
+		if catalogRow != nil {
+			// Catalog-authoritative — Wave2 may be nil (explicit "no Wave 2")
+			// or non-nil (Wave 2 registered via catalog.RegisterWave2). Either
+			// way the type is known to the Wave 2 layer.
+			continue
+		}
+		t.Errorf(
+			"resource type %q has no explicit Wave 2 signal — "+
+				"either register via catalog.RegisterWave2 (catalog-authoritative; nil is the "+
+				"explicit \"no Wave 2\" signal) or add an IssueEnricherRegistry entry "+
+				"(legacy path). Currently neither path knows about this type.",
+			td.ShortName,
+		)
 	}
 }
 
@@ -152,4 +172,91 @@ func min(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// ---------------------------------------------------------------------------
+// AS-726 PR-04i — messaging catalog cutover (Phase 04)
+// ---------------------------------------------------------------------------
+
+// TestMessagingCatalogIsAuthoritative pins the AS-726 PR-04i acceptance: every
+// messaging top-level type has its Wave 1 fetcher, FieldKeys, and Related defs
+// living on the catalog row — not in the legacy resource/IssueEnricher registries.
+//
+// Snapshot counts come from the spec §1 file inventory (verified against the
+// legacy RegisterRelated() blocks in internal/aws/*_related.go BEFORE the cutover).
+// If a related def is added or removed, this test must change too — that's the
+// contract: docs/related-resources.md is the source of truth, and the catalog
+// row must mirror it.
+//
+// IssueEnricherFieldKeys are checked for the 5 messaging types that legacy
+// registered them (sqs, sns, eb-rule, sfn, ses). msk, sns-sub, and kinesis
+// have no Wave 2 field keys (msk's enricher writes no extra keys; sns-sub
+// and kinesis are the NoOp deletions covered by TestNoOpWave2ReturnsAbsent).
+//
+// Navigable is checked for the 4 types whose legacy init() called
+// RegisterDefaultNavFields: sns-sub, eb-rule, msk, sfn.
+func TestMessagingCatalogIsAuthoritative(t *testing.T) {
+	cases := []struct {
+		shortName              string
+		expectedRelated        int
+		expectedNavigable      int
+		expectedIssueFieldKeys []string // exact, in order
+		expectsWave2           bool
+	}{
+		{"sqs", 7, 0, []string{"dlq"}, true},
+		{"sns", 4, 0, []string{"subs_count"}, true},
+		{"sns-sub", 3, 1, nil, false}, // Wave 2 file deleted — see TestNoOpWave2ReturnsAbsent
+		{"eb-rule", 7, 1, []string{"target_count"}, true},
+		{"kinesis", 5, 0, nil, false}, // Wave 2 file deleted — see TestNoOpWave2ReturnsAbsent
+		{"msk", 10, 1, nil, true},
+		{"sfn", 6, 1, []string{"last_run"}, true},
+		{"ses", 5, 0, []string{"status"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.shortName, func(t *testing.T) {
+			ct := catalog.Find(tc.shortName)
+			if ct == nil {
+				t.Fatalf("catalog.Find(%q) returned nil — messaging row missing from catalog", tc.shortName)
+			}
+			if ct.Fetcher == nil {
+				t.Errorf("%s: Fetcher missing on catalog row — legacy registration still authoritative", tc.shortName)
+			}
+			if len(ct.FieldKeys) == 0 {
+				t.Errorf("%s: FieldKeys empty on catalog row — legacy registration still authoritative", tc.shortName)
+			}
+			if got := len(ct.Related); got != tc.expectedRelated {
+				t.Errorf("%s: catalog Related has %d entries, want %d (per spec §1 inventory)",
+					tc.shortName, got, tc.expectedRelated)
+			}
+			if got := len(ct.Navigable); got != tc.expectedNavigable {
+				t.Errorf("%s: catalog Navigable has %d entries, want %d",
+					tc.shortName, got, tc.expectedNavigable)
+			}
+			if tc.expectsWave2 {
+				if ct.Wave2 == nil {
+					t.Errorf("%s: catalog Wave2 nil, want non-nil (legacy registered a Wave 2 enricher)", tc.shortName)
+				}
+			} else {
+				if ct.Wave2 != nil {
+					t.Errorf("%s: catalog Wave2 non-nil, want nil (NoOp file deleted per spec §4)", tc.shortName)
+				}
+			}
+			if got := ct.IssueEnricherFieldKeys; !stringSliceEqual(got, tc.expectedIssueFieldKeys) {
+				t.Errorf("%s: catalog IssueEnricherFieldKeys = %v, want %v",
+					tc.shortName, got, tc.expectedIssueFieldKeys)
+			}
+		})
+	}
+}
+
+func stringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/tests/unit/catalog_mutator_test.go
+++ b/tests/unit/catalog_mutator_test.go
@@ -1,0 +1,336 @@
+package unit
+
+// catalog_mutator_test.go — AS-726 PR-04i — unit tests for the eight new
+// catalog mutators added to internal/catalog/catalog.go.
+//
+// Contract under test (per docs/refactor/AS-726-pr04i-messaging.md §2):
+//   - RegisterFetcher / RegisterWave2 / RegisterRelated / RegisterNavigable /
+//     RegisterFieldKeys / RegisterChildView — panic on duplicate non-nil register.
+//   - RegisterIssueEnricherFieldKeys — idempotent; dedups across calls.
+//   - FindChild — returns nil for unregistered, non-nil + populated for registered.
+//
+// Catalog state for the top-level Register* mutators is keyed by ShortName and
+// looks up an existing row in catalog.ResourceTypes. To avoid polluting real
+// resource rows the tests use synthetic shortNames added via test helpers the
+// Coder must expose alongside the mutators:
+//
+//   func catalog.AddForTest(def ResourceTypeDef)       // appends to ResourceTypes
+//   func catalog.RemoveForTest(shortName string)       // removes by ShortName
+//
+// These are the minimal scaffolding needed to test mutator semantics in
+// isolation — they are NOT consumed by production code. See spec §2 hint:
+// "Catalog state is package-level; if you need a reset, add catalog.ResetForTest()
+// and ask the Coder to expose it."
+
+import (
+	"context"
+	"testing"
+
+	"github.com/k2m30/a9s/v3/internal/catalog"
+	"github.com/k2m30/a9s/v3/internal/domain"
+)
+
+// noopFetcher is a minimal PaginatedFetcher used as the mutator's argument
+// where the value's content is irrelevant — only its presence/absence.
+func noopFetcher(_ context.Context, _ any, _ string) (domain.FetchResult, error) {
+	return domain.FetchResult{}, nil
+}
+
+func noopChildFetcher(_ context.Context, _ any, _ domain.ParentContext, _ string) (domain.FetchResult, error) {
+	return domain.FetchResult{}, nil
+}
+
+// expectPanic runs fn and reports a test failure if it does NOT panic.
+func expectPanic(t *testing.T, label string, fn func()) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("%s: expected panic, got nil", label)
+		}
+	}()
+	fn()
+}
+
+// ---------------------------------------------------------------------------
+// RegisterFetcher
+// ---------------------------------------------------------------------------
+
+func TestRegisterFetcher(t *testing.T) {
+	t.Run("happy_path_register_then_find", func(t *testing.T) {
+		sn := "_qa_test_fetcher_happy"
+		catalog.AddForTest(catalog.ResourceTypeDef{ShortName: sn})
+		defer catalog.RemoveForTest(sn)
+
+		catalog.RegisterFetcher(sn, noopFetcher)
+
+		ct := catalog.Find(sn)
+		if ct == nil {
+			t.Fatalf("catalog.Find(%q) returned nil after RegisterFetcher", sn)
+		}
+		if ct.Fetcher == nil {
+			t.Errorf("RegisterFetcher did not set Fetcher on the catalog row")
+		}
+	})
+
+	t.Run("panic_on_duplicate", func(t *testing.T) {
+		sn := "_qa_test_fetcher_dup"
+		catalog.AddForTest(catalog.ResourceTypeDef{ShortName: sn})
+		defer catalog.RemoveForTest(sn)
+
+		catalog.RegisterFetcher(sn, noopFetcher)
+		expectPanic(t, "RegisterFetcher second call on populated row", func() {
+			catalog.RegisterFetcher(sn, noopFetcher)
+		})
+	})
+}
+
+// ---------------------------------------------------------------------------
+// RegisterWave2
+// ---------------------------------------------------------------------------
+
+func TestRegisterWave2(t *testing.T) {
+	t.Run("happy_path_register_then_find", func(t *testing.T) {
+		sn := "_qa_test_wave2_happy"
+		catalog.AddForTest(catalog.ResourceTypeDef{ShortName: sn})
+		defer catalog.RemoveForTest(sn)
+
+		marker := struct{ Tag string }{Tag: "marker"}
+		catalog.RegisterWave2(sn, marker)
+
+		ct := catalog.Find(sn)
+		if ct == nil {
+			t.Fatalf("catalog.Find(%q) returned nil after RegisterWave2", sn)
+		}
+		if ct.Wave2 == nil {
+			t.Errorf("RegisterWave2 did not set Wave2 on the catalog row")
+		}
+	})
+
+	t.Run("panic_on_duplicate", func(t *testing.T) {
+		sn := "_qa_test_wave2_dup"
+		catalog.AddForTest(catalog.ResourceTypeDef{ShortName: sn})
+		defer catalog.RemoveForTest(sn)
+
+		catalog.RegisterWave2(sn, struct{ Tag string }{Tag: "first"})
+		expectPanic(t, "RegisterWave2 second call on populated row", func() {
+			catalog.RegisterWave2(sn, struct{ Tag string }{Tag: "second"})
+		})
+	})
+}
+
+// ---------------------------------------------------------------------------
+// RegisterRelated
+// ---------------------------------------------------------------------------
+
+func TestRegisterRelated(t *testing.T) {
+	t.Run("happy_path_register_then_find", func(t *testing.T) {
+		sn := "_qa_test_related_happy"
+		catalog.AddForTest(catalog.ResourceTypeDef{ShortName: sn})
+		defer catalog.RemoveForTest(sn)
+
+		defs := []domain.RelatedDef{{TargetType: "_qa_target", DisplayName: "QA Target"}}
+		catalog.RegisterRelated(sn, defs)
+
+		ct := catalog.Find(sn)
+		if ct == nil {
+			t.Fatalf("catalog.Find(%q) returned nil after RegisterRelated", sn)
+		}
+		if len(ct.Related) != 1 || ct.Related[0].TargetType != "_qa_target" {
+			t.Errorf("RegisterRelated did not set Related on the catalog row; got %+v", ct.Related)
+		}
+	})
+
+	t.Run("panic_on_duplicate", func(t *testing.T) {
+		sn := "_qa_test_related_dup"
+		catalog.AddForTest(catalog.ResourceTypeDef{ShortName: sn})
+		defer catalog.RemoveForTest(sn)
+
+		first := []domain.RelatedDef{{TargetType: "_qa_target_a"}}
+		second := []domain.RelatedDef{{TargetType: "_qa_target_b"}}
+		catalog.RegisterRelated(sn, first)
+		expectPanic(t, "RegisterRelated second call on populated row", func() {
+			catalog.RegisterRelated(sn, second)
+		})
+	})
+}
+
+// ---------------------------------------------------------------------------
+// RegisterNavigable
+// ---------------------------------------------------------------------------
+
+func TestRegisterNavigable(t *testing.T) {
+	t.Run("happy_path_register_then_find", func(t *testing.T) {
+		sn := "_qa_test_nav_happy"
+		catalog.AddForTest(catalog.ResourceTypeDef{ShortName: sn})
+		defer catalog.RemoveForTest(sn)
+
+		fields := []domain.NavigableField{{FieldPath: "RoleArn", TargetType: "role"}}
+		catalog.RegisterNavigable(sn, fields)
+
+		ct := catalog.Find(sn)
+		if ct == nil {
+			t.Fatalf("catalog.Find(%q) returned nil after RegisterNavigable", sn)
+		}
+		if len(ct.Navigable) != 1 || ct.Navigable[0].FieldPath != "RoleArn" {
+			t.Errorf("RegisterNavigable did not set Navigable on the catalog row; got %+v", ct.Navigable)
+		}
+	})
+
+	t.Run("panic_on_duplicate", func(t *testing.T) {
+		sn := "_qa_test_nav_dup"
+		catalog.AddForTest(catalog.ResourceTypeDef{ShortName: sn})
+		defer catalog.RemoveForTest(sn)
+
+		catalog.RegisterNavigable(sn, []domain.NavigableField{{FieldPath: "A", TargetType: "x"}})
+		expectPanic(t, "RegisterNavigable second call on populated row", func() {
+			catalog.RegisterNavigable(sn, []domain.NavigableField{{FieldPath: "B", TargetType: "y"}})
+		})
+	})
+}
+
+// ---------------------------------------------------------------------------
+// RegisterFieldKeys
+// ---------------------------------------------------------------------------
+
+func TestRegisterFieldKeys(t *testing.T) {
+	t.Run("happy_path_register_then_find", func(t *testing.T) {
+		sn := "_qa_test_fk_happy"
+		catalog.AddForTest(catalog.ResourceTypeDef{ShortName: sn})
+		defer catalog.RemoveForTest(sn)
+
+		catalog.RegisterFieldKeys(sn, []string{"alpha", "beta"})
+
+		ct := catalog.Find(sn)
+		if ct == nil {
+			t.Fatalf("catalog.Find(%q) returned nil after RegisterFieldKeys", sn)
+		}
+		if len(ct.FieldKeys) != 2 || ct.FieldKeys[0] != "alpha" || ct.FieldKeys[1] != "beta" {
+			t.Errorf("RegisterFieldKeys did not set FieldKeys correctly; got %v", ct.FieldKeys)
+		}
+	})
+
+	t.Run("panic_on_duplicate", func(t *testing.T) {
+		sn := "_qa_test_fk_dup"
+		catalog.AddForTest(catalog.ResourceTypeDef{ShortName: sn})
+		defer catalog.RemoveForTest(sn)
+
+		catalog.RegisterFieldKeys(sn, []string{"alpha"})
+		expectPanic(t, "RegisterFieldKeys second call on populated row", func() {
+			catalog.RegisterFieldKeys(sn, []string{"beta"})
+		})
+	})
+}
+
+// ---------------------------------------------------------------------------
+// RegisterIssueEnricherFieldKeys — IDEMPOTENT (dedups)
+// ---------------------------------------------------------------------------
+
+func TestRegisterIssueEnricherFieldKeys(t *testing.T) {
+	t.Run("happy_path_register_then_find", func(t *testing.T) {
+		sn := "_qa_test_iefk_happy"
+		catalog.AddForTest(catalog.ResourceTypeDef{ShortName: sn})
+		defer catalog.RemoveForTest(sn)
+
+		catalog.RegisterIssueEnricherFieldKeys(sn, []string{"dlq"})
+
+		ct := catalog.Find(sn)
+		if ct == nil {
+			t.Fatalf("catalog.Find(%q) returned nil after RegisterIssueEnricherFieldKeys", sn)
+		}
+		if len(ct.IssueEnricherFieldKeys) != 1 || ct.IssueEnricherFieldKeys[0] != "dlq" {
+			t.Errorf("RegisterIssueEnricherFieldKeys did not set keys; got %v", ct.IssueEnricherFieldKeys)
+		}
+	})
+
+	t.Run("dedups_across_calls", func(t *testing.T) {
+		sn := "_qa_test_iefk_dedup"
+		catalog.AddForTest(catalog.ResourceTypeDef{ShortName: sn})
+		defer catalog.RemoveForTest(sn)
+
+		catalog.RegisterIssueEnricherFieldKeys(sn, []string{"alpha", "beta"})
+		catalog.RegisterIssueEnricherFieldKeys(sn, []string{"beta", "gamma"})
+
+		ct := catalog.Find(sn)
+		if ct == nil {
+			t.Fatalf("catalog.Find(%q) returned nil", sn)
+		}
+		got := ct.IssueEnricherFieldKeys
+		if len(got) != 3 {
+			t.Fatalf("expected union of 3 keys after dedup, got %d: %v", len(got), got)
+		}
+		// Order: original order preserved, new (non-dup) keys appended.
+		want := []string{"alpha", "beta", "gamma"}
+		for i, k := range want {
+			if got[i] != k {
+				t.Errorf("IssueEnricherFieldKeys[%d] = %q, want %q (full: %v)", i, got[i], k, got)
+			}
+		}
+	})
+
+	t.Run("idempotent_second_call_same_keys", func(t *testing.T) {
+		sn := "_qa_test_iefk_idem"
+		catalog.AddForTest(catalog.ResourceTypeDef{ShortName: sn})
+		defer catalog.RemoveForTest(sn)
+
+		catalog.RegisterIssueEnricherFieldKeys(sn, []string{"x"})
+		catalog.RegisterIssueEnricherFieldKeys(sn, []string{"x"})
+
+		ct := catalog.Find(sn)
+		if ct == nil {
+			t.Fatalf("catalog.Find(%q) returned nil", sn)
+		}
+		if len(ct.IssueEnricherFieldKeys) != 1 {
+			t.Errorf("idempotent register should yield 1 key, got %v", ct.IssueEnricherFieldKeys)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// RegisterChildView / FindChild
+// ---------------------------------------------------------------------------
+
+func TestRegisterChildView(t *testing.T) {
+	t.Run("happy_path_register_then_find", func(t *testing.T) {
+		sn := "_qa_test_childview_happy"
+
+		catalog.RegisterChildView(catalog.ResourceTypeDef{
+			Name:         "QA Child Happy",
+			ShortName:    sn,
+			ChildFetcher: noopChildFetcher,
+			Columns:      []domain.Column{{Key: "id", Title: "ID"}},
+			CopyField:    "id",
+		})
+
+		got := catalog.FindChild(sn)
+		if got == nil {
+			t.Fatalf("FindChild(%q) returned nil after RegisterChildView", sn)
+		}
+		if got.ShortName != sn {
+			t.Errorf("FindChild ShortName = %q, want %q", got.ShortName, sn)
+		}
+		if got.ChildFetcher == nil {
+			t.Errorf("FindChild returned entry with nil ChildFetcher")
+		}
+		if len(got.Columns) == 0 {
+			t.Errorf("FindChild returned entry with empty Columns")
+		}
+		if got.CopyField != "id" {
+			t.Errorf("FindChild CopyField = %q, want %q", got.CopyField, "id")
+		}
+	})
+
+	t.Run("panic_on_duplicate", func(t *testing.T) {
+		sn := "_qa_test_childview_dup"
+		catalog.RegisterChildView(catalog.ResourceTypeDef{ShortName: sn, ChildFetcher: noopChildFetcher})
+		expectPanic(t, "RegisterChildView second call with same shortName", func() {
+			catalog.RegisterChildView(catalog.ResourceTypeDef{ShortName: sn, ChildFetcher: noopChildFetcher})
+		})
+	})
+}
+
+func TestFindChild_ReturnsNilForUnregistered(t *testing.T) {
+	got := catalog.FindChild("_qa_test_unregistered_child_xyz")
+	if got != nil {
+		t.Errorf("FindChild on unregistered shortName returned %+v, want nil", got)
+	}
+}

--- a/tests/unit/catalog_mutator_test.go
+++ b/tests/unit/catalog_mutator_test.go
@@ -292,6 +292,7 @@ func TestRegisterIssueEnricherFieldKeys(t *testing.T) {
 func TestRegisterChildView(t *testing.T) {
 	t.Run("happy_path_register_then_find", func(t *testing.T) {
 		sn := "_qa_test_childview_happy"
+		defer catalog.RemoveForTest(sn)
 
 		catalog.RegisterChildView(catalog.ResourceTypeDef{
 			Name:         "QA Child Happy",
@@ -321,6 +322,7 @@ func TestRegisterChildView(t *testing.T) {
 
 	t.Run("panic_on_duplicate", func(t *testing.T) {
 		sn := "_qa_test_childview_dup"
+		defer catalog.RemoveForTest(sn)
 		catalog.RegisterChildView(catalog.ResourceTypeDef{ShortName: sn, ChildFetcher: noopChildFetcher})
 		expectPanic(t, "RegisterChildView second call with same shortName", func() {
 			catalog.RegisterChildView(catalog.ResourceTypeDef{ShortName: sn, ChildFetcher: noopChildFetcher})

--- a/tests/unit/messaging_child_view_test.go
+++ b/tests/unit/messaging_child_view_test.go
@@ -1,0 +1,55 @@
+package unit
+
+// messaging_child_view_test.go — AS-726 PR-04i — verify the four messaging
+// child views are registered through the new catalog child registry, with
+// intact column/fetcher metadata.
+//
+// Per spec §4 the child-view init()s (currently in sns_sub_by_topic.go,
+// eb_rule_targets.go, sfn_executions.go, sfn_execution_history.go) are
+// migrated from `resource.RegisterChildType` + `resource.RegisterPaginatedChild`
+// to `catalog.RegisterChildView`. `catalog.FindChild` is the new authoritative
+// accessor for messaging children.
+//
+// The CopyField expectations come from the spec's inline-after blocks in §4:
+//
+//   sns_subscriptions     → CopyField "endpoint"
+//   eb_rule_targets       → CopyField "target_arn"
+//   sfn_executions        → CopyField "execution_arn"
+//   sfn_execution_history → CopyField "event_detail"
+
+import (
+	"testing"
+
+	"github.com/k2m30/a9s/v3/internal/catalog"
+)
+
+func TestMessagingChildViewsViaCatalog(t *testing.T) {
+	cases := []struct {
+		shortName string
+		copyField string
+	}{
+		{"sns_subscriptions", "endpoint"},
+		{"eb_rule_targets", "target_arn"},
+		{"sfn_executions", "execution_arn"},
+		{"sfn_execution_history", "event_detail"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.shortName, func(t *testing.T) {
+			c := catalog.FindChild(tc.shortName)
+			if c == nil {
+				t.Fatalf("catalog.FindChild(%q) returned nil — messaging child view not registered via catalog", tc.shortName)
+			}
+			if c.ChildFetcher == nil {
+				t.Errorf("%s: ChildFetcher nil on catalog child row", tc.shortName)
+			}
+			if len(c.Columns) == 0 {
+				t.Errorf("%s: Columns empty on catalog child row", tc.shortName)
+			}
+			if c.CopyField != tc.copyField {
+				t.Errorf("%s: CopyField = %q, want %q (per spec §4 inline-after block)",
+					tc.shortName, c.CopyField, tc.copyField)
+			}
+		})
+	}
+}

--- a/tests/unit/messaging_noop_wave2_test.go
+++ b/tests/unit/messaging_noop_wave2_test.go
@@ -1,0 +1,47 @@
+package unit
+
+// messaging_noop_wave2_test.go — AS-726 PR-04i — verify that the two NoOp-only
+// issue-enrichment files (sns_sub_issue_enrichment.go, kinesis_issue_enrichment.go)
+// are gone and the catalog row's Wave2 == nil is the explicit "no Wave 2" signal.
+//
+// Why this test must verify the NEGATIVE:
+//
+// Before AS-726, sns-sub and kinesis each had a 6-line init() that called
+// `registerIssueEnricher("sns-sub", NoOpIssueEnricher, 100)`. After AS-726,
+// those files are deleted (spec §4) and catalog-row Wave2 == nil becomes the
+// "no Wave 2" signal. `aws.GetIssueEnricher` must return `(IssueEnricher{}, false)`
+// in that case — NOT a NoOp registration cast through catalog.Wave2 or routed
+// through a fallback in the legacy IssueEnricherRegistry map.
+//
+// If the Coder accidentally leaves the NoOp call in place (e.g. moves it from
+// a deleted file to a still-existing file), `ok` will be true, masking the
+// deletion. The test catches that by asserting ok=false explicitly.
+
+import (
+	"testing"
+
+	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+)
+
+func TestNoOpWave2ReturnsAbsent(t *testing.T) {
+	// Per spec §4: the NoOp-only init() blocks are deleted, and catalog
+	// Wave2 == nil is the explicit "no Wave 2" signal. GetIssueEnricher
+	// must surface that as ok=false.
+	cases := []string{"sns-sub", "kinesis"}
+
+	for _, sn := range cases {
+		t.Run(sn, func(t *testing.T) {
+			e, ok := awsclient.GetIssueEnricher(sn)
+			if ok {
+				t.Errorf("aws.GetIssueEnricher(%q) returned ok=true; expected false. "+
+					"NoOp-only Wave 2 file should be deleted per AS-726 PR-04i §4. "+
+					"Returned enricher: Priority=%d, Fn-nil=%v",
+					sn, e.Priority, e.Fn == nil)
+			}
+			if e.Fn != nil {
+				t.Errorf("aws.GetIssueEnricher(%q) returned non-nil Fn; expected zero IssueEnricher. "+
+					"A stray re-registration is masking the NoOp deletion.", sn)
+			}
+		})
+	}
+}

--- a/tests/unit/qa_attention_signals_doc_test.go
+++ b/tests/unit/qa_attention_signals_doc_test.go
@@ -176,10 +176,13 @@ func TestAttentionSignalsDoc(t *testing.T) {
 				}
 			}
 
-			// Assertion 3: Wave 2 non-empty → registered enricher.
+			// Assertion 3: Wave 2 non-empty → registered enricher (catalog
+			// Wave2 or legacy IssueEnricherRegistry, per aws.GetIssueEnricher).
+			// Post-AS-726 PR-04i, messaging Wave 2 enrichers live on the
+			// catalog row; un-migrated categories still use the legacy map.
 			if !isNoneCell(row.Wave2) {
-				if _, ok := awsclient.IssueEnricherRegistry[row.ShortName]; !ok {
-					t.Errorf("docs Wave 2 signal for %q but no entry in awsclient.IssueEnricherRegistry", row.ShortName)
+				if _, ok := awsclient.GetIssueEnricher(row.ShortName); !ok {
+					t.Errorf("docs Wave 2 signal for %q but no Wave 2 enricher registered (neither catalog Wave2 nor IssueEnricherRegistry)", row.ShortName)
 				}
 			}
 		})

--- a/tests/unit/qa_coverage_gaps_test.go
+++ b/tests/unit/qa_coverage_gaps_test.go
@@ -219,10 +219,16 @@ func TestIssueEnricherRegistry_AllExpectedKeys(t *testing.T) {
 	// The original 8 enrichers from issue #196. These must still be
 	// registered (real, not noop) — they're the foundational Wave 2
 	// implementations.
+	//
+	// Post-AS-726 PR-04i, "sfn" lives on the catalog row's Wave2 field
+	// rather than IssueEnricherRegistry. Use aws.GetIssueEnricher, which
+	// consults catalog Wave2 first then falls back to the legacy map, so
+	// either registration path satisfies the test.
 	expected := []string{"rds", "dbi", "ebs", "cb", "tg", "pipeline", "sfn", "glue"}
 	for _, key := range expected {
-		if e, ok := awsclient.IssueEnricherRegistry[key]; !ok || e.Fn == nil {
-			t.Errorf("IssueEnricherRegistry[%q].Fn is nil or missing", key)
+		e, ok := awsclient.GetIssueEnricher(key)
+		if !ok || e.Fn == nil {
+			t.Errorf("Wave 2 enricher for %q missing (neither catalog Wave2 nor IssueEnricherRegistry has it)", key)
 		}
 	}
 }

--- a/tests/unit/qa_enrichment_dispatch_test.go
+++ b/tests/unit/qa_enrichment_dispatch_test.go
@@ -41,16 +41,19 @@ var originalIssue196Enrichers = []string{
 }
 
 // TestIssueEnricherRegistry_OriginalSetStillRegistered pins the original 8
-// enrichers from issue #196.
+// enrichers from issue #196. Post-AS-726 PR-04i, "sfn" lives on the catalog
+// row's Wave2 field rather than IssueEnricherRegistry. Use aws.GetIssueEnricher
+// which consults catalog Wave2 first then falls back to the legacy map, so
+// either registration path satisfies the test.
 func TestIssueEnricherRegistry_OriginalSetStillRegistered(t *testing.T) {
 	for _, shortName := range originalIssue196Enrichers {
-		fn, ok := awsclient.IssueEnricherRegistry[shortName]
+		fn, ok := awsclient.GetIssueEnricher(shortName)
 		if !ok {
-			t.Errorf("IssueEnricherRegistry missing entry for %q", shortName)
+			t.Errorf("Wave 2 enricher for %q missing (neither catalog Wave2 nor IssueEnricherRegistry has it)", shortName)
 			continue
 		}
 		if fn.Fn == nil {
-			t.Errorf("IssueEnricherRegistry[%q].Fn is nil — must be a non-nil IssueEnricherFunc", shortName)
+			t.Errorf("Wave 2 enricher for %q has nil Fn — must be a non-nil IssueEnricherFunc", shortName)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Wires the 9 messaging resource types (sqs, sns, sns-sub, eb-rule, kinesis, msk, sfn, ses + the 4 child views) onto the catalog row as the single source of truth for `Fetcher` / `Wave2` / `Related` / `Navigable` / `FieldKeys` / `IssueEnricherFieldKeys` / `Children`, per `docs/refactor/AS-726-pr04i-messaging.md`.

Parent: **AS-726** · Coder issue: **AS-742** · QA sibling: AS-726/QA

### What changed

**Catalog surface (`internal/catalog/`)**
- `types.go`: add `FieldKeys`, `IssueEnricherFieldKeys`, `ChildFetcher` to `ResourceTypeDef`.
- `catalog.go`: add 8 mutators (`RegisterFetcher`, `RegisterWave2`, `RegisterRelated`, `RegisterNavigable`, `RegisterFieldKeys`, `RegisterIssueEnricherFieldKeys`, `RegisterChildView`, `FindChild`) + `childTypes` map + `AddForTest`/`RemoveForTest` test scaffolding. Panic-on-duplicate per spec; `RegisterIssueEnricherFieldKeys` dedups (legacy behavior).
- `FindIndex` exported for non-catalog mutator callers.

**Accessor wrappers (`internal/resource/`)**
- `registry.go`: `GetFieldKeys`, `GetIssueEnricherFieldKeys`, `GetChildType`, `GetPaginatedChildFetcher` consult catalog first, fall back to legacy maps. `GetFieldKeys` also consults `catalog.FindChild` (child views live in `catalog.childTypes`).
- `related.go`: `GetRelated` unions catalog + legacy (so `zzz_ct_events_all_related.go`'s `AppendRelated` continues to surface CloudTrail Events on migrated types); `BootstrapActiveNavFields` seeds from `catalog.All().Navigable`.

**Messaging service-file rewires (24 files)** — every `resource.Register*` / `registerIssueEnricher` call in messaging `init()`s replaced with the equivalent `catalog.Register*` call. Function bodies, fetcher closures, and related-checker functions unchanged. Child views (`sns_subscriptions`, `eb_rule_targets`, `sfn_executions`, `sfn_execution_history`) collapse into a single `catalog.RegisterChildView` call.

**Deletes**
- `internal/aws/sns_sub_issue_enrichment.go` (NoOp-only)
- `internal/aws/kinesis_issue_enrichment.go` (NoOp-only)

With catalog-routed lookup, `ct.Wave2 == nil` IS the "no Wave 2" signal, and `aws.GetIssueEnricher` returns `(IssueEnricher{}, false)`. Verified by QA's `TestNoOpWave2ReturnsAbsent`.

**Test-contract updates**
- `qa_attention_signals_doc_test.go`, `qa_coverage_gaps_test.go`, `qa_enrichment_dispatch_test.go` switched from reading the legacy `IssueEnricherRegistry` map directly to `aws.GetIssueEnricher`, which is the catalog-aware accessor and surfaces enrichers from either source.

### Verification (run locally — all clean)

```bash
go build ./...                         # clean
go test ./...                          # all packages pass; tests/unit 13.7s
golangci-lint run --timeout=5m ./...   # 0 issues
govulncheck ./...                      # no vulnerabilities
go fix -inline ./...                   # no diff

# Messaging service files: zero legacy register calls
grep -nE 'resource\.(RegisterFieldKeys|RegisterPaginated|RegisterRelated|RegisterDefaultNavFields|RegisterPaginatedChild|RegisterChildType|RegisterIssueEnricherFieldKeys)|registerIssueEnricher\(' \
  internal/aws/sqs*.go internal/aws/sns*.go internal/aws/eb_rule*.go \
  internal/aws/kinesis*.go internal/aws/msk*.go internal/aws/sfn*.go internal/aws/ses*.go
# (empty — pass)

# Non-messaging categories still use legacy register (sanity)
grep -nE 'resource\.(RegisterFieldKeys|RegisterPaginated|RegisterRelated)' internal/aws/ec2*.go internal/aws/rds*.go
# (non-empty — pass; migrate in sibling PRs)

# NoOp-only Wave-2 files gone
ls internal/aws/sns_sub_issue_enrichment.go internal/aws/kinesis_issue_enrichment.go
# No such file or directory (pass)
```

### Scope discipline

Out of scope (untouched per spec):
- `internal/aws/eb_related.go`, `internal/aws/eb_issue_enrichment.go` (Elastic Beanstalk env — compute category)
- `internal/aws/issue_enrichment.go` — `IssueEnricherRegistry` + `GetIssueEnricher` fallback retained for the 11 categories still on the legacy registration path. PR-04n deletes the fallback once all categories are migrated.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all green (incl. QA's failing tests on this branch)
- [x] `golangci-lint run` 0 issues
- [x] `govulncheck` clean
- [x] `go fix -inline` no diff
- [x] Messaging-file grep gate empty; non-messaging grep non-empty
- [x] Both NoOp Wave 2 files deleted
- [ ] Stage 5: CodeReviewer + CodexReviewer + Architect (size ≥ M)
- [ ] Stage 6: `make ready-to-push` (CI)

Refs: AS-726, AS-741, AS-742

Co-Authored-By: Paperclip <noreply@paperclip.ing>