### PR TITLE
docs(refactor): AS-650 PR-05a-h4 spec — screen-builder registry + 4 handler ports + 5a-extract close

### DIFF
--- a/docs/refactor/05-boundary.md
+++ b/docs/refactor/05-boundary.md
@@ -214,7 +214,7 @@ This preserves today's stack-walking semantics — every matching view in the st
 - `internal/runtime/handlers_related.go` — moved from `internal/tui/app_handlers_related_navigate.go`.
 - `internal/runtime/probes.go`, `enrich.go`, `related.go`, `fetchers.go` — moved from corresponding `app_*.go` files.
 - `internal/runtime/state.go` — `RuntimeState` struct: the view-ready state the UI shell renders. Snapshot of caches, current findings, queue progress, task state, etc.
-- `internal/tui/screens.go` — Bubble Tea screen builders (`runtime.ScreenID -> tea.Model`) used by the TUI adapter only.
+- `internal/tui/screens.go` — Bubble Tea screen builders (`runtime.ScreenID -> tea.Model`) used by the TUI adapter only. The concrete registry plus its first four ScreenIDs (profile selector, reveal, child list, theme apply) lands in PR-05a-h4-a; see [`05-pr-05a-h4.md`](./05-pr-05a-h4.md).
 
 #### Files modified
 
@@ -262,6 +262,8 @@ rg 'tea\\.|bubbletea' internal/runtime/ internal/domain/ internal/session/ inter
 wc -l internal/tui/app.go
 # expected: 300–400 lines (was ~880)
 ```
+
+> **Status note (post AS-646 audit, 2026-05-20)**: the exit criteria above did not land with PR-05a-h2/h3 — `internal/tui` still imports `internal/session` and `internal/aws`, and `app.go` grew to ~986 LOC during the migration. The follow-on spec [`05-pr-05a-h4.md`](./05-pr-05a-h4.md) (AS-650) breaks the residual work into three child PRs (h4-a screen-builder + four handler ports; h4-b `Update()`-switch extraction; h4-c final import scrub) and is the first to pass the bash gates above when it ships.
 
 Behavior verification:
 - `make test` and `make test-race` pass.

--- a/docs/refactor/05-pr-05a-h2.md
+++ b/docs/refactor/05-pr-05a-h2.md
@@ -141,7 +141,7 @@ These stay in their current `internal/tui/app_*.go` files until the screen-build
 | `handleEnterChildView` | `internal/tui/app_screens.go:37` | Calls `views.NewChildResourceList(...)`, pushes a `*ResourceListModel` |
 | `handleThemeSelected` | `internal/tui/app_session.go:227` | Mutates `styles.ApplyTheme(...)` (renderer-side), iterates `m.stack` to invalidate `*ResourceListModel` style caches, pops the selector |
 
-A successor PR (PR-05a-h4) will tackle these together when the screen-builder registry is wired.
+A successor PR (PR-05a-h4) will tackle these together when the screen-builder registry is wired. See [`05-pr-05a-h4.md`](./05-pr-05a-h4.md) — that spec is the Stage 2 design output for AS-650 and breaks the work into three child PRs (h4-a screen-builder + four handler ports; h4-b `Update()`-switch extraction; h4-c final `internal/session` / `internal/aws` import scrub).
 
 ### New UIIntent variants (in `internal/runtime/intent.go`)
 
@@ -303,4 +303,4 @@ L. Estimated 700–1000 LOC (300 new Core methods + 200 thin adapters + 100 inte
 
 - Spec contract: [`05-boundary.md`](./05-boundary.md) §"5a-extract"
 - Predecessor PR: #353 (AS-147) — split `app_handlers.go` and created `internal/runtime/handlers.go` stub
-- Sibling: [`05-pr-05a-h4-screen-registry`] — TBD; tackles the four view-stack handlers when the screen-builder registry lands.
+- Sibling: [`05-pr-05a-h4.md`](./05-pr-05a-h4.md) — tackles the four view-stack handlers + the broader `internal/tui/` boundary-clean exit (AS-650 spec).

--- a/docs/refactor/05-pr-05a-h4.md
+++ b/docs/refactor/05-pr-05a-h4.md
@@ -1,0 +1,635 @@
+# PR-05a-h4 — Screen-builder registry; four view-stack-pushing handler ports; final 5a-extract boundary close
+
+**Parent program**: AS-72 (Phase-05 PR-05a-extract). Predecessor: AS-315a/b (PR-05a-h2 field migration + handler port) and AS-147 (PR-05a-h1 handler-file split). Spec contract: [`05-boundary.md`](./05-boundary.md) §"5a-extract".
+
+This document is the Stage 2 design output for AS-650. It is the last spec under the 5a-extract umbrella: when its three child PRs (`h4-a`, `h4-b`, `h4-c`) merge, `internal/tui/` stops importing `internal/session` and `internal/aws`, `internal/tui/app.go` lands in the 300–400 LOC target, and the Stage 2 exit criteria in [`05-boundary.md`](./05-boundary.md):230-264 are met for the first time.
+
+## Why this work exists
+
+PR-05a-h3 (AS-315b) intentionally **deferred** four handlers because each one constructs a view object via `views.New*` and pushes it onto `m.stack`. Punching that through the runtime without a renderer-aware screen contract would have required either inventing a closure-carrying intent that smuggles `tea.Model` factories through the shared core (anti-pattern) or wiring a full screen-builder registry as a side quest (out of scope for AS-315). That side quest is this PR.
+
+In addition, AS-646 §Gap 3 audited the post-h3 state of `internal/tui/` and found three concrete deltas vs the boundary spec:
+
+1. **Four view-stack-pushing handlers still own renderer construction directly.** Tracked in `05-pr-05a-h2.md`:135-144. The four are `handleProfilesLoaded`, `handleValueRevealed`, `handleEnterChildView`, `handleThemeSelected`.
+2. **`internal/tui/app.go` is 986 LOC** vs target 300–400 (and a pre-refactor baseline of ~880). The growth came from inline session-mutation logic that snuck into `Update()` switch cases (`ResourcesLoaded`, `RelatedCheckResult`, `IdentityLoaded`) during h2/h3 to avoid widening the migration. Those switch-case bodies are runtime concerns — they read and write `Session.ResourceCache`, `Session.RelatedCache`, `Session.LazyResourceCache`, `Session.ProbeResources`, etc.
+3. **`internal/tui/` still imports `internal/session` and `internal/aws`.** Production-code violations live in `app.go`, `app_accessors.go`, `probe_adapter.go`, `runtime_adapter.go`, `runtime_adapter_navigate.go`, `runtime_adapter_related.go`. The h3 work eliminated none of these — it was scoped to handler bodies only.
+
+AS-650 lists `app_input.go`, `app_flash.go`, `app_session.go`, `app_screens.go` as the "four remaining handler families." Resolution:
+
+| File | Disposition | Rationale |
+|---|---|---|
+| `app_input.go` | **Stays in `internal/tui/`.** Verify boundary-clean (no `internal/session` / `internal/aws` imports). | Keyboard input is a UI concern (`05-boundary.md`:222). It is already boundary-clean today; this PR adds a regression guard. |
+| `app_flash.go` | **Stays in `internal/tui/`.** No further port. | h3 already ported `handleFlash`, `handleClearFlash`, `handleAPIError` to `runtime.Core`; the file now contains three ≤12-line thin adapters. Touching it again is churn. |
+| `app_session.go` | **Two of five handlers ported here.** `handleProfilesLoaded` and `handleThemeSelected` move to thin adapters; the three h3-ported adapters stay. | Both deferred handlers push selectors and rely on the screen-builder registry that this PR introduces. |
+| `app_screens.go` | **Both handlers ported here.** File becomes two ≤12-line thin adapters. | Both `handleValueRevealed` and `handleEnterChildView` push concrete screens via `views.New*`. They become canonical `PushScreen` emitters. |
+
+## Boundary invariant (unchanged)
+
+`internal/runtime/` MUST remain Bubble Tea-free.
+
+```bash
+go list -f '{{.Imports}}' github.com/k2m30/a9s/v3/internal/runtime | grep -E 'bubbletea|lipgloss|bubbles'
+# expected: zero hits
+```
+
+After PR-05a-h4-c merges, the inverse invariant also lands for the first time:
+
+```bash
+go list -f '{{.Imports}}' github.com/k2m30/a9s/v3/internal/tui | grep -E 'internal/session|internal/aws$'
+# expected: zero hits
+```
+
+(The literal `internal/aws$` anchor avoids matching child packages like `internal/aws/identity` if any are introduced later. Tests under `tests/unit/` are allowed to import both; only the `internal/tui` production tree is gated.)
+
+## Child-PR breakdown — three PRs, all mandatory to close 5a-extract
+
+The work splits into three child PRs filed under AS-646 (parent program AS-72). Each is independently mergeable. h4-a unblocks h4-b unblocks h4-c. The ordering is forced: h4-a introduces the screen-builder contract; h4-b moves the Update()-switch session writes into runtime methods that emit `PatchResourceList`/`PatchDetail`; h4-c removes the now-unreferenced `internal/session` / `internal/aws` imports.
+
+```
+h4-a (handler ports + screen builder)  ──┐
+                                          ├──▶ h4-c (final import scrub)
+h4-b (Update()-switch extraction)       ──┘
+```
+
+`h4-a` and `h4-b` are independent (they touch disjoint code paths) and may merge in either order; `h4-c` waits on both because it deletes the imports they last referenced.
+
+---
+
+## PR-05a-h4-a — Screen-builder registry; four deferred handler ports
+
+**Sizing**: L. Estimated 900–1100 LOC (4 handler ports × ~80 LOC each + screen builder map + 4 typed payloads + 6 unit tests + adapter wiring).
+
+### What "screen-builder registry" means
+
+Two halves:
+
+1. **Runtime side** (`internal/runtime/screens.go`, already exists as types-only stub): the platform-agnostic `ScreenID` constants and a typed `ScreenPayload` interface — the runtime carries per-screen typed payload structs inside the existing `PushScreen` intent.
+2. **TUI side** (`internal/tui/screens.go`, **new file**): a `Builders` map keyed by `ScreenID` that resolves to a renderer-side closure `func(runtime.ScreenPayload) (views.View, tea.Cmd)`. The adapter populates this map once in `tui.New(...)`.
+
+The runtime never sees `tea.Model` / `views.View`. The adapter never invents `ScreenID`s — they live in `internal/runtime`.
+
+### Typed ScreenPayload contract (mirrors existing TaskPayload pattern)
+
+New in `internal/runtime/screens.go`:
+
+```go
+// ScreenPayload is the marker interface for typed per-Screen payload structs.
+// PushScreen carries one of these; adapters type-switch on it to recover
+// the typed fields. Empty payload structs are permitted.
+type ScreenPayload interface {
+    isScreenPayload()
+}
+
+const (
+    ScreenProfileSelector ScreenID = "profile-selector"
+    ScreenReveal          ScreenID = "reveal"
+    ScreenChildList       ScreenID = "child-list"
+    // ScreenRegionSelector / ScreenThemeSelector / ScreenHelp / ScreenIdentity
+    // are emitted by existing Navigate handling — not by this PR. They are
+    // listed here only to anchor the constant block; their handler ports
+    // are out of scope.
+)
+
+type ProfileSelectorPayload struct {
+    Profiles []string
+    Current  string
+}
+func (ProfileSelectorPayload) isScreenPayload() {}
+
+type RevealPayload struct {
+    ResourceID string
+    Value      string
+}
+func (RevealPayload) isScreenPayload() {}
+
+type ChildListPayload struct {
+    ChildType     string
+    ParentContext map[string]string
+    DisplayName   string
+}
+func (ChildListPayload) isScreenPayload() {}
+```
+
+`PushScreen` gains a `Payload` field:
+
+```go
+// internal/runtime/intent.go (modified)
+type PushScreen struct {
+    ID      ScreenID
+    Context ScreenContext // unchanged — capability-screen routing fields
+    Payload ScreenPayload // nil when Context.Capability handles the routing
+}
+```
+
+The existing `ScreenContext` (resource-type / resource-id / capability / query) stays as the high-level dispatch hint for capability screens (logs, ct.scan, cost). The new `Payload` carries per-screen typed data for selector/reveal/child screens. **Both can be set on the same intent**; the adapter type-switches on `ID` to decide which fields matter.
+
+### TUI-side Builders (new file `internal/tui/screens.go`)
+
+```go
+package tui
+
+import (
+    tea "charm.land/bubbletea/v2"
+
+    "github.com/k2m30/a9s/v3/internal/runtime"
+    "github.com/k2m30/a9s/v3/internal/tui/views"
+)
+
+// screenBuilder constructs a renderer-side view from a runtime-emitted
+// screen payload. The adapter holds one builder per runtime.ScreenID.
+type screenBuilder func(payload runtime.ScreenPayload) (views.View, tea.Cmd)
+
+// builders is the Bubble Tea adapter's parallel of runtime.ScreenRegistry:
+// ScreenID -> concrete builder closure. Populated once in tui.New(...).
+type builders map[runtime.ScreenID]screenBuilder
+
+// defaultBuilders returns the canonical builder set for this adapter.
+// The closures capture m.keys, m.viewConfig, and any other adapter-side
+// state they need at construction time. Callers may shadow individual
+// entries in tests.
+func defaultBuilders(m *Model) builders {
+    return builders{
+        runtime.ScreenProfileSelector: func(p runtime.ScreenPayload) (views.View, tea.Cmd) {
+            psp, ok := p.(runtime.ProfileSelectorPayload)
+            if !ok { /* defensive: payload-type mismatch */ return nil, nil }
+            v := views.NewProfile(psp.Profiles, psp.Current, m.keys)
+            v.SetSize(m.innerSize())
+            return &v, nil
+        },
+        runtime.ScreenReveal: func(p runtime.ScreenPayload) (views.View, tea.Cmd) {
+            rp, ok := p.(runtime.RevealPayload)
+            if !ok { return nil, nil }
+            v := views.NewReveal(rp.ResourceID, rp.Value, m.keys)
+            v.SetSize(m.innerSize())
+            return &v, nil
+        },
+        runtime.ScreenChildList: func(p runtime.ScreenPayload) (views.View, tea.Cmd) {
+            clp, ok := p.(runtime.ChildListPayload)
+            if !ok { return nil, nil }
+            childTypeDef := resource.GetChildType(clp.ChildType)
+            if childTypeDef == nil { return nil, nil } // adapter handles unknown-type flash
+            rl := views.NewChildResourceList(*childTypeDef, clp.ParentContext, clp.DisplayName, m.viewConfig, m.keys)
+            rl.SetSize(m.innerSize())
+            _, initCmd := rl.Init()
+            fetchCmd := m.fetchChildResources(clp.ChildType, clp.ParentContext)
+            return &rl, tea.Batch(initCmd, fetchCmd)
+        },
+    }
+}
+```
+
+`tui.Model` gains a `screens builders` field (set in `tui.New`).
+
+`applyIntents` gains a `PushScreen` case:
+
+```go
+case runtime.PushScreen:
+    builder, ok := m.screens[v.ID]
+    if !ok {
+        // No registered builder — runtime emitted an ID this adapter doesn't render.
+        // Surface as flash so the operator sees the misconfig.
+        cmds = append(cmds, func() tea.Msg {
+            return messages.Flash{Text: fmt.Sprintf("no screen builder: %s", v.ID), IsError: true}
+        })
+        break
+    }
+    view, cmd := builder(v.Payload)
+    if view != nil {
+        m.pushView(view)
+    }
+    if cmd != nil {
+        cmds = append(cmds, cmd)
+    }
+```
+
+A parallel `PopScreen` case for the existing intent variant is also added — `m.popView()` and done.
+
+### Handler ports
+
+| Handler | Current location (post-h3) | New Core method | New intents emitted | Notes |
+|---|---|---|---|---|
+| `handleProfilesLoaded` | `app_session.go:147` | `HandleProfilesLoaded(ProfilesLoadedEvent) ([]UIIntent, []TaskRequest)` | `PushScreen{ID: ScreenProfileSelector, Payload: ProfileSelectorPayload{...}}` | Core reads `c.Session().Profile` for `Current`. Event carries `Profiles []string`. |
+| `handleValueRevealed` | `app_screens.go:22` | `HandleValueRevealed(ValueRevealedEvent) ([]UIIntent, []TaskRequest)` | Success: `PushScreen{ID: ScreenReveal, Payload: RevealPayload{...}}`. Error: `FlashIntent{Text: "reveal failed: " + err}`. | Event carries `ResourceID`, `Value`, `Err`. Core branches on `Err != nil`. |
+| `handleEnterChildView` | `app_screens.go:37` | `HandleEnterChildView(EnterChildViewEvent) ([]UIIntent, []TaskRequest)` | Unknown child type: `FlashIntent{Text: "unknown child type: " + ChildType, IsError: true}`. Otherwise: `PushScreen{ID: ScreenChildList, Payload: ChildListPayload{...}}` + `TaskRequest{Kind: TaskKindFetchChildResources, ...}`. | Core validates via `resource.GetChildType(...)` (no Bubble Tea touched). Adapter-side closure runs the fetch task. |
+| `handleThemeSelected` | `app_session.go:95` | Two Core methods (file I/O cannot run inside Core) — see below | `ApplyThemeIntent`, `PopSelectorIntent`, `FlashIntent`, plus `TaskKindReadThemeFile` and `TaskKindSaveThemeConfig` | The theme-apply path is renderer-state mutation; it has to be an intent the adapter applies because `lipgloss.SetDefaultRenderer` is renderer-scope. |
+
+#### Theme-selected split (renderer-state mutation problem)
+
+`handleThemeSelected` today reads the theme file from disk, parses it, calls `styles.ApplyTheme(t)` (mutates renderer state), invalidates the header cache, walks `m.stack` invalidating `*ResourceListModel` style caches, pops the selector, and persists the choice. Core cannot do file I/O. The split:
+
+1. **Adapter dispatches a `ThemeSelectedMsg`.** `app_session.go`'s `handleThemeSelected` translates this to `runtime.ThemeSelectedEvent{Theme: msg.Theme}` and calls `c.HandleThemeSelected(...)`.
+2. **`(c *Core) HandleThemeSelected`** returns a single `TaskRequest{Kind: TaskKindReadThemeFile, Payload: ReadThemePayload{Theme: msg.Theme}}` and no intents yet. (Optimization: the path-resolution side `config.ThemePath(...)` can run inside Core because `internal/config` is allowed; the disk read is the part that has to be a task.)
+3. **Adapter runs the read task**, dispatches `messages.ThemeFileRead{Theme: msg.Theme, Bytes: data, Err: err}` back through `Update()`.
+4. **`(c *Core) HandleThemeFileRead`** parses YAML via `styles.ThemeFromYAML(...)`. On error: returns `FlashIntent` only. On success: returns:
+   - `ApplyThemeIntent{Theme: parsedTheme, Name: msg.Theme}` (new intent variant; the adapter applies it via `styles.ApplyTheme` + header-cache invalidation + ResourceListModel style-cache invalidation walk + `m.activeTheme = name`).
+   - `PopSelectorIntent{}` (existing).
+   - `FlashIntent{Text: "Theme: " + name}` (existing).
+   - `TaskRequest{Kind: TaskKindSaveThemeConfig, Payload: SaveThemeConfigPayload{Theme: msg.Theme}}` (new).
+
+The single-write contract (persist BEFORE apply) is preserved: Core's flow is read → parse → return [Apply, Pop, Flash, Persist] intents-and-tasks atomically. The adapter is sequenced by Bubble Tea's command pipeline — Apply intent runs before the next `Update()` tick, and the persist task runs in a tea.Cmd closure that returns `nil` (or a flash if the persist failed). If save fails *after* apply, the adapter flashes an error and the user re-selects on the next start. This is a behaviour change vs the current "abort entire change on save fail" logic; the new ordering is forced by the runtime/renderer split.
+
+**Decision: accept the ordering change.** Save-fail is a rare disk-full / permission-denied path; the user-visible regression (theme is applied for this session even if config persist failed) is minor compared to the boundary purity gain. The Coder must add a unit test asserting both branches:
+
+- Read OK → parse OK → 3 intents (Apply, Pop, Flash) + 1 task (Save).
+- Read OK → parse fail → 1 intent (FlashIntent error) only.
+- Read fail → 1 intent (FlashIntent error) only.
+- Save fail → adapter-side flash; verify the task's failure path emits `messages.Flash` with the save error text.
+
+(`styles.ApplyTheme` is renderer-side; Core never calls it. The "Apply" is an intent, applied by the TUI adapter as the renderer state mutation.)
+
+### New runtime types
+
+`internal/runtime/screens.go` adds:
+
+- `ScreenPayload` marker interface.
+- `ScreenProfileSelector`, `ScreenReveal`, `ScreenChildList` `ScreenID` constants.
+- `ProfileSelectorPayload`, `RevealPayload`, `ChildListPayload` typed payload structs.
+
+`internal/runtime/intent.go` adds:
+
+- `PushScreen.Payload ScreenPayload` field.
+- `ApplyThemeIntent struct{ Theme *styles.Theme; Name string }`.
+
+  **Important**: `styles.Theme` is currently defined under `internal/tui/styles/`. That package is *not* renderer-coupled today — it owns `lipgloss.Style` definitions but exposes them as values, not as `tea.*` types. Hosting `*styles.Theme` inside a runtime intent means `internal/runtime/` would gain a transitive dependency on `lipgloss`. **Two acceptable resolutions**:
+
+  - **Option A (preferred)**: extract `internal/tui/styles/theme.go`'s `Theme` value type (the YAML-decoded struct, no `lipgloss.Style` fields — just colour strings and palette names) into `internal/domain/theme.go`. Pure data, no renderer types. The `*lipgloss.Style` derivation stays in `internal/tui/styles/`. Then `ApplyThemeIntent.Theme` is `*domain.Theme`.
+  - **Option B (fallback)**: define `ApplyThemeIntent` to carry the parsed YAML *bytes* (`Bytes []byte`) and the theme name. The adapter re-parses via `styles.ThemeFromYAML(...)` and applies. Slightly wasteful but keeps Core out of the theme-struct decoding business entirely.
+
+  The Coder picks A or B at implementation time. A is cleaner; B is faster to land. Either preserves the boundary invariant.
+
+- `PopScreen` — already exists, no change.
+
+`internal/runtime/tasks.go` adds:
+
+- `TaskKindFetchChildResources TaskKind = "fetch-child-resources"` + `FetchChildResourcesPayload{ChildType string; ParentContext map[string]string}`.
+- `TaskKindReadThemeFile TaskKind = "read-theme-file"` + `ReadThemePayload{Theme string}`.
+- `TaskKindSaveThemeConfig TaskKind = "save-theme-config"` + `SaveThemeConfigPayload{Theme string}`.
+
+`internal/runtime/handlers.go` adds:
+
+- `HandleProfilesLoaded(ProfilesLoadedEvent)` — emits `PushScreen{ScreenProfileSelector, ..., ProfileSelectorPayload{...}}`.
+- `HandleValueRevealed(ValueRevealedEvent)` — branches on Err; emits `PushScreen` or `FlashIntent`.
+- `HandleEnterChildView(EnterChildViewEvent)` — emits `PushScreen` + `TaskRequest{TaskKindFetchChildResources}`.
+- `HandleThemeSelected(ThemeSelectedEvent)` — emits `TaskRequest{TaskKindReadThemeFile}`.
+- `HandleThemeFileRead(ThemeFileReadEvent)` — parses, emits Apply/Pop/Flash + Save task.
+
+Event-type definitions for the five new events live in `internal/runtime/handlers.go` alongside the existing event types from h3.
+
+### Files added (h4-a)
+
+- `internal/tui/screens.go` — new file with `builders` type and `defaultBuilders(*Model)`.
+- `internal/runtime/screens_handlers_test.go` — Core-direct unit coverage for the five new `Handle*` methods (one test per method, plus an extra for the theme parse-error branch and the theme read-error branch).
+
+### Files modified (h4-a)
+
+- `internal/runtime/screens.go` — add `ScreenPayload` interface, 3 `ScreenID` constants, 3 typed payload structs.
+- `internal/runtime/intent.go` — extend `PushScreen` with `Payload ScreenPayload`; add `ApplyThemeIntent`.
+- `internal/runtime/tasks.go` — add 3 new `TaskKind` constants + 3 typed payload structs.
+- `internal/runtime/handlers.go` — add 5 new `Handle*` methods (theme-selected splits into two).
+- `internal/runtime/orchestrator.go` — `HandleEvent` routes new event types (optional; the per-event `Handle*` entrypoints are sufficient — Coder picks the style consistent with h3).
+- `internal/tui/app.go`:
+  - Add `screens builders` field to `Model`.
+  - `tui.New(...)` populates `m.screens = defaultBuilders(&m)`.
+  - `applyIntents` gains `PushScreen`, `PopScreen`, `ApplyThemeIntent` cases.
+  - `tasksToCmd` gains `TaskKindFetchChildResources`, `TaskKindReadThemeFile`, `TaskKindSaveThemeConfig` cases.
+- `internal/tui/app_session.go`:
+  - `handleProfilesLoaded` shrinks to ≤10 LOC thin adapter.
+  - `handleThemeSelected` shrinks to ≤10 LOC thin adapter (dispatches `ThemeSelectedEvent`; the actual file I/O happens inside a task closure that adapter-side `tasksToCmd` translates).
+- `internal/tui/app_screens.go`:
+  - `handleValueRevealed` shrinks to ≤10 LOC thin adapter.
+  - `handleEnterChildView` shrinks to ≤10 LOC thin adapter.
+- `internal/domain/theme.go` (Option A only) — new pure-data `Theme` value type, no `lipgloss` import.
+- `internal/tui/styles/theme.go` (Option A only) — reshape to wrap `domain.Theme` for its YAML-decoding entry points; lipgloss-derivation logic unchanged.
+
+### Acceptance (h4-a)
+
+```bash
+# Five new Core methods land in handlers.go:
+rg 'func \(c \*Core\) (HandleProfilesLoaded|HandleValueRevealed|HandleEnterChildView|HandleThemeSelected|HandleThemeFileRead)' internal/runtime/handlers.go | wc -l
+# expected: 5
+
+# Boundary still clean on runtime side:
+go list -f '{{.Imports}}' github.com/k2m30/a9s/v3/internal/runtime | grep -E 'bubbletea|lipgloss|bubbles'
+# expected: zero hits
+
+# Four adapters shrunk to ≤12 LOC:
+for h in handleProfilesLoaded handleThemeSelected; do
+  awk "/^func \\(m Model\\) ${h}\\(/,/^}/" internal/tui/app_session.go | wc -l
+done
+for h in handleValueRevealed handleEnterChildView; do
+  awk "/^func \\(m Model\\) ${h}\\(/,/^}/" internal/tui/app_screens.go | wc -l
+done
+# expected: each ≤12
+
+# Builder map exists:
+rg 'screens\s+builders|defaultBuilders' internal/tui/screens.go
+# expected: present
+
+# PushScreen intent now carries Payload:
+rg 'Payload\s+ScreenPayload' internal/runtime/intent.go
+# expected: 1 hit (inside PushScreen)
+# AND inside ReplaceScreen if Option A is chosen by Coder
+
+# Per-handler Core-direct tests:
+rg 'func Test.*(ProfilesLoaded|ValueRevealed|EnterChildView|ThemeSelected|ThemeFileRead)' internal/runtime/screens_handlers_test.go | wc -l
+# expected: ≥6 (one per method + 1 extra for theme parse-error branch)
+
+# Build + tests + race + lint + security:
+make ready-to-push
+```
+
+### Behavior verification (h4-a)
+
+- `./a9s --demo`: `:profile` opens selector → select profile → reconnects. `:theme` opens selector → select → applies. On `x` (reveal) over a secret-bearing resource, RevealModel pushes. On `L` (logs) / child-view drilldown, child resource list pushes with header.
+- Unknown-screen-ID smoke: temporarily emit `PushScreen{ID: "bogus"}` from a unit-test path and assert `messages.Flash{IsError: true}` is emitted.
+
+---
+
+## PR-05a-h4-b — `app.go` Update()-switch inline-mutation extraction
+
+**Sizing**: L. Estimated 700–1000 LOC (3 large switch-case bodies extracted + tests + intent additions).
+
+### What this PR removes
+
+`internal/tui/app.go:312-559` contains three `Update()` switch cases whose bodies inline session-cache mutations that should live in `runtime.Core`:
+
+| Switch case | Lines | What the body does today | Becomes |
+|---|---|---|---|
+| `messages.ResourcesLoaded` | 312–390 | `deriveFindingsForType`; updates `m.core.Session().ResourceCache[rt] = &session.ResourceCacheEntry{...}` (in two branches: active-RL view writeback, and not-active-view direct cache); writes `Session.ProbeResources[rt]` + `ProbeTruncated[rt]` on `TypeGen != 0`; dispatches `probeEnrichment(...)`. | `(c *Core) HandleResourcesLoaded(ResourcesLoadedEvent) ([]UIIntent, []TaskRequest)`. Returns intents that pass the data to the adapter for view-state mutation and tasks that re-dispatch the probe. |
+| `messages.RelatedCheckResult` | 421–556 | Writes `Session.RelatedCache.Set(...)`; iterates `msg.CachedPages` → `Session.ResourceCache` + `LazyResourceCache` writes with canonicalization; iterates `LazyAddedResources` → de-duped `LazyResourceCache` extends; surfaces three independent error-flash paths (LazyAddError, checker err, both). | `(c *Core) HandleRelatedCheckResult(RelatedCheckResultEvent)`. Same outputs, expressed as intents + flash intents. |
+| `messages.IdentityLoaded` / `IdentityError` | dispatched at 391–394 to `handleIdentityLoaded` / `handleIdentityError` which live elsewhere | Inline today; `Session.Identity = id` plus header invalidation. | `(c *Core) HandleIdentityLoaded(IdentityLoadedEvent)` — emits `SetIdentityIntent` (new) + header-invalidate intent. |
+
+Plus three smaller inline mutations:
+
+- `messages.EnrichDetailResult` (lines 405-420): `deriveFindingsForResource` mutation — moves to Core.
+- `tea.WindowSizeMsg` related-dispatch detection (lines 246-260): runtime concern — moves to Core.
+- The `pendingRelatedDispatch` re-arm logic on detail view — same.
+
+### New intent variants (in `internal/runtime/intent.go`)
+
+```go
+// PatchResourceCache writes a single ResourceCacheEntry into the adapter's
+// session cache. Emitted by HandleResourcesLoaded after the write-through
+// branch decides to cache the loaded slice.
+type PatchResourceCache struct {
+    ResourceType string
+    Entry        domain.ResourceCacheEntry // (or, if cleaner, an inline struct copy)
+}
+func (PatchResourceCache) isIntent() {}
+
+// PatchRelatedCache appends one resolved related result to the related-cache.
+type PatchRelatedCache struct {
+    ResourceType string
+    SourceID     string
+    DefDisplayName string
+    Result       domain.RelatedResult
+}
+func (PatchRelatedCache) isIntent() {}
+
+// PatchLazyResourceCache merges sparse lazy-added resources into the
+// LazyResourceCache (de-duped by ID, canonicalized by ShortName).
+type PatchLazyResourceCache struct {
+    Adds map[string][]resource.Resource
+}
+func (PatchLazyResourceCache) isIntent() {}
+
+// SetIdentityIntent writes the resolved caller identity to Session.Identity
+// and invalidates the header cache so the next render picks it up.
+type SetIdentityIntent struct {
+    Identity *domain.CallerIdentity // domain-side mirror of awsclient.CallerIdentity
+}
+func (SetIdentityIntent) isIntent() {}
+
+// HeaderInvalidateIntent clears the adapter's header cache key so the next
+// View() pass recomputes. Emitted after identity / theme / profile changes.
+type HeaderInvalidateIntent struct{}
+func (HeaderInvalidateIntent) isIntent() {}
+```
+
+### Identity-type cross-package mirror
+
+`awsclient.CallerIdentity` is the on-the-wire AWS type today. The runtime emits it across the boundary; the adapter consumes it. After 5a-extract, `internal/tui/` must not import `internal/aws`, so the identity type needs a domain mirror:
+
+```go
+// internal/domain/identity.go (new)
+type CallerIdentity struct {
+    AccountID, AccountAlias, Arn, RoleName, UserName, SessionName, IdentityName string
+    IsAssumedRole bool
+}
+```
+
+The runtime converts `*awsclient.CallerIdentity` → `*domain.CallerIdentity` at the runtime/aws boundary (it lives inside `runtime/` which IS allowed to import `internal/aws`). The adapter consumes only `*domain.CallerIdentity`.
+
+`ResourceCacheEntry` and `RelatedCacheResult` similarly need domain mirrors *or* their definitions move from `internal/session` to `internal/domain` (since they're pure-data structs already, the latter is cleaner — defer to h4-c's import-elimination sweep).
+
+### Files added (h4-b)
+
+- `internal/runtime/handlers_resources.go` — new file owning `HandleResourcesLoaded`, `HandleEnrichDetailResult`, `HandleRelatedCheckResult`, `HandleIdentityLoaded`, `HandleIdentityError`. Three of these are large; splitting them into a sibling file mirrors the existing `handlers_availability.go` / `handlers_navigate.go` / `handlers_related.go` pattern.
+- `internal/domain/identity.go` — `CallerIdentity` value type.
+- `internal/runtime/handlers_resources_test.go` — one unit test per method, plus error-branch coverage.
+
+### Files modified (h4-b)
+
+- `internal/runtime/intent.go` — add 5 new intent variants above.
+- `internal/runtime/handlers.go` — orchestrator wiring (or per-event entrypoints — Coder's choice consistent with h3).
+- `internal/tui/app.go`:
+  - `Update()` `messages.ResourcesLoaded` case shrinks to `return m.coreUpdate(msg)` (~3 LOC).
+  - `Update()` `messages.RelatedCheckResult` case shrinks to `return m.coreUpdate(msg)` (~3 LOC).
+  - `Update()` `messages.EnrichDetailResult` case shrinks to thin adapter (~5 LOC).
+  - `Update()` `messages.IdentityLoaded` / `IdentityError` cases route through `coreUpdate`.
+  - `Update()` `tea.WindowSizeMsg` `pendingRelatedDispatch` re-arm moves out — adapter only emits the existing detail-pending-dispatch event; Core decides.
+  - `applyIntents` gains 5 new cases.
+- `internal/tui/runtime_adapter.go`:
+  - `handleEnrichDetail`'s `awsclient.DetailEnrichmentCtx` construction moves into Core. The adapter receives a runtime-side payload type.
+- `internal/tui/runtime_adapter_navigate.go`:
+  - The `awsclient.CallerIdentity` type-assertion at line 567 becomes a `*domain.CallerIdentity` type-assertion.
+  - The `m.core.Session().RuleSets = session.NewRuleSetStore()` calls (lines 435, 483) move into Core.
+  - `awsclient.AllRegions()` (line 260) becomes `c.AllRegions()` exposed on `runtime.Core`.
+
+### Acceptance (h4-b)
+
+```bash
+# Update() switch cases shrunk:
+awk '/case messages\.ResourcesLoaded:/,/^\tcase /' internal/tui/app.go | wc -l
+# expected: ≤6 (case header + body + next case header)
+awk '/case messages\.RelatedCheckResult:/,/^\tcase /' internal/tui/app.go | wc -l
+# expected: ≤6
+
+# app.go LOC moves toward target:
+wc -l internal/tui/app.go
+# expected: ≤700 after h4-b (still above 300–400 target — h4-c finishes)
+
+# 5+ new Core handler methods in handlers_resources.go:
+rg 'func \(c \*Core\) Handle' internal/runtime/handlers_resources.go | wc -l
+# expected: ≥5
+
+# Domain mirror types present:
+rg 'type CallerIdentity struct' internal/domain/identity.go
+# expected: 1 hit
+
+# Tests cover new methods:
+rg 'func Test.*(ResourcesLoaded|RelatedCheckResult|IdentityLoaded|EnrichDetailResult)' internal/runtime/handlers_resources_test.go | wc -l
+# expected: ≥5
+
+# Build + tests + race + lint + security:
+make ready-to-push
+```
+
+### Behavior verification (h4-b)
+
+- `./a9s --demo`: list refresh, detail enrichment, related-panel cold load + lazy-add (e.g., KMS customer-managed filter), identity panel (`i` key), profile/region switch (verify identity refreshes and header re-renders).
+- Race-detector smoke: `make test-race` with the gen-counter gauntlet (the new Core methods own all writes to ResourceCache / RelatedCache / LazyResourceCache — race-detector validates the move).
+
+---
+
+## PR-05a-h4-c — final `internal/session` / `internal/aws` import elimination
+
+**Sizing**: M. Estimated 400–600 LOC (mechanical; mostly delete + re-target imports + collapse helpers).
+
+### What's left to eliminate after h4-b
+
+After h4-a and h4-b merge, the residual production-code import sites in `internal/tui/` are (current state, verified by grep):
+
+| File | Lines | What it imports | Why it's still there post-h4-b |
+|---|---|---|---|
+| `app.go` | 13, 18 | `awsclient`, `session` | `WithClients` option signature (`*awsclient.ServiceClients`); residual `&session.ResourceCacheEntry{...}` literal in `cacheTopLevelResourceList` |
+| `app_accessors.go` | 11 | `session` | `Session()` accessor returns `*session.Session` |
+| `probe_adapter.go` | 13 | `awsclient` | `awsclient.IssueEnricherRegistry[shortName].Fn == nil` lookup |
+| `runtime_adapter.go` | 36 | `awsclient` | `awsclient.DetailEnrichmentCtx` construction (eliminated by h4-b — re-verify) |
+| `runtime_adapter_navigate.go` | 31, 36 | `awsclient`, `session` | `awsclient.AllRegions` and identity type-assertion (eliminated by h4-b — re-verify); `session.RelatedCacheKey`, `session.NewRuleSetStore` literals (residual) |
+| `runtime_adapter_related.go` | 43 | `session` | `session.RelatedCacheKey`, `session.RelatedCacheReplay` calls |
+
+### Plan
+
+#### 1. Move pure-data cache-key + result types to `internal/domain` (or `internal/runtime`)
+
+Today, `session.RelatedCacheKey(...)` is a free function and `session.RelatedCacheReplay(...)` is its inverse. Move them to `internal/runtime/relatedcache.go` (or `internal/domain/relatedcache.go` if other packages — `internal/aws`? — need them too). Adapter calls switch from `session.RelatedCacheKey(...)` to `m.core.RelatedCacheKey(...)` (or `runtime.RelatedCacheKey(...)` if free-function).
+
+`ResourceCacheEntry` likewise moves from `internal/session` to `internal/domain` (it is a pure-data struct).
+
+`RuleSetStore` is more involved — it owns mutable state, currently lives in `internal/session`. The `m.core.Session().RuleSets = session.NewRuleSetStore()` resets in `runtime_adapter_navigate.go` move into Core methods that already own those reset moments. Adapter calls `c.ResetRuleSets()` instead.
+
+#### 2. `Session()` accessor — replace with typed Core accessors
+
+The accessor at `app_accessors.go:17` is the largest remaining boundary leak. The adapter uses it in dozens of sites (`m.core.Session().Profile`, `m.core.Session().Identity`, `m.core.Session().ConnectGen`, `m.core.Session().ResourceCache[rt]`, …). h4-c replaces each call with a typed Core method:
+
+- `m.core.Profile()` instead of `m.core.Session().Profile`
+- `m.core.Region()` instead of `m.core.Session().Region`
+- `m.core.Identity()` instead of `m.core.Session().Identity` — returns `*domain.CallerIdentity` (the mirror added in h4-b)
+- `m.core.ConnectGen()` instead of `m.core.Session().ConnectGen`
+- `m.core.ResourceCache(rt)` instead of `m.core.Session().ResourceCache[rt]` — returns `(*domain.ResourceCacheEntry, bool)`
+- `m.core.LazyResourceCache(rt)` similarly
+- `m.core.SetIdentityFetching(bool)` instead of `m.core.Session().IdentityFetching = true`
+
+For writes that h4-b didn't yet absorb (small ones like `m.core.Session().Command = ""` clears), expose targeted setters: `m.core.ClearCommand()`, etc.
+
+The `Session()` accessor itself is then deleted, and `internal/tui/app_accessors.go` becomes just the typed accessor pass-throughs (or merges into another file).
+
+#### 3. `WithClients` option — accept domain-level transport handle
+
+The exported `WithClients(*awsclient.ServiceClients)` option is the last `awsclient.*` mention in `app.go`. Two options:
+
+- **Option A**: introduce a runtime-side handle type and expose `tui.WithClients(*runtime.ServiceClients)` (alias / re-export) — the adapter never sees `awsclient.*`.
+- **Option B**: define `WithClients(any)` and rely on runtime to type-check. Loses static safety; rejected.
+
+Option A: define `runtime.ServiceClients = *awsclient.ServiceClients` (type alias) in `internal/runtime/transport.go`. `internal/runtime/` already imports `internal/aws`. The TUI signature changes to `*runtime.ServiceClients`. Demo and integration callers update.
+
+#### 4. `IssueEnricherRegistry` lookup — runtime API
+
+`probe_adapter.go:164` checks `awsclient.IssueEnricherRegistry[shortName].Fn == nil`. This is a runtime concern. Replace with `c.HasIssueEnricher(shortName) bool` exposed on Core.
+
+#### 5. `AllRegions` — runtime API
+
+Already noted in h4-b; reconfirm in h4-c that `awsclient.AllRegions()` is no longer referenced from any `internal/tui/*.go`.
+
+### Files added (h4-c)
+
+- `internal/runtime/transport.go` — `type ServiceClients = awsclient.ServiceClients` type alias. (Or rename to `Clients`.)
+- `internal/runtime/relatedcache.go` — `RelatedCacheKey`, `RelatedCacheReplay` free functions (moved verbatim from `internal/session`).
+- `internal/domain/resource_cache.go` — `ResourceCacheEntry` value type (moved from `internal/session`).
+- `internal/runtime/accessors.go` — typed Core accessors (`Profile`, `Region`, `Identity`, `ConnectGen`, `ResourceCache`, `LazyResourceCache`, etc.).
+
+### Files modified (h4-c)
+
+- `internal/session/session.go` — re-export `RelatedCacheKey` / `RelatedCacheReplay` as deprecated stubs that delegate to runtime (or delete and force callers to update) — Coder decides based on cross-package call graph.
+- `internal/tui/app.go` — drop `awsclient`, `session` imports; switch `WithClients` signature.
+- `internal/tui/app_accessors.go` — delete `Session()` accessor; file may be deleted entirely if no other accessors remain.
+- `internal/tui/probe_adapter.go` — replace `awsclient.IssueEnricherRegistry` lookup with `m.core.HasIssueEnricher(...)`.
+- `internal/tui/runtime_adapter.go` — drop `awsclient` import (already cleaned by h4-b; verify).
+- `internal/tui/runtime_adapter_navigate.go` — drop `awsclient` + `session` imports; switch identity type-assert, switch cache-key calls.
+- `internal/tui/runtime_adapter_related.go` — drop `session` import; switch cache-key + replay calls.
+
+### Acceptance (h4-c — the 5a-extract Stage 2 exit gate)
+
+```bash
+# THE boundary check (first time this passes since 05-boundary.md was written):
+go list -f '{{.Imports}}' github.com/k2m30/a9s/v3/internal/tui | tr ' ' '\n' | grep -E 'internal/session|internal/aws$'
+# expected: zero hits
+
+# app.go in the target range:
+wc -l internal/tui/app.go
+# expected: 300–400
+
+# Session() accessor deleted:
+rg 'func \(m Model\) Session\(\)' internal/tui/
+# expected: zero hits
+
+# No bare *awsclient.ServiceClients in tui production:
+rg 'awsclient\.' internal/tui/ --type go | grep -v _test
+# expected: zero hits
+
+# No bare session. usage in tui production:
+rg '\bsession\.' internal/tui/ --type go | grep -v _test
+# expected: zero hits (`m.core.Session()` is also gone)
+
+# Runtime still Bubble Tea-free:
+go list -f '{{.Imports}}' github.com/k2m30/a9s/v3/internal/runtime | grep -E 'bubbletea|lipgloss|bubbles'
+# expected: zero hits
+
+# Full build + tests + race + lint + security:
+make ready-to-push
+
+# Integration smoke (PR-05a-extract exit verification per 05-boundary.md:266-269):
+./a9s --demo  # exercise list → detail → YAML, profile-switch, region-switch, Ctrl+R, Wave 2 progress
+A9S_CT_PROFILE=<profile> go test -tags integration ./tests/integration/ -run TestFullRelatedViewValidation
+```
+
+### Behavior verification (h4-c)
+
+Mechanical; relies on h4-a and h4-b having already moved the logic. Acceptance is the import-boundary gate plus a full `./a9s --demo` regression pass.
+
+---
+
+## Out of scope (all three child PRs)
+
+- `handleKeyMsg` in `app_input.go` — stays in `internal/tui/` (`05-boundary.md`:222). Verified boundary-clean in h4-a's regression guard.
+- `app_flash.go` — already a thin adapter post-h3; no edits.
+- The `Cmd` / `Event` typed-message split (PR-05b) — independent of 5a-extract.
+- The `domain.Gen` collapse (PR-05a-gens) — independent of 5a-extract.
+- Renaming `internal/aws/` → `internal/transport/` — decided no, ever (`04-catalog.md` "Out of scope").
+- New capability screens (logs, ct.scan, cost) — the registry exists post-h4-a, but Phase 05 ships no capability handlers.
+- Future desktop-shell adapter — Phase 05 deliberately defers the second adapter (`05-boundary.md`:15, 30).
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| `ApplyThemeIntent` carrying `*styles.Theme` pulls lipgloss into runtime | Pick Option A (extract `domain.Theme` pure-data type) or Option B (carry YAML bytes). Coder must pick at start of h4-a; reviewer enforces. |
+| Theme-apply ordering change (apply BEFORE persist, vs current persist BEFORE apply) regresses save-failure UX | The new ordering is forced by the runtime/renderer split. Save-fail surfaces via `messages.Flash` from the save task's error path. Unit test the save-fail branch in h4-a. |
+| Builder map lookup miss (runtime emits an ID with no registered builder) silently does nothing | Adapter flashes "no screen builder: <id>" on miss (specified in h4-a `applyIntents` PushScreen case). Smoke-tested via a temporary bogus-ID emit. |
+| `m.core.Session()` accessor delete in h4-c misses a call site; build red | Pre-h4-c: run `rg 'm\.core\.Session\(\)' internal/tui/ --type go` to enumerate. Replace each with the typed Core accessor. Compile catches anything left. |
+| `Session.RuleSets = session.NewRuleSetStore()` resets inline in `runtime_adapter_navigate.go` rely on adapter timing semantics | h4-c moves the reset into a Core method called at the same lifecycle point. Verified by integration test (rule-set reset on Refresh/profile-switch). |
+| `WithClients(*runtime.ServiceClients)` type alias breaks demo / integration callers | Type aliases are transparent under Go's type system — call sites compile unchanged. Re-run `go vet` after the alias lands. |
+| `RelatedCacheKey`/`RelatedCacheReplay` move breaks consumers under `internal/aws/` | Deprecated stubs in `internal/session/` keep the package re-export working until cross-package callers are updated. Coder enumerates with `rg 'session\.RelatedCacheKey\|session\.RelatedCacheReplay' --type go` and resolves in the same PR. |
+| h4-b and h4-a merge order produces a transient broken-boundary state | Both PRs are independently mergeable; only h4-c requires both. h4-a touches handler bodies + new screen types; h4-b touches Update()-switch cases + new patch intents. No shared file beyond `app.go` (h4-a adds `screens` field; h4-b shrinks switch cases). Rebases handle the small `app.go` overlap. |
+| `wc -l internal/tui/app.go` post-h4-c lands above 400 | If app.go is still too large after h4-c, file a follow-on (PR-05a-h4-d) extracting `applyIntents` and `tasksToCmd` into a sibling `runtime_adapter.go`-style file. Not anticipated — the budget after h4-b is comfortably ≤500, and h4-c removes another ~80 LOC. |
+
+## Cross-references
+
+- Spec contract: [`05-boundary.md`](./05-boundary.md) §"5a-extract"
+- Predecessors:
+  - PR #353 (AS-147 / PR-05a-h1) — handler-file split + runtime/handlers.go stub
+  - PR-05a-h2 (AS-315a, [`05-pr-05a-h2.md`](./05-pr-05a-h2.md) §PR-05a-h2) — 13-field migration
+  - PR-05a-h3 (AS-315b, [`05-pr-05a-h2.md`](./05-pr-05a-h2.md) §PR-05a-h3) — six handler ports
+- This PR (AS-650): the screen-builder registry and the four h3-deferred handler ports — closes the deferral named at `05-pr-05a-h2.md`:144 and `05-boundary.md`:218.
+- Successor: none under 5a-extract. PR-05a-gens (separately tracked) follows.


### PR DESCRIPTION
## Summary

Stage 2 design output for **AS-650** (AS-646 Gap 3 follow-on). Authors `docs/refactor/05-pr-05a-h4.md` and splits the remaining 5a-extract work into three child PRs under AS-72.

- **h4-a** — screen-builder registry (typed `ScreenPayload` variants, mirroring the h3 `TaskPayload` pattern) + four h3-deferred handler ports (`handleProfilesLoaded`, `handleValueRevealed`, `handleEnterChildView`, `handleThemeSelected`). Theme-apply split into read-task + parse-handler so file I/O stays out of Core.
- **h4-b** — extract inline session-cache mutations from `internal/tui/app.go` `Update()` switch cases (`ResourcesLoaded`, `RelatedCheckResult`, `IdentityLoaded`, `EnrichDetailResult`) into Core methods. Adds `PatchResourceCache` / `PatchRelatedCache` / `PatchLazyResourceCache` / `SetIdentityIntent` intent variants. Mirrors `awsclient.CallerIdentity` into `internal/domain`.
- **h4-c** — final `internal/session` / `internal/aws` import scrub. Replaces `m.core.Session()` with typed Core accessors, moves `RelatedCacheKey`/`Replay` to `internal/runtime/`, type-aliases `runtime.ServiceClients = awsclient.ServiceClients`.

Together the three child PRs close [`05-boundary.md`](https://github.com/k2m30/a9s/blob/main/docs/refactor/05-boundary.md) §5a-extract exit criteria for the first time: zero `internal/session`+`internal/aws` imports under `internal/tui/` (production), `app.go` lands in the 300–400 LOC target (currently 986), and `internal/runtime/` remains Bubble Tea-free.

The four files named in AS-650 (`app_input.go`, `app_flash.go`, `app_session.go`, `app_screens.go`) are dispositioned: `app_input.go` and `app_flash.go` stay as-is (keyboard input is per-`05-boundary.md:222` UI concern; flash handlers are already h3 thin adapters). `app_session.go` and `app_screens.go` shrink to thin adapters for the four deferred handlers.

Cross-links: [`05-boundary.md`](https://github.com/k2m30/a9s/blob/main/docs/refactor/05-boundary.md) exit-criteria block now points to this spec; [`05-pr-05a-h2.md:144`](https://github.com/k2m30/a9s/blob/main/docs/refactor/05-pr-05a-h2.md#L144) successor-PR placeholder is replaced with a link.

Refs **AS-650** (this spec), **AS-646** (Gap 3 tracker), **AS-72** (Phase-05 PR-05a-extract program).

## Test plan

This PR adds only documentation. Implementation lands in three follow-on PRs filed under AS-646.

- [x] `docs/refactor/05-pr-05a-h4.md` exists, mirrors the h2/h3 style (header → why → boundary → per-child-PR sections with file list, acceptance, sizing → out-of-scope → risk register → cross-references).
- [x] Cross-links from `05-boundary.md` exit-criteria block and `05-pr-05a-h2.md:144`.
- [x] Spec exists in `docs/refactor/` so it is excluded from `make mdlint` per the existing `Makefile` rule.
- [ ] Stage 5 reviewers (CodeReviewer + CodexReviewer + Architect for size M+) sign off.
- [ ] Three follow-on implementation issues filed under AS-646 with proper blocker chain (h4-a unblocks h4-b unblocks h4-c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)