### PR TITLE
feat(phase-05-pr-05a-h4-a): port 4 view-stack handlers to runtime.Core (AS-769)

### DIFF
--- a/docs/refactor/05-pr-05a-h4.md
+++ b/docs/refactor/05-pr-05a-h4.md
@@ -237,6 +237,17 @@ The single-write contract (persist BEFORE apply) is preserved: Core's flow is re
 
 (`styles.ApplyTheme` is renderer-side; Core never calls it. The "Apply" is an intent, applied by the TUI adapter as the renderer state mutation.)
 
+> **AS-784 follow-up (PR #391, Stage 5 NEEDS CHANGES).** The initial port of
+> `HandleThemeFileRead` under Option B-bytes-carry skipped the Core-side
+> `styles.ThemeFromYAML` validation step and emitted `TaskKindSaveThemeConfig`
+> unconditionally on read success. Effect: malformed-YAML or invalid-hex
+> theme files would be persisted to `config.yaml` even though the adapter
+> rejected the apply. AS-784 restores the spec contract by validating in
+> Core (parse-then-emit) — Save is now gated on parse success. The
+> regression is pinned by `TestCore_HandleThemeFileRead_ParseErrorEmitsFlashOnly`
+> and `TestCore_HandleThemeFileRead_InvalidHexColorEmitsFlashOnly` in
+> `internal/runtime/screens_handlers_test.go`.
+
 ### New runtime types
 
 `internal/runtime/screens.go` adds:

--- a/internal/runtime/handlers.go
+++ b/internal/runtime/handlers.go
@@ -22,7 +22,9 @@
 //	HandleValueRevealed  — emits PushScreen{ScreenReveal,...} or FlashIntent (h4-a).
 //	HandleEnterChildView — emits PushScreen{ScreenChildList,...} + fetch task (h4-a).
 //	HandleThemeSelected  — emits TaskKindReadThemeFile (h4-a).
-//	HandleThemeFileRead  — emits Apply/Pop/Flash + Save task on success (h4-a).
+//	HandleThemeFileRead  — parses YAML; on parse OK emits Apply/Pop/Flash +
+//	                       Save task; on parse fail emits error flash only
+//	                       (Save is gated on parse success — AS-784).
 //
 // What stays in the TUI adapter (out of scope):
 //
@@ -40,6 +42,7 @@ import (
 	"github.com/k2m30/a9s/v3/internal/config"
 	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+	"github.com/k2m30/a9s/v3/internal/tui/styles"
 )
 
 // Flash auto-clear durations. apiErrorFlashDuration is the longer 5 s window
@@ -528,23 +531,41 @@ func (c *Core) HandleThemeSelected(ev ThemeSelectedEvent) ([]UIIntent, []TaskReq
 	return nil, tasks
 }
 
-// HandleThemeFileRead is the second half of the theme-selected flow.
-// Read failure emits a single "Cannot read theme: <err>" flash; read
-// success emits four results in this order: ApplyThemeIntent (carries
-// the YAML Bytes; adapter re-parses via styles.ThemeFromYAML and on
-// parse failure emits its own flash), PopSelectorIntent (closes the
-// theme selector), success FlashIntent ("Theme: <name>"), and a
-// TaskKindSaveThemeConfig task that persists the choice to config.yaml.
+// HandleThemeFileRead is the second half of the theme-selected flow and
+// branches on three outcomes:
 //
-// PR-05a-h4-a Option B chose ordering "apply-then-persist" over the
-// pre-h4 "persist-then-apply" because the runtime/renderer split forces
-// the persist task to fire asynchronously; the save-fail UX delta
-// (theme stays applied for this session even if config save failed) is
-// documented in docs/refactor/05-pr-05a-h4.md §"Theme-selected split".
+//  1. Read failure → single "Cannot read theme: <err>" error flash, no apply,
+//     no pop, no save.
+//  2. Read OK, parse failure → single "Bad theme YAML: <err>" error flash,
+//     no apply, no pop, no save. The selector stays open so the user can
+//     retry. Validation is performed via styles.ThemeFromYAML; the returned
+//     Theme is discarded because Option B-bytes-carry hands the bytes to the
+//     adapter, which re-derives the Theme for renderer state.
+//  3. Read OK, parse OK → four results in order: ApplyThemeIntent (carries
+//     the YAML Bytes; the adapter re-parses via styles.ThemeFromYAML),
+//     PopSelectorIntent, success FlashIntent ("Theme: <name>"), and a
+//     TaskKindSaveThemeConfig task that persists the choice to config.yaml.
+//
+// The parse-then-emit ordering is the AS-784 fix for the AS-769 invariant
+// violation: the pre-fix handler emitted Save unconditionally on read
+// success, so a malformed-YAML theme would be persisted to disk even though
+// the adapter rejected the apply.
+//
+// PR-05a-h4-a Option B-bytes-carry keeps ApplyThemeIntent's payload as raw
+// bytes (the adapter does the second parse for the renderer state); the
+// save-fail UX delta (theme stays applied for the session even if config
+// save fails) is documented in docs/refactor/05-pr-05a-h4.md §"Theme-
+// selected split".
 func (c *Core) HandleThemeFileRead(ev ThemeFileReadEvent) ([]UIIntent, []TaskRequest) {
 	if ev.Err != nil {
 		return []UIIntent{FlashIntent{
 			Text:    "Cannot read theme: " + ev.Err.Error(),
+			IsError: true,
+		}}, nil
+	}
+	if _, err := styles.ThemeFromYAML(ev.Bytes); err != nil {
+		return []UIIntent{FlashIntent{
+			Text:    "Bad theme YAML: " + err.Error(),
 			IsError: true,
 		}}, nil
 	}

--- a/internal/runtime/handlers.go
+++ b/internal/runtime/handlers.go
@@ -1,5 +1,5 @@
 // handlers.go — shell-level handler bodies ported from internal/tui in
-// Phase-05 PR-05a-h3 (AS-315b / AS-324).
+// Phase-05 PR-05a-h3 (AS-315b / AS-324) and PR-05a-h4-a (AS-650 / AS-769).
 //
 // Each ported handler is a (c *Core) Handle* method that consumes a typed
 // runtime event, applies session-scoped state changes, and returns
@@ -10,7 +10,7 @@
 // translates the returned intents and tasks back into adapter-visible side
 // effects.
 //
-// What lives here (this PR):
+// What lives here (post h3 + h4-a):
 //
 //	HandleFlash          — flash gen bump + history; schedules ClearFlash tick.
 //	HandleClearFlash     — flash auto-clear honouring the session-owned gen.
@@ -18,14 +18,18 @@
 //	HandleClientsReady   — clients/identity wiring + post-connect refresh / boot.
 //	HandleProfileSelected— rotate, rollback latch, request reconnect.
 //	HandleRegionSelected — mirror of HandleProfileSelected for region.
+//	HandleProfilesLoaded — emits PushScreen{ScreenProfileSelector,...} (h4-a).
+//	HandleValueRevealed  — emits PushScreen{ScreenReveal,...} or FlashIntent (h4-a).
+//	HandleEnterChildView — emits PushScreen{ScreenChildList,...} + fetch task (h4-a).
+//	HandleThemeSelected  — emits TaskKindReadThemeFile (h4-a).
+//	HandleThemeFileRead  — emits Apply/Pop/Flash + Save task on success (h4-a).
 //
 // What stays in the TUI adapter (out of scope):
 //
 //   - handleKeyMsg (keyboard dispatch) — owns key.Matches semantics on
 //     adapter-owned tea types.
-//   - handleProfilesLoaded / handleValueRevealed / handleEnterChildView /
-//     handleThemeSelected — push concrete views onto the adapter view stack,
-//     which requires the screen-builder registry that lands in a successor PR.
+//   - The Update()-switch session-mutation extraction (ResourcesLoaded,
+//     RelatedCheckResult, IdentityLoaded, EnrichDetailResult) — PR-05a-h4-b.
 package runtime
 
 import (
@@ -33,7 +37,9 @@ import (
 	"time"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/config"
 	"github.com/k2m30/a9s/v3/internal/domain"
+	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 // Flash auto-clear durations. apiErrorFlashDuration is the longer 5 s window
@@ -387,6 +393,170 @@ func (c *Core) HandleProfileSelected(ev ProfileSelectedEvent) ([]UIIntent, []Tas
 			Payload: FlashTickPayload{Gen: ev.NewGen, Duration: flashDuration},
 		},
 	}
+	return intents, tasks
+}
+
+// ProfilesLoadedEvent / ValueRevealedEvent / EnterChildViewEvent /
+// ThemeSelectedEvent / ThemeFileReadEvent — adapter-translated forms of
+// the corresponding messages.* (and TUI-private profilesLoadedMsg) for
+// the four h3-deferred view-stack handlers ported in PR-05a-h4-a.
+
+// ProfilesLoadedEvent carries the list of AWS profiles the adapter loaded
+// from disk. HandleProfilesLoaded emits a PushScreen{ScreenProfileSelector}
+// whose payload pairs the list with the session's current profile.
+type ProfilesLoadedEvent struct {
+	Profiles []string
+}
+
+// ValueRevealedEvent carries the result of a reveal fetch (`x` key over a
+// secret-bearing resource). On Err the handler emits a flash error; on
+// success it emits a PushScreen{ScreenReveal} carrying the value.
+type ValueRevealedEvent struct {
+	ResourceID string
+	Value      string
+	Err        error
+}
+
+// EnterChildViewEvent carries the child-type short name, the parent
+// context map used by the fetcher, and the display name rendered as the
+// child view's frame title. Unknown ChildType yields a flash error.
+type EnterChildViewEvent struct {
+	ChildType     string
+	ParentContext map[string]string
+	DisplayName   string
+}
+
+// ThemeSelectedEvent carries the theme filename the user confirmed.
+// HandleThemeSelected resolves the path via config.ThemePath; the disk
+// read itself runs in a TaskKindReadThemeFile dispatch whose result the
+// adapter routes back as messages.ThemeFileRead → HandleThemeFileRead.
+type ThemeSelectedEvent struct {
+	Theme string
+}
+
+// ThemeFileReadEvent carries the bytes read from disk in response to
+// the read task, together with any I/O error. HandleThemeFileRead
+// branches on Err: read failure emits a flash error; read success emits
+// ApplyThemeIntent (Option B carries Bytes + Name, adapter re-parses
+// via styles.ThemeFromYAML before applying), PopSelectorIntent, a
+// success FlashIntent ("Theme: <name>"), and a TaskKindSaveThemeConfig
+// task. See docs/refactor/05-pr-05a-h4.md §"Theme-selected split".
+type ThemeFileReadEvent struct {
+	Theme string
+	Bytes []byte
+	Err   error
+}
+
+// HandleProfilesLoaded emits a PushScreen{ScreenProfileSelector} carrying
+// the profile list paired with the session's currently-active profile so
+// the selector can render the "(current)" indicator. No tasks fire — the
+// adapter's builder closure constructs the SelectorModel synchronously.
+func (c *Core) HandleProfilesLoaded(ev ProfilesLoadedEvent) ([]UIIntent, []TaskRequest) {
+	intents := []UIIntent{PushScreen{
+		ID: ScreenProfileSelector,
+		Payload: ProfileSelectorPayload{
+			Profiles: ev.Profiles,
+			Current:  c.session.Profile,
+		},
+	}}
+	return intents, nil
+}
+
+// HandleValueRevealed branches on Err. On error the handler emits a
+// "reveal failed: <err>" flash so the user sees why the reveal aborted;
+// on success it emits a PushScreen{ScreenReveal} whose payload carries
+// the resource ID and decrypted value the adapter renders.
+func (c *Core) HandleValueRevealed(ev ValueRevealedEvent) ([]UIIntent, []TaskRequest) {
+	if ev.Err != nil {
+		return []UIIntent{FlashIntent{
+			Text:    "reveal failed: " + ev.Err.Error(),
+			IsError: true,
+		}}, nil
+	}
+	intents := []UIIntent{PushScreen{
+		ID: ScreenReveal,
+		Payload: RevealPayload{
+			ResourceID: ev.ResourceID,
+			Value:      ev.Value,
+		},
+	}}
+	return intents, nil
+}
+
+// HandleEnterChildView validates ChildType via resource.GetChildType and
+// either flashes an "unknown child type" error or emits a
+// PushScreen{ScreenChildList} paired with a TaskKindFetchChildResources
+// task. The adapter's screen builder constructs the ChildResourceList view
+// and runs its Init() command; the fetch task kicks off paginated loading.
+func (c *Core) HandleEnterChildView(ev EnterChildViewEvent) ([]UIIntent, []TaskRequest) {
+	if resource.GetChildType(ev.ChildType) == nil {
+		return []UIIntent{FlashIntent{
+			Text:    fmt.Sprintf("unknown child type: %s", ev.ChildType),
+			IsError: true,
+		}}, nil
+	}
+	intents := []UIIntent{PushScreen{
+		ID:      ScreenChildList,
+		Payload: ChildListPayload(ev),
+	}}
+	tasks := []TaskRequest{{
+		Key: TaskKey{Kind: TaskKindFetchChildResources, Scope: ev.ChildType},
+		Payload: FetchChildResourcesPayload{
+			ChildType:     ev.ChildType,
+			ParentContext: ev.ParentContext,
+		},
+	}}
+	return intents, tasks
+}
+
+// HandleThemeSelected validates the theme path via config.ThemePath (a
+// non-renderer-coupled package) and either flashes an "Invalid theme:
+// <err>" error or emits a TaskKindReadThemeFile task. The adapter's task
+// closure performs the os.ReadFile and dispatches messages.ThemeFileRead
+// → HandleThemeFileRead, which owns the apply/pop/flash/save sequence.
+func (c *Core) HandleThemeSelected(ev ThemeSelectedEvent) ([]UIIntent, []TaskRequest) {
+	if _, err := config.ThemePath(ev.Theme); err != nil {
+		return []UIIntent{FlashIntent{
+			Text:    "Invalid theme: " + err.Error(),
+			IsError: true,
+		}}, nil
+	}
+	tasks := []TaskRequest{{
+		Key:     TaskKey{Kind: TaskKindReadThemeFile, Scope: ev.Theme},
+		Payload: ReadThemePayload(ev),
+	}}
+	return nil, tasks
+}
+
+// HandleThemeFileRead is the second half of the theme-selected flow.
+// Read failure emits a single "Cannot read theme: <err>" flash; read
+// success emits four results in this order: ApplyThemeIntent (carries
+// the YAML Bytes; adapter re-parses via styles.ThemeFromYAML and on
+// parse failure emits its own flash), PopSelectorIntent (closes the
+// theme selector), success FlashIntent ("Theme: <name>"), and a
+// TaskKindSaveThemeConfig task that persists the choice to config.yaml.
+//
+// PR-05a-h4-a Option B chose ordering "apply-then-persist" over the
+// pre-h4 "persist-then-apply" because the runtime/renderer split forces
+// the persist task to fire asynchronously; the save-fail UX delta
+// (theme stays applied for this session even if config save failed) is
+// documented in docs/refactor/05-pr-05a-h4.md §"Theme-selected split".
+func (c *Core) HandleThemeFileRead(ev ThemeFileReadEvent) ([]UIIntent, []TaskRequest) {
+	if ev.Err != nil {
+		return []UIIntent{FlashIntent{
+			Text:    "Cannot read theme: " + ev.Err.Error(),
+			IsError: true,
+		}}, nil
+	}
+	intents := []UIIntent{
+		ApplyThemeIntent{Bytes: ev.Bytes, Name: ev.Theme},
+		PopSelectorIntent{},
+		FlashIntent{Text: "Theme: " + ev.Theme},
+	}
+	tasks := []TaskRequest{{
+		Key:     TaskKey{Kind: TaskKindSaveThemeConfig, Scope: ev.Theme},
+		Payload: SaveThemeConfigPayload{Theme: ev.Theme},
+	}}
 	return intents, tasks
 }
 

--- a/internal/runtime/intent.go
+++ b/internal/runtime/intent.go
@@ -76,12 +76,46 @@ func (PatchMenu) isIntent() {}
 
 // PushScreen asks the adapter to materialize and push the named screen
 // onto its view stack with the given context.
+//
+// Payload carries per-screen typed data (selectors, reveal results,
+// child-list parameters). It is nil for capability screens whose
+// adapter-side builder resolves everything from ScreenContext alone.
+// PR-05a-h4-a introduced Payload alongside the four ported view-stack
+// handlers; pre-h4-a callers that emit PushScreen with Context only
+// continue to work because the builder closures type-switch on Payload
+// and tolerate the zero value when their ScreenID does not require it.
 type PushScreen struct {
 	ID      ScreenID
 	Context ScreenContext
+	Payload ScreenPayload
 }
 
 func (PushScreen) isIntent() {}
+
+// ApplyThemeIntent asks the adapter to swap the active theme and
+// invalidate any caches that materialised colour-dependent state
+// (header text, per-row styled caches in ResourceListModel views, …).
+//
+// PR-05a-h4-a chose Option B from docs/refactor/05-pr-05a-h4.md
+// §"Theme-selected split": the runtime carries the parsed YAML *bytes*
+// and the theme filename, and the adapter re-parses via
+// styles.ThemeFromYAML before applying. This keeps the runtime free of
+// any lipgloss / Bubble Tea coupling that hosting a *styles.Theme
+// would force. Option A (extracting a domain.Theme value type) was
+// considered cleaner but is a larger refactor properly scoped to a
+// follow-on PR; B preserves the boundary invariant today.
+//
+// On parse failure the adapter MUST emit a flash describing the
+// failure and skip the apply; the persist task that this intent ships
+// with continues to fire because the runtime already committed to the
+// new theme name. (Save-fail surfaces a separate adapter-side flash
+// from the SaveThemeConfig task.)
+type ApplyThemeIntent struct {
+	Bytes []byte
+	Name  string
+}
+
+func (ApplyThemeIntent) isIntent() {}
 
 // PopScreen asks the adapter to pop the topmost screen off its view
 // stack. The runtime owns no view stack itself; this is purely a

--- a/internal/runtime/messages/event.go
+++ b/internal/runtime/messages/event.go
@@ -237,3 +237,20 @@ func (EnrichDetailResult) isEvent()              {}
 func (m EnrichDetailResult) GenStamp() domain.Gen { return m.Generation }
 func (EnrichDetailResult) GenAspect() Aspect      { return AspectEnrichDetail }
 func (EnrichDetailResult) AcceptZeroGen() bool    { return true }
+
+// ThemeFileRead delivers the bytes of a theme YAML file read from disk
+// in response to a TaskKindReadThemeFile dispatch. Theme is the theme
+// filename the user selected; Bytes is the raw YAML payload (nil on
+// read error); Err is non-nil when the read failed. PR-05a-h4-a
+// (AS-769) introduced this event so the runtime can split the
+// theme-selected flow into a Core-side handler (HandleThemeSelected,
+// emits the read task) and a second Core-side handler
+// (HandleThemeFileRead, emits Apply/Pop/Flash + Save task) without
+// performing file I/O inside Core.
+type ThemeFileRead struct {
+	Theme string
+	Bytes []byte
+	Err   error
+}
+
+func (ThemeFileRead) isEvent() {}

--- a/internal/runtime/screens.go
+++ b/internal/runtime/screens.go
@@ -8,6 +8,9 @@
 // render multi-screen workflows (logs, CloudTrail, cost views, …) without
 // growing central shell switches. Phase 05 PR-05a-scaffold creates the
 // types only; per-handler PRs (AS-72-h1..h8) wire them to live behavior.
+// PR-05a-h4-a (AS-769) adds the typed ScreenPayload contract and the
+// concrete selector/reveal/child-list payloads used by the four ported
+// view-stack-pushing handlers.
 package runtime
 
 import "github.com/k2m30/a9s/v3/internal/domain"
@@ -16,6 +19,15 @@ import "github.com/k2m30/a9s/v3/internal/domain"
 // it to look up the renderer-specific builder; the shared core never
 // constructs renderer types itself.
 type ScreenID string
+
+// Screen IDs emitted by PR-05a-h4-a handlers. Capability screens
+// (logs, ct.scan, cost) reuse the existing ScreenContext-only PushScreen
+// path and are not enumerated here.
+const (
+	ScreenProfileSelector ScreenID = "profile-selector"
+	ScreenReveal          ScreenID = "reveal"
+	ScreenChildList       ScreenID = "child-list"
+)
 
 // ScreenContext is the input handed to an adapter when the runtime asks
 // it to push, replace, or otherwise materialize a screen. Renderer-free.
@@ -26,6 +38,43 @@ type ScreenContext struct {
 	// Query is the zero value when the screen is not query-driven.
 	Query domain.QuerySpec
 }
+
+// ScreenPayload is the marker interface for typed per-Screen payload
+// structs. PushScreen.Payload carries one of these; adapters type-switch
+// on the concrete type to recover the payload fields. nil Payload is
+// permitted when ScreenContext.Capability alone suffices for routing.
+type ScreenPayload interface {
+	isScreenPayload()
+}
+
+// ProfileSelectorPayload carries the profile list + the currently-active
+// profile name for the profile selector screen.
+type ProfileSelectorPayload struct {
+	Profiles []string
+	Current  string
+}
+
+func (ProfileSelectorPayload) isScreenPayload() {}
+
+// RevealPayload carries the resource ID and decrypted value for the
+// reveal screen (`x` key over a secret-bearing resource).
+type RevealPayload struct {
+	ResourceID string
+	Value      string
+}
+
+func (RevealPayload) isScreenPayload() {}
+
+// ChildListPayload carries the child-type short name, the parent context
+// map used by the child fetcher, and the human-readable display name
+// rendered as the child view's frame title.
+type ChildListPayload struct {
+	ChildType     string
+	ParentContext map[string]string
+	DisplayName   string
+}
+
+func (ChildListPayload) isScreenPayload() {}
 
 // ScreenDescriptor declaratively describes one registrable screen. Used by
 // the adapter to wire its builder map and by the runtime to validate that

--- a/internal/runtime/screens_handlers_test.go
+++ b/internal/runtime/screens_handlers_test.go
@@ -368,6 +368,84 @@ func TestCore_HandleThemeFileRead_ReadErrorEmitsFlashOnly(t *testing.T) {
 	}
 }
 
+// TestCore_HandleThemeFileRead_ParseErrorEmitsFlashOnly pins the AS-784
+// invariant: when read succeeds but the YAML cannot be parsed by
+// styles.ThemeFromYAML, the handler must emit exactly one error flash and
+// MUST NOT emit ApplyThemeIntent, PopSelectorIntent, or any
+// TaskKindSaveThemeConfig task. Pre-AS-784 the handler emitted Save
+// unconditionally on read success, persisting an invalid theme choice to
+// disk even though the adapter rejected the apply.
+func TestCore_HandleThemeFileRead_ParseErrorEmitsFlashOnly(t *testing.T) {
+	c := newCore()
+
+	// Malformed YAML — the leading `:` token is not a valid YAML node.
+	// styles.ThemeFromYAML returns "theme YAML parse error: …".
+	badBytes := []byte(":\n  not yaml at all\n: : :\n")
+
+	intents, tasks := c.HandleThemeFileRead(ThemeFileReadEvent{
+		Theme: "broken.yaml",
+		Bytes: badBytes,
+	})
+
+	if len(tasks) != 0 {
+		t.Errorf("expected zero tasks on parse error, got %d (%v)", len(tasks), taskKinds(tasks))
+	}
+	if hasTaskKind(tasks, TaskKindSaveThemeConfig) {
+		t.Errorf("expected NO TaskKindSaveThemeConfig on parse error; invalid theme must not be persisted")
+	}
+	if _, ok := findApplyTheme(intents); ok {
+		t.Errorf("expected no ApplyThemeIntent on parse error")
+	}
+	if findPopSelector(intents) {
+		t.Errorf("expected no PopSelectorIntent on parse error — selector stays open so user can retry")
+	}
+	fi, ok := findFlashIntent(intents)
+	if !ok {
+		t.Fatalf("expected FlashIntent, got intents=%#v", intents)
+	}
+	if !fi.IsError {
+		t.Errorf("expected IsError=true on parse error, got IsError=false")
+	}
+	const prefix = "Bad theme YAML: "
+	if len(fi.Text) < len(prefix) || fi.Text[:len(prefix)] != prefix {
+		t.Errorf("Text=%q want prefix %q", fi.Text, prefix)
+	}
+}
+
+// TestCore_HandleThemeFileRead_InvalidHexColorEmitsFlashOnly exercises the
+// second parse-fail branch styles.ThemeFromYAML guards: YAML that parses as
+// a themeYAML struct but contains an invalid hex colour string. Same
+// invariants as the malformed-YAML test above — Save must NOT fire.
+func TestCore_HandleThemeFileRead_InvalidHexColorEmitsFlashOnly(t *testing.T) {
+	c := newCore()
+
+	// Valid YAML shape, invalid hex colour value (`notahex` fails
+	// hexColorRe in styles/theme.go).
+	badBytes := []byte("name: Custom\ncolors:\n  accent: \"notahex\"\n")
+
+	intents, tasks := c.HandleThemeFileRead(ThemeFileReadEvent{
+		Theme: "bad-hex.yaml",
+		Bytes: badBytes,
+	})
+
+	if hasTaskKind(tasks, TaskKindSaveThemeConfig) {
+		t.Errorf("expected NO TaskKindSaveThemeConfig on invalid hex colour")
+	}
+	if _, ok := findApplyTheme(intents); ok {
+		t.Errorf("expected no ApplyThemeIntent on invalid hex colour")
+	}
+	if findPopSelector(intents) {
+		t.Errorf("expected no PopSelectorIntent on invalid hex colour")
+	}
+	fi, ok := findFlashIntent(intents)
+	if !ok {
+		t.Fatalf("expected FlashIntent, got intents=%#v", intents)
+	}
+	if !fi.IsError {
+		t.Errorf("expected IsError=true on invalid hex colour")
+	}
+}
+
 // ---- shared helper ---------------------------------------------------------
 
 // taskKinds extracts the TaskKind slice from tasks for diagnostic prints.

--- a/internal/runtime/screens_handlers_test.go
+++ b/internal/runtime/screens_handlers_test.go
@@ -1,0 +1,380 @@
+// screens_handlers_test.go — Core-direct unit tests for the five
+// view-stack handler ports added in Phase-05 PR-05a-h4-a (AS-650 / AS-769):
+//
+//	HandleProfilesLoaded — emits PushScreen{ScreenProfileSelector,...}.
+//	HandleValueRevealed  — emits PushScreen{ScreenReveal,...} or flash on Err.
+//	HandleEnterChildView — emits PushScreen{ScreenChildList,...} + fetch task;
+//	                       unknown ChildType flashes an error.
+//	HandleThemeSelected  — emits TaskKindReadThemeFile; invalid name flashes.
+//	HandleThemeFileRead  — emits Apply/Pop/Flash + Save task on success;
+//	                       read failure flashes.
+//
+// Package runtime (not runtime_test) so the suite can access unexported
+// fields when needed; the helpers in handlers_test.go (newCore, findFlashIntent,
+// hasTaskKind, …) are reused here.
+package runtime
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// ---- helpers ---------------------------------------------------------------
+
+// findPushScreen returns the first PushScreen intent in xs and a bool flag.
+func findPushScreen(xs []UIIntent) (PushScreen, bool) {
+	for _, x := range xs {
+		if ps, ok := x.(PushScreen); ok {
+			return ps, true
+		}
+	}
+	return PushScreen{}, false
+}
+
+// findApplyTheme returns the first ApplyThemeIntent and a bool flag.
+func findApplyTheme(xs []UIIntent) (ApplyThemeIntent, bool) {
+	for _, x := range xs {
+		if at, ok := x.(ApplyThemeIntent); ok {
+			return at, true
+		}
+	}
+	return ApplyThemeIntent{}, false
+}
+
+// findFetchChildResources returns the first FetchChildResourcesPayload
+// task and a bool flag.
+func findFetchChildResources(tasks []TaskRequest) (FetchChildResourcesPayload, bool) {
+	for _, t := range tasks {
+		if p, ok := t.Payload.(FetchChildResourcesPayload); ok {
+			return p, true
+		}
+	}
+	return FetchChildResourcesPayload{}, false
+}
+
+func findReadTheme(tasks []TaskRequest) (ReadThemePayload, bool) {
+	for _, t := range tasks {
+		if p, ok := t.Payload.(ReadThemePayload); ok {
+			return p, true
+		}
+	}
+	return ReadThemePayload{}, false
+}
+
+func findSaveTheme(tasks []TaskRequest) (SaveThemeConfigPayload, bool) {
+	for _, t := range tasks {
+		if p, ok := t.Payload.(SaveThemeConfigPayload); ok {
+			return p, true
+		}
+	}
+	return SaveThemeConfigPayload{}, false
+}
+
+// withTempChildType registers a throwaway child type for the duration of
+// the test so HandleEnterChildView's resource.GetChildType validation
+// finds something. Cleans up via t.Cleanup.
+func withTempChildType(t *testing.T, shortName string) {
+	t.Helper()
+	resource.RegisterChildType(resource.ResourceTypeDef{
+		Name:      "Test " + shortName,
+		ShortName: shortName,
+		Columns:   []resource.Column{{Key: "id", Title: "ID", Width: 8}},
+	})
+	t.Cleanup(func() {
+		resource.UnregisterChildType(shortName)
+	})
+}
+
+// ---- HandleProfilesLoaded ----------------------------------------------------
+
+func TestCore_HandleProfilesLoaded_EmitsProfileSelectorPushScreen(t *testing.T) {
+	c := newCore()
+	c.session.Profile = "dev-account"
+
+	intents, tasks := c.HandleProfilesLoaded(ProfilesLoadedEvent{
+		Profiles: []string{"default", "dev-account", "prod-account"},
+	})
+
+	if len(tasks) != 0 {
+		t.Errorf("expected zero tasks, got %d", len(tasks))
+	}
+	ps, ok := findPushScreen(intents)
+	if !ok {
+		t.Fatalf("expected PushScreen intent, got intents=%#v", intents)
+	}
+	if ps.ID != ScreenProfileSelector {
+		t.Errorf("expected ScreenID=%s, got %s", ScreenProfileSelector, ps.ID)
+	}
+	pp, ok := ps.Payload.(ProfileSelectorPayload)
+	if !ok {
+		t.Fatalf("expected ProfileSelectorPayload, got %T", ps.Payload)
+	}
+	if len(pp.Profiles) != 3 || pp.Profiles[1] != "dev-account" {
+		t.Errorf("unexpected Profiles slice: %v", pp.Profiles)
+	}
+	if pp.Current != "dev-account" {
+		t.Errorf("expected Current=dev-account (from session), got %q", pp.Current)
+	}
+}
+
+// ---- HandleValueRevealed -----------------------------------------------------
+
+func TestCore_HandleValueRevealed_SuccessEmitsRevealPushScreen(t *testing.T) {
+	c := newCore()
+
+	intents, tasks := c.HandleValueRevealed(ValueRevealedEvent{
+		ResourceID: "/prod/db/password",
+		Value:      "hunter2",
+	})
+
+	if len(tasks) != 0 {
+		t.Errorf("expected zero tasks on success, got %d", len(tasks))
+	}
+	ps, ok := findPushScreen(intents)
+	if !ok {
+		t.Fatalf("expected PushScreen intent, got intents=%#v", intents)
+	}
+	if ps.ID != ScreenReveal {
+		t.Errorf("expected ScreenID=%s, got %s", ScreenReveal, ps.ID)
+	}
+	rp, ok := ps.Payload.(RevealPayload)
+	if !ok {
+		t.Fatalf("expected RevealPayload, got %T", ps.Payload)
+	}
+	if rp.ResourceID != "/prod/db/password" || rp.Value != "hunter2" {
+		t.Errorf("payload mismatch: id=%q value=%q", rp.ResourceID, rp.Value)
+	}
+}
+
+func TestCore_HandleValueRevealed_ErrorEmitsFlash(t *testing.T) {
+	c := newCore()
+
+	intents, tasks := c.HandleValueRevealed(ValueRevealedEvent{
+		ResourceID: "/secrets/x",
+		Err:        errors.New("permission denied"),
+	})
+
+	if len(tasks) != 0 {
+		t.Errorf("expected zero tasks on error, got %d", len(tasks))
+	}
+	if _, ok := findPushScreen(intents); ok {
+		t.Errorf("expected no PushScreen on error, got one")
+	}
+	fi, ok := findFlashIntent(intents)
+	if !ok {
+		t.Fatalf("expected FlashIntent, got intents=%#v", intents)
+	}
+	if !fi.IsError {
+		t.Errorf("expected IsError=true, got false")
+	}
+	if got, want := fi.Text, "reveal failed: permission denied"; got != want {
+		t.Errorf("Text=%q want %q", got, want)
+	}
+}
+
+// ---- HandleEnterChildView ----------------------------------------------------
+
+func TestCore_HandleEnterChildView_KnownTypeEmitsScreenAndTask(t *testing.T) {
+	c := newCore()
+	const childType = "h4a_test_child_known"
+	withTempChildType(t, childType)
+
+	intents, tasks := c.HandleEnterChildView(EnterChildViewEvent{
+		ChildType:     childType,
+		ParentContext: map[string]string{"bucket": "my-bucket"},
+		DisplayName:   "my-bucket",
+	})
+
+	ps, ok := findPushScreen(intents)
+	if !ok {
+		t.Fatalf("expected PushScreen, got intents=%#v", intents)
+	}
+	if ps.ID != ScreenChildList {
+		t.Errorf("expected ScreenChildList, got %s", ps.ID)
+	}
+	clp, ok := ps.Payload.(ChildListPayload)
+	if !ok {
+		t.Fatalf("expected ChildListPayload, got %T", ps.Payload)
+	}
+	if clp.ChildType != childType || clp.DisplayName != "my-bucket" {
+		t.Errorf("payload mismatch: %#v", clp)
+	}
+	if clp.ParentContext["bucket"] != "my-bucket" {
+		t.Errorf("ParentContext lost: %v", clp.ParentContext)
+	}
+
+	fp, ok := findFetchChildResources(tasks)
+	if !ok {
+		t.Fatalf("expected FetchChildResources task, got tasks=%#v", tasks)
+	}
+	if fp.ChildType != childType {
+		t.Errorf("task ChildType=%q want %q", fp.ChildType, childType)
+	}
+	if fp.ParentContext["bucket"] != "my-bucket" {
+		t.Errorf("task ParentContext lost: %v", fp.ParentContext)
+	}
+	if !hasTaskKind(tasks, TaskKindFetchChildResources) {
+		t.Errorf("expected TaskKindFetchChildResources in tasks, got %v", taskKinds(tasks))
+	}
+}
+
+func TestCore_HandleEnterChildView_UnknownTypeEmitsFlashError(t *testing.T) {
+	c := newCore()
+
+	intents, tasks := c.HandleEnterChildView(EnterChildViewEvent{
+		ChildType:     "totally-not-registered-h4a",
+		ParentContext: map[string]string{},
+		DisplayName:   "X",
+	})
+
+	if len(tasks) != 0 {
+		t.Errorf("expected zero tasks on unknown type, got %d", len(tasks))
+	}
+	if _, ok := findPushScreen(intents); ok {
+		t.Errorf("expected no PushScreen on unknown type, got one")
+	}
+	fi, ok := findFlashIntent(intents)
+	if !ok {
+		t.Fatalf("expected FlashIntent, got intents=%#v", intents)
+	}
+	if !fi.IsError {
+		t.Errorf("expected IsError=true")
+	}
+	if got, want := fi.Text, "unknown child type: totally-not-registered-h4a"; got != want {
+		t.Errorf("Text=%q want %q", got, want)
+	}
+}
+
+// ---- HandleThemeSelected -----------------------------------------------------
+
+func TestCore_HandleThemeSelected_ValidNameEmitsReadTask(t *testing.T) {
+	c := newCore()
+
+	intents, tasks := c.HandleThemeSelected(ThemeSelectedEvent{Theme: "tokyo-night.yaml"})
+
+	if len(intents) != 0 {
+		t.Errorf("expected zero intents on valid name, got %#v", intents)
+	}
+	rp, ok := findReadTheme(tasks)
+	if !ok {
+		t.Fatalf("expected ReadThemePayload task, got tasks=%#v", tasks)
+	}
+	if rp.Theme != "tokyo-night.yaml" {
+		t.Errorf("Theme=%q want tokyo-night.yaml", rp.Theme)
+	}
+	if !hasTaskKind(tasks, TaskKindReadThemeFile) {
+		t.Errorf("expected TaskKindReadThemeFile in tasks, got %v", taskKinds(tasks))
+	}
+}
+
+func TestCore_HandleThemeSelected_InvalidNameEmitsFlashError(t *testing.T) {
+	c := newCore()
+
+	// Empty theme name is rejected by config.ThemePath with a deterministic error.
+	intents, tasks := c.HandleThemeSelected(ThemeSelectedEvent{Theme: ""})
+
+	if len(tasks) != 0 {
+		t.Errorf("expected zero tasks on invalid name, got %d", len(tasks))
+	}
+	fi, ok := findFlashIntent(intents)
+	if !ok {
+		t.Fatalf("expected FlashIntent, got intents=%#v", intents)
+	}
+	if !fi.IsError {
+		t.Errorf("expected IsError=true")
+	}
+	const prefix = "Invalid theme: "
+	if len(fi.Text) < len(prefix) || fi.Text[:len(prefix)] != prefix {
+		t.Errorf("Text=%q want prefix %q", fi.Text, prefix)
+	}
+}
+
+// ---- HandleThemeFileRead -----------------------------------------------------
+
+func TestCore_HandleThemeFileRead_SuccessEmitsApplyPopFlashAndSaveTask(t *testing.T) {
+	c := newCore()
+	bytes := []byte("name: Custom\ncolors:\n  accent: \"#ffffff\"\n")
+
+	intents, tasks := c.HandleThemeFileRead(ThemeFileReadEvent{
+		Theme: "custom.yaml",
+		Bytes: bytes,
+	})
+
+	at, ok := findApplyTheme(intents)
+	if !ok {
+		t.Fatalf("expected ApplyThemeIntent, got intents=%#v", intents)
+	}
+	if at.Name != "custom.yaml" {
+		t.Errorf("ApplyTheme Name=%q want custom.yaml", at.Name)
+	}
+	if len(at.Bytes) != len(bytes) {
+		t.Errorf("ApplyTheme carried %d bytes, expected %d", len(at.Bytes), len(bytes))
+	}
+	if !findPopSelector(intents) {
+		t.Errorf("expected PopSelectorIntent in intents, got %#v", intents)
+	}
+	fi, ok := findFlashIntent(intents)
+	if !ok {
+		t.Fatalf("expected success FlashIntent, got intents=%#v", intents)
+	}
+	if fi.IsError {
+		t.Errorf("success flash must not be IsError")
+	}
+	if got, want := fi.Text, "Theme: custom.yaml"; got != want {
+		t.Errorf("Text=%q want %q", got, want)
+	}
+
+	sp, ok := findSaveTheme(tasks)
+	if !ok {
+		t.Fatalf("expected SaveThemeConfig task, got tasks=%#v", tasks)
+	}
+	if sp.Theme != "custom.yaml" {
+		t.Errorf("Save Theme=%q want custom.yaml", sp.Theme)
+	}
+	if !hasTaskKind(tasks, TaskKindSaveThemeConfig) {
+		t.Errorf("expected TaskKindSaveThemeConfig in tasks, got %v", taskKinds(tasks))
+	}
+}
+
+func TestCore_HandleThemeFileRead_ReadErrorEmitsFlashOnly(t *testing.T) {
+	c := newCore()
+
+	intents, tasks := c.HandleThemeFileRead(ThemeFileReadEvent{
+		Theme: "missing.yaml",
+		Err:   errors.New("open ~/.a9s/themes/missing.yaml: no such file or directory"),
+	})
+
+	if len(tasks) != 0 {
+		t.Errorf("expected zero tasks on read error, got %d", len(tasks))
+	}
+	if _, ok := findApplyTheme(intents); ok {
+		t.Errorf("expected no ApplyThemeIntent on read error")
+	}
+	if findPopSelector(intents) {
+		t.Errorf("expected no PopSelectorIntent on read error")
+	}
+	fi, ok := findFlashIntent(intents)
+	if !ok {
+		t.Fatalf("expected FlashIntent, got intents=%#v", intents)
+	}
+	if !fi.IsError {
+		t.Errorf("expected IsError=true on read error")
+	}
+	const prefix = "Cannot read theme: "
+	if len(fi.Text) < len(prefix) || fi.Text[:len(prefix)] != prefix {
+		t.Errorf("Text=%q want prefix %q", fi.Text, prefix)
+	}
+}
+
+// ---- shared helper ---------------------------------------------------------
+
+// taskKinds extracts the TaskKind slice from tasks for diagnostic prints.
+func taskKinds(tasks []TaskRequest) []TaskKind {
+	out := make([]TaskKind, 0, len(tasks))
+	for _, t := range tasks {
+		out = append(out, t.Key.Kind)
+	}
+	return out
+}

--- a/internal/runtime/tasks.go
+++ b/internal/runtime/tasks.go
@@ -62,6 +62,25 @@ const (
 	// impossible "wrong concrete type on ClientsReadyMsg.Clients" branch to
 	// route the error through HandleAPIError's classification flow.
 	TaskKindEmitAPIError TaskKind = "emit-api-error"
+
+	// TaskKindFetchChildResources asks the adapter to run the paginated
+	// child-resource fetcher for the (childType, parentContext) carried by
+	// FetchChildResourcesPayload and dispatch the result as
+	// messages.ResourcesLoaded. Emitted by HandleEnterChildView.
+	TaskKindFetchChildResources TaskKind = "fetch-child-resources"
+
+	// TaskKindReadThemeFile asks the adapter to resolve the theme file path
+	// via config.ThemePath and read the YAML bytes from disk, then dispatch
+	// the bytes back as messages.ThemeFileRead so HandleThemeFileRead can
+	// emit the apply/pop/flash/save sequence. Emitted by HandleThemeSelected.
+	TaskKindReadThemeFile TaskKind = "read-theme-file"
+
+	// TaskKindSaveThemeConfig asks the adapter to persist the theme choice
+	// to config.yaml via config.SaveTheme. Emitted by HandleThemeFileRead on
+	// the success branch alongside the ApplyThemeIntent + PopSelectorIntent
+	// + success FlashIntent. Save failures surface adapter-side as a
+	// messages.Flash error; the in-memory theme remains applied.
+	TaskKindSaveThemeConfig TaskKind = "save-theme-config"
 )
 
 // TaskKey uniquely identifies one background task. Scope is kind-specific
@@ -201,3 +220,37 @@ type EmitAPIErrorPayload struct {
 }
 
 func (EmitAPIErrorPayload) isTaskPayload() {}
+
+// FetchChildResourcesPayload carries the child-type short name and the
+// parent context map used by the adapter's paginated child fetcher.
+// Emitted by HandleEnterChildView so the adapter's tasksToCmd can build
+// the existing fetchChildResources closure without parsing TaskKey.Scope.
+type FetchChildResourcesPayload struct {
+	ChildType     string
+	ParentContext map[string]string
+}
+
+func (FetchChildResourcesPayload) isTaskPayload() {}
+
+// ReadThemePayload carries the theme filename whose YAML the adapter
+// must read from disk. The adapter resolves the absolute path via
+// config.ThemePath and reads via os.ReadFile, dispatching the result
+// (or read error) back as messages.ThemeFileRead.
+type ReadThemePayload struct {
+	Theme string
+}
+
+func (ReadThemePayload) isTaskPayload() {}
+
+// SaveThemeConfigPayload carries the theme filename the adapter must
+// persist to config.yaml via config.SaveTheme. Emitted by
+// HandleThemeFileRead's success branch after the apply/pop/flash
+// intents. A save failure surfaces as a Flash; the in-memory theme
+// remains applied (intentional ordering change vs the pre-h4-a
+// persist-before-apply behaviour, documented in
+// docs/refactor/05-pr-05a-h4.md §"Theme-selected split").
+type SaveThemeConfigPayload struct {
+	Theme string
+}
+
+func (SaveThemeConfigPayload) isTaskPayload() {}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -94,6 +94,14 @@ type Model struct {
 	headerCacheKey string
 
 	isDemo bool // true when running in --demo mode (synthetic clients); controls Wave 2 skip
+
+	// screens is the renderer-side parallel of runtime.ScreenRegistry: it
+	// resolves runtime.ScreenID -> builder closure for the four ported
+	// view-stack handlers (HandleProfilesLoaded, HandleValueRevealed,
+	// HandleEnterChildView, HandleThemeSelected). Populated once in New()
+	// via defaultBuilders(&m); tests may shadow entries by assigning to
+	// individual map keys.
+	screens builders
 }
 
 // Option configures the root Model.
@@ -181,6 +189,7 @@ func New(profile, region string, opts ...Option) Model {
 		appCtx:      ctx,
 		appCancel:   cancel,
 	}
+	m.screens = defaultBuilders()
 	for _, opt := range opts {
 		opt(&m)
 	}
@@ -290,6 +299,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleRegionSelected(msg)
 	case messages.ThemeSelected:
 		return m.handleThemeSelected(msg)
+	case messages.ThemeFileRead:
+		return m.handleThemeFileRead(msg)
 	case profilesLoadedMsg:
 		return m.handleProfilesLoaded(msg)
 	case messages.ValueRevealed:
@@ -716,9 +727,74 @@ func (m *Model) applyIntents(intents []runtime.UIIntent) []tea.Cmd {
 			})
 		case runtime.ClearFlash:
 			m.flash.active = false
+		case runtime.PushScreen:
+			if c := m.pushScreen(v); c != nil {
+				cmds = append(cmds, c)
+			}
+		case runtime.PopScreen:
+			m.popView()
+		case runtime.ApplyThemeIntent:
+			if c := m.applyTheme(v); c != nil {
+				cmds = append(cmds, c)
+			}
+		case runtime.PopSelectorIntent:
+			if _, ok := m.activeView().(*views.SelectorModel); ok {
+				m.popView()
+			}
 		}
 	}
 	return cmds
+}
+
+// pushScreen resolves the runtime-emitted PushScreen via the screens
+// builder map and pushes the resulting view onto the stack. The live
+// *Model is passed to the builder at invocation so it observes the
+// current keymap / viewConfig / innerSize() rather than a stale
+// snapshot captured at tui.New time. A missing builder (unknown
+// ScreenID) surfaces as a flash so the operator sees the misconfig;
+// a builder that returns a nil view is silently dropped (the builder
+// itself owns the "I refuse to render this payload" decision).
+func (m *Model) pushScreen(v runtime.PushScreen) tea.Cmd {
+	builder, ok := m.screens[v.ID]
+	if !ok {
+		id := string(v.ID)
+		return func() tea.Msg {
+			return messages.Flash{Text: "no screen builder: " + id, IsError: true}
+		}
+	}
+	view, cmd := builder(m, v.Payload)
+	if view != nil {
+		m.pushView(view)
+	}
+	return cmd
+}
+
+// applyTheme parses the YAML bytes carried by ApplyThemeIntent and, on
+// success, swaps the active theme, invalidates the header cache, walks
+// the view stack invalidating ResourceListModel style caches, and sets
+// m.activeTheme so the next theme selector renders the "(current)"
+// indicator correctly. On parse failure the adapter emits a flash and
+// skips the apply; the persist task (queued separately) still fires
+// because the runtime already committed to the new theme name —
+// matching the documented Option B trade-off in
+// docs/refactor/05-pr-05a-h4.md §"Theme-selected split".
+func (m *Model) applyTheme(v runtime.ApplyThemeIntent) tea.Cmd {
+	t, err := styles.ThemeFromYAML(v.Bytes)
+	if err != nil {
+		text := "Bad theme YAML: " + err.Error()
+		return func() tea.Msg {
+			return messages.Flash{Text: text, IsError: true}
+		}
+	}
+	styles.ApplyTheme(t)
+	m.activeTheme = v.Name
+	m.headerCacheKey = ""
+	for _, sv := range m.stack {
+		if rl, ok := sv.(*views.ResourceListModel); ok {
+			rl.InvalidateStyleCache()
+		}
+	}
+	return nil
 }
 
 // tasksToCmd converts a []runtime.TaskRequest returned by m.core.HandleEvent
@@ -741,6 +817,20 @@ func (m *Model) tasksToCmd(tasks []runtime.TaskRequest) tea.Cmd {
 			cmd := m.saveAvailabilityCache()
 			if cmd != nil {
 				cmds = append(cmds, cmd)
+			}
+		case runtime.TaskKindFetchChildResources:
+			if p, ok := req.Payload.(runtime.FetchChildResourcesPayload); ok {
+				if cmd := m.fetchChildResources(p.ChildType, p.ParentContext); cmd != nil {
+					cmds = append(cmds, cmd)
+				}
+			}
+		case runtime.TaskKindReadThemeFile:
+			if p, ok := req.Payload.(runtime.ReadThemePayload); ok {
+				cmds = append(cmds, readThemeFileCmd(p))
+			}
+		case runtime.TaskKindSaveThemeConfig:
+			if p, ok := req.Payload.(runtime.SaveThemeConfigPayload); ok {
+				cmds = append(cmds, saveThemeConfigCmd(p))
 			}
 		}
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -773,10 +773,17 @@ func (m *Model) pushScreen(v runtime.PushScreen) tea.Cmd {
 // success, swaps the active theme, invalidates the header cache, walks
 // the view stack invalidating ResourceListModel style caches, and sets
 // m.activeTheme so the next theme selector renders the "(current)"
-// indicator correctly. On parse failure the adapter emits a flash and
-// skips the apply; the persist task (queued separately) still fires
-// because the runtime already committed to the new theme name —
-// matching the documented Option B trade-off in
+// indicator correctly.
+//
+// Post-AS-784: Core's HandleThemeFileRead pre-validates the YAML via
+// styles.ThemeFromYAML before emitting ApplyThemeIntent + Save task. The
+// adapter parse-error branch below is therefore defensive — under normal
+// flow the bytes are guaranteed to parse. The branch is retained so any
+// future caller that constructs ApplyThemeIntent without the Core
+// validation gate (e.g. a test harness or a different entrypoint) still
+// surfaces a flash instead of silently swapping in a partially-decoded
+// theme. The Save task is no longer queued on parse failure because
+// HandleThemeFileRead gates it on parse success — see
 // docs/refactor/05-pr-05a-h4.md §"Theme-selected split".
 func (m *Model) applyTheme(v runtime.ApplyThemeIntent) tea.Cmd {
 	t, err := styles.ThemeFromYAML(v.Bytes)

--- a/internal/tui/app_screens.go
+++ b/internal/tui/app_screens.go
@@ -1,50 +1,42 @@
 package tui
 
-// app_screens.go — view-stack push handlers for screens that are constructed
-// in response to a runtime/event signal (reveal result, child-view enter).
-// Split out of internal/tui/app_handlers.go in Phase-05 PR-05a-h1 (AS-147).
-// Both bodies call views.New<Screen>(...) Bubble Tea constructors and
-// manipulate the adapter-owned view stack — they stay in tui by design.
-// A follow-up PR can replace direct construction with PushScreen UIIntent
-// emission once ScreenID/ScreenContext cover Reveal/ChildList contexts.
+// app_screens.go — view-stack push handlers for screens that are
+// constructed in response to a runtime/event signal (reveal result,
+// child-view enter). Split out of internal/tui/app_handlers.go in
+// Phase-05 PR-05a-h1 (AS-147). PR-05a-h4-a (AS-769) ported both bodies
+// to (c *Core) Handle* methods backed by the screen-builder registry
+// in internal/tui/screens.go; each adapter below is a ≤12-line shim
+// that translates the message to its runtime.*Event, calls the Core
+// method, and dispatches the returned intents/tasks.
 
 import (
-	"fmt"
-
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/k2m30/a9s/v3/internal/resource"
+	"github.com/k2m30/a9s/v3/internal/runtime"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
-	"github.com/k2m30/a9s/v3/internal/tui/views"
 )
 
-// handleValueRevealed pushes the reveal view or flashes an error.
+// handleValueRevealed delegates to runtime.Core.HandleValueRevealed.
+// On Err the Core emits a flash error; on success it emits
+// PushScreen{ScreenReveal, RevealPayload{...}} which the screens.go
+// builder materialises as a RevealModel.
 func (m Model) handleValueRevealed(msg messages.ValueRevealed) (tea.Model, tea.Cmd) {
-	if msg.Err != nil {
-		errText := "reveal failed: " + msg.Err.Error()
-		return m, func() tea.Msg {
-			return messages.Flash{Text: errText, IsError: true}
-		}
-	}
-	rv := views.NewReveal(msg.ResourceID, msg.Value, m.keys)
-	rv.SetSize(m.innerSize())
-	m.pushView(&rv)
-	return m, nil
+	intents, tasks := m.core.HandleValueRevealed(runtime.ValueRevealedEvent{
+		ResourceID: msg.ResourceID, Value: msg.Value, Err: msg.Err,
+	})
+	cmd := m.dispatchCoreScreenResult(intents, tasks)
+	return m, cmd
 }
 
-// handleEnterChildView creates a child resource list view and kicks off a fetch
-// using the child type registry. This is the generic handler for all child views.
+// handleEnterChildView delegates to runtime.Core.HandleEnterChildView.
+// The Core validates ChildType via resource.GetChildType; unknown
+// types flash an error, known types emit PushScreen{ScreenChildList}
+// paired with a TaskKindFetchChildResources whose payload the adapter
+// translates into the existing fetchChildResources closure.
 func (m Model) handleEnterChildView(msg messages.EnterChildView) (tea.Model, tea.Cmd) {
-	childTypeDef := resource.GetChildType(msg.ChildType)
-	if childTypeDef == nil {
-		return m, func() tea.Msg {
-			return messages.Flash{Text: fmt.Sprintf("unknown child type: %s", msg.ChildType), IsError: true}
-		}
-	}
-	rl := views.NewChildResourceList(*childTypeDef, msg.ParentContext, msg.DisplayName, m.viewConfig, m.keys)
-	rl.SetSize(m.innerSize())
-	rl, initCmd := rl.Init()
-	m.pushView(&rl)
-	fetchCmd := m.fetchChildResources(msg.ChildType, msg.ParentContext)
-	return m, tea.Batch(initCmd, fetchCmd)
+	intents, tasks := m.core.HandleEnterChildView(runtime.EnterChildViewEvent{
+		ChildType: msg.ChildType, ParentContext: msg.ParentContext, DisplayName: msg.DisplayName,
+	})
+	cmd := m.dispatchCoreScreenResult(intents, tasks)
+	return m, cmd
 }

--- a/internal/tui/app_session.go
+++ b/internal/tui/app_session.go
@@ -9,19 +9,18 @@ package tui
 // the messages.* into the runtime.*Event, call the Core method, apply
 // returned intents, and translate returned tasks into tea.Cmds.
 //
-// handleThemeSelected and handleProfilesLoaded stay in the TUI adapter
-// for now — they push concrete view structs onto the adapter view stack,
-// which requires the screen-builder registry that lands in a successor PR.
+// PR-05a-h4-a (AS-769) ports the remaining four view-stack handlers
+// (handleProfilesLoaded, handleValueRevealed, handleEnterChildView,
+// handleThemeSelected) to (c *Core) Handle* methods backed by the
+// screen-builder registry in screens.go. handleThemeFileRead is a new
+// thin adapter introduced by h4-a to complete the two-step theme flow
+// (read task → HandleThemeFileRead → Apply/Pop/Flash + Save task).
 
 import (
-	"os"
-
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/k2m30/a9s/v3/internal/config"
 	"github.com/k2m30/a9s/v3/internal/runtime"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
-	"github.com/k2m30/a9s/v3/internal/tui/styles"
 	"github.com/k2m30/a9s/v3/internal/tui/views"
 )
 
@@ -88,65 +87,35 @@ func (m Model) handleRegionSelected(msg messages.RegionSelected) (tea.Model, tea
 	return m, cmd
 }
 
-// handleThemeSelected applies the selected theme, invalidates style caches,
-// pops the selector, and persists the choice to config.yaml. Stays in the
-// TUI adapter pending the screen-builder registry that successor PRs need
-// to push the selector view from a Core method.
+// handleThemeSelected delegates to runtime.Core.HandleThemeSelected, which
+// resolves the path via config.ThemePath and emits a TaskKindReadThemeFile.
+// The adapter task closure performs the os.ReadFile and dispatches
+// messages.ThemeFileRead → handleThemeFileRead for the apply/pop/save flow.
 func (m Model) handleThemeSelected(msg messages.ThemeSelected) (tea.Model, tea.Cmd) {
-	path, err := config.ThemePath(msg.Theme)
-	if err != nil {
-		return m, func() tea.Msg {
-			return messages.Flash{Text: "Invalid theme: " + err.Error(), IsError: true}
-		}
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return m, func() tea.Msg {
-			return messages.Flash{Text: "Cannot read theme: " + err.Error(), IsError: true}
-		}
-	}
-	t, err := styles.ThemeFromYAML(data)
-	if err != nil {
-		return m, func() tea.Msg {
-			return messages.Flash{Text: "Bad theme YAML: " + err.Error(), IsError: true}
-		}
-	}
-
-	// Persist BEFORE applying — if save fails, abort the change entirely.
-	if saveErr := config.SaveTheme(msg.Theme); saveErr != nil {
-		return m, func() tea.Msg {
-			return messages.Flash{Text: "Cannot save theme config: " + saveErr.Error(), IsError: true}
-		}
-	}
-
-	// Save succeeded — now apply the theme.
-	styles.ApplyTheme(t)
-	m.activeTheme = msg.Theme
-
-	// Invalidate header cache.
-	m.headerCacheKey = ""
-
-	// Invalidate styledRowCache on all ResourceListModel views in the stack.
-	for _, v := range m.stack {
-		if rl, ok := v.(*views.ResourceListModel); ok {
-			rl.InvalidateStyleCache()
-		}
-	}
-
-	// Pop the selector view.
-	if _, ok := m.activeView().(*views.SelectorModel); ok {
-		m.popView()
-	}
-
-	return m, func() tea.Msg {
-		return messages.Flash{Text: "Theme: " + msg.Theme}
-	}
+	intents, tasks := m.core.HandleThemeSelected(runtime.ThemeSelectedEvent{Theme: msg.Theme})
+	cmd := m.dispatchCoreScreenResult(intents, tasks)
+	return m, cmd
 }
 
-// handleProfilesLoaded pushes the profile selector view onto the stack.
+// handleThemeFileRead delegates to runtime.Core.HandleThemeFileRead, which
+// branches on read error → flash or success → ApplyThemeIntent (bytes) +
+// PopSelectorIntent + success Flash + TaskKindSaveThemeConfig.
+func (m Model) handleThemeFileRead(msg messages.ThemeFileRead) (tea.Model, tea.Cmd) {
+	intents, tasks := m.core.HandleThemeFileRead(runtime.ThemeFileReadEvent{
+		Theme: msg.Theme, Bytes: msg.Bytes, Err: msg.Err,
+	})
+	cmd := m.dispatchCoreScreenResult(intents, tasks)
+	return m, cmd
+}
+
+// handleProfilesLoaded delegates to runtime.Core.HandleProfilesLoaded,
+// which emits PushScreen{ScreenProfileSelector, ProfileSelectorPayload{...}}.
+// The screens.go builder constructs the SelectorModel and pushes it.
 func (m Model) handleProfilesLoaded(msg profilesLoadedMsg) (tea.Model, tea.Cmd) {
-	p := views.NewProfile(msg.profiles, m.core.Session().Profile, m.keys)
-	p.SetSize(m.innerSize())
-	m.pushView(&p)
-	return m, nil
+	intents, tasks := m.core.HandleProfilesLoaded(runtime.ProfilesLoadedEvent{
+		Profiles: msg.profiles,
+	})
+	cmd := m.dispatchCoreScreenResult(intents, tasks)
+	return m, cmd
 }
+

--- a/internal/tui/runtime_adapter.go
+++ b/internal/tui/runtime_adapter.go
@@ -115,6 +115,12 @@ func (m *Model) applyIntent(intent runtime.UIIntent) tea.Cmd {
 		if rl, ok := m.activeView().(*views.ResourceListModel); ok {
 			return m.refreshResourceList(*rl)
 		}
+	case runtime.PushScreen:
+		return m.pushScreen(v)
+	case runtime.PopScreen:
+		m.popView()
+	case runtime.ApplyThemeIntent:
+		return m.applyTheme(v)
 	}
 	return nil
 }
@@ -147,6 +153,14 @@ func (m Model) runtimeTasksToCmd(tasks []runtime.TaskRequest) tea.Cmd {
 			cmds = append(cmds, emitNavigateCmd(p))
 		case runtime.EmitAPIErrorPayload:
 			cmds = append(cmds, emitAPIErrorCmd(p))
+		case runtime.FetchChildResourcesPayload:
+			if cmd := m.fetchChildResources(p.ChildType, p.ParentContext); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		case runtime.ReadThemePayload:
+			cmds = append(cmds, readThemeFileCmd(p))
+		case runtime.SaveThemeConfigPayload:
+			cmds = append(cmds, saveThemeConfigCmd(p))
 		}
 	}
 	switch len(cmds) {

--- a/internal/tui/screens.go
+++ b/internal/tui/screens.go
@@ -1,0 +1,149 @@
+// screens.go — Bubble Tea adapter's screen-builder registry. This is the
+// renderer-side parallel of runtime.ScreenRegistry: the runtime emits
+// PushScreen{ID, Context, Payload}; the adapter resolves ID through the
+// builders map below and invokes the closure to construct the concrete
+// views.View plus any follow-up tea.Cmd. The runtime never sees
+// tea.Model or views.View; the adapter never invents ScreenIDs (they
+// live in internal/runtime).
+//
+// Three builders ship in PR-05a-h4-a (AS-769) for the four ported
+// view-stack handlers: profile selector, reveal, child list. Capability
+// screens (logs, ct.scan, cost) remain out of scope until their handler
+// PRs land.
+package tui
+
+import (
+	"os"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/k2m30/a9s/v3/internal/config"
+	"github.com/k2m30/a9s/v3/internal/resource"
+	"github.com/k2m30/a9s/v3/internal/runtime"
+	"github.com/k2m30/a9s/v3/internal/runtime/messages"
+	"github.com/k2m30/a9s/v3/internal/tui/views"
+)
+
+// screenBuilder constructs a renderer-side view from a runtime-emitted
+// screen payload. The adapter holds one builder per runtime.ScreenID
+// and invokes it with the live *Model so the builder sees the current
+// keymap, viewConfig, and innerSize() — not a snapshot from tui.New
+// (the model is passed by value through Update so a builder closure
+// that captured *Model at construction would see a stale, zero-sized
+// copy after the first WindowSizeMsg).
+//
+// A builder may return a nil view to signal "skip the push" — used by
+// the child-list builder when the runtime emitted an unknown ChildType
+// (defensive: Core already validates, so this is belt-and-suspenders).
+type screenBuilder func(m *Model, payload runtime.ScreenPayload) (views.View, tea.Cmd)
+
+// builders maps runtime.ScreenID -> concrete builder closure. Populated
+// once in tui.New(...) via defaultBuilders; tests may shadow individual
+// entries by assigning to m.screens after construction.
+type builders map[runtime.ScreenID]screenBuilder
+
+// defaultBuilders returns the canonical builder set for the live TUI
+// adapter. Each builder reads m.keys, m.viewConfig, and m.innerSize()
+// from the *Model passed in at invocation time so successive
+// PushScreens reflect the current keymap / viewConfig / terminal size.
+func defaultBuilders() builders {
+	return builders{
+		runtime.ScreenProfileSelector: func(m *Model, p runtime.ScreenPayload) (views.View, tea.Cmd) {
+			psp, ok := p.(runtime.ProfileSelectorPayload)
+			if !ok {
+				return nil, nil
+			}
+			v := views.NewProfile(psp.Profiles, psp.Current, m.keys)
+			v.SetSize(m.innerSize())
+			return &v, nil
+		},
+		runtime.ScreenReveal: func(m *Model, p runtime.ScreenPayload) (views.View, tea.Cmd) {
+			rp, ok := p.(runtime.RevealPayload)
+			if !ok {
+				return nil, nil
+			}
+			v := views.NewReveal(rp.ResourceID, rp.Value, m.keys)
+			v.SetSize(m.innerSize())
+			return &v, nil
+		},
+		runtime.ScreenChildList: func(m *Model, p runtime.ScreenPayload) (views.View, tea.Cmd) {
+			clp, ok := p.(runtime.ChildListPayload)
+			if !ok {
+				return nil, nil
+			}
+			childTypeDef := resource.GetChildType(clp.ChildType)
+			if childTypeDef == nil {
+				return nil, nil
+			}
+			rl := views.NewChildResourceList(*childTypeDef, clp.ParentContext, clp.DisplayName, m.viewConfig, m.keys)
+			rl.SetSize(m.innerSize())
+			rl, initCmd := rl.Init()
+			return &rl, initCmd
+		},
+	}
+}
+
+// dispatchCoreScreenResult walks the intents/tasks returned by an h4-a
+// Handle* method using the plural-semantics path (applyIntents +
+// tasksToCmd). The key behavioural difference from dispatchHandlerResult
+// (used by h3 handlers) is that FlashIntent is re-emitted as
+// messages.Flash via cmd rather than direct-mutated. h3 handlers
+// pre-bump m.flash.gen and pair FlashIntent with FlashTickPayload so
+// direct-mutation works there; h4-a handlers do not own the flash gen
+// dance (their flashes route back through handleFlash → HandleFlash to
+// pick up the auto-clear tick), so re-emitting preserves the
+// pre-port observable behaviour: the cmd produces a messages.Flash
+// that downstream tests assert on.
+func (m *Model) dispatchCoreScreenResult(intents []runtime.UIIntent, tasks []runtime.TaskRequest) tea.Cmd {
+	cmds := m.applyIntents(intents)
+	if tc := m.tasksToCmd(tasks); tc != nil {
+		cmds = append(cmds, tc)
+	}
+	switch len(cmds) {
+	case 0:
+		return nil
+	case 1:
+		return cmds[0]
+	default:
+		return tea.Batch(cmds...)
+	}
+}
+
+// readThemeFileCmd resolves the theme file path via config.ThemePath and
+// reads the YAML bytes from disk, dispatching the result (or error) as
+// messages.ThemeFileRead so HandleThemeFileRead can emit the
+// apply/pop/flash/save sequence. Pure adapter-side I/O — the runtime
+// owns no file-system handles.
+func readThemeFileCmd(p runtime.ReadThemePayload) tea.Cmd {
+	theme := p.Theme
+	return func() tea.Msg {
+		path, err := config.ThemePath(theme)
+		if err != nil {
+			return messages.ThemeFileRead{Theme: theme, Err: err}
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return messages.ThemeFileRead{Theme: theme, Err: err}
+		}
+		return messages.ThemeFileRead{Theme: theme, Bytes: data}
+	}
+}
+
+// saveThemeConfigCmd persists the chosen theme name to config.yaml via
+// config.SaveTheme. On error the adapter surfaces a flash; on success
+// no message fires (the user already saw the success flash emitted by
+// HandleThemeFileRead's intent slice). Decoupled from the apply step so
+// a save failure does not roll back the in-memory theme change —
+// matching the documented Option B trade-off.
+func saveThemeConfigCmd(p runtime.SaveThemeConfigPayload) tea.Cmd {
+	theme := p.Theme
+	return func() tea.Msg {
+		if err := config.SaveTheme(theme); err != nil {
+			return messages.Flash{
+				Text:    "Cannot save theme config: " + err.Error(),
+				IsError: true,
+			}
+		}
+		return nil
+	}
+}

--- a/tests/unit/app_handlers_theme_profile_test.go
+++ b/tests/unit/app_handlers_theme_profile_test.go
@@ -55,8 +55,15 @@ func TestHandleThemeSelected_InvalidThemeName(t *testing.T) {
 	}
 }
 
-// TestHandleThemeSelected_ThemeFileNotFound verifies that sending a ThemeSelectedMsg
-// with a syntactically valid but non-existent filename returns FlashMsg{IsError: true}.
+// TestHandleThemeSelected_ThemeFileNotFound verifies that selecting a theme
+// whose filename is syntactically valid but missing on disk surfaces a
+// "Cannot read theme: …" FlashMsg to the user.
+//
+// PR-05a-h4-a (AS-769) split the theme-selected flow into two round trips:
+// ThemeSelected → TaskKindReadThemeFile dispatch → messages.ThemeFileRead →
+// HandleThemeFileRead → FlashIntent (error). The test drives both steps:
+// the first cmd produces messages.ThemeFileRead{Err: ...}; feeding that
+// back through the root model produces the user-visible FlashMsg.
 func TestHandleThemeSelected_ThemeFileNotFound(t *testing.T) {
 	withTuiVersion(t, "test")
 	tmp := t.TempDir()
@@ -64,15 +71,31 @@ func TestHandleThemeSelected_ThemeFileNotFound(t *testing.T) {
 
 	m := newRootSizedModel()
 
-	// Valid filename format but the file does not exist on disk.
+	// Step 1: ThemeSelected → ReadThemeFile task → ThemeFileRead{Err}.
 	_, cmd := rootApplyMsg(m, messages.ThemeSelected{Theme: "nonexistent-theme-xyz.yaml"})
 	if cmd == nil {
-		t.Fatal("handleThemeSelected with missing theme file should return a cmd")
+		t.Fatal("handleThemeSelected with missing theme file should return a cmd (read task)")
 	}
-	msg := cmd()
+	readResult := cmd()
+	tfr, ok := readResult.(messages.ThemeFileRead)
+	if !ok {
+		t.Fatalf("expected messages.ThemeFileRead from read task, got %T", readResult)
+	}
+	if tfr.Err == nil {
+		t.Fatalf("expected ThemeFileRead.Err to be set for missing file, got nil")
+	}
+
+	// Step 2: feed ThemeFileRead back through the root model.
+	// HandleThemeFileRead branches on Err and emits a FlashIntent which the
+	// h4-a plural-dispatch path re-emits as messages.Flash.
+	_, flashCmd := rootApplyMsg(m, tfr)
+	if flashCmd == nil {
+		t.Fatal("handleThemeFileRead on read error should return a cmd (flash re-emit)")
+	}
+	msg := flashCmd()
 	flash, ok := msg.(messages.Flash)
 	if !ok {
-		t.Fatalf("expected FlashMsg, got %T", msg)
+		t.Fatalf("expected messages.Flash from HandleThemeFileRead error branch, got %T", msg)
 	}
 	if !flash.IsError {
 		t.Errorf("FlashMsg.IsError = false, want true (file not found)")


### PR DESCRIPTION
## Summary

Implements PR-05a-h4-a per spec [`docs/refactor/05-pr-05a-h4.md`](https://github.com/k2m30/a9s/blob/main/docs/refactor/05-pr-05a-h4.md) §"PR-05a-h4-a" (AS-650). Issue: AS-769.

Ports four h3-deferred view-stack handlers (`handleProfilesLoaded`, `handleValueRevealed`, `handleEnterChildView`, `handleThemeSelected`) plus a new `handleThemeFileRead` two-step continuation to `(c *Core) Handle*` methods backed by a screen-builder registry in `internal/tui/screens.go`. Each adapter shrinks to a 5–7 LOC thin shim.

## Option B chosen for `ApplyThemeIntent`

Per spec §"Theme-selected split", Option B (carry parsed YAML bytes + theme name; adapter re-parses via `styles.ThemeFromYAML`) was selected over Option A (extract `domain.Theme` pure-data type). Rationale: smaller surface area, faster to land, preserves boundary invariant. Option A's domain-Theme extraction is left to a follow-on PR if cleaner-data parity becomes warranted.

## Acceptance gates (all green locally)

```
rg 'func \(c \*Core\) (HandleProfilesLoaded|HandleValueRevealed|HandleEnterChildView|HandleThemeSelected|HandleThemeFileRead)' internal/runtime/handlers.go | wc -l
→ 5

go list -f '{{.Imports}}' github.com/k2m30/a9s/v3/internal/runtime | grep -E 'bubbletea|lipgloss|bubbles'
→ zero hits (boundary clean)

rg 'screens\s+builders|defaultBuilders' internal/tui/screens.go → present
rg 'Payload\s+ScreenPayload' internal/runtime/intent.go → 1 hit

Adapter body LOC (≤12 target):
  handleProfilesLoaded   = 7
  handleThemeSelected    = 5
  handleThemeFileRead    = 7
  handleValueRevealed    = 7
  handleEnterChildView   = 7

screens_handlers_test.go function count → 9 (target ≥6)
```

## Design notes

- **Builders take `*Model` at invocation time**, not captured at construction. Because `tui.Model` flows through `Update()` by value, a builder that captured `*Model` in `tui.New(...)` would freeze a zero-size pointer the first `WindowSizeMsg` never updates — caught by `TestQA_SSM_RevealViewShowsParameterValue` rendering a 1×1 viewport (single char `s` instead of the full value). The fix passes the live `*Model` through `pushScreen(...)` to the builder.

- **`dispatchCoreScreenResult` (plural-semantics `applyIntents`)** is the dispatch helper for the h4-a handlers. h3 handlers use `dispatchHandlerResult` (singular `applyIntent`) because they pre-bump `m.flash.gen` and pair `FlashIntent` with `FlashTickPayload`. h4-a handlers don't own that gen dance — their flashes re-emit as `messages.Flash` so the existing `handleFlash → HandleFlash` chain handles gen bump + auto-clear tick. Preserves pre-port observable behaviour (cmd that fires `messages.Flash`).

- **One existing test updated**: `TestHandleThemeSelected_ThemeFileNotFound` — the pre-h4 single round-trip (`ThemeSelected → Flash`) architecturally splits into two (`ThemeSelected → ReadThemeFile task → ThemeFileRead{Err} → Flash`). The test now drives both steps and asserts the same user-visible flash text. Behaviour preserved, assertion adjusted to the new architecture.

## Out of scope (separate PRs per spec)

- `Update()`-switch session-mutation extraction (`messages.ResourcesLoaded`, `RelatedCheckResult`, `IdentityLoaded`, `EnrichDetailResult`) — **PR-05a-h4-b**.
- Final `internal/session` / `internal/aws` import scrub — **PR-05a-h4-c**.
- `internal/tui/app.go` shrink to 300–400 LOC — depends on h4-b + h4-c.
- `handleKeyMsg` / `app_flash.go` stay per spec.

## Test plan

- [x] `go test ./...` green
- [x] `golangci-lint run ./...` 0 issues
- [x] `govulncheck ./...` no vulnerabilities
- [x] `go fix -inline -diff ./...` clean
- [x] `verify-readonly` grep clean
- [x] `check-readme` in sync
- [x] snapshot tests (unit + integration) green
- [x] Runtime boundary invariant: zero `bubbletea|lipgloss|bubbles` imports
- [ ] `make test-race` — gated by pod CGO availability (per project-level memory `reference_a9s_stage6_pod_bootstrap`); CI will run

Closes AS-769.

🤖 Generated with [Claude Code](https://claude.com/claude-code)