### PR TITLE
ci(AS-827): wire `make integration` as permanent Stage-5 gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,24 @@ jobs:
       - name: Check for write API calls
         run: make verify-readonly
 
+  integration:
+    # AS-827 — permanent Stage-5 gate. Mirrors `make integration` locally and
+    # the supplement command on PR #392 (`go test -tags integration
+    # ./tests/integration/ -count=1 -timeout 300s`). Ubuntu-only by design:
+    # integration tests target the linux runner shape; cross-OS coverage
+    # belongs to the `test` matrix.
+    name: Integration
+    if: github.event_name == 'pull_request' && needs.changes.outputs.go == 'true'
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: go.mod
+      - name: Run integration tests
+        run: make integration
+
   markdown-lint:
     name: Markdown lint
     if: github.event_name == 'pull_request' && (needs.changes.outputs.not_docs != 'true' || needs.changes.outputs.md == 'true')


### PR DESCRIPTION
## Summary

- Adds a dedicated `integration` job to `.github/workflows/ci.yml` that runs `make integration` on every Go-touching PR.
- Mirrors the local pre-push command exactly (`go test -tags integration ./tests/integration/ -count=1 -timeout 300s`).
- Closes the gap that Architect (verdict 2026-05-21T02:54:55Z) and CodexReviewer (NEEDS CHANGES) both flagged on PR #392 (AS-795a): the integration suite was only ever invoked ad-hoc by CodeReviewer, never enforced by CI.

## Design choices

- **Separate job** rather than appending a step to the existing `test` job — `test` runs an OS matrix (ubuntu / macos / windows); integration coverage is linux-only by design, so running it inside the matrix would 3x the wall time for no extra signal. The supplement command on PR #392 explicitly targeted ubuntu.
- **Reuses** `actions/setup-go`'s built-in cache surface; no new cache keys.
- **Gated** on `needs.changes.outputs.go == 'true'` so docs-only PRs still hit the existing stub path. The changes-filter already lists `.github/workflows/ci.yml`, so this PR will exercise the new lane against itself.
- **Timeout** is enforced at the `make integration` recipe (300s, ~13x the 22.9s wall observed on PR #392 head).

## Scope

`+18 LOC` of YAML, single file (`.github/workflows/ci.yml`). Well under the ≤30 LOC budget in AS-827.

## Branch protection note (flag from AS-827)

This PR adds the lane; **marking the new `Integration` check as required for merge in branch protection rules is a separate concern owned by the repo admin / CTO**. Per AS-827 acceptance:

> The lane is required for merge (branch protection update may be a separate concern; flag in PR description if so).

Flagged. After this merges and the lane appears on at least one PR, branch protection should be updated to add `Integration` to the required-checks list.

## Test plan

- [x] `python3 -c yaml` not available locally; `actionlint` (via `go run github.com/rhysd/actionlint/cmd/actionlint@latest`) ran clean against the modified file.
- [ ] CI on this PR runs the new `Integration` lane against itself (changes-filter includes `.github/workflows/ci.yml`, so `go: 'true'` triggers all gates including the new one).
- [ ] Verify the `Integration` lane shows up in `gh pr checks <PR>` and goes green.

## Refs

- AS-827 (this issue)
- AS-795a / PR #392 (origin of the follow-up commitment)