### PR TITLE
feat(refactor): AS-815 security init() → catalog migration

### DIFF
--- a/internal/aws/catalog_security.go
+++ b/internal/aws/catalog_security.go
@@ -114,6 +114,14 @@ var securityTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // stat
 			if err != nil {
 				return result, err
 			}
+			// Inline group policies are not paginated by AWS — fetch once on the
+			// first page only. Appending on every continuation token would
+			// duplicate the same inline rows across pages (CodeRabbit finding
+			// on PR #397). The original init() in iam_policies.go had the same
+			// bug; the catalog migration site is the natural place to land the fix.
+			if continuationToken != "" {
+				return result, nil
+			}
 			inlines, inlineErr := fetchInlineGroupPolicies(ctx, c.IAM)
 			// Partial failure: inline group policy enumeration failed for some
 			// groups. Preserve the inline results we did get, then propagate the

--- a/internal/aws/catalog_security.go
+++ b/internal/aws/catalog_security.go
@@ -1,11 +1,14 @@
 package aws
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/domain"
+	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func colorRole(r domain.Resource) domain.Color {
@@ -63,6 +66,30 @@ var securityTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // stat
 			DisplayNameKey: "role_name",
 		}},
 		Color: colorRole,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchIAMRolesPage(ctx, c.IAM, continuationToken)
+		},
+		Wave2: IssueEnricher{Fn: EnrichIAMRoleLastUsed, Priority: 100},
+		FieldKeys: []string{
+			"role_name", "role_id", "path", "create_date", "description",
+			"assume_role_policy_document", "trust_wildcard", "trust_summary",
+			"policy_resources",
+		},
+		Related: []domain.RelatedDef{
+			{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkRoleLambda, NeedsTargetCache: true},
+			{TargetType: "glue", DisplayName: "Glue Jobs", Checker: checkRoleGlue, NeedsTargetCache: true},
+			{TargetType: "ng", DisplayName: "Node Groups", Checker: checkRoleNG, NeedsTargetCache: true},
+			{TargetType: "policy", DisplayName: "IAM Policies", Checker: checkRolePolicy, NeedsTargetCache: false},
+			{TargetType: "ec2", DisplayName: "EC2 Instances", Checker: checkRoleEC2, NeedsTargetCache: true},
+			{TargetType: "eks", DisplayName: "EKS Clusters", Checker: checkRoleEKS, NeedsTargetCache: true},
+			{TargetType: "iam-group", DisplayName: "IAM Groups (trust)", Checker: checkRoleIamGroup, NeedsTargetCache: false},
+			{TargetType: "iam-user", DisplayName: "IAM Users (trust)", Checker: checkRoleIamUser, NeedsTargetCache: false},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("role"), NeedsTargetCache: false},
+		},
 	},
 	{
 		Name:          "IAM Policies",
@@ -78,6 +105,49 @@ var securityTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // stat
 			{Key: "create_date", Title: "Created", Width: 22, Sortable: true},
 		},
 		Color: colorPolicy,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			result, err := FetchIAMPoliciesPage(ctx, c.IAM, continuationToken)
+			if err != nil {
+				return result, err
+			}
+			inlines, inlineErr := fetchInlineGroupPolicies(ctx, c.IAM)
+			// Partial failure: inline group policy enumeration failed for some
+			// groups. Preserve the inline results we did get, then propagate the
+			// composite error so app.go's ResourcesLoadedMsg handler surfaces it
+			// via FlashMsg → `!` log (per E1–E6). Managed policies above are
+			// still returned in result.Resources regardless.
+			result.Resources = append(result.Resources, inlines...)
+			if result.Pagination != nil {
+				result.Pagination.PageSize = len(result.Resources)
+			}
+			return result, inlineErr
+		},
+		Wave2: IssueEnricher{Fn: EnrichIAMPolicy, Priority: 100},
+		FieldKeys: []string{
+			"policy_name", "policy_type", "attachment_count", "is_attachable",
+			"path", "create_date",
+		},
+		FetchByIDs: func(ctx context.Context, clients any, ids []string) ([]resource.Resource, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return nil, fmt.Errorf("AWS clients not initialized")
+			}
+			if c.IAMPolicies() == nil {
+				return nil, fmt.Errorf("IAMPolicies store not initialized on ServiceClients")
+			}
+			return FetchIAMPoliciesByIDsFull(ctx, c.IAM, ids, c.IAMPolicies())
+		},
+		Related: []domain.RelatedDef{
+			{TargetType: "role", DisplayName: "IAM Roles", Checker: checkPolicyRole, NeedsTargetCache: false},
+			{TargetType: "iam-user", DisplayName: "IAM Users", Checker: checkPolicyUser, NeedsTargetCache: false},
+			{TargetType: "iam-group", DisplayName: "IAM Groups", Checker: checkPolicyGroup, NeedsTargetCache: false},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("policy"), NeedsTargetCache: false},
+		},
+		DetailEnrich: enrichPolicy,
 	},
 	{
 		Name:          "IAM Users",
@@ -93,6 +163,23 @@ var securityTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // stat
 			{Key: "password_last_used", Title: "Password Last Used", Width: 22, Sortable: true},
 		},
 		Color: colorIAMUser,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchIAMUsersPage(ctx, c.IAM, continuationToken)
+		},
+		Wave2: IssueEnricher{Fn: EnrichIAMUserMFA, Priority: 100},
+		FieldKeys: []string{
+			"user_name", "user_id", "path", "create_date", "password_last_used",
+			"has_console_password",
+		},
+		Related: []domain.RelatedDef{
+			{TargetType: "iam-group", DisplayName: "IAM Groups", Checker: checkUserGroup, NeedsTargetCache: false},
+			{TargetType: "policy", DisplayName: "IAM Policies", Checker: checkUserPolicy, NeedsTargetCache: false},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: checkIAMUserCtEvents, NeedsTargetCache: false},
+		},
 	},
 	{
 		Name:          "IAM Groups",
@@ -114,6 +201,20 @@ var securityTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // stat
 			DisplayNameKey: "group_name",
 		}},
 		Color: colorIAMGroup,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchIAMGroupsPage(ctx, c.IAM, continuationToken)
+		},
+		Wave2:     IssueEnricher{Fn: EnrichIAMGroup, Priority: 100},
+		FieldKeys: []string{"group_name", "group_id", "path", "create_date", "arn"},
+		Related: []domain.RelatedDef{
+			{TargetType: "iam-user", DisplayName: "IAM Users", Checker: checkGroupUser, NeedsTargetCache: false},
+			{TargetType: "policy", DisplayName: "IAM Policies", Checker: checkGroupPolicy, NeedsTargetCache: false},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("iam-group"), NeedsTargetCache: false},
+		},
 	},
 	{
 		Name:          "WAF Web ACLs",
@@ -127,5 +228,41 @@ var securityTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // stat
 			{Key: "description", Title: "Description", Width: 36, Sortable: false},
 		},
 		Color: colorWAF,
+	},
+}
+
+// securityChildTypes carries the migrated child-type entries for the security
+// category. Replayed onto resource.childTypes + paginatedChildRegistry by
+// aws.Install() via the bridge in install.go.
+var securityChildTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // static catalog: intentional package-level var
+	{
+		Name:      "Group Members",
+		ShortName: "iam_group_members",
+		Columns:   resource.IAMGroupMemberColumns(),
+		CopyField: "user_name",
+		FieldKeys: []string{
+			"user_name", "user_id", "arn", "path", "create_date", "password_last_used",
+		},
+		ChildFetcher: func(ctx context.Context, clients any, parentCtx resource.ParentContext, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchIAMGroupMembers(ctx, c.IAM, parentCtx, continuationToken)
+		},
+	},
+	{
+		Name:      "Role Policies",
+		ShortName: "role_policies",
+		Columns:   resource.RolePolicyColumns(),
+		FieldKeys: []string{"policy_name", "policy_arn", "policy_type"},
+		ChildFetcher: func(ctx context.Context, clients any, parentCtx resource.ParentContext, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchRolePolicies(ctx, c.IAM, c.IAM, parentCtx, continuationToken)
+		},
+		DetailEnrich: enrichRolePolicy,
 	},
 }

--- a/internal/aws/iam_group_members.go
+++ b/internal/aws/iam_group_members.go
@@ -9,27 +9,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("iam_group_members", []string{
-		"user_name", "user_id", "arn", "path", "create_date", "password_last_used",
-	})
-
-	resource.RegisterPaginatedChild("iam_group_members", func(ctx context.Context, clients any, parentCtx resource.ParentContext, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchIAMGroupMembers(ctx, c.IAM, parentCtx, continuationToken)
-	})
-
-	resource.RegisterChildType(resource.ResourceTypeDef{
-		Name:      "Group Members",
-		ShortName: "iam_group_members",
-		Columns:   resource.IAMGroupMemberColumns(),
-		CopyField: "user_name",
-	})
-}
-
 // FetchIAMGroupMembers calls the IAM GetGroup API and converts the response
 // into a FetchResult of generic Resource structs representing group members.
 // A single API call is made per invocation; IsTruncated and NextToken (Marker)

--- a/internal/aws/iam_groups.go
+++ b/internal/aws/iam_groups.go
@@ -10,25 +10,8 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("iam-group", []string{"group_name", "group_id", "path", "create_date", "arn"})
-
-	resource.RegisterPaginated("iam-group", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchIAMGroupsPage(ctx, c.IAM, continuationToken)
-	})
-
-	resource.RegisterRelated("iam-group", []resource.RelatedDef{
-		{TargetType: "iam-user", DisplayName: "IAM Users", Checker: checkGroupUser, NeedsTargetCache: false},
-		{TargetType: "policy", DisplayName: "IAM Policies", Checker: checkGroupPolicy, NeedsTargetCache: false},
-	})
-
-	// iamtypes.Group: no navigable cross-ref fields — the Group struct carries only
-	// GroupName, GroupId, Arn, Path, CreateDate. Members and policies are runtime API relationships.
-}
+// iamtypes.Group: no navigable cross-ref fields — the Group struct carries only
+// GroupName, GroupId, Arn, Path, CreateDate. Members and policies are runtime API relationships.
 
 // FetchIAMGroups calls the IAM ListGroups API and returns all pages of groups.
 // Used by tests; the production path uses the per-page fetcher for pagination.

--- a/internal/aws/iam_policies.go
+++ b/internal/aws/iam_policies.go
@@ -24,49 +24,6 @@ type iamPolicyStore interface {
 	Clear()
 }
 
-func init() {
-	resource.RegisterFieldKeys("policy", []string{"policy_name", "policy_type", "attachment_count", "is_attachable", "path", "create_date"})
-
-	resource.RegisterPaginated("policy", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		result, err := FetchIAMPoliciesPage(ctx, c.IAM, continuationToken)
-		if err != nil {
-			return result, err
-		}
-		inlines, inlineErr := fetchInlineGroupPolicies(ctx, c.IAM)
-		// Partial failure: inline group policy enumeration failed for some
-		// groups. Preserve the inline results we did get, then propagate the
-		// composite error so app.go's ResourcesLoadedMsg handler surfaces it
-		// via FlashMsg → `!` log (per E1–E6). Managed policies above are
-		// still returned in result.Resources regardless.
-		result.Resources = append(result.Resources, inlines...)
-		if result.Pagination != nil {
-			result.Pagination.PageSize = len(result.Resources)
-		}
-		return result, inlineErr
-	})
-
-	resource.RegisterFetchByIDs("policy", func(ctx context.Context, clients any, ids []string) ([]resource.Resource, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return nil, fmt.Errorf("AWS clients not initialized")
-		}
-		if c.IAMPolicies() == nil {
-			return nil, fmt.Errorf("IAMPolicies store not initialized on ServiceClients")
-		}
-		return FetchIAMPoliciesByIDsFull(ctx, c.IAM, ids, c.IAMPolicies())
-	})
-
-	resource.RegisterRelated("policy", []resource.RelatedDef{
-		{TargetType: "role", DisplayName: "IAM Roles", Checker: checkPolicyRole, NeedsTargetCache: false},
-		{TargetType: "iam-user", DisplayName: "IAM Users", Checker: checkPolicyUser, NeedsTargetCache: false},
-		{TargetType: "iam-group", DisplayName: "IAM Groups", Checker: checkPolicyGroup, NeedsTargetCache: false},
-	})
-}
-
 // FetchIAMPolicies calls the IAM ListPolicies API and returns all pages of
 // customer-managed policies. Used by tests; the production path uses the per-page fetcher for pagination.
 func FetchIAMPolicies(ctx context.Context, api IAMListPoliciesAPI) ([]resource.Resource, error) {

--- a/internal/aws/iam_policy_detail_enrichment.go
+++ b/internal/aws/iam_policy_detail_enrichment.go
@@ -17,10 +17,6 @@ type PolicyEnriched struct {
 	Document any `json:"Document,omitempty" yaml:"Document,omitempty"`
 }
 
-func init() {
-	resource.RegisterDetailEnricher("policy", enrichPolicy)
-}
-
 // enrichPolicy fetches the policy document for a top-level IAM policy.
 // All top-level policies are managed (Scope=Local), so only the managed
 // document path is needed.

--- a/internal/aws/iam_role_policies.go
+++ b/internal/aws/iam_role_policies.go
@@ -18,26 +18,6 @@ type RolePolicyRow struct {
 	Document   any `json:"Document,omitempty" yaml:"Document,omitempty"`
 }
 
-func init() {
-	resource.RegisterFieldKeys("role_policies", []string{
-		"policy_name", "policy_arn", "policy_type",
-	})
-
-	resource.RegisterPaginatedChild("role_policies", func(ctx context.Context, clients any, parentCtx resource.ParentContext, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchRolePolicies(ctx, c.IAM, c.IAM, parentCtx, continuationToken)
-	})
-
-	resource.RegisterChildType(resource.ResourceTypeDef{
-		Name:      "Role Policies",
-		ShortName: "role_policies",
-		Columns:   resource.RolePolicyColumns(),
-	})
-}
-
 // FetchRolePolicies calls ListAttachedRolePolicies and ListRolePolicies to
 // retrieve both managed and inline policies attached to the given IAM role.
 // A single API call is made for each list per invocation. Managed policies

--- a/internal/aws/iam_role_policies_detail_enrichment.go
+++ b/internal/aws/iam_role_policies_detail_enrichment.go
@@ -7,10 +7,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterDetailEnricher("role_policies", enrichRolePolicy)
-}
-
 // enrichRolePolicy fetches the policy document for a role_policies resource
 // and returns an enriched copy with Document set on RawStruct.
 // Uses the session-scoped PolicyDocs cache provided on DetailEnrichmentCtx.

--- a/internal/aws/iam_roles.go
+++ b/internal/aws/iam_roles.go
@@ -13,18 +13,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("role", []string{"role_name", "role_id", "path", "create_date", "description", "assume_role_policy_document", "trust_wildcard", "trust_summary", "policy_resources"})
-
-	resource.RegisterPaginated("role", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchIAMRolesPage(ctx, c.IAM, continuationToken)
-	})
-}
-
 // FetchIAMRoles calls the IAM ListRoles API and returns all pages of roles.
 // Used by tests; the production path uses the per-page fetcher for pagination.
 func FetchIAMRoles(ctx context.Context, api IAMListRolesAPI) ([]resource.Resource, error) {

--- a/internal/aws/iam_roles_related.go
+++ b/internal/aws/iam_roles_related.go
@@ -18,19 +18,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterRelated("role", []resource.RelatedDef{
-		{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkRoleLambda, NeedsTargetCache: true},
-		{TargetType: "glue", DisplayName: "Glue Jobs", Checker: checkRoleGlue, NeedsTargetCache: true},
-		{TargetType: "ng", DisplayName: "Node Groups", Checker: checkRoleNG, NeedsTargetCache: true},
-		{TargetType: "policy", DisplayName: "IAM Policies", Checker: checkRolePolicy, NeedsTargetCache: false},
-		{TargetType: "ec2", DisplayName: "EC2 Instances", Checker: checkRoleEC2, NeedsTargetCache: true},
-		{TargetType: "eks", DisplayName: "EKS Clusters", Checker: checkRoleEKS, NeedsTargetCache: true},
-		{TargetType: "iam-group", DisplayName: "IAM Groups (trust)", Checker: checkRoleIamGroup, NeedsTargetCache: false},
-		{TargetType: "iam-user", DisplayName: "IAM Users (trust)", Checker: checkRoleIamUser, NeedsTargetCache: false},
-	})
-}
-
 // checkRoleEKS scans the eks cluster cache for clusters whose RoleArn matches this
 // role's ARN or name. Pattern C.
 func checkRoleEKS(ctx context.Context, clients any, res resource.Resource, cache resource.ResourceCache) resource.RelatedCheckResult {

--- a/internal/aws/iam_users.go
+++ b/internal/aws/iam_users.go
@@ -10,27 +10,9 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("iam-user", []string{"user_name", "user_id", "path", "create_date", "password_last_used", "has_console_password"})
-
-	resource.RegisterPaginated("iam-user", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchIAMUsersPage(ctx, c.IAM, continuationToken)
-	})
-
-	resource.RegisterRelated("iam-user", []resource.RelatedDef{
-		{TargetType: "iam-group", DisplayName: "IAM Groups", Checker: checkUserGroup, NeedsTargetCache: false},
-		{TargetType: "policy", DisplayName: "IAM Policies", Checker: checkUserPolicy, NeedsTargetCache: false},
-		{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: checkIAMUserCtEvents, NeedsTargetCache: false},
-	})
-
-	// iamtypes.User: no navigable cross-ref fields in the rendered detail view.
-	// Groups membership is a runtime API relationship (checkUserGroup), not a field on the User struct.
-	// PermissionsBoundary.PermissionsBoundaryArn exists but policy ARNs don't match a9s policy IDs.
-}
+// iamtypes.User: no navigable cross-ref fields in the rendered detail view.
+// Groups membership is a runtime API relationship (checkUserGroup), not a field on the User struct.
+// PermissionsBoundary.PermissionsBoundaryArn exists but policy ARNs don't match a9s policy IDs.
 
 // FetchIAMUsers calls the IAM ListUsers API and returns all pages of users.
 // Used by tests; the production path uses the per-page fetcher for pagination.

--- a/internal/aws/install.go
+++ b/internal/aws/install.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"sync"
 
 	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/domain"
@@ -54,18 +55,16 @@ func ctEventsCheckerFor(shortName string) domain.RelatedChecker {
 func Install() {
 	catalog.SetTypes(allTopLevelTypes())
 	catalog.SetChildTypes(allChildTypes())
-	if installed {
-		return
-	}
-	bridgeCatalogToLegacy()
-	installed = true
+	bridgeOnce.Do(bridgeCatalogToLegacy)
 }
 
-// installed tracks whether bridgeCatalogToLegacy has run. The legacy
-// internal/resource maps include at least one panic-on-duplicate registrar
-// (RegisterDetailEnricher) so the bridge must run exactly once even though
-// the catalog itself accepts idempotent SetTypes calls.
-var installed bool //nolint:gochecknoglobals // process-scope install gate
+// bridgeOnce gates bridgeCatalogToLegacy to a single execution per process.
+// The legacy internal/resource maps include at least one panic-on-duplicate
+// registrar (RegisterDetailEnricher) so the bridge must run exactly once even
+// though catalog.SetTypes accepts idempotent calls. sync.Once is preferred
+// over a plain bool to guard against the race between concurrent Install()
+// callers landing both into bridgeCatalogToLegacy (per CodeRabbit on PR #397).
+var bridgeOnce sync.Once //nolint:gochecknoglobals // process-scope install gate
 
 // bridgeCatalogToLegacy populates the internal/resource legacy maps from the
 // catalog struct fields. Required during the AS-795b–m transition because

--- a/internal/aws/install.go
+++ b/internal/aws/install.go
@@ -54,8 +54,18 @@ func ctEventsCheckerFor(shortName string) domain.RelatedChecker {
 func Install() {
 	catalog.SetTypes(allTopLevelTypes())
 	catalog.SetChildTypes(allChildTypes())
+	if installed {
+		return
+	}
 	bridgeCatalogToLegacy()
+	installed = true
 }
+
+// installed tracks whether bridgeCatalogToLegacy has run. The legacy
+// internal/resource maps include at least one panic-on-duplicate registrar
+// (RegisterDetailEnricher) so the bridge must run exactly once even though
+// the catalog itself accepts idempotent SetTypes calls.
+var installed bool //nolint:gochecknoglobals // process-scope install gate
 
 // bridgeCatalogToLegacy populates the internal/resource legacy maps from the
 // catalog struct fields. Required during the AS-795b–m transition because
@@ -92,13 +102,16 @@ func bridgeCatalogToLegacy() {
 		if rt.Reveal != nil {
 			resource.RegisterRevealFetcher(rt.ShortName, rt.Reveal)
 		}
+		if rt.DetailEnrich != nil {
+			resource.RegisterDetailEnricher(rt.ShortName, rt.DetailEnrich)
+		}
 	}
 	// Child types: replay catalog child-type entries onto the legacy
 	// resource.childTypes + paginatedChildRegistry maps so consumers calling
 	// resource.GetChildType / resource.GetPaginatedChildFetcher continue to
-	// resolve migrated entries. AS-808 / PR #395 round-2 introduces the first
-	// migrated child (ecr_images); sibling category PRs append their own
-	// `<cat>ChildTypes` slices to allChildTypes() above.
+	// resolve migrated entries. Child loop introduced by AS-808 / PR #395
+	// (containers, ecr_images); AS-815 / PR #397 adds DetailEnrich support
+	// here so the role_policies detail enricher resolves through the bridge.
 	for _, ct := range allChildTypes() {
 		resource.RegisterChildType(ct)
 		if ct.ChildFetcher != nil {
@@ -106,6 +119,9 @@ func bridgeCatalogToLegacy() {
 		}
 		if len(ct.FieldKeys) > 0 {
 			resource.RegisterFieldKeys(ct.ShortName, ct.FieldKeys)
+		}
+		if ct.DetailEnrich != nil {
+			resource.RegisterDetailEnricher(ct.ShortName, ct.DetailEnrich)
 		}
 	}
 }
@@ -141,9 +157,11 @@ func allTopLevelTypes() []catalog.ResourceTypeDef {
 // localized to one new `all = append(all, <cat>ChildTypes...)` line.
 //
 // First populated in AS-808 / PR #395 round-2 with containersChildTypes
-// (ecr_images).
+// (ecr_images); AS-815 / PR #397 adds securityChildTypes
+// (iam_group_members, role_policies).
 func allChildTypes() []catalog.ResourceTypeDef {
 	var all []catalog.ResourceTypeDef
 	all = append(all, containersChildTypes...)
+	all = append(all, securityChildTypes...)
 	return all
 }


### PR DESCRIPTION
## Summary

- Migrates the **security** category's per-type wiring from `init()` bodies into the catalog struct literal (`internal/aws/catalog_security.go`). 6 types in scope: 4 top-level (`role`, `policy`, `iam-user`, `iam-group`) and 2 child (`iam_group_members`, `role_policies`).
- Extends `aws.Install()` bridge to replay `DetailEnrich` and the new `securityChildTypes` slice onto the legacy `internal/resource` maps, mirroring the AS-808 (containers) child-type pattern.
- Per-category PR after AS-807 (compute, merged) and AS-810 (databases, PR #396, open). Spec: `docs/refactor/AS-795-init-cycle-break.md` §3 + §5.2.

Parent: AS-805 (umbrella). Sibling: AS-808 / PR #395 (containers) lands an analogous child-type loop in `install.go`; trivial merge resolution either way.

## Acceptance

```bash
rg '^func init\(\)' internal/aws/iam_roles.go internal/aws/iam_policies.go \
   internal/aws/iam_users.go internal/aws/iam_groups.go \
   internal/aws/iam_group_members.go internal/aws/iam_role_policies.go
# → zero hits

rg 'Fetcher:' internal/aws/catalog_security.go
# → 6 hits (4 top-level + 2 child)
```

## What stayed in `init()`

Per AS-807 / AS-810 precedent, the legacy `IssueEnricherRegistry` is still iterated by `BuildEnrichQueue` / `runtime_adapter_navigate` / `probe_adapter` / `TestAttentionSignalsDoc` — AS-795n deletes those consumers. So `iam_{role,policy,user,group}_issue_enrichment.go` keep their `init()` bodies (including `RegisterIssueEnricherFieldKeys`).

## Idempotency note

`resource.RegisterDetailEnricher` panics on duplicate. The install bridge now runs at most once per process via a package-level `installed` flag in `install.go`; `catalog.SetTypes` stays idempotent on identical input. `TestCatalogInstall_Idempotent` passes locally.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (unit + integration)
- [x] `go test -tags integration ./...` (AS-827 gate)
- [x] `golangci-lint run ./...` → 0 issues
- [x] `govulncheck ./...` → no vulnerabilities
- [x] `go fix -inline -diff ./...` → clean
- [x] Golden|Scenario snapshots + Visual|Scenario integration snapshots all pass
- [x] verify-readonly: pass
- [x] README in sync
- [ ] `test-race` blocked by missing cgo/gcc in pod (documented under AS-149)
- [ ] mdlint not run (no .md changes in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>