### PR TITLE
feat(refactor): AS-809 / AS-795d networking init() → catalog migration

### DIFF
--- a/internal/aws/catalog_networking.go
+++ b/internal/aws/catalog_networking.go
@@ -1,10 +1,13 @@
 package aws
 
 import (
+	"context"
+	"fmt"
 	"strconv"
 
 	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/domain"
+	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func colorELB(r domain.Resource) domain.Color {
@@ -191,6 +194,34 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			DisplayNameKey: "lb_name",
 		}},
 		Color: colorELB,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchLoadBalancersPage(ctx, c.ELBv2, continuationToken)
+		},
+		Wave2:     IssueEnricher{Fn: EnrichELBAttributes, Priority: 100},
+		FieldKeys: []string{"name", "dns_name", "type", "scheme", "state", "vpc_id", "load_balancer_arn"},
+		Related: []domain.RelatedDef{
+			{TargetType: "tg", DisplayName: "Target Groups", Checker: checkELBTargetGroups, NeedsTargetCache: true},
+			{TargetType: "alarm", DisplayName: "CW Alarms", Checker: checkELBAlarms, NeedsTargetCache: true},
+			{TargetType: "sg", DisplayName: "Security Groups", Checker: checkELBSG},
+			{TargetType: "vpc", DisplayName: "VPC", Checker: checkELBVPC},
+			{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkELBCFN},
+			{TargetType: "r53", DisplayName: "Route 53 Records", Checker: checkELBR53},
+			{TargetType: "acm", DisplayName: "ACM Certificates", Checker: checkELBACM},
+			{TargetType: "cf", DisplayName: "CloudFront", Checker: checkELBCF},
+			{TargetType: "eni", DisplayName: "Network Interfaces", Checker: checkELBENI, NeedsTargetCache: true},
+			{TargetType: "s3", DisplayName: "S3 Buckets", Checker: checkELBS3},
+			{TargetType: "subnet", DisplayName: "Subnets", Checker: checkELBSubnet},
+			{TargetType: "waf", DisplayName: "WAF Web ACLs", Checker: checkELBWAF},
+		},
+		Navigable: []domain.NavigableField{
+			{FieldPath: "VpcId", TargetType: "vpc"},
+			{FieldPath: "SecurityGroups", TargetType: "sg"},
+			{FieldPath: "AvailabilityZones.SubnetId", TargetType: "subnet"},
+		},
 	},
 	{
 		Name:          "Target Groups",
@@ -213,6 +244,37 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			DisplayNameKey: "Name",
 		}},
 		Color: colorTG,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchTargetGroupsPage(ctx, c.ELBv2, continuationToken)
+		},
+		Wave2:                  IssueEnricher{Fn: EnrichTargetGroupHealth, Priority: 10},
+		IssueEnricherFieldKeys: []string{"health_summary"},
+		FieldKeys:              []string{"target_group_name", "port", "protocol", "vpc_id", "target_type", "health_check_path"},
+		Related: []domain.RelatedDef{
+			{TargetType: "elb", DisplayName: "Load Balancers", Checker: checkTGELB, NeedsTargetCache: false},
+			{TargetType: "ecs-svc", DisplayName: "ECS Services", Checker: checkTGECSSvc, NeedsTargetCache: true},
+			{TargetType: "asg", DisplayName: "Auto Scaling Groups", Checker: checkTGASG, NeedsTargetCache: true},
+			{TargetType: "alarm", DisplayName: "CW Alarms", Checker: checkTGAlarm, NeedsTargetCache: true},
+			{TargetType: "vpc", DisplayName: "VPC", Checker: checkTGVPC},
+			{TargetType: "backup", DisplayName: "Backup Plans", Checker: checkTGBackup},
+			{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkTGCFN},
+			{TargetType: "dbc", DisplayName: "DocumentDB Clusters", Checker: checkTGDBC},
+			{TargetType: "dbi", DisplayName: "RDS Instances", Checker: checkTGDBI},
+			{TargetType: "ec2", DisplayName: "EC2 Instances", Checker: checkTGEC2},
+			{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkTGLambda},
+			{TargetType: "logs", DisplayName: "Log Groups", Checker: checkTGLogs},
+			{TargetType: "dbi-snap", DisplayName: "DB Instance Snapshots", Checker: checkTGDBISnap},
+			{TargetType: "sg", DisplayName: "Security Groups", Checker: checkTGSG},
+			{TargetType: "subnet", DisplayName: "Subnets", Checker: checkTGSubnet},
+		},
+		Navigable: []domain.NavigableField{
+			{FieldPath: "VpcId", TargetType: "vpc"},
+			{FieldPath: "LoadBalancerArns", TargetType: "elb"},
+		},
 	},
 	{
 		Name:          "Security Groups",
@@ -227,6 +289,26 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{Key: "description", Title: "Description", Width: 36, Sortable: false},
 		},
 		Color: colorSG,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchSecurityGroupsPage(ctx, c.EC2, continuationToken)
+		},
+		FieldKeys: []string{"group_id", "group_name", "vpc_id", "description", "dangerous_open_count", "wide_open", "risk_summary"},
+		Related: []domain.RelatedDef{
+			{TargetType: "vpc", DisplayName: "VPC", Checker: checkSGVPC, NeedsTargetCache: false},
+			{TargetType: "ec2", DisplayName: "EC2 Instances", Checker: checkSGEC2, NeedsTargetCache: true},
+			{TargetType: "eni", DisplayName: "Network Interfaces", Checker: checkSGENI, NeedsTargetCache: true},
+			{TargetType: "elb", DisplayName: "Load Balancers", Checker: checkSGELB, NeedsTargetCache: true},
+			{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkSGLambda, NeedsTargetCache: true},
+			{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkSGCFN, NeedsTargetCache: false},
+			{TargetType: "sg", DisplayName: "Referencing SGs", Checker: checkSGSG, NeedsTargetCache: true},
+		},
+		Navigable: []domain.NavigableField{
+			{FieldPath: "VpcId", TargetType: "vpc"},
+		},
 	},
 	{
 		Name:          "VPCs",
@@ -242,6 +324,29 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{Key: "is_default", Title: "Default", Width: 9, Sortable: true},
 		},
 		Color: colorVPC,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchVPCsPage(ctx, c.EC2, continuationToken)
+		},
+		Wave2:                  IssueEnricher{Fn: EnrichVPCFlowLogs, Priority: 100},
+		IssueEnricherFieldKeys: []string{"flow_logs"},
+		FieldKeys:              []string{"vpc_id", "name", "cidr_block", "state", "is_default"},
+		Related: []domain.RelatedDef{
+			{TargetType: "subnet", DisplayName: "Subnets", Checker: checkVPCSubnet, NeedsTargetCache: true},
+			{TargetType: "sg", DisplayName: "Security Groups", Checker: checkVPCSG, NeedsTargetCache: true},
+			{TargetType: "ec2", DisplayName: "EC2 Instances", Checker: checkVPCEC2, NeedsTargetCache: true},
+			{TargetType: "elb", DisplayName: "Load Balancers", Checker: checkVPCELB, NeedsTargetCache: true},
+			{TargetType: "nat", DisplayName: "NAT Gateways", Checker: checkVPCNAT, NeedsTargetCache: true},
+			{TargetType: "igw", DisplayName: "Internet Gateways", Checker: checkVPCIGW, NeedsTargetCache: true},
+			{TargetType: "rtb", DisplayName: "Route Tables", Checker: checkVPCRTB, NeedsTargetCache: true},
+			{TargetType: "vpce", DisplayName: "VPC Endpoints", Checker: checkVPCVPCE, NeedsTargetCache: true},
+			{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkVPCCFN, NeedsTargetCache: false},
+			{TargetType: "eni", DisplayName: "Network Interfaces", Checker: checkVPCENI, NeedsTargetCache: true},
+			{TargetType: "tgw", DisplayName: "Transit Gateways", Checker: checkVPCTGW, NeedsTargetCache: false},
+		},
 	},
 	{
 		Name:          "Subnets",
@@ -259,6 +364,30 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{Key: "available_ips", Title: "Available IPs", Width: 14, Sortable: true},
 		},
 		Color: colorSubnet,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchSubnetsPage(ctx, c.EC2, continuationToken)
+		},
+		FieldKeys: []string{"subnet_id", "name", "vpc_id", "cidr_block", "availability_zone", "state", "available_ips"},
+		Related: []domain.RelatedDef{
+			{TargetType: "ec2", DisplayName: "EC2 Instances", Checker: checkSubnetEC2, NeedsTargetCache: true},
+			{TargetType: "eni", DisplayName: "Network Interfaces", Checker: checkSubnetENI, NeedsTargetCache: true},
+			{TargetType: "nat", DisplayName: "NAT Gateways", Checker: checkSubnetNAT, NeedsTargetCache: true},
+			{TargetType: "elb", DisplayName: "Load Balancers", Checker: checkSubnetELB, NeedsTargetCache: true},
+			{TargetType: "rtb", DisplayName: "Route Tables", Checker: checkSubnetRTB, NeedsTargetCache: true},
+			{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkSubnetCFN, NeedsTargetCache: false},
+			{TargetType: "vpc", DisplayName: "VPC", Checker: checkSubnetVPC},
+			{TargetType: "asg", DisplayName: "Auto Scaling Groups", Checker: checkSubnetASG, NeedsTargetCache: true},
+			{TargetType: "efs", DisplayName: "EFS File Systems", Checker: checkSubnetEFS},
+			{TargetType: "eks", DisplayName: "EKS Clusters", Checker: checkSubnetEKS, NeedsTargetCache: true},
+			{TargetType: "vpce", DisplayName: "VPC Endpoints", Checker: checkSubnetVPCE, NeedsTargetCache: true},
+		},
+		Navigable: []domain.NavigableField{
+			{FieldPath: "VpcId", TargetType: "vpc"},
+		},
 	},
 	{
 		Name:          "Route Tables",
@@ -274,6 +403,33 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{Key: "associations_count", Title: "Assoc.", Width: 8, Sortable: true},
 		},
 		Color: colorRTB,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchRouteTablesPage(ctx, c.EC2, continuationToken)
+		},
+		FieldKeys: []string{"route_table_id", "name", "vpc_id", "routes_count", "associations_count", "blackhole_routes_count", "is_main"},
+		Related: []domain.RelatedDef{
+			{TargetType: "subnet", DisplayName: "Subnets", Checker: checkRTBSubnet, NeedsTargetCache: true},
+			{TargetType: "nat", DisplayName: "NAT Gateways", Checker: checkRTBNAT, NeedsTargetCache: true},
+			{TargetType: "igw", DisplayName: "Internet Gateways", Checker: checkRTBIGW, NeedsTargetCache: true},
+			{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkRTBCFN, NeedsTargetCache: true},
+			{TargetType: "vpc", DisplayName: "VPC", Checker: checkRTBVPC},
+			{TargetType: "eni", DisplayName: "Network Interfaces", Checker: checkRTBENI, NeedsTargetCache: true},
+			{TargetType: "tgw", DisplayName: "Transit Gateways", Checker: checkRTBTGW, NeedsTargetCache: true},
+			{TargetType: "vpce", DisplayName: "VPC Endpoints", Checker: checkRTBVPCE, NeedsTargetCache: true},
+		},
+		Navigable: []domain.NavigableField{
+			{FieldPath: "VpcId", TargetType: "vpc"},
+			{FieldPath: "Associations.SubnetId", TargetType: "subnet"},
+			{FieldPath: "Routes.NatGatewayId", TargetType: "nat"},
+			{FieldPath: "Routes.GatewayId", TargetType: "igw"},
+			{FieldPath: "Routes.NetworkInterfaceId", TargetType: "eni"},
+			{FieldPath: "Routes.TransitGatewayId", TargetType: "tgw"},
+			{FieldPath: "Routes.VpcPeeringConnectionId", TargetType: "vpc"},
+		},
 	},
 	{
 		Name:          "NAT Gateways",
@@ -290,6 +446,27 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{Key: "public_ip", Title: "Public IP", Width: 16, Sortable: false},
 		},
 		Color: colorNAT,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchNatGatewaysPage(ctx, c.EC2, continuationToken)
+		},
+		FieldKeys: []string{"nat_gateway_id", "name", "vpc_id", "subnet_id", "state", "public_ip"},
+		Related: []domain.RelatedDef{
+			{TargetType: "vpc", DisplayName: "VPCs", Checker: checkNATVPC, NeedsTargetCache: true},
+			{TargetType: "subnet", DisplayName: "Subnets", Checker: checkNATSubnet, NeedsTargetCache: true},
+			{TargetType: "rtb", DisplayName: "Route Tables", Checker: checkNATRTB, NeedsTargetCache: true},
+			{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: checkNATAlarm, NeedsTargetCache: true},
+			{TargetType: "eip", DisplayName: "Elastic IPs", Checker: checkNATEIP, NeedsTargetCache: true},
+			{TargetType: "eni", DisplayName: "Network Interfaces", Checker: checkNATENI, NeedsTargetCache: true},
+		},
+		Navigable: []domain.NavigableField{
+			{FieldPath: "VpcId", TargetType: "vpc"},
+			{FieldPath: "SubnetId", TargetType: "subnet"},
+			{FieldPath: "NatGatewayAddresses.AllocationId", TargetType: "eip"},
+		},
 	},
 	{
 		Name:          "Internet Gateways",
@@ -304,6 +481,21 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{Key: "state", Title: "State", Width: 12, Sortable: true},
 		},
 		Color: colorIGW,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchInternetGatewaysPage(ctx, c.EC2, continuationToken)
+		},
+		FieldKeys: []string{"igw_id", "name", "vpc_id", "state", "attachments_count"},
+		Related: []domain.RelatedDef{
+			{TargetType: "vpc", DisplayName: "VPCs", Checker: checkIGWVPC, NeedsTargetCache: true},
+			{TargetType: "rtb", DisplayName: "Route Tables", Checker: checkIGWRTB, NeedsTargetCache: true},
+		},
+		Navigable: []domain.NavigableField{
+			{FieldPath: "Attachments.VpcId", TargetType: "vpc"},
+		},
 	},
 	{
 		Name:          "Elastic IPs",
@@ -320,6 +512,37 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{Key: "domain", Title: "Domain", Width: 8, Sortable: true},
 		},
 		Color: colorEIP,
+		Fetcher: func(ctx context.Context, clients any, _ string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			resources, err := FetchElasticIPs(ctx, c.EC2)
+			if err != nil {
+				return resource.FetchResult{}, err
+			}
+			return resource.FetchResult{
+				Resources:  resources,
+				Pagination: &resource.PaginationMeta{IsTruncated: false, TotalHint: len(resources), PageSize: len(resources)},
+			}, nil
+		},
+		FieldKeys: []string{"allocation_id", "name", "public_ip", "association_id", "instance_id", "domain", "status"},
+		Related: []domain.RelatedDef{
+			{TargetType: "ec2", DisplayName: "EC2 Instances", Checker: checkEIPEC2},
+			{TargetType: "eni", DisplayName: "Network Interfaces", Checker: checkEIPENI},
+			{TargetType: "nat", DisplayName: "NAT Gateways", Checker: checkEIPNAT, NeedsTargetCache: true},
+			{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: checkEIPAlarm},
+			{TargetType: "asg", DisplayName: "Auto Scaling Groups", Checker: checkEIPASG},
+			{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkEIPCFN},
+			{TargetType: "ecs", DisplayName: "ECS Clusters", Checker: checkEIPECS},
+			{TargetType: "ecs-svc", DisplayName: "ECS Services", Checker: checkEIPECSSvc},
+			{TargetType: "ecs-task", DisplayName: "ECS Tasks", Checker: checkEIPECSTask},
+			{TargetType: "logs", DisplayName: "Log Groups", Checker: checkEIPLogs},
+		},
+		Navigable: []domain.NavigableField{
+			{FieldPath: "InstanceId", TargetType: "ec2"},
+			{FieldPath: "NetworkInterfaceId", TargetType: "eni"},
+		},
 	},
 	{
 		Name:          "VPC Endpoints",
@@ -335,6 +558,36 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{Key: "vpc_id", Title: "VPC ID", Width: 24, Sortable: true},
 		},
 		Color: colorVPCE,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchVPCEndpointsPage(ctx, c.EC2, continuationToken)
+		},
+		FieldKeys: []string{"vpce_id", "service_name", "type", "state", "vpc_id"},
+		Related: []domain.RelatedDef{
+			{TargetType: "subnet", DisplayName: "Subnets", Checker: checkVPCESubnet, NeedsTargetCache: false},
+			{TargetType: "sg", DisplayName: "Security Groups", Checker: checkVPCESG, NeedsTargetCache: false},
+			{TargetType: "rtb", DisplayName: "Route Tables", Checker: checkVPCERTB, NeedsTargetCache: false},
+			{TargetType: "eni", DisplayName: "Network Interfaces", Checker: checkVPCEENI, NeedsTargetCache: false},
+			{TargetType: "vpc", DisplayName: "VPC", Checker: checkVPCEVPC},
+			{TargetType: "acm", DisplayName: "ACM Certificates", Checker: checkVPCEACM},
+			{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: checkVPCEAlarm},
+			{TargetType: "cf", DisplayName: "CloudFront", Checker: checkVPCECF},
+			{TargetType: "logs", DisplayName: "Log Groups", Checker: checkVPCELogs},
+			{TargetType: "r53", DisplayName: "Route 53 Zones", Checker: checkVPCER53},
+			{TargetType: "s3", DisplayName: "S3 Buckets", Checker: checkVPCES3},
+			{TargetType: "tg", DisplayName: "Target Groups", Checker: checkVPCETG},
+			{TargetType: "waf", DisplayName: "WAF Web ACLs", Checker: checkVPCEWAF},
+		},
+		Navigable: []domain.NavigableField{
+			{FieldPath: "VpcId", TargetType: "vpc"},
+			{FieldPath: "SubnetIds", TargetType: "subnet"},
+			{FieldPath: "NetworkInterfaceIds", TargetType: "eni"},
+			{FieldPath: "Groups.GroupId", TargetType: "sg"},
+			{FieldPath: "RouteTableIds", TargetType: "rtb"},
+		},
 	},
 	{
 		Name:          "Transit Gateways",
@@ -350,6 +603,22 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{Key: "description", Title: "Description", Width: 30, Sortable: false},
 		},
 		Color: colorTGW,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchTransitGatewaysPage(ctx, c.EC2, continuationToken)
+		},
+		Wave2:                  IssueEnricher{Fn: EnrichTGWAttachments, Priority: 100},
+		IssueEnricherFieldKeys: []string{"att_status"},
+		FieldKeys:              []string{"tgw_id", "name", "state", "owner_id", "description"},
+		Related: []domain.RelatedDef{
+			{TargetType: "vpc", DisplayName: "VPCs", Checker: checkTGWVPC, NeedsTargetCache: false},
+			{TargetType: "rtb", DisplayName: "Route Tables", Checker: checkTGWRTB, NeedsTargetCache: true},
+			{TargetType: "role", DisplayName: "IAM Role", Checker: checkTGWRole, NeedsTargetCache: false},
+			{TargetType: "subnet", DisplayName: "Subnets", Checker: checkTGWSubnet, NeedsTargetCache: false},
+		},
 	},
 	{
 		Name:          "Network Interfaces",
@@ -367,5 +636,31 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{Key: "private_ip", Title: "Private IP", Width: 16, Sortable: false},
 		},
 		Color: colorENI,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchNetworkInterfacesPage(ctx, c.EC2, continuationToken)
+		},
+		FieldKeys: []string{"eni_id", "name", "status", "type", "vpc_id", "private_ip", "requester_managed"},
+		Related: []domain.RelatedDef{
+			{TargetType: "ec2", DisplayName: "EC2 Instances", Checker: checkENIEC2, NeedsTargetCache: true},
+			{TargetType: "sg", DisplayName: "Security Groups", Checker: checkENISG, NeedsTargetCache: true},
+			{TargetType: "eip", DisplayName: "Elastic IPs", Checker: checkENIEIP, NeedsTargetCache: true},
+			{TargetType: "vpc", DisplayName: "VPC", Checker: checkENIVPC},
+			{TargetType: "subnet", DisplayName: "Subnet", Checker: checkENISubnet},
+			{TargetType: "elb", DisplayName: "Load Balancers", Checker: checkENIELB},
+			{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkENILambda},
+			{TargetType: "nat", DisplayName: "NAT Gateways", Checker: checkENINAT, NeedsTargetCache: true},
+			{TargetType: "vpce", DisplayName: "VPC Endpoints", Checker: checkENIVPCE, NeedsTargetCache: true},
+		},
+		Navigable: []domain.NavigableField{
+			{FieldPath: "VpcId", TargetType: "vpc"},
+			{FieldPath: "SubnetId", TargetType: "subnet"},
+			{FieldPath: "Groups.GroupId", TargetType: "sg"},
+			{FieldPath: "Attachment.InstanceId", TargetType: "ec2"},
+			{FieldPath: "Association.AllocationId", TargetType: "eip"},
+		},
 	},
 }

--- a/internal/aws/catalog_networking.go
+++ b/internal/aws/catalog_networking.go
@@ -216,6 +216,7 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{TargetType: "s3", DisplayName: "S3 Buckets", Checker: checkELBS3},
 			{TargetType: "subnet", DisplayName: "Subnets", Checker: checkELBSubnet},
 			{TargetType: "waf", DisplayName: "WAF Web ACLs", Checker: checkELBWAF},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("elb")},
 		},
 		Navigable: []domain.NavigableField{
 			{FieldPath: "VpcId", TargetType: "vpc"},
@@ -270,6 +271,7 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{TargetType: "dbi-snap", DisplayName: "DB Instance Snapshots", Checker: checkTGDBISnap},
 			{TargetType: "sg", DisplayName: "Security Groups", Checker: checkTGSG},
 			{TargetType: "subnet", DisplayName: "Subnets", Checker: checkTGSubnet},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("tg")},
 		},
 		Navigable: []domain.NavigableField{
 			{FieldPath: "VpcId", TargetType: "vpc"},
@@ -305,6 +307,7 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkSGLambda, NeedsTargetCache: true},
 			{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkSGCFN, NeedsTargetCache: false},
 			{TargetType: "sg", DisplayName: "Referencing SGs", Checker: checkSGSG, NeedsTargetCache: true},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("sg")},
 		},
 		Navigable: []domain.NavigableField{
 			{FieldPath: "VpcId", TargetType: "vpc"},
@@ -346,6 +349,7 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkVPCCFN, NeedsTargetCache: false},
 			{TargetType: "eni", DisplayName: "Network Interfaces", Checker: checkVPCENI, NeedsTargetCache: true},
 			{TargetType: "tgw", DisplayName: "Transit Gateways", Checker: checkVPCTGW, NeedsTargetCache: false},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("vpc")},
 		},
 	},
 	{
@@ -384,6 +388,7 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{TargetType: "efs", DisplayName: "EFS File Systems", Checker: checkSubnetEFS},
 			{TargetType: "eks", DisplayName: "EKS Clusters", Checker: checkSubnetEKS, NeedsTargetCache: true},
 			{TargetType: "vpce", DisplayName: "VPC Endpoints", Checker: checkSubnetVPCE, NeedsTargetCache: true},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("subnet")},
 		},
 		Navigable: []domain.NavigableField{
 			{FieldPath: "VpcId", TargetType: "vpc"},
@@ -420,6 +425,7 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{TargetType: "eni", DisplayName: "Network Interfaces", Checker: checkRTBENI, NeedsTargetCache: true},
 			{TargetType: "tgw", DisplayName: "Transit Gateways", Checker: checkRTBTGW, NeedsTargetCache: true},
 			{TargetType: "vpce", DisplayName: "VPC Endpoints", Checker: checkRTBVPCE, NeedsTargetCache: true},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("rtb")},
 		},
 		Navigable: []domain.NavigableField{
 			{FieldPath: "VpcId", TargetType: "vpc"},
@@ -461,6 +467,7 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: checkNATAlarm, NeedsTargetCache: true},
 			{TargetType: "eip", DisplayName: "Elastic IPs", Checker: checkNATEIP, NeedsTargetCache: true},
 			{TargetType: "eni", DisplayName: "Network Interfaces", Checker: checkNATENI, NeedsTargetCache: true},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("nat")},
 		},
 		Navigable: []domain.NavigableField{
 			{FieldPath: "VpcId", TargetType: "vpc"},
@@ -492,6 +499,7 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 		Related: []domain.RelatedDef{
 			{TargetType: "vpc", DisplayName: "VPCs", Checker: checkIGWVPC, NeedsTargetCache: true},
 			{TargetType: "rtb", DisplayName: "Route Tables", Checker: checkIGWRTB, NeedsTargetCache: true},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("igw")},
 		},
 		Navigable: []domain.NavigableField{
 			{FieldPath: "Attachments.VpcId", TargetType: "vpc"},
@@ -538,6 +546,7 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{TargetType: "ecs-svc", DisplayName: "ECS Services", Checker: checkEIPECSSvc},
 			{TargetType: "ecs-task", DisplayName: "ECS Tasks", Checker: checkEIPECSTask},
 			{TargetType: "logs", DisplayName: "Log Groups", Checker: checkEIPLogs},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("eip")},
 		},
 		Navigable: []domain.NavigableField{
 			{FieldPath: "InstanceId", TargetType: "ec2"},
@@ -580,6 +589,7 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{TargetType: "s3", DisplayName: "S3 Buckets", Checker: checkVPCES3},
 			{TargetType: "tg", DisplayName: "Target Groups", Checker: checkVPCETG},
 			{TargetType: "waf", DisplayName: "WAF Web ACLs", Checker: checkVPCEWAF},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("vpce")},
 		},
 		Navigable: []domain.NavigableField{
 			{FieldPath: "VpcId", TargetType: "vpc"},
@@ -618,6 +628,7 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{TargetType: "rtb", DisplayName: "Route Tables", Checker: checkTGWRTB, NeedsTargetCache: true},
 			{TargetType: "role", DisplayName: "IAM Role", Checker: checkTGWRole, NeedsTargetCache: false},
 			{TargetType: "subnet", DisplayName: "Subnets", Checker: checkTGWSubnet, NeedsTargetCache: false},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("tgw")},
 		},
 	},
 	{
@@ -654,6 +665,7 @@ var networkingTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkENILambda},
 			{TargetType: "nat", DisplayName: "NAT Gateways", Checker: checkENINAT, NeedsTargetCache: true},
 			{TargetType: "vpce", DisplayName: "VPC Endpoints", Checker: checkENIVPCE, NeedsTargetCache: true},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("eni")},
 		},
 		Navigable: []domain.NavigableField{
 			{FieldPath: "VpcId", TargetType: "vpc"},

--- a/internal/aws/eip.go
+++ b/internal/aws/eip.go
@@ -10,25 +10,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("eip", []string{"allocation_id", "name", "public_ip", "association_id", "instance_id", "domain", "status"})
-
-	resource.RegisterPaginated("eip", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		resources, err := FetchElasticIPs(ctx, c.EC2)
-		if err != nil {
-			return resource.FetchResult{}, err
-		}
-		return resource.FetchResult{
-			Resources:  resources,
-			Pagination: &resource.PaginationMeta{IsTruncated: false, TotalHint: len(resources), PageSize: len(resources)},
-		}, nil
-	})
-}
-
 // FetchElasticIPs calls the EC2 DescribeAddresses API and converts the
 // response into a slice of generic Resource structs.
 func FetchElasticIPs(ctx context.Context, api EC2DescribeAddressesAPI) ([]resource.Resource, error) {

--- a/internal/aws/eip_related.go
+++ b/internal/aws/eip_related.go
@@ -10,26 +10,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterDefaultNavFields("eip", []resource.NavigableField{
-		{FieldPath: "InstanceId", TargetType: "ec2"},
-		{FieldPath: "NetworkInterfaceId", TargetType: "eni"},
-	})
-
-	resource.RegisterRelated("eip", []resource.RelatedDef{
-		{TargetType: "ec2", DisplayName: "EC2 Instances", Checker: checkEIPEC2},
-		{TargetType: "eni", DisplayName: "Network Interfaces", Checker: checkEIPENI},
-		{TargetType: "nat", DisplayName: "NAT Gateways", Checker: checkEIPNAT, NeedsTargetCache: true},
-		{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: checkEIPAlarm},
-		{TargetType: "asg", DisplayName: "Auto Scaling Groups", Checker: checkEIPASG},
-		{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkEIPCFN},
-		{TargetType: "ecs", DisplayName: "ECS Clusters", Checker: checkEIPECS},
-		{TargetType: "ecs-svc", DisplayName: "ECS Services", Checker: checkEIPECSSvc},
-		{TargetType: "ecs-task", DisplayName: "ECS Tasks", Checker: checkEIPECSTask},
-		{TargetType: "logs", DisplayName: "Log Groups", Checker: checkEIPLogs},
-	})
-}
-
 // checkEIPEC2 returns the EC2 instance associated with this Elastic IP (Pattern F).
 func checkEIPEC2(_ context.Context, _ any, res resource.Resource, _ resource.ResourceCache) resource.RelatedCheckResult {
 	raw, ok := assertStruct[ec2types.Address](res.RawStruct)

--- a/internal/aws/elb.go
+++ b/internal/aws/elb.go
@@ -11,39 +11,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("elb", []string{"name", "dns_name", "type", "scheme", "state", "vpc_id", "load_balancer_arn"})
-
-	resource.RegisterPaginated("elb", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchLoadBalancersPage(ctx, c.ELBv2, continuationToken)
-	})
-
-	resource.RegisterDefaultNavFields("elb", []resource.NavigableField{
-		{FieldPath: "VpcId", TargetType: "vpc"},
-		{FieldPath: "SecurityGroups", TargetType: "sg"},
-		{FieldPath: "AvailabilityZones.SubnetId", TargetType: "subnet"},
-	})
-
-	resource.RegisterRelated("elb", []resource.RelatedDef{
-		{TargetType: "tg", DisplayName: "Target Groups", Checker: checkELBTargetGroups, NeedsTargetCache: true},
-		{TargetType: "alarm", DisplayName: "CW Alarms", Checker: checkELBAlarms, NeedsTargetCache: true},
-		{TargetType: "sg", DisplayName: "Security Groups", Checker: checkELBSG},
-		{TargetType: "vpc", DisplayName: "VPC", Checker: checkELBVPC},
-		{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkELBCFN},
-		{TargetType: "r53", DisplayName: "Route 53 Records", Checker: checkELBR53},
-		{TargetType: "acm", DisplayName: "ACM Certificates", Checker: checkELBACM},
-		{TargetType: "cf", DisplayName: "CloudFront", Checker: checkELBCF},
-		{TargetType: "eni", DisplayName: "Network Interfaces", Checker: checkELBENI, NeedsTargetCache: true},
-		{TargetType: "s3", DisplayName: "S3 Buckets", Checker: checkELBS3},
-		{TargetType: "subnet", DisplayName: "Subnets", Checker: checkELBSubnet},
-		{TargetType: "waf", DisplayName: "WAF Web ACLs", Checker: checkELBWAF},
-	})
-}
-
 // FetchLoadBalancers calls the ELBv2 DescribeLoadBalancers API and converts the
 // response into a slice of generic Resource structs.
 func FetchLoadBalancers(ctx context.Context, api ELBv2DescribeLoadBalancersAPI) ([]resource.Resource, error) {

--- a/internal/aws/eni.go
+++ b/internal/aws/eni.go
@@ -12,18 +12,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("eni", []string{"eni_id", "name", "status", "type", "vpc_id", "private_ip", "requester_managed"})
-
-	resource.RegisterPaginated("eni", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchNetworkInterfacesPage(ctx, c.EC2, continuationToken)
-	})
-}
-
 // FetchNetworkInterfaces calls the EC2 DescribeNetworkInterfaces API and converts the
 // response into a slice of generic Resource structs.
 func FetchNetworkInterfaces(ctx context.Context, api EC2DescribeNetworkInterfacesAPI) ([]resource.Resource, error) {

--- a/internal/aws/eni_related.go
+++ b/internal/aws/eni_related.go
@@ -11,28 +11,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterDefaultNavFields("eni", []resource.NavigableField{
-		{FieldPath: "VpcId", TargetType: "vpc"},
-		{FieldPath: "SubnetId", TargetType: "subnet"},
-		{FieldPath: "Groups.GroupId", TargetType: "sg"},
-		{FieldPath: "Attachment.InstanceId", TargetType: "ec2"},
-		{FieldPath: "Association.AllocationId", TargetType: "eip"},
-	})
-
-	resource.RegisterRelated("eni", []resource.RelatedDef{
-		{TargetType: "ec2", DisplayName: "EC2 Instances", Checker: checkENIEC2, NeedsTargetCache: true},
-		{TargetType: "sg", DisplayName: "Security Groups", Checker: checkENISG, NeedsTargetCache: true},
-		{TargetType: "eip", DisplayName: "Elastic IPs", Checker: checkENIEIP, NeedsTargetCache: true},
-		{TargetType: "vpc", DisplayName: "VPC", Checker: checkENIVPC},
-		{TargetType: "subnet", DisplayName: "Subnet", Checker: checkENISubnet},
-		{TargetType: "elb", DisplayName: "Load Balancers", Checker: checkENIELB},
-		{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkENILambda},
-		{TargetType: "nat", DisplayName: "NAT Gateways", Checker: checkENINAT, NeedsTargetCache: true},
-		{TargetType: "vpce", DisplayName: "VPC Endpoints", Checker: checkENIVPCE, NeedsTargetCache: true},
-	})
-}
-
 // checkENIEC2 extracts Attachment.InstanceId from the ENI RawStruct and searches
 // the ec2 cache for a matching instance.
 func checkENIEC2(ctx context.Context, clients any, res resource.Resource, cache resource.ResourceCache) resource.RelatedCheckResult {

--- a/internal/aws/igw.go
+++ b/internal/aws/igw.go
@@ -11,27 +11,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("igw", []string{"igw_id", "name", "vpc_id", "state", "attachments_count"})
-
-	resource.RegisterDefaultNavFields("igw", []resource.NavigableField{
-		{FieldPath: "Attachments.VpcId", TargetType: "vpc"},
-	})
-
-	resource.RegisterRelated("igw", []resource.RelatedDef{
-		{TargetType: "vpc", DisplayName: "VPCs", Checker: checkIGWVPC, NeedsTargetCache: true},
-		{TargetType: "rtb", DisplayName: "Route Tables", Checker: checkIGWRTB, NeedsTargetCache: true},
-	})
-
-	resource.RegisterPaginated("igw", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchInternetGatewaysPage(ctx, c.EC2, continuationToken)
-	})
-}
-
 // FetchInternetGateways calls the EC2 DescribeInternetGateways API and converts the
 // response into a slice of generic Resource structs.
 func FetchInternetGateways(ctx context.Context, api EC2DescribeInternetGatewaysAPI) ([]resource.Resource, error) {

--- a/internal/aws/nat.go
+++ b/internal/aws/nat.go
@@ -11,33 +11,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("nat", []string{"nat_gateway_id", "name", "vpc_id", "subnet_id", "state", "public_ip"})
-
-	resource.RegisterPaginated("nat", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchNatGatewaysPage(ctx, c.EC2, continuationToken)
-	})
-
-	resource.RegisterDefaultNavFields("nat", []resource.NavigableField{
-		{FieldPath: "VpcId", TargetType: "vpc"},
-		{FieldPath: "SubnetId", TargetType: "subnet"},
-		{FieldPath: "NatGatewayAddresses.AllocationId", TargetType: "eip"},
-	})
-
-	resource.RegisterRelated("nat", []resource.RelatedDef{
-		{TargetType: "vpc", DisplayName: "VPCs", Checker: checkNATVPC, NeedsTargetCache: true},
-		{TargetType: "subnet", DisplayName: "Subnets", Checker: checkNATSubnet, NeedsTargetCache: true},
-		{TargetType: "rtb", DisplayName: "Route Tables", Checker: checkNATRTB, NeedsTargetCache: true},
-		{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: checkNATAlarm, NeedsTargetCache: true},
-		{TargetType: "eip", DisplayName: "Elastic IPs", Checker: checkNATEIP, NeedsTargetCache: true},
-		{TargetType: "eni", DisplayName: "Network Interfaces", Checker: checkNATENI, NeedsTargetCache: true},
-	})
-}
-
 // FetchNatGateways calls the EC2 DescribeNatGateways API and converts the
 // response into a slice of generic Resource structs.
 func FetchNatGateways(ctx context.Context, api EC2DescribeNatGatewaysAPI) ([]resource.Resource, error) {

--- a/internal/aws/rtb.go
+++ b/internal/aws/rtb.go
@@ -11,18 +11,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("rtb", []string{"route_table_id", "name", "vpc_id", "routes_count", "associations_count", "blackhole_routes_count", "is_main"})
-
-	resource.RegisterPaginated("rtb", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchRouteTablesPage(ctx, c.EC2, continuationToken)
-	})
-}
-
 // FetchRouteTables calls the EC2 DescribeRouteTables API and converts the
 // response into a slice of generic Resource structs.
 func FetchRouteTables(ctx context.Context, api EC2DescribeRouteTablesAPI) ([]resource.Resource, error) {

--- a/internal/aws/rtb_related.go
+++ b/internal/aws/rtb_related.go
@@ -12,29 +12,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterDefaultNavFields("rtb", []resource.NavigableField{
-		{FieldPath: "VpcId", TargetType: "vpc"},
-		{FieldPath: "Associations.SubnetId", TargetType: "subnet"},
-		{FieldPath: "Routes.NatGatewayId", TargetType: "nat"},
-		{FieldPath: "Routes.GatewayId", TargetType: "igw"},
-		{FieldPath: "Routes.NetworkInterfaceId", TargetType: "eni"},
-		{FieldPath: "Routes.TransitGatewayId", TargetType: "tgw"},
-		{FieldPath: "Routes.VpcPeeringConnectionId", TargetType: "vpc"},
-	})
-
-	resource.RegisterRelated("rtb", []resource.RelatedDef{
-		{TargetType: "subnet", DisplayName: "Subnets", Checker: checkRTBSubnet, NeedsTargetCache: true},
-		{TargetType: "nat", DisplayName: "NAT Gateways", Checker: checkRTBNAT, NeedsTargetCache: true},
-		{TargetType: "igw", DisplayName: "Internet Gateways", Checker: checkRTBIGW, NeedsTargetCache: true},
-		{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkRTBCFN, NeedsTargetCache: true},
-		{TargetType: "vpc", DisplayName: "VPC", Checker: checkRTBVPC},
-		{TargetType: "eni", DisplayName: "Network Interfaces", Checker: checkRTBENI, NeedsTargetCache: true},
-		{TargetType: "tgw", DisplayName: "Transit Gateways", Checker: checkRTBTGW, NeedsTargetCache: true},
-		{TargetType: "vpce", DisplayName: "VPC Endpoints", Checker: checkRTBVPCE, NeedsTargetCache: true},
-	})
-}
-
 // checkRTBSubnet searches the subnet cache for subnets associated with this route table.
 // It extracts SubnetIds from ec2types.RouteTable.Associations[] (Pattern C — cache lookup).
 func checkRTBSubnet(ctx context.Context, clients any, res resource.Resource, cache resource.ResourceCache) resource.RelatedCheckResult {

--- a/internal/aws/sg.go
+++ b/internal/aws/sg.go
@@ -136,18 +136,6 @@ func computeSGRiskFields(perms []ec2types.IpPermission) (string, string, string)
 	return strconv.Itoa(dangerousCount), wideOpenStr, riskSummary
 }
 
-func init() {
-	resource.RegisterFieldKeys("sg", []string{"group_id", "group_name", "vpc_id", "description", "dangerous_open_count", "wide_open", "risk_summary"})
-
-	resource.RegisterPaginated("sg", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchSecurityGroupsPage(ctx, c.EC2, continuationToken)
-	})
-}
-
 // FetchSecurityGroups calls the EC2 DescribeSecurityGroups API and returns all
 // pages of security groups. Used by tests; the production path uses the per-page fetcher for pagination.
 func FetchSecurityGroups(ctx context.Context, api EC2DescribeSecurityGroupsAPI) ([]resource.Resource, error) {

--- a/internal/aws/sg_related.go
+++ b/internal/aws/sg_related.go
@@ -12,22 +12,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterRelated("sg", []resource.RelatedDef{
-		{TargetType: "vpc", DisplayName: "VPC", Checker: checkSGVPC, NeedsTargetCache: false},
-		{TargetType: "ec2", DisplayName: "EC2 Instances", Checker: checkSGEC2, NeedsTargetCache: true},
-		{TargetType: "eni", DisplayName: "Network Interfaces", Checker: checkSGENI, NeedsTargetCache: true},
-		{TargetType: "elb", DisplayName: "Load Balancers", Checker: checkSGELB, NeedsTargetCache: true},
-		{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkSGLambda, NeedsTargetCache: true},
-		{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkSGCFN, NeedsTargetCache: false},
-		{TargetType: "sg", DisplayName: "Referencing SGs", Checker: checkSGSG, NeedsTargetCache: true},
-	})
-
-	resource.RegisterDefaultNavFields("sg", []resource.NavigableField{
-		{FieldPath: "VpcId", TargetType: "vpc"},
-	})
-}
-
 // checkSGVPC reads the vpc_id field directly from the SG resource.
 // No cache access needed — the field is populated by the SG fetcher.
 func checkSGVPC(_ context.Context, _ any, res resource.Resource, _ resource.ResourceCache) resource.RelatedCheckResult {

--- a/internal/aws/subnet.go
+++ b/internal/aws/subnet.go
@@ -11,18 +11,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("subnet", []string{"subnet_id", "name", "vpc_id", "cidr_block", "availability_zone", "state", "available_ips"})
-
-	resource.RegisterPaginated("subnet", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchSubnetsPage(ctx, c.EC2, continuationToken)
-	})
-}
-
 // FetchSubnets calls the EC2 DescribeSubnets API and converts the
 // response into a slice of generic Resource structs.
 func FetchSubnets(ctx context.Context, api EC2DescribeSubnetsAPI) ([]resource.Resource, error) {

--- a/internal/aws/subnet_related.go
+++ b/internal/aws/subnet_related.go
@@ -12,26 +12,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterDefaultNavFields("subnet", []resource.NavigableField{
-		{FieldPath: "VpcId", TargetType: "vpc"},
-	})
-
-	resource.RegisterRelated("subnet", []resource.RelatedDef{
-		{TargetType: "ec2", DisplayName: "EC2 Instances", Checker: checkSubnetEC2, NeedsTargetCache: true},
-		{TargetType: "eni", DisplayName: "Network Interfaces", Checker: checkSubnetENI, NeedsTargetCache: true},
-		{TargetType: "nat", DisplayName: "NAT Gateways", Checker: checkSubnetNAT, NeedsTargetCache: true},
-		{TargetType: "elb", DisplayName: "Load Balancers", Checker: checkSubnetELB, NeedsTargetCache: true},
-		{TargetType: "rtb", DisplayName: "Route Tables", Checker: checkSubnetRTB, NeedsTargetCache: true},
-		{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkSubnetCFN, NeedsTargetCache: false},
-		{TargetType: "vpc", DisplayName: "VPC", Checker: checkSubnetVPC},
-		{TargetType: "asg", DisplayName: "Auto Scaling Groups", Checker: checkSubnetASG, NeedsTargetCache: true},
-		{TargetType: "efs", DisplayName: "EFS File Systems", Checker: checkSubnetEFS},
-		{TargetType: "eks", DisplayName: "EKS Clusters", Checker: checkSubnetEKS, NeedsTargetCache: true},
-		{TargetType: "vpce", DisplayName: "VPC Endpoints", Checker: checkSubnetVPCE, NeedsTargetCache: true},
-	})
-}
-
 // checkSubnetEC2 searches the ec2 cache for instances whose SubnetId matches
 // the subnet's ID. Uses assertStruct since subnet_id is not in EC2 Fields map.
 func checkSubnetEC2(ctx context.Context, clients any, res resource.Resource, cache resource.ResourceCache) resource.RelatedCheckResult {

--- a/internal/aws/tg.go
+++ b/internal/aws/tg.go
@@ -10,18 +10,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("tg", []string{"target_group_name", "port", "protocol", "vpc_id", "target_type", "health_check_path"})
-
-	resource.RegisterPaginated("tg", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchTargetGroupsPage(ctx, c.ELBv2, continuationToken)
-	})
-}
-
 // FetchTargetGroups calls the ELBv2 DescribeTargetGroups API and converts the
 // response into a slice of generic Resource structs.
 func FetchTargetGroups(ctx context.Context, api ELBv2DescribeTargetGroupsAPI) ([]resource.Resource, error) {

--- a/internal/aws/tg_related.go
+++ b/internal/aws/tg_related.go
@@ -15,31 +15,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterRelated("tg", []resource.RelatedDef{
-		{TargetType: "elb", DisplayName: "Load Balancers", Checker: checkTGELB, NeedsTargetCache: false},
-		{TargetType: "ecs-svc", DisplayName: "ECS Services", Checker: checkTGECSSvc, NeedsTargetCache: true},
-		{TargetType: "asg", DisplayName: "Auto Scaling Groups", Checker: checkTGASG, NeedsTargetCache: true},
-		{TargetType: "alarm", DisplayName: "CW Alarms", Checker: checkTGAlarm, NeedsTargetCache: true},
-		{TargetType: "vpc", DisplayName: "VPC", Checker: checkTGVPC},
-		{TargetType: "backup", DisplayName: "Backup Plans", Checker: checkTGBackup},
-		{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkTGCFN},
-		{TargetType: "dbc", DisplayName: "DocumentDB Clusters", Checker: checkTGDBC},
-		{TargetType: "dbi", DisplayName: "RDS Instances", Checker: checkTGDBI},
-		{TargetType: "ec2", DisplayName: "EC2 Instances", Checker: checkTGEC2},
-		{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkTGLambda},
-		{TargetType: "logs", DisplayName: "Log Groups", Checker: checkTGLogs},
-		{TargetType: "dbi-snap", DisplayName: "DB Instance Snapshots", Checker: checkTGDBISnap},
-		{TargetType: "sg", DisplayName: "Security Groups", Checker: checkTGSG},
-		{TargetType: "subnet", DisplayName: "Subnets", Checker: checkTGSubnet},
-	})
-
-	resource.RegisterDefaultNavFields("tg", []resource.NavigableField{
-		{FieldPath: "VpcId", TargetType: "vpc"},
-		{FieldPath: "LoadBalancerArns", TargetType: "elb"},
-	})
-}
-
 // tgARN returns the Target Group ARN from Fields or RawStruct.
 func tgARN(res resource.Resource) string {
 	if arn := res.Fields["target_group_arn"]; arn != "" {

--- a/internal/aws/tgw.go
+++ b/internal/aws/tgw.go
@@ -11,18 +11,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("tgw", []string{"tgw_id", "name", "state", "owner_id", "description"})
-
-	resource.RegisterPaginated("tgw", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchTransitGatewaysPage(ctx, c.EC2, continuationToken)
-	})
-}
-
 // FetchTransitGateways calls the EC2 DescribeTransitGateways API and converts the
 // response into a slice of generic Resource structs.
 func FetchTransitGateways(ctx context.Context, api EC2DescribeTransitGatewaysAPI) ([]resource.Resource, error) {

--- a/internal/aws/tgw_related.go
+++ b/internal/aws/tgw_related.go
@@ -15,35 +15,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterRelated("tgw", []resource.RelatedDef{
-		{
-			TargetType:       "vpc",
-			DisplayName:      "VPCs",
-			Checker:          checkTGWVPC,
-			NeedsTargetCache: false,
-		},
-		{
-			TargetType:       "rtb",
-			DisplayName:      "Route Tables",
-			Checker:          checkTGWRTB,
-			NeedsTargetCache: true,
-		},
-		{
-			TargetType:       "role",
-			DisplayName:      "IAM Role",
-			Checker:          checkTGWRole,
-			NeedsTargetCache: false,
-		},
-		{
-			TargetType:       "subnet",
-			DisplayName:      "Subnets",
-			Checker:          checkTGWSubnet,
-			NeedsTargetCache: false,
-		},
-	})
-}
-
 // checkTGWVPC calls ec2:DescribeTransitGatewayVpcAttachments filtered by the
 // TGW id and collects the VpcId of each returned attachment (Pattern A —
 // direct API call). DevOps consensus (5/5 reviewers) agrees this is the

--- a/internal/aws/vpc.go
+++ b/internal/aws/vpc.go
@@ -11,18 +11,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("vpc", []string{"vpc_id", "name", "cidr_block", "state", "is_default"})
-
-	resource.RegisterPaginated("vpc", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchVPCsPage(ctx, c.EC2, continuationToken)
-	})
-}
-
 // FetchVPCs calls the EC2 DescribeVpcs API and converts the
 // response into a slice of generic Resource structs.
 func FetchVPCs(ctx context.Context, api EC2DescribeVpcsAPI) ([]resource.Resource, error) {

--- a/internal/aws/vpc_related.go
+++ b/internal/aws/vpc_related.go
@@ -11,22 +11,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterRelated("vpc", []resource.RelatedDef{
-		{TargetType: "subnet", DisplayName: "Subnets", Checker: checkVPCSubnet, NeedsTargetCache: true},
-		{TargetType: "sg", DisplayName: "Security Groups", Checker: checkVPCSG, NeedsTargetCache: true},
-		{TargetType: "ec2", DisplayName: "EC2 Instances", Checker: checkVPCEC2, NeedsTargetCache: true},
-		{TargetType: "elb", DisplayName: "Load Balancers", Checker: checkVPCELB, NeedsTargetCache: true},
-		{TargetType: "nat", DisplayName: "NAT Gateways", Checker: checkVPCNAT, NeedsTargetCache: true},
-		{TargetType: "igw", DisplayName: "Internet Gateways", Checker: checkVPCIGW, NeedsTargetCache: true},
-		{TargetType: "rtb", DisplayName: "Route Tables", Checker: checkVPCRTB, NeedsTargetCache: true},
-		{TargetType: "vpce", DisplayName: "VPC Endpoints", Checker: checkVPCVPCE, NeedsTargetCache: true},
-		{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkVPCCFN, NeedsTargetCache: false},
-		{TargetType: "eni", DisplayName: "Network Interfaces", Checker: checkVPCENI, NeedsTargetCache: true},
-		{TargetType: "tgw", DisplayName: "Transit Gateways", Checker: checkVPCTGW, NeedsTargetCache: false},
-	})
-}
-
 // checkVPCSubnet searches the subnet cache for subnets whose vpc_id field
 // matches this VPC's ID.
 func checkVPCSubnet(ctx context.Context, clients any, res resource.Resource, cache resource.ResourceCache) resource.RelatedCheckResult {

--- a/internal/aws/vpce.go
+++ b/internal/aws/vpce.go
@@ -11,18 +11,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("vpce", []string{"vpce_id", "service_name", "type", "state", "vpc_id"})
-
-	resource.RegisterPaginated("vpce", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchVPCEndpointsPage(ctx, c.EC2, continuationToken)
-	})
-}
-
 // FetchVPCEndpoints calls the EC2 DescribeVpcEndpoints API and converts the
 // response into a slice of generic Resource structs.
 func FetchVPCEndpoints(ctx context.Context, api EC2DescribeVpcEndpointsAPI) ([]resource.Resource, error) {

--- a/internal/aws/vpce_related.go
+++ b/internal/aws/vpce_related.go
@@ -12,32 +12,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterDefaultNavFields("vpce", []resource.NavigableField{
-		{FieldPath: "VpcId", TargetType: "vpc"},
-		{FieldPath: "SubnetIds", TargetType: "subnet"},
-		{FieldPath: "NetworkInterfaceIds", TargetType: "eni"},
-		{FieldPath: "Groups.GroupId", TargetType: "sg"},
-		{FieldPath: "RouteTableIds", TargetType: "rtb"},
-	})
-
-	resource.RegisterRelated("vpce", []resource.RelatedDef{
-		{TargetType: "subnet", DisplayName: "Subnets", Checker: checkVPCESubnet, NeedsTargetCache: false},
-		{TargetType: "sg", DisplayName: "Security Groups", Checker: checkVPCESG, NeedsTargetCache: false},
-		{TargetType: "rtb", DisplayName: "Route Tables", Checker: checkVPCERTB, NeedsTargetCache: false},
-		{TargetType: "eni", DisplayName: "Network Interfaces", Checker: checkVPCEENI, NeedsTargetCache: false},
-		{TargetType: "vpc", DisplayName: "VPC", Checker: checkVPCEVPC},
-		{TargetType: "acm", DisplayName: "ACM Certificates", Checker: checkVPCEACM},
-		{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: checkVPCEAlarm},
-		{TargetType: "cf", DisplayName: "CloudFront", Checker: checkVPCECF},
-		{TargetType: "logs", DisplayName: "Log Groups", Checker: checkVPCELogs},
-		{TargetType: "r53", DisplayName: "Route 53 Zones", Checker: checkVPCER53},
-		{TargetType: "s3", DisplayName: "S3 Buckets", Checker: checkVPCES3},
-		{TargetType: "tg", DisplayName: "Target Groups", Checker: checkVPCETG},
-		{TargetType: "waf", DisplayName: "WAF Web ACLs", Checker: checkVPCEWAF},
-	})
-}
-
 // checkVPCESubnet reads SubnetIds from the VpcEndpoint RawStruct directly.
 // Pattern F: all data is in RawStruct, no cache lookup needed.
 func checkVPCESubnet(_ context.Context, _ any, res resource.Resource, _ resource.ResourceCache) resource.RelatedCheckResult {


### PR DESCRIPTION
## Summary

Migrates the **networking** category's per-type wiring from `init()` bodies in `internal/aws/<svc>.go` and `internal/aws/<svc>_related.go` into the catalog struct literal at `internal/aws/catalog_networking.go`.

12 resources covered: `elb, tg, sg, vpc, subnet, rtb, nat, igw, eip, vpce, tgw, eni`.

Per AS-795 §5.2 per-category template, each entry now carries:
- `Fetcher` (12/12 — `eip` keeps its custom non-paginated closure)
- `FieldKeys` (12/12)
- `Wave2` (4/12: `elb`, `tg`, `vpc`, `tgw` — the four real enrichers)
- `IssueEnricherFieldKeys` (3/12: `tg→[health_summary]`, `vpc→[flow_logs]`, `tgw→[att_status]`; `elb` has none registered)
- `Related` (12/12)
- `Navigable` (10/12 — `vpc` and `tgw` have no NavigableFields)

## Per Architect Stage 2 spec

Following the published spec ([AS-809 comment `392d3d0a`](https://github.com/k2m30/a9s/issues) at 05:28Z 2026-05-21):

- All 12 networking resources migrate in this PR (no deferrals; no child-type entries in `catalog_networking.go`).
- NoOp Wave 2 enrichers (`sg, subnet, rtb, nat, igw, eip, vpce, eni`) → `Wave2` field omitted (zero value = no Wave 2 in catalog).
- The 12 `_issue_enrichment.go` `init()` bodies are **untouched** (legacy `IssueEnricherRegistry` parity for `TestAttentionSignalsDoc`; AS-795n cleans them).
- `eip` Fetcher closure preserves its custom non-paginated form verbatim from the deleted init().

## Acceptance verification

```
$ rg '^func init\(\)' internal/aws/{elb,tg,sg,vpc,subnet,rtb,nat,igw,eip,vpce,tgw,eni}.go \
    internal/aws/{tg,sg,vpc,subnet,rtb,eip,vpce,tgw,eni}_related.go
# ZERO hits (21 files cleaned)

$ rg 'Fetcher:' internal/aws/catalog_networking.go         # 12 hits
$ rg 'Wave2:' internal/aws/catalog_networking.go           #  4 hits (elb, tg, vpc, tgw)
$ rg 'IssueEnricherFieldKeys:' internal/aws/catalog_networking.go  # 3 hits (tg, vpc, tgw)

$ go build ./...                       # clean
$ go test ./tests/unit/                # PASS (24.4s)
$ go test ./tests/unit/ -run 'Golden|Scenario'  # PASS — no snapshot drift
$ golangci-lint run ./...              # 0 issues
$ govulncheck ./...                    # no vulnerabilities
$ go test -tags integration ./tests/integration/...  # PASS (46.3s) — AS-827 gate
$ go fix -inline -diff ./...           # clean
$ verify-readonly                      # all API calls read-only
```

## Precedents copied

- PR #392 (AS-795a scaffold)
- PR #393 (AS-807 / compute)
- PR #395 (AS-808 / containers)
- PR #396 (AS-810 / databases)
- PR #397 (AS-815 / security — in-flight)

## Refs

- Issue: [AS-809](https://github.com/k2m30/a9s) — AS-795d networking init() → catalog
- Parent: AS-805 (umbrella)
- Acceptance gate: AS-795o (unblocks AS-731)
- Spec: `docs/refactor/AS-795-init-cycle-break.md` §3 + §5.2

## Test plan

- [x] `go test ./tests/unit/` — pass
- [x] `go test ./tests/unit/ -run 'Golden|Scenario'` — no snapshot drift
- [x] `golangci-lint run ./...` — 0 issues
- [x] `govulncheck ./...` — clean
- [x] `go test -tags integration ./tests/integration/...` — pass (AS-827 gate)
- [x] `verify-readonly` — all API calls read-only

Co-Authored-By: Paperclip <noreply@paperclip.ing>