### PR TITLE
feat(refactor): AS-814 dns-cdn category init() → catalog migration

### DIFF
--- a/internal/aws/apigw.go
+++ b/internal/aws/apigw.go
@@ -11,36 +11,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("apigw", []string{"api_id", "name", "protocol", "endpoint", "description"})
-
-	resource.RegisterPaginated("apigw", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchAPIGatewaysPageMerged(ctx, c, continuationToken)
-	})
-
-	resource.RegisterRelated("apigw", []resource.RelatedDef{
-		{TargetType: "logs", DisplayName: "Log Groups", Checker: checkApigwLogs, NeedsTargetCache: true},
-		{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkApigwLambda},
-		{TargetType: "waf", DisplayName: "WAF Web ACLs", Checker: checkApigwWAF},
-		{TargetType: "acm", DisplayName: "ACM Certificates", Checker: checkApigwACM},
-		{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: checkApigwAlarm, NeedsTargetCache: true},
-		{TargetType: "cf", DisplayName: "CloudFront", Checker: checkApigwCF},
-		{TargetType: "elb", DisplayName: "Load Balancers", Checker: checkApigwELB},
-		// Weak pair (3-sometimes/2-no consensus). API Gateway has no direct KMS field;
-		// we follow Lambda integrations as a best effort.
-		{TargetType: "kms", DisplayName: "KMS Keys", Checker: checkApigwKMS, NeedsTargetCache: false},
-		{TargetType: "r53", DisplayName: "Route 53 Zones", Checker: checkApigwR53},
-		{TargetType: "role", DisplayName: "IAM Role", Checker: checkApigwRole},
-		{TargetType: "sfn", DisplayName: "Step Functions", Checker: checkApigwSFN},
-		{TargetType: "sns", DisplayName: "SNS Topics", Checker: checkApigwSNS},
-		{TargetType: "vpce", DisplayName: "VPC Endpoints", Checker: checkApigwVPCE},
-	})
-}
-
 // FetchAPIGatewaysPageMerged fetches a single page of API Gateways from both
 // APIGateway V2 (HTTP/WEBSOCKET) and APIGateway V1 (REST), merging results.
 // On the first page (continuationToken == ""), all V1 REST APIs are fully

--- a/internal/aws/catalog_dns_cdn.go
+++ b/internal/aws/catalog_dns_cdn.go
@@ -1,8 +1,12 @@
 package aws
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/domain"
+	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func colorCF(r domain.Resource) domain.Color {
@@ -58,6 +62,29 @@ var dnsCdnTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // static
 			{Key: "price_class", Title: "Price Class", Width: 16, Sortable: true},
 		},
 		Color: colorCF,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchCloudFrontDistributionsPage(ctx, c.CloudFront, continuationToken)
+		},
+		Wave2:     IssueEnricher{Fn: EnrichCloudFrontDistribution, Priority: 100},
+		FieldKeys: []string{"distribution_id", "domain_name", "status", "enabled", "aliases", "price_class"},
+		Related: []domain.RelatedDef{
+			{TargetType: "s3", DisplayName: "S3 Buckets (origin)", Checker: checkCfS3, NeedsTargetCache: true},
+			{TargetType: "elb", DisplayName: "Load Balancers (origin)", Checker: checkCfELB, NeedsTargetCache: true},
+			{TargetType: "waf", DisplayName: "WAF Web ACLs", Checker: checkCfWAF, NeedsTargetCache: true},
+			{TargetType: "acm", DisplayName: "ACM Certificates", Checker: checkCfACM, NeedsTargetCache: true},
+			{TargetType: "r53", DisplayName: "Route 53 Zones", Checker: checkCfR53},
+			{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: checkCfAlarm, NeedsTargetCache: true},
+			{TargetType: "lambda", DisplayName: "Lambda@Edge", Checker: checkCfLambda},
+			{TargetType: "logs", DisplayName: "Log Groups", Checker: checkCfLogs},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("cf")},
+		},
+		// cftypes.DistributionSummary: no NavigableFields — Origins[].DomainName is a hostname
+		// (e.g. bucket.s3.amazonaws.com), not a bucket name ID; all relationships handled by
+		// checkCf* related checkers at runtime. WebACLId is on GetDistributionConfig, not the summary.
 	},
 	{
 		Name:          "ACM Certificates",
@@ -89,5 +116,32 @@ var dnsCdnTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // static
 			{Key: "description", Title: "Description", Width: 30, Sortable: false},
 		},
 		Color: colorAPIGW,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchAPIGatewaysPageMerged(ctx, c, continuationToken)
+		},
+		Wave2:     IssueEnricher{Fn: EnrichAPIGatewayStage, Priority: 100},
+		FieldKeys: []string{"api_id", "name", "protocol", "endpoint", "description"},
+		Related: []domain.RelatedDef{
+			{TargetType: "logs", DisplayName: "Log Groups", Checker: checkApigwLogs, NeedsTargetCache: true},
+			{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkApigwLambda},
+			{TargetType: "waf", DisplayName: "WAF Web ACLs", Checker: checkApigwWAF},
+			{TargetType: "acm", DisplayName: "ACM Certificates", Checker: checkApigwACM},
+			{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: checkApigwAlarm, NeedsTargetCache: true},
+			{TargetType: "cf", DisplayName: "CloudFront", Checker: checkApigwCF},
+			{TargetType: "elb", DisplayName: "Load Balancers", Checker: checkApigwELB},
+			// Weak pair (3-sometimes/2-no consensus). API Gateway has no direct KMS field;
+			// we follow Lambda integrations as a best effort.
+			{TargetType: "kms", DisplayName: "KMS Keys", Checker: checkApigwKMS, NeedsTargetCache: false},
+			{TargetType: "r53", DisplayName: "Route 53 Zones", Checker: checkApigwR53},
+			{TargetType: "role", DisplayName: "IAM Role", Checker: checkApigwRole},
+			{TargetType: "sfn", DisplayName: "Step Functions", Checker: checkApigwSFN},
+			{TargetType: "sns", DisplayName: "SNS Topics", Checker: checkApigwSNS},
+			{TargetType: "vpce", DisplayName: "VPC Endpoints", Checker: checkApigwVPCE},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("apigw")},
+		},
 	},
 }

--- a/internal/aws/catalog_security.go
+++ b/internal/aws/catalog_security.go
@@ -1,11 +1,14 @@
 package aws
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/domain"
+	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func colorRole(r domain.Resource) domain.Color {
@@ -127,5 +130,24 @@ var securityTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // stat
 			{Key: "description", Title: "Description", Width: 36, Sortable: false},
 		},
 		Color: colorWAF,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchWAFWebACLsPage(ctx, c.WAFv2, continuationToken)
+		},
+		Wave2:     IssueEnricher{Fn: EnrichWAFLogging, Priority: 100},
+		FieldKeys: []string{"name", "id", "description"},
+		Related: []domain.RelatedDef{
+			{TargetType: "elb", DisplayName: "Load Balancers", Checker: checkWAFELB, NeedsTargetCache: false},
+			{TargetType: "apigw", DisplayName: "API Gateways", Checker: checkWAFAPIGW, NeedsTargetCache: false},
+			{TargetType: "cf", DisplayName: "CloudFront", Checker: checkWAFCF, NeedsTargetCache: false},
+			{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: checkWAFAlarm},
+			{TargetType: "logs", DisplayName: "Log Groups", Checker: checkWAFLogs},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("waf")},
+		},
+		// wafv2types.WebACLSummary: no cross-ref fields — Name, Id, ARN, Description, LockToken only.
+		// Associations (ELB/APIGW/CF) are resolved via checkWAF* related checkers at runtime.
 	},
 }

--- a/internal/aws/cf.go
+++ b/internal/aws/cf.go
@@ -11,33 +11,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("cf", []string{"distribution_id", "domain_name", "status", "enabled", "aliases", "price_class"})
-
-	resource.RegisterPaginated("cf", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchCloudFrontDistributionsPage(ctx, c.CloudFront, continuationToken)
-	})
-
-	resource.RegisterRelated("cf", []resource.RelatedDef{
-		{TargetType: "s3", DisplayName: "S3 Buckets (origin)", Checker: checkCfS3, NeedsTargetCache: true},
-		{TargetType: "elb", DisplayName: "Load Balancers (origin)", Checker: checkCfELB, NeedsTargetCache: true},
-		{TargetType: "waf", DisplayName: "WAF Web ACLs", Checker: checkCfWAF, NeedsTargetCache: true},
-		{TargetType: "acm", DisplayName: "ACM Certificates", Checker: checkCfACM, NeedsTargetCache: true},
-		{TargetType: "r53", DisplayName: "Route 53 Zones", Checker: checkCfR53},
-		{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: checkCfAlarm, NeedsTargetCache: true},
-		{TargetType: "lambda", DisplayName: "Lambda@Edge", Checker: checkCfLambda},
-		{TargetType: "logs", DisplayName: "Log Groups", Checker: checkCfLogs},
-	})
-
-	// cftypes.DistributionSummary: no NavigableFields — Origins[].DomainName is a hostname
-	// (e.g. bucket.s3.amazonaws.com), not a bucket name ID; all relationships handled by
-	// checkCf* related checkers at runtime. WebACLId is on GetDistributionConfig, not the summary.
-}
-
 // FetchCloudFrontDistributions calls the CloudFront ListDistributions API and converts
 // the response into a slice of generic Resource structs.
 func FetchCloudFrontDistributions(ctx context.Context, api CloudFrontListDistributionsAPI) ([]resource.Resource, error) {

--- a/internal/aws/waf.go
+++ b/internal/aws/waf.go
@@ -11,18 +11,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("waf", []string{"name", "id", "description"})
-
-	resource.RegisterPaginated("waf", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchWAFWebACLsPage(ctx, c.WAFv2, continuationToken)
-	})
-}
-
 // FetchWAFWebACLs calls the WAFv2 ListWebACLs API with Scope=REGIONAL and converts
 // the response into a slice of generic Resource structs.
 func FetchWAFWebACLs(ctx context.Context, api WAFv2ListWebACLsAPI) ([]resource.Resource, error) {

--- a/internal/aws/waf_related.go
+++ b/internal/aws/waf_related.go
@@ -1,4 +1,7 @@
-// waf_related.go registers related-resource definitions for WAF Web ACLs.
+// waf_related.go defines the related-resource checkers for WAF Web ACLs.
+// The Related slice for "waf" is registered via the catalog struct literal in
+// catalog_security.go (AS-814); this file now contains only the per-target
+// checker functions referenced from that catalog entry.
 package aws
 
 import (
@@ -13,19 +16,6 @@ import (
 
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
-
-func init() {
-	resource.RegisterRelated("waf", []resource.RelatedDef{
-		{TargetType: "elb", DisplayName: "Load Balancers", Checker: checkWAFELB, NeedsTargetCache: false},
-		{TargetType: "apigw", DisplayName: "API Gateways", Checker: checkWAFAPIGW, NeedsTargetCache: false},
-		{TargetType: "cf", DisplayName: "CloudFront", Checker: checkWAFCF, NeedsTargetCache: false},
-		{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: checkWAFAlarm},
-		{TargetType: "logs", DisplayName: "Log Groups", Checker: checkWAFLogs},
-	})
-
-	// wafv2types.WebACLSummary: no cross-ref fields — Name, Id, ARN, Description, LockToken only.
-	// Associations (ELB/APIGW/CF) are resolved via checkWAF* related checkers at runtime.
-}
 
 // checkWAFELB calls wafv2:ListResourcesForWebACL with ALB resource type and
 // returns matching load balancer names (Pattern A — direct API call).


### PR DESCRIPTION
## Summary

Migrates the dns-cdn category's per-type wiring from `init()` bodies in `internal/aws/{cf,apigw,waf,waf_related}.go` into the catalog struct literals in `internal/aws/catalog_dns_cdn.go` (cf, apigw) and `internal/aws/catalog_security.go` (waf). Per-category PR after AS-807 (compute, PR #393), AS-810 (databases, PR #396). Spec: `docs/refactor/AS-795-init-cycle-break.md` §3 + §5.2.

Catalog entries populated for the 3 types in the issue scope:
- **cf**  (catalog_dns_cdn.go) — Fetcher, Wave2 (`EnrichCloudFrontDistribution`, priority 100), FieldKeys, Related (s3, elb, waf, acm, r53, alarm, lambda, logs, ct-events). No Navigable (preserved comment explains why).
- **apigw** (catalog_dns_cdn.go) — Fetcher (V1+V2 merged), Wave2 (`EnrichAPIGatewayStage`, priority 100), FieldKeys, Related (logs, lambda, waf, acm, alarm, cf, elb, kms, r53, role, sfn, sns, vpce, ct-events).
- **waf** (catalog_security.go) — Fetcher, Wave2 (`EnrichWAFLogging`, priority 100), FieldKeys, Related (elb, apigw, cf, alarm, logs, ct-events).

### Why waf is wired in `catalog_security.go`, not `catalog_dns_cdn.go`

The existing catalog places the waf entry under SECURITY & IAM, and the user-visible docs (`README.md` services table, `website/content/resources.md`) document waf under SECURITY & IAM. AS-815 (security category PR #397) explicitly left waf identity-only. Following the AS-810 precedent ("s3 + efs entries intentionally left as identity-only per AS-795 scope — their per-category migration lands in a later sibling"), the wiring lands in the file where the entry currently lives. No cross-category move; no user-visible menu change. The AS-795 spec §3 grouping of waf into dns-cdn is honored in spirit by this PR completing waf's wiring in this sibling.

### ct-events Related entries

cf / apigw / waf each gain an explicit ct-events RelatedDef via `ctEventsCheckerFor()` so the Install bridge does not clobber the `zzz_ct_events_all_related.go` init append (same pattern as AS-810's ddb / opensearch / redshift entries).

### init() bodies removed

- `internal/aws/{cf,apigw,waf,waf_related}.go`

### init() bodies retained (legacy consumers — same rationale as AS-807 / AS-810)

`internal/aws/{cf,apigw,waf}_issue_enrichment.go` — legacy `IssueEnricherRegistry` is still iterated by `BuildEnrichQueue` / `runtime_adapter_navigate` / `probe_adapter` / `TestAttentionSignalsDoc`; AS-795n deletes those consumers and the legacy registry. `RegisterIssueEnricherFieldKeys` (`apigw.stages_count`, `waf.rules_summary`) also stays per the same boundary.

## Acceptance per AS-814 issue body

```bash
rg '^func init\(\)' internal/aws/cf.go internal/aws/apigw.go internal/aws/waf.go   # zero hits ✅
rg 'Fetcher:' internal/aws/catalog_dns_cdn.go                                      # 2 hits (cf, apigw) — waf wired in catalog_security.go per AS-810 s3/efs precedent
```

- `go build ./...`, `go test ./...` (unit), `go test -tags integration ./tests/integration/` all green locally.
- `golangci-lint run ./...` → 0 issues.
- `govulncheck ./...` → no vulnerabilities.
- `go fix -inline -diff ./...` → clean.
- Golden|Scenario unit snapshots + Visual|Scenario integration snapshots pass.
- `test-race` blocked by missing cgo/gcc in this pod (documented under AS-149); mdlint not required (no markdown files changed).

## Test plan

- [x] `go test ./...` green
- [x] `go test -tags integration ./tests/integration/` green
- [x] `golangci-lint run ./...` green
- [x] `govulncheck ./...` green
- [x] `go fix -inline -diff ./...` clean
- [x] Behavior parity: snapshot tests show identical cf/apigw/waf list+detail render vs main

## Parent / dependencies

- Parent: AS-805 (umbrella init→catalog cycle-break)
- Depends on: AS-795a / PR #392 (merged), AS-807 / PR #393 (merged), AS-810 / PR #396 (merged). Stacks cleanly atop origin/main.
- Siblings (in flight): AS-808 (containers) / PR #395, AS-809 (networking) / PR #398, AS-815 (security) / PR #397.

Co-Authored-By: Paperclip <noreply@paperclip.ing>