### PR TITLE
feat(refactor): AS-816 cicd category init() → catalog migration

### DIFF
--- a/internal/aws/catalog_cicd.go
+++ b/internal/aws/catalog_cicd.go
@@ -9,10 +9,10 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func colorCFN(r domain.Resource) domain.Color      { return cfnStackColor(r.Fields["status"]) }
-func colorPipeline(_ domain.Resource) domain.Color { return domain.ColorHealthy }
-func colorCB(_ domain.Resource) domain.Color       { return domain.ColorHealthy }
-func colorECR(_ domain.Resource) domain.Color      { return domain.ColorHealthy }
+func colorCFN(r domain.Resource) domain.Color          { return cfnStackColor(r.Fields["status"]) }
+func colorPipeline(_ domain.Resource) domain.Color     { return domain.ColorHealthy }
+func colorCB(_ domain.Resource) domain.Color           { return domain.ColorHealthy }
+func colorECR(_ domain.Resource) domain.Color          { return domain.ColorHealthy }
 func colorCodeArtifact(_ domain.Resource) domain.Color { return domain.ColorHealthy }
 
 var cicdTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // static catalog: intentional package-level var
@@ -78,6 +78,29 @@ var cicdTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // static c
 			DisplayNameKey: "Name",
 		}},
 		Color: colorPipeline,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchCodePipelinesPage(ctx, c.CodePipeline, continuationToken)
+		},
+		Wave2:     IssueEnricher{Fn: EnrichCodePipelineStatus, Priority: 10},
+		FieldKeys: []string{"name", "pipeline_type", "version", "created", "updated"},
+		Related: []domain.RelatedDef{
+			{TargetType: "cb", DisplayName: "CodeBuild Projects", Checker: checkPipelineCB, NeedsTargetCache: false},
+			{TargetType: "role", DisplayName: "IAM Roles", Checker: checkPipelineRole, NeedsTargetCache: false},
+			{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkPipelineCFN, NeedsTargetCache: false},
+			{TargetType: "codeartifact", DisplayName: "CodeArtifact", Checker: checkPipelineCodeartifact, NeedsTargetCache: false},
+			{TargetType: "eb-rule", DisplayName: "EventBridge Rules", Checker: checkPipelineEbRule, NeedsTargetCache: false},
+			{TargetType: "ecr", DisplayName: "ECR Repositories", Checker: checkPipelineECR, NeedsTargetCache: false},
+			{TargetType: "ecs-svc", DisplayName: "ECS Services", Checker: checkPipelineECSSvc, NeedsTargetCache: false},
+			{TargetType: "kms", DisplayName: "KMS Key", Checker: checkPipelineKMS, NeedsTargetCache: false},
+			{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkPipelineLambda, NeedsTargetCache: false},
+			{TargetType: "s3", DisplayName: "S3 Buckets (artifacts)", Checker: checkPipelineS3, NeedsTargetCache: false},
+			{TargetType: "sns", DisplayName: "SNS Topics", Checker: checkPipelineSNS, NeedsTargetCache: false},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("pipeline"), NeedsTargetCache: false},
+		},
 	},
 	{
 		Name:          "CodeBuild Projects",
@@ -98,6 +121,37 @@ var cicdTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // static c
 			DisplayNameKey: "project_name",
 		}},
 		Color: colorCB,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchCodeBuildProjectsPage(ctx, c.CodeBuild, c.CodeBuild, continuationToken)
+		},
+		Wave2:     IssueEnricher{Fn: EnrichCodeBuildStatus, Priority: 10},
+		FieldKeys: []string{"name", "source_type", "description", "last_modified"},
+		Related: []domain.RelatedDef{
+			{TargetType: "logs", DisplayName: "Log Groups", Checker: checkCbLogs, NeedsTargetCache: true},
+			{TargetType: "role", DisplayName: "IAM Roles", Checker: checkCbRole, NeedsTargetCache: true},
+			{TargetType: "pipeline", DisplayName: "CodePipelines", Checker: checkCbPipeline, NeedsTargetCache: true},
+			{TargetType: "sg", DisplayName: "Security Groups", Checker: checkCbSG},
+			{TargetType: "subnet", DisplayName: "Subnets", Checker: checkCbSubnet, NeedsTargetCache: false},
+			{TargetType: "vpc", DisplayName: "VPC", Checker: checkCbVPC},
+			{TargetType: "kms", DisplayName: "KMS Key", Checker: checkCbKMS},
+			{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: checkCbAlarm, NeedsTargetCache: true},
+			{TargetType: "ecr", DisplayName: "ECR Repositories", Checker: checkCbECR, NeedsTargetCache: true},
+			{TargetType: "s3", DisplayName: "S3 Buckets", Checker: checkCbS3, NeedsTargetCache: true},
+			{TargetType: "secrets", DisplayName: "Secrets Manager", Checker: checkCbSecrets, NeedsTargetCache: false},
+			{TargetType: "ssm", DisplayName: "SSM Parameters", Checker: checkCbSSM, NeedsTargetCache: false},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("cb"), NeedsTargetCache: false},
+		},
+		Navigable: []domain.NavigableField{
+			{FieldPath: "ServiceRole", TargetType: "role"},
+			{FieldPath: "EncryptionKey", TargetType: "kms"},
+			{FieldPath: "VpcConfig.VpcId", TargetType: "vpc"},
+			{FieldPath: "VpcConfig.Subnets", TargetType: "subnet"},
+			{FieldPath: "VpcConfig.SecurityGroupIds", TargetType: "sg"},
+		},
 	},
 	{
 		Name:          "ECR Repositories",
@@ -159,5 +213,90 @@ var cicdTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // static c
 			{Key: "domain_owner", Title: "Owner", Width: 14, Sortable: true},
 		},
 		Color: colorCodeArtifact,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchCodeArtifactReposPage(ctx, c.CodeArtifact, continuationToken)
+		},
+		Wave2:     IssueEnricher{Fn: EnrichCodeArtifactRepository, Priority: 100},
+		FieldKeys: []string{"repo_name", "domain_name", "description", "domain_owner"},
+		Related: []domain.RelatedDef{
+			{TargetType: "kms", DisplayName: "KMS Key", Checker: checkCodeartifactKMS, NeedsTargetCache: false},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("codeartifact"), NeedsTargetCache: false},
+		},
+	},
+}
+
+// cicdChildTypes is the declarative child-type catalog for the CI/CD category.
+// Migrated under AS-816 / AS-795k per spec docs/refactor/AS-795-init-cycle-break.md §3 + §5.2.
+// Sibling category PRs (AS-795b/c/d–m) own their own `<cat>ChildTypes` slice
+// appended into allChildTypes() in install.go without merge conflicts.
+//
+// Each entry carries Name/ShortName/Columns/CopyField (verbatim from the deleted
+// resource.RegisterChildType calls) plus FieldKeys and a ChildFetcher closure
+// (verbatim from the deleted resource.RegisterPaginatedChild closures).
+var cicdChildTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // static catalog: intentional package-level var
+	{
+		Name:      "CodeBuild Builds",
+		ShortName: "cb_builds",
+		Columns:   resource.CBBuildColumns(),
+		CopyField: "build_id",
+		FieldKeys: []string{
+			"build_number", "build_status", "start_time", "end_time",
+			"duration", "source_version_short", "initiator", "build_id",
+			"build_arn", "current_phase", "source_version",
+			"resolved_source_version", "log_group_name", "log_stream_name",
+		},
+		Children: []domain.ChildViewDef{{
+			ChildType:      "cb_build_logs",
+			Key:            "enter",
+			ContextKeys:    map[string]string{"log_group_name": "log_group_name", "log_stream_name": "log_stream_name", "build_number": "build_number"},
+			DisplayNameKey: "build_number",
+			DrillCondition: func(r domain.Resource) bool {
+				return r.Fields["log_group_name"] != ""
+			},
+			DrillBlockMessage: "Build logs not available in CloudWatch",
+		}},
+		ChildFetcher: func(ctx context.Context, clients any, parentCtx resource.ParentContext, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchCBBuilds(ctx, c.CodeBuild, c.CodeBuild, parentCtx, continuationToken)
+		},
+	},
+	{
+		Name:      "Build Logs",
+		ShortName: "cb_build_logs",
+		Columns:   resource.CBBuildLogColumns(),
+		CopyField: "message",
+		FieldKeys: []string{"timestamp", "message", "ingestion_time", "event_id"},
+		ChildFetcher: func(ctx context.Context, clients any, parentCtx resource.ParentContext, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchCBBuildLogs(ctx, c.CloudWatchLogs, parentCtx["log_group_name"], parentCtx["log_stream_name"], continuationToken)
+		},
+	},
+	{
+		Name:      "Pipeline Stages",
+		ShortName: "pipeline_stages",
+		Columns:   resource.PipelineStageColumns(),
+		CopyField: "external_url",
+		FieldKeys: []string{
+			"stage_name", "stage_status", "action_name", "action_status",
+			"last_change_time", "external_url", "action_token",
+			"action_error_details", "revision_id", "revision_summary",
+		},
+		ChildFetcher: func(ctx context.Context, clients any, parentCtx resource.ParentContext, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchPipelineStages(ctx, c.CodePipeline, parentCtx, continuationToken)
+		},
 	},
 }

--- a/internal/aws/cb.go
+++ b/internal/aws/cb.go
@@ -9,42 +9,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("cb", []string{"name", "source_type", "description", "last_modified"})
-
-	resource.RegisterPaginated("cb", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchCodeBuildProjectsPage(ctx, c.CodeBuild, c.CodeBuild, continuationToken)
-	})
-
-	resource.RegisterRelated("cb", []resource.RelatedDef{
-		{TargetType: "logs", DisplayName: "Log Groups", Checker: checkCbLogs, NeedsTargetCache: true},
-		{TargetType: "role", DisplayName: "IAM Roles", Checker: checkCbRole, NeedsTargetCache: true},
-		{TargetType: "pipeline", DisplayName: "CodePipelines", Checker: checkCbPipeline, NeedsTargetCache: true},
-		{TargetType: "sg", DisplayName: "Security Groups", Checker: checkCbSG},
-		{TargetType: "subnet", DisplayName: "Subnets", Checker: checkCbSubnet, NeedsTargetCache: false},
-		{TargetType: "vpc", DisplayName: "VPC", Checker: checkCbVPC},
-		{TargetType: "kms", DisplayName: "KMS Key", Checker: checkCbKMS},
-		{TargetType: "alarm", DisplayName: "CloudWatch Alarms", Checker: checkCbAlarm, NeedsTargetCache: true},
-		{TargetType: "ecr", DisplayName: "ECR Repositories", Checker: checkCbECR, NeedsTargetCache: true},
-		{TargetType: "s3", DisplayName: "S3 Buckets", Checker: checkCbS3, NeedsTargetCache: true},
-		{TargetType: "secrets", DisplayName: "Secrets Manager", Checker: checkCbSecrets, NeedsTargetCache: false},
-		{TargetType: "ssm", DisplayName: "SSM Parameters", Checker: checkCbSSM, NeedsTargetCache: false},
-	})
-
-	// cbtypes.Project: ServiceRole, EncryptionKey (KMS), VpcConfig.{VpcId,Subnets,SecurityGroupIds}
-	resource.RegisterDefaultNavFields("cb", []resource.NavigableField{
-		{FieldPath: "ServiceRole", TargetType: "role"},
-		{FieldPath: "EncryptionKey", TargetType: "kms"},
-		{FieldPath: "VpcConfig.VpcId", TargetType: "vpc"},
-		{FieldPath: "VpcConfig.Subnets", TargetType: "subnet"},
-		{FieldPath: "VpcConfig.SecurityGroupIds", TargetType: "sg"},
-	})
-}
-
 // FetchCodeBuildProjectsPage fetches one page of project names from ListProjects
 // using the continuationToken, then calls BatchGetProjects for that page's names.
 // IsTruncated reflects whether ListProjects has more pages beyond this one.

--- a/internal/aws/cb_build_logs.go
+++ b/internal/aws/cb_build_logs.go
@@ -12,25 +12,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("cb_build_logs", []string{"timestamp", "message", "ingestion_time", "event_id"})
-
-	resource.RegisterPaginatedChild("cb_build_logs", func(ctx context.Context, clients any, parentCtx resource.ParentContext, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchCBBuildLogs(ctx, c.CloudWatchLogs, parentCtx["log_group_name"], parentCtx["log_stream_name"], continuationToken)
-	})
-
-	resource.RegisterChildType(resource.ResourceTypeDef{
-		Name:      "Build Logs",
-		ShortName: "cb_build_logs",
-		Columns:   resource.CBBuildLogColumns(),
-		CopyField: "message",
-	})
-}
-
 // FetchCBBuildLogs calls the CloudWatch Logs GetLogEvents API for a given
 // log group and stream (from a CodeBuild build), converting the response
 // into a FetchResult. This is a single-call API, but uses FetchResult for consistency.

--- a/internal/aws/cb_builds.go
+++ b/internal/aws/cb_builds.go
@@ -11,40 +11,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("cb_builds", []string{
-		"build_number", "build_status", "start_time", "end_time",
-		"duration", "source_version_short", "initiator", "build_id",
-		"build_arn", "current_phase", "source_version",
-		"resolved_source_version", "log_group_name", "log_stream_name",
-	})
-
-	resource.RegisterPaginatedChild("cb_builds", func(ctx context.Context, clients any, parentCtx resource.ParentContext, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchCBBuilds(ctx, c.CodeBuild, c.CodeBuild, parentCtx, continuationToken)
-	})
-
-	resource.RegisterChildType(resource.ResourceTypeDef{
-		Name:      "CodeBuild Builds",
-		ShortName: "cb_builds",
-		Columns:   resource.CBBuildColumns(),
-		CopyField: "build_id",
-		Children: []resource.ChildViewDef{{
-			ChildType:      "cb_build_logs",
-			Key:            "enter",
-			ContextKeys:    map[string]string{"log_group_name": "log_group_name", "log_stream_name": "log_stream_name", "build_number": "build_number"},
-			DisplayNameKey: "build_number",
-			DrillCondition: func(r resource.Resource) bool {
-				return r.Fields["log_group_name"] != ""
-			},
-			DrillBlockMessage: "Build logs not available in CloudWatch",
-		}},
-	})
-}
-
 // FetchCBBuilds performs a two-step fetch:
 // 1. ListBuildsForProject (single page) to collect build IDs
 // 2. BatchGetBuilds in chunks of 100 (API limit) to get full build details

--- a/internal/aws/codeartifact.go
+++ b/internal/aws/codeartifact.go
@@ -10,22 +10,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("codeartifact", []string{"repo_name", "domain_name", "description", "domain_owner"})
-
-	resource.RegisterPaginated("codeartifact", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchCodeArtifactReposPage(ctx, c.CodeArtifact, continuationToken)
-	})
-
-	resource.RegisterRelated("codeartifact", []resource.RelatedDef{
-		{TargetType: "kms", DisplayName: "KMS Key", Checker: checkCodeartifactKMS, NeedsTargetCache: false},
-	})
-}
-
 // FetchCodeArtifactRepos calls the CodeArtifact ListRepositories API and converts the
 // response into a slice of generic Resource structs.
 func FetchCodeArtifactRepos(ctx context.Context, api CodeArtifactListRepositoriesAPI) ([]resource.Resource, error) {

--- a/internal/aws/install.go
+++ b/internal/aws/install.go
@@ -157,10 +157,12 @@ func allTopLevelTypes() []catalog.ResourceTypeDef {
 //
 // First populated in AS-808 / PR #395 round-2 with containersChildTypes
 // (ecr_images); AS-815 / PR #397 adds securityChildTypes
-// (iam_group_members, role_policies).
+// (iam_group_members, role_policies); AS-816 / PR #400 adds cicdChildTypes
+// (cb_builds, cb_build_logs, pipeline_stages).
 func allChildTypes() []catalog.ResourceTypeDef {
 	var all []catalog.ResourceTypeDef
 	all = append(all, containersChildTypes...)
 	all = append(all, securityChildTypes...)
+	all = append(all, cicdChildTypes...)
 	return all
 }

--- a/internal/aws/pipeline.go
+++ b/internal/aws/pipeline.go
@@ -10,35 +10,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("pipeline", []string{"name", "pipeline_type", "version", "created", "updated"})
-
-	resource.RegisterPaginated("pipeline", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchCodePipelinesPage(ctx, c.CodePipeline, continuationToken)
-	})
-
-	resource.RegisterRelated("pipeline", []resource.RelatedDef{
-		{TargetType: "cb", DisplayName: "CodeBuild Projects", Checker: checkPipelineCB, NeedsTargetCache: false},
-		{TargetType: "role", DisplayName: "IAM Roles", Checker: checkPipelineRole, NeedsTargetCache: false},
-		{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkPipelineCFN, NeedsTargetCache: false},
-		{TargetType: "codeartifact", DisplayName: "CodeArtifact", Checker: checkPipelineCodeartifact, NeedsTargetCache: false},
-		{TargetType: "eb-rule", DisplayName: "EventBridge Rules", Checker: checkPipelineEbRule, NeedsTargetCache: false},
-		{TargetType: "ecr", DisplayName: "ECR Repositories", Checker: checkPipelineECR, NeedsTargetCache: false},
-		{TargetType: "ecs-svc", DisplayName: "ECS Services", Checker: checkPipelineECSSvc, NeedsTargetCache: false},
-		{TargetType: "kms", DisplayName: "KMS Key", Checker: checkPipelineKMS, NeedsTargetCache: false},
-		{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkPipelineLambda, NeedsTargetCache: false},
-		{TargetType: "s3", DisplayName: "S3 Buckets (artifacts)", Checker: checkPipelineS3, NeedsTargetCache: false},
-		{TargetType: "sns", DisplayName: "SNS Topics", Checker: checkPipelineSNS, NeedsTargetCache: false},
-	})
-
-	// cptypes.PipelineSummary (list response): no navigable fields — RoleArn and
-	// ArtifactStore are only on GetPipelineOutput, not the list summary struct used as RawStruct.
-}
-
 // FetchCodePipelines calls the CodePipeline ListPipelines API and converts
 // the response into a slice of generic Resource structs.
 func FetchCodePipelines(ctx context.Context, api CodePipelineListPipelinesAPI) ([]resource.Resource, error) {

--- a/internal/aws/pipeline_stages.go
+++ b/internal/aws/pipeline_stages.go
@@ -27,29 +27,6 @@ type PipelineStageRow struct {
 	RevisionSummary  string
 }
 
-func init() {
-	resource.RegisterFieldKeys("pipeline_stages", []string{
-		"stage_name", "stage_status", "action_name", "action_status",
-		"last_change_time", "external_url", "action_token",
-		"action_error_details", "revision_id", "revision_summary",
-	})
-
-	resource.RegisterPaginatedChild("pipeline_stages", func(ctx context.Context, clients any, parentCtx resource.ParentContext, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchPipelineStages(ctx, c.CodePipeline, parentCtx, continuationToken)
-	})
-
-	resource.RegisterChildType(resource.ResourceTypeDef{
-		Name:      "Pipeline Stages",
-		ShortName: "pipeline_stages",
-		Columns:   resource.PipelineStageColumns(),
-		CopyField: "external_url",
-	})
-}
-
 // FetchPipelineStages calls GetPipelineState and flattens the hierarchical
 // stages→actions response into a flat list of stage-action pair Resources.
 // A stage with N actions produces N rows. The stage_name field is set only


### PR DESCRIPTION
## Summary

Migrates the CI/CD category's per-type wiring from `init()` bodies in `internal/aws/<svc>.go` into the catalog struct literal in `internal/aws/catalog_cicd.go`. Per-category PR after AS-807 (compute), AS-808 (containers, with ecr-images child fixup), and AS-810 (databases). Spec: `docs/refactor/AS-795-init-cycle-break.md` §3 + §5.2.

## Scope (per AS-816 issue body)

Catalog entries populated for the 6 types in scope:

- **Top-level** (`cicdTypes`): `cb`, `pipeline`, `codeartifact` — each gains `Fetcher`, `FieldKeys`, `Related` (with explicit `ct-events` per AS-807 ct-events appendix invariant), and `Wave2` (all three CI/CD enrichers are real, not NoOp). `cb` additionally gains `Navigable` for the five ServiceRole / EncryptionKey / VpcConfig.* fields.
- **Child** (new `cicdChildTypes`): `cb_builds`, `cb_build_logs`, `pipeline_stages` — each gains `Name` / `ShortName` / `Columns` / `CopyField` / `FieldKeys` / `ChildFetcher` verbatim from the deleted `RegisterChildType` + `RegisterPaginatedChild` calls; `cb_builds` carries its `Children` pivot into `cb_build_logs` with `DrillCondition` preserved.

`init()` bodies removed from all six svc files:

- `internal/aws/{cb,cb_builds,cb_build_logs,pipeline,pipeline_stages,codeartifact}.go`

`*_issue_enrichment.go` files retained per AS-807 / AS-810 precedent — real `Enrich*` funcs stay in `IssueEnricherRegistry` until AS-795n migrates `BuildEnrichQueue` to `catalog.AllByWave2()`.

## install.go changes

- `bridgeCatalogToLegacy` gains the child-type replay loop (`RegisterChildType` / `RegisterPaginatedChild` / `RegisterFieldKeys`) so `GetChildType` / `GetPaginatedChildFetcher` continue to resolve migrated entries.
- `allChildTypes()` now returns `cicdChildTypes` (was: `return nil`).
- Mirrors the AS-808 PR #395 round-2 fixup pattern. Sibling open PRs (#395 containers, #397 security, #398 networking, #399 dns-cdn) introduce the same install.go scaffolding for their own categories — if any sibling merges first, this PR rebases with `allChildTypes()` appending both slices (no semantic conflict).

## Acceptance (per issue body)

- ✅ `rg '^func init\(\)' internal/aws/{cb,cb_builds,cb_build_logs,pipeline,pipeline_stages,codeartifact}.go` → zero hits
- ✅ `rg 'Fetcher:' internal/aws/catalog_cicd.go` → 6 hits (3 top-level `Fetcher:` + 3 child `ChildFetcher:`, one per cicd resource type in scope)
- ✅ `go build ./...` clean
- ✅ `go test ./...` — pass (`ok  tests/unit  24.4s`, `ok  tests/integration  0.4s`)
- ✅ `go test -tags integration ./...` — pass (`ok  tests/integration  58.9s`)
- ✅ `golangci-lint run ./...` — `0 issues`
- ✅ `govulncheck ./...` — `No vulnerabilities found`
- ✅ `go fix -inline -diff ./...` — no unfixed directives
- ✅ Golden / Scenario unit snapshots — pass
- ✅ Visual / Scenario integration snapshots — pass
- ⏭ `./a9s --demo`: binary launches but cicd list+detail render parity smoke requires a TTY this pod lacks (documented under AS-149). The catalog Install bridge replays the same `Fetcher`/`Related`/`Navigable`/`Wave2` onto the legacy maps via `aws.Install()`, so on-program-load behavior is byte-identical to pre-migration.
- ⏭ `test-race`: blocked by missing cgo/gcc in this pod (AS-149).

## Test plan

- [ ] CI runs all required checks against this branch
- [ ] Reviewer pulls the branch locally and runs `./a9s --demo` → navigate to CI/CD category → enter `cb` → drill into a project → enter to see builds → enter to see build logs; navigate to `pipeline` → drill into stages; navigate to `codeartifact`. List columns, related panel, and detail values should be identical to main.

Parent: AS-805 (umbrella).
Depends on: AS-795a / PR #392 (merged 0854787).