### PR TITLE
feat(refactor): AS-811 monitoring category init() → catalog migration

### DIFF
--- a/internal/aws/alarm.go
+++ b/internal/aws/alarm.go
@@ -12,40 +12,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("alarm", []string{"alarm_name", "state", "metric_name", "namespace", "threshold", "actions_count"})
-
-	resource.RegisterPaginated("alarm", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchCloudWatchAlarmsPage(ctx, c.CloudWatch, continuationToken)
-	})
-
-	resource.RegisterRelated("alarm", []resource.RelatedDef{
-		{TargetType: "sns", DisplayName: "SNS Topics", Checker: checkAlarmSNS, NeedsTargetCache: false},
-		{TargetType: "asg", DisplayName: "Auto Scaling Groups", Checker: checkAlarmASG, NeedsTargetCache: true},
-		{TargetType: "apigw", DisplayName: "API Gateways", Checker: checkAlarmAPIGW},
-		{TargetType: "cb", DisplayName: "CodeBuild Projects", Checker: checkAlarmCB},
-		{TargetType: "dbi", DisplayName: "RDS Instances", Checker: checkAlarmDBI},
-		{TargetType: "ec2", DisplayName: "EC2 Instances", Checker: checkAlarmEC2},
-		{TargetType: "ecs", DisplayName: "ECS Clusters", Checker: checkAlarmECS},
-		{TargetType: "eks", DisplayName: "EKS Clusters", Checker: checkAlarmEKS},
-		{TargetType: "kms", DisplayName: "KMS Keys", Checker: checkAlarmKMS},
-		{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkAlarmLambda},
-		{TargetType: "logs", DisplayName: "Log Groups", Checker: checkAlarmLogs},
-		{TargetType: "s3", DisplayName: "S3 Buckets", Checker: checkAlarmS3},
-		{TargetType: "sfn", DisplayName: "Step Functions", Checker: checkAlarmSFN},
-		{TargetType: "waf", DisplayName: "WAF Web ACLs", Checker: checkAlarmWAF},
-		{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: checkAlarmCTEvents, NeedsTargetCache: true},
-	})
-
-	// cwtypes.MetricAlarm: Dimensions[].Value may reference EC2/RDS/ELB IDs but Dimensions
-	// is heterogeneous — a single FieldPath cannot map to one target type. AlarmActions/OKActions
-	// contain SNS ARNs, already handled by checkAlarmSNS. No single-type NavigableField applicable.
-}
-
 // FetchCloudWatchAlarms calls the CloudWatch DescribeAlarms API and returns all
 // pages of alarms. Used by tests; the production path uses the per-page fetcher for pagination.
 func FetchCloudWatchAlarms(ctx context.Context, api CloudWatchDescribeAlarmsAPI) ([]resource.Resource, error) {

--- a/internal/aws/catalog_monitoring.go
+++ b/internal/aws/catalog_monitoring.go
@@ -1,11 +1,14 @@
 package aws
 
 import (
+	"context"
+	"fmt"
 	"strconv"
 	"time"
 
 	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/domain"
+	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/semantics/ctevent"
 )
 
@@ -88,6 +91,31 @@ var monitoringTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			DisplayNameKey: "alarm_name",
 		}},
 		Color: colorAlarm,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchCloudWatchAlarmsPage(ctx, c.CloudWatch, continuationToken)
+		},
+		FieldKeys: []string{"alarm_name", "state", "metric_name", "namespace", "threshold", "actions_count"},
+		Related: []domain.RelatedDef{
+			{TargetType: "sns", DisplayName: "SNS Topics", Checker: checkAlarmSNS, NeedsTargetCache: false},
+			{TargetType: "asg", DisplayName: "Auto Scaling Groups", Checker: checkAlarmASG, NeedsTargetCache: true},
+			{TargetType: "apigw", DisplayName: "API Gateways", Checker: checkAlarmAPIGW},
+			{TargetType: "cb", DisplayName: "CodeBuild Projects", Checker: checkAlarmCB},
+			{TargetType: "dbi", DisplayName: "RDS Instances", Checker: checkAlarmDBI},
+			{TargetType: "ec2", DisplayName: "EC2 Instances", Checker: checkAlarmEC2},
+			{TargetType: "ecs", DisplayName: "ECS Clusters", Checker: checkAlarmECS},
+			{TargetType: "eks", DisplayName: "EKS Clusters", Checker: checkAlarmEKS},
+			{TargetType: "kms", DisplayName: "KMS Keys", Checker: checkAlarmKMS},
+			{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkAlarmLambda},
+			{TargetType: "logs", DisplayName: "Log Groups", Checker: checkAlarmLogs},
+			{TargetType: "s3", DisplayName: "S3 Buckets", Checker: checkAlarmS3},
+			{TargetType: "sfn", DisplayName: "Step Functions", Checker: checkAlarmSFN},
+			{TargetType: "waf", DisplayName: "WAF Web ACLs", Checker: checkAlarmWAF},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: checkAlarmCTEvents, NeedsTargetCache: true},
+		},
 	},
 	{
 		Name:          "CloudWatch Log Groups",
@@ -108,6 +136,28 @@ var monitoringTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			DisplayNameKey: "log_group_name",
 		}},
 		Color: colorLogs,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchCloudWatchLogGroupsPage(ctx, c.CloudWatchLogs, continuationToken)
+		},
+		Wave2:     IssueEnricher{Fn: EnrichLogsMetricFilters, Priority: 100},
+		FieldKeys: []string{"log_group_name", "stored_bytes", "retention_days", "creation_time", "kms_key_id"},
+		Related: []domain.RelatedDef{
+			{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkLogsLambda, NeedsTargetCache: true},
+			{TargetType: "alarm", DisplayName: "CW Alarms", Checker: checkLogsAlarms, NeedsTargetCache: true},
+			{TargetType: "kms", DisplayName: "KMS Key", Checker: checkLogsKMS},
+			{TargetType: "apigw", DisplayName: "API Gateway", Checker: checkLogsAPIGW, NeedsTargetCache: true},
+			{TargetType: "ecs-task", DisplayName: "ECS Tasks", Checker: checkLogsECSTask, NeedsTargetCache: true},
+			{TargetType: "kinesis", DisplayName: "Kinesis Streams", Checker: checkLogsKinesis},
+			{TargetType: "s3", DisplayName: "S3 (exports)", Checker: checkLogsS3},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("logs")},
+		},
+		Navigable: []domain.NavigableField{
+			{FieldPath: "KmsKeyId", TargetType: "kms"},
+		},
 	},
 	{
 		Name:          "CloudTrail Trails",
@@ -122,6 +172,36 @@ var monitoringTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 			{Key: "multi_region", Title: "Multi-Region", Width: 14, Sortable: true},
 		},
 		Color: colorTrail,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			resources, err := FetchCloudTrailTrails(ctx, c.CloudTrail)
+			if err != nil {
+				return resource.FetchResult{}, err
+			}
+			return resource.FetchResult{
+				Resources:  resources,
+				Pagination: &resource.PaginationMeta{IsTruncated: false, TotalHint: len(resources), PageSize: len(resources)},
+			}, nil
+		},
+		FieldKeys: []string{"trail_name", "s3_bucket", "home_region", "multi_region", "is_logging", "latest_delivery_error", "log_file_validation_enabled"},
+		Related: []domain.RelatedDef{
+			{TargetType: "s3", DisplayName: "S3 Bucket", Checker: checkTrailS3, NeedsTargetCache: true},
+			{TargetType: "logs", DisplayName: "Log Groups", Checker: checkTrailLogs, NeedsTargetCache: true},
+			{TargetType: "sns", DisplayName: "SNS Topic", Checker: checkTrailSNS, NeedsTargetCache: true},
+			{TargetType: "kms", DisplayName: "KMS Key", Checker: checkTrailKMS, NeedsTargetCache: true},
+			{TargetType: "role", DisplayName: "IAM Role", Checker: checkTrailRole},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("trail")},
+		},
+		Navigable: []domain.NavigableField{
+			{FieldPath: "S3BucketName", TargetType: "s3"},
+			{FieldPath: "KmsKeyId", TargetType: "kms"},
+			{FieldPath: "SnsTopicARN", TargetType: "sns"},
+			{FieldPath: "CloudWatchLogsLogGroupArn", TargetType: "logs"},
+			{FieldPath: "CloudWatchLogsRoleArn", TargetType: "role"},
+		},
 	},
 	{
 		Name:      "CloudTrail Events",
@@ -140,5 +220,43 @@ var monitoringTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // st
 		ExcludeFromIssueBadge: true,
 		Color:                 colorCTEvents,
 		Project:               ctevent.Project,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchCloudTrailEventsPage(ctx, c.CloudTrail, continuationToken)
+		},
+		FilteredFetcher: func(ctx context.Context, clients any, filter map[string]string, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchCloudTrailEventsPageFiltered(ctx, c.CloudTrail, filter, continuationToken)
+		},
+		FieldKeys: []string{"event_name", "time", "event_time", "event_time_raw", "user", "source", "resource_type", "resource_name", "read_only", "role_name", "status", "_ct.verb", "_ct.actor", "_ct.origin", "_ct.target", "_ct.target_raw", "_ct.outcome"},
+		Related: []domain.RelatedDef{
+			{TargetType: "role", DisplayName: "IAM Roles", Checker: checkCtEventsRole, NeedsTargetCache: true},
+			{TargetType: "iam-user", DisplayName: "IAM Users", Checker: checkCtEventsUser, NeedsTargetCache: true},
+			{TargetType: "ec2", DisplayName: "EC2 Instances", Checker: checkCtEventsEC2, NeedsTargetCache: true},
+			{TargetType: "s3", DisplayName: "S3 Buckets", Checker: checkCtEventsS3, NeedsTargetCache: true},
+			{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkCtEventsLambda, NeedsTargetCache: true},
+			{TargetType: "dbi", DisplayName: "RDS Instances", Checker: checkCtEventsRDS, NeedsTargetCache: true},
+			{TargetType: "kms", DisplayName: "KMS Keys", Checker: checkCtEventsKMS, NeedsTargetCache: true},
+			{TargetType: "secrets", DisplayName: "Secrets", Checker: checkCtEventsSecrets, NeedsTargetCache: true},
+			{TargetType: "vpce", DisplayName: "VPC Endpoints", Checker: checkCtEventsVPCE, NeedsTargetCache: true},
+			{TargetType: "sg", DisplayName: "Security Groups", Checker: checkCtEventsSG, NeedsTargetCache: true},
+			{TargetType: "ddb", DisplayName: "DynamoDB Tables", Checker: checkCtEventsDDB, NeedsTargetCache: true},
+			{TargetType: "cfn", DisplayName: "CloudFormation Stacks", Checker: checkCtEventsCFN, NeedsTargetCache: true},
+			{TargetType: "trail", DisplayName: "CloudTrail Trails", Checker: checkCtEventsTrail, NeedsTargetCache: true},
+			{TargetType: "ct-events", DisplayName: "CT events by AccessKeyId", Checker: checkCtEventsPivotByAccessKeyId, NeedsTargetCache: false},
+			{TargetType: "ct-events", DisplayName: "CT events by Username", Checker: checkCtEventsPivotByUsername, NeedsTargetCache: false},
+			{TargetType: "ct-events", DisplayName: "CT events by EventName", Checker: checkCtEventsPivotByEventName, NeedsTargetCache: false},
+			{TargetType: "ct-events", DisplayName: "CT events by SharedEventId", Checker: checkCtEventsPivotBySharedEventId, NeedsTargetCache: false},
+		},
+		Navigable: []domain.NavigableField{
+			{FieldPath: "user", TargetType: "iam-user"},
+			{FieldPath: "role_name", TargetType: "role"},
+		},
 	},
 }

--- a/internal/aws/ct_events.go
+++ b/internal/aws/ct_events.go
@@ -16,54 +16,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/semantics/ctevent"
 )
 
-func init() {
-	resource.RegisterFieldKeys("ct-events", []string{"event_name", "time", "event_time", "event_time_raw", "user", "source", "resource_type", "resource_name", "read_only", "role_name", "status", "_ct.verb", "_ct.actor", "_ct.origin", "_ct.target", "_ct.target_raw", "_ct.outcome"})
-
-	// Paginated fetcher for resource list browsing (M key load-more).
-	resource.RegisterPaginated("ct-events", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchCloudTrailEventsPage(ctx, c.CloudTrail, continuationToken)
-	})
-
-	// Filtered paginated fetcher for related navigation (e.g., IAM User → ct-events via Username).
-	resource.RegisterFilteredPaginated("ct-events", func(ctx context.Context, clients any, filter map[string]string, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchCloudTrailEventsPageFiltered(ctx, c.CloudTrail, filter, continuationToken)
-	})
-
-	resource.RegisterRelated("ct-events", []resource.RelatedDef{
-		{TargetType: "role", DisplayName: "IAM Roles", Checker: checkCtEventsRole, NeedsTargetCache: true},
-		{TargetType: "iam-user", DisplayName: "IAM Users", Checker: checkCtEventsUser, NeedsTargetCache: true},
-		{TargetType: "ec2", DisplayName: "EC2 Instances", Checker: checkCtEventsEC2, NeedsTargetCache: true},
-		{TargetType: "s3", DisplayName: "S3 Buckets", Checker: checkCtEventsS3, NeedsTargetCache: true},
-		{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkCtEventsLambda, NeedsTargetCache: true},
-		{TargetType: "dbi", DisplayName: "RDS Instances", Checker: checkCtEventsRDS, NeedsTargetCache: true},
-		{TargetType: "kms", DisplayName: "KMS Keys", Checker: checkCtEventsKMS, NeedsTargetCache: true},
-		{TargetType: "secrets", DisplayName: "Secrets", Checker: checkCtEventsSecrets, NeedsTargetCache: true},
-		{TargetType: "vpce", DisplayName: "VPC Endpoints", Checker: checkCtEventsVPCE, NeedsTargetCache: true},
-		{TargetType: "sg", DisplayName: "Security Groups", Checker: checkCtEventsSG, NeedsTargetCache: true},
-		{TargetType: "ddb", DisplayName: "DynamoDB Tables", Checker: checkCtEventsDDB, NeedsTargetCache: true},
-		{TargetType: "cfn", DisplayName: "CloudFormation Stacks", Checker: checkCtEventsCFN, NeedsTargetCache: true},
-		{TargetType: "trail", DisplayName: "CloudTrail Trails", Checker: checkCtEventsTrail, NeedsTargetCache: true},
-		// Self-pivot entries (ct-events → ct-events): navigate to events filtered by attribute.
-		{TargetType: "ct-events", DisplayName: "CT events by AccessKeyId", Checker: checkCtEventsPivotByAccessKeyId, NeedsTargetCache: false},
-		{TargetType: "ct-events", DisplayName: "CT events by Username", Checker: checkCtEventsPivotByUsername, NeedsTargetCache: false},
-		{TargetType: "ct-events", DisplayName: "CT events by EventName", Checker: checkCtEventsPivotByEventName, NeedsTargetCache: false},
-		{TargetType: "ct-events", DisplayName: "CT events by SharedEventId", Checker: checkCtEventsPivotBySharedEventId, NeedsTargetCache: false},
-	})
-
-	resource.RegisterDefaultNavFields("ct-events", []resource.NavigableField{
-		{FieldPath: "user", TargetType: "iam-user"},
-		{FieldPath: "role_name", TargetType: "role"},
-	})
-}
-
 // FetchCloudTrailEvents fetches all CloudTrail LookupEvents pages and returns
 // the combined resources. Used by related-resource cold-cache checks and tests.
 func FetchCloudTrailEvents(ctx context.Context, api CloudTrailLookupEventsAPI) ([]resource.Resource, error) {

--- a/internal/aws/cwlogs.go
+++ b/internal/aws/cwlogs.go
@@ -10,33 +10,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("logs", []string{"log_group_name", "stored_bytes", "retention_days", "creation_time", "kms_key_id"})
-
-	resource.RegisterPaginated("logs", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchCloudWatchLogGroupsPage(ctx, c.CloudWatchLogs, continuationToken)
-	})
-
-	resource.RegisterRelated("logs", []resource.RelatedDef{
-		{TargetType: "lambda", DisplayName: "Lambda Functions", Checker: checkLogsLambda, NeedsTargetCache: true},
-		{TargetType: "alarm", DisplayName: "CW Alarms", Checker: checkLogsAlarms, NeedsTargetCache: true},
-		{TargetType: "kms", DisplayName: "KMS Key", Checker: checkLogsKMS},
-		{TargetType: "apigw", DisplayName: "API Gateway", Checker: checkLogsAPIGW, NeedsTargetCache: true},
-		{TargetType: "ecs-task", DisplayName: "ECS Tasks", Checker: checkLogsECSTask, NeedsTargetCache: true},
-		{TargetType: "kinesis", DisplayName: "Kinesis Streams", Checker: checkLogsKinesis},
-		{TargetType: "s3", DisplayName: "S3 (exports)", Checker: checkLogsS3},
-	})
-
-	// cloudwatchlogstypes.LogGroup: KmsKeyId
-	resource.RegisterDefaultNavFields("logs", []resource.NavigableField{
-		{FieldPath: "KmsKeyId", TargetType: "kms"},
-	})
-}
-
 // FetchCloudWatchLogGroups calls the CloudWatchLogs DescribeLogGroups API and
 // returns all pages of log groups. Used by tests; the production path uses the per-page fetcher for pagination.
 func FetchCloudWatchLogGroups(ctx context.Context, api CWLogsDescribeLogGroupsAPI) ([]resource.Resource, error) {

--- a/internal/aws/trail.go
+++ b/internal/aws/trail.go
@@ -9,25 +9,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("trail", []string{"trail_name", "s3_bucket", "home_region", "multi_region", "is_logging", "latest_delivery_error", "log_file_validation_enabled"})
-
-	resource.RegisterPaginated("trail", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		resources, err := FetchCloudTrailTrails(ctx, c.CloudTrail)
-		if err != nil {
-			return resource.FetchResult{}, err
-		}
-		return resource.FetchResult{
-			Resources:  resources,
-			Pagination: &resource.PaginationMeta{IsTruncated: false, TotalHint: len(resources), PageSize: len(resources)},
-		}, nil
-	})
-}
-
 // FetchCloudTrailTrails calls DescribeTrails and GetTrailStatus (per trail)
 // so the list row can classify `is_logging=false` / `latest_delivery_error` as
 // broken. GetTrailStatus is the authoritative source for logging health; the

--- a/internal/aws/trail_related.go
+++ b/internal/aws/trail_related.go
@@ -10,24 +10,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterRelated("trail", []resource.RelatedDef{
-		{TargetType: "s3", DisplayName: "S3 Bucket", Checker: checkTrailS3, NeedsTargetCache: true},
-		{TargetType: "logs", DisplayName: "Log Groups", Checker: checkTrailLogs, NeedsTargetCache: true},
-		{TargetType: "sns", DisplayName: "SNS Topic", Checker: checkTrailSNS, NeedsTargetCache: true},
-		{TargetType: "kms", DisplayName: "KMS Key", Checker: checkTrailKMS, NeedsTargetCache: true},
-		{TargetType: "role", DisplayName: "IAM Role", Checker: checkTrailRole},
-	})
-
-	resource.RegisterDefaultNavFields("trail", []resource.NavigableField{
-		{FieldPath: "S3BucketName", TargetType: "s3"},
-		{FieldPath: "KmsKeyId", TargetType: "kms"},
-		{FieldPath: "SnsTopicARN", TargetType: "sns"},
-		{FieldPath: "CloudWatchLogsLogGroupArn", TargetType: "logs"},
-		{FieldPath: "CloudWatchLogsRoleArn", TargetType: "role"},
-	})
-}
-
 // checkTrailS3 searches the s3 cache for the bucket this trail writes logs to.
 // Pattern C — match S3BucketName from RawStruct against s3 cache IDs (bucket names).
 func checkTrailS3(ctx context.Context, clients any, res resource.Resource, cache resource.ResourceCache) resource.RelatedCheckResult {


### PR DESCRIPTION
Migrates the **monitoring** category's per-type wiring from `init()` bodies in `internal/aws/<svc>.go` into the catalog struct literal in `internal/aws/catalog_monitoring.go`.

Per-category PR after AS-807 (compute), AS-808/810 (databases). Spec: `docs/refactor/AS-795-init-cycle-break.md` §3 + §5.2.

## Summary

- **Catalog entries populated** for the 4 top-level monitoring types: `alarm`, `logs`, `trail`, `ct-events`. Each entry gains `Fetcher`, `FieldKeys`, `Related`, `Navigable` as applicable, plus `Wave2` for the one real enricher (`logs` → `EnrichLogsMetricFilters`). `alarm`/`trail`/`ct-events` register NoOp per `docs/attention-signals.md` (trail's fetcher does in-line Wave 2 `GetTrailStatus`), so `Wave2` stays nil per the AS-795 spec §5.2 template. `ct-events` also gains `FilteredFetcher` for related-pivot navigation.
- **Files with `func init()` removed**: `internal/aws/{alarm,cwlogs,trail,ct_events}.go` and `internal/aws/trail_related.go`.
- **Files retained for legacy consumers** (same rationale as AS-807/AS-810): `internal/aws/{alarm,logs,trail,ct_events}_issue_enrichment.go` — the legacy `IssueEnricherRegistry` is still iterated by `BuildEnrichQueue` / `runtime_adapter_navigate` / `probe_adapter` / `TestAttentionSignalsDoc`; AS-795n deletes those consumers and the legacy registry. `logs_issue_enrichment.go` also still owns `RegisterIssueEnricherFieldKeys("logs", ["last_event_at"])`.
- **ct-events RelatedDef bridge**: `logs` and `trail` catalog entries gain an explicit ct-events Related entry via `ctEventsCheckerFor()` so the Install bridge does not clobber the `zzz_ct_events_all_related.go` init append. `alarm` already had a custom ct-events checker (`checkAlarmCTEvents`) — preserved verbatim. `ct-events` self-pivots via the four existing `checkCtEventsPivotBy*` functions.
- **Out of scope per sibling precedent** (AS-807, AS-810): child-type files `log_streams.go` and `log_events.go` keep their `init()` bodies. Child types use `catalog.SetChildTypes` (empty in AS-795a) — neither AS-807 nor AS-810 migrated their child types (`asg_activities`, `ecs_svc_events`, `rds_events`, etc.) and AS-811 follows the same pattern.

## Acceptance per AS-811 issue body

```bash
rg '^func init\(\)' internal/aws/alarm.go internal/aws/cwlogs.go internal/aws/trail.go internal/aws/ct_events.go internal/aws/trail_related.go
# zero hits ✓

rg 'Fetcher:' internal/aws/catalog_monitoring.go
# 5 hits (4 top-level entries + 1 FilteredFetcher on ct-events) ✓
```

Plus locally green: `go build`, `go test ./tests/unit/`, `go test -tags integration ./tests/integration/`, `golangci-lint`, `govulncheck`, `gofix`, `verify-readonly`, `check-readme`, snapshot tests, `mdlint`. `test-race` blocked by missing cgo/gcc in this pod (documented under AS-149).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./tests/unit/ -count=1 -timeout 180s` — `ok 36.969s`
- [x] `go test -tags integration ./tests/integration/... -count=1` — `ok 47.831s`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `govulncheck ./...` — no vulnerabilities
- [x] `go fix -inline -diff ./...` — clean
- [x] `go test ./tests/unit/ -run 'Golden|Scenario'` + `go test -tags integration -run 'Visual|Scenario'` snapshot suites green
- [x] `markdownlint-cli2` clean
- [ ] CI `test-race` (this pod lacks cgo/gcc per AS-149; relying on GitHub Actions)
- [ ] CI required-checks green on `feat/as-811-monitoring-catalog`

## Parent / dependencies

- Parent umbrella: AS-805
- Depends on: AS-795a / PR #392 (merged)
- Sibling category PRs: #393 (AS-807 compute, merged), #395 (AS-808 containers, open), #396 (AS-810 databases, merged), #397 (AS-815 security, open), #398 (AS-809 networking, open), #399 (AS-814 dns-cdn, open), #400 (AS-816 cicd, open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)