### PR TITLE
feat(refactor): AS-813 secrets category init() → catalog migration

### DIFF
--- a/internal/aws/catalog_secrets.go
+++ b/internal/aws/catalog_secrets.go
@@ -1,11 +1,14 @@
 package aws
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/domain"
+	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func colorSecrets(r domain.Resource) domain.Color {
@@ -81,6 +84,39 @@ var secretsTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // stati
 			{Key: "rotation_enabled", Title: "Rotation", Width: 10, Sortable: true},
 		},
 		Color: colorSecrets,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchSecretsPage(ctx, c.SecretsManager, continuationToken)
+		},
+		Reveal: func(ctx context.Context, clients any, resourceID string) (string, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return "", fmt.Errorf("AWS clients not initialized")
+			}
+			return RevealSecret(ctx, c.SecretsManager, resourceID)
+		},
+		FieldKeys: []string{"secret_name", "description", "last_accessed", "last_changed", "rotation_enabled", "arn", "status"},
+		Related: []domain.RelatedDef{
+			{TargetType: "kms", DisplayName: "KMS Keys", Checker: checkSecretsKMS, NeedsTargetCache: true},
+			{TargetType: "lambda", DisplayName: "Lambda (rotation)", Checker: checkSecretsLambda, NeedsTargetCache: true},
+			{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkSecretsCFN, NeedsTargetCache: true},
+			{TargetType: "dbi", DisplayName: "RDS Instances", Checker: checkSecretsDBI, NeedsTargetCache: true},
+			{TargetType: "cb", DisplayName: "CodeBuild Projects", Checker: checkSecretsCB, NeedsTargetCache: true},
+			{TargetType: "codeartifact", DisplayName: "CodeArtifact Domains", Checker: checkSecretsCodeArtifact},
+			{TargetType: "eb", DisplayName: "Elastic Beanstalk", Checker: checkSecretsEB, NeedsTargetCache: true},
+			{TargetType: "ecs-task", DisplayName: "ECS Tasks", Checker: checkSecretsECSTask, NeedsTargetCache: true},
+			{TargetType: "logs", DisplayName: "Log Groups", Checker: checkSecretsLogs},
+			{TargetType: "role", DisplayName: "IAM Roles", Checker: checkSecretsRole},
+			{TargetType: "sns", DisplayName: "SNS Topics", Checker: checkSecretsSNS},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("secrets")},
+		},
+		Navigable: []domain.NavigableField{
+			{FieldPath: "KmsKeyId", TargetType: "kms"},
+			{FieldPath: "RotationLambdaARN", TargetType: "lambda"},
+		},
 	},
 	{
 		Name:          "SSM Parameters",
@@ -96,6 +132,28 @@ var secretsTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // stati
 			{Key: "description", Title: "Description", Width: 30, Sortable: false},
 		},
 		Color: colorSSM,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchSSMParametersPage(ctx, c.SSM, continuationToken)
+		},
+		Reveal: func(ctx context.Context, clients any, resourceID string) (string, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return "", fmt.Errorf("AWS clients not initialized")
+			}
+			return RevealSSMParameter(ctx, c.SSM, resourceID)
+		},
+		FieldKeys: []string{"name", "type", "version", "last_modified", "description", "risk"},
+		Related: []domain.RelatedDef{
+			{TargetType: "kms", DisplayName: "KMS Key", Checker: checkSSMKMS, NeedsTargetCache: true},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("ssm")},
+		},
+		Navigable: []domain.NavigableField{
+			{FieldPath: "KeyId", TargetType: "kms"},
+		},
 	},
 	{
 		Name:          "KMS Keys",
@@ -111,5 +169,30 @@ var secretsTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // stati
 			{Key: "description", Title: "Description", Width: 36, Sortable: false},
 		},
 		Color: colorKMS,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchKMSKeysPage(ctx, c, continuationToken)
+		},
+		Wave2: IssueEnricher{Fn: EnrichKMSRotation, Priority: 100},
+		FetchByIDs: func(ctx context.Context, clients any, ids []string) ([]resource.Resource, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return nil, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchKMSKeysByIDs(ctx, c, ids)
+		},
+		FieldKeys:              []string{"alias", "key_id", "status", "description"},
+		IssueEnricherFieldKeys: []string{"rotation_enabled"},
+		Related: []domain.RelatedDef{
+			{TargetType: "ebs", DisplayName: "EBS Volumes", Checker: checkKMSEBS, NeedsTargetCache: true},
+			{TargetType: "dbi", DisplayName: "RDS Instances", Checker: checkKMSRDS, NeedsTargetCache: true},
+			{TargetType: "secrets", DisplayName: "Secrets Manager", Checker: checkKMSSecrets, NeedsTargetCache: true},
+			{TargetType: "s3", DisplayName: "S3 Buckets", Checker: checkKMSS3, NeedsTargetCache: false},
+			{TargetType: "role", DisplayName: "IAM Roles (grants)", Checker: checkKMSRole, NeedsTargetCache: false},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("kms")},
+		},
 	},
 }

--- a/internal/aws/kms.go
+++ b/internal/aws/kms.go
@@ -12,34 +12,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("kms", []string{"alias", "key_id", "status", "description"})
-
-	resource.RegisterPaginated("kms", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchKMSKeysPage(ctx, c, continuationToken)
-	})
-
-	resource.RegisterFetchByIDs("kms", func(ctx context.Context, clients any, ids []string) ([]resource.Resource, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return nil, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchKMSKeysByIDs(ctx, c, ids)
-	})
-
-	resource.RegisterRelated("kms", []resource.RelatedDef{
-		{TargetType: "ebs", DisplayName: "EBS Volumes", Checker: checkKMSEBS, NeedsTargetCache: true},
-		{TargetType: "dbi", DisplayName: "RDS Instances", Checker: checkKMSRDS, NeedsTargetCache: true},
-		{TargetType: "secrets", DisplayName: "Secrets Manager", Checker: checkKMSSecrets, NeedsTargetCache: true},
-		{TargetType: "s3", DisplayName: "S3 Buckets", Checker: checkKMSS3, NeedsTargetCache: false},
-		{TargetType: "role", DisplayName: "IAM Roles (grants)", Checker: checkKMSRole, NeedsTargetCache: false},
-	})
-}
-
 // FetchKMSKeysPage fetches a single page of KMS keys using the registered
 // paginated fetcher pattern.
 //

--- a/internal/aws/secrets.go
+++ b/internal/aws/secrets.go
@@ -12,25 +12,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("secrets", []string{"secret_name", "description", "last_accessed", "last_changed", "rotation_enabled", "arn", "status"})
-	resource.RegisterRevealFetcher("secrets", func(ctx context.Context, clients any, resourceID string) (string, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return "", fmt.Errorf("AWS clients not initialized")
-		}
-		return RevealSecret(ctx, c.SecretsManager, resourceID)
-	})
-
-	resource.RegisterPaginated("secrets", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchSecretsPage(ctx, c.SecretsManager, continuationToken)
-	})
-}
-
 // FetchSecrets calls the SecretsManager ListSecrets API and returns all pages
 // of secrets. Used by tests; the production path uses the per-page fetcher for pagination.
 func FetchSecrets(ctx context.Context, api SecretsManagerListSecretsAPI) ([]resource.Resource, error) {

--- a/internal/aws/secrets_related.go
+++ b/internal/aws/secrets_related.go
@@ -13,29 +13,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterRelated("secrets", []resource.RelatedDef{
-		{TargetType: "kms", DisplayName: "KMS Keys", Checker: checkSecretsKMS, NeedsTargetCache: true},
-		{TargetType: "lambda", DisplayName: "Lambda (rotation)", Checker: checkSecretsLambda, NeedsTargetCache: true},
-		{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkSecretsCFN, NeedsTargetCache: true},
-		{TargetType: "dbi", DisplayName: "RDS Instances", Checker: checkSecretsDBI, NeedsTargetCache: true},
-		{TargetType: "cb", DisplayName: "CodeBuild Projects", Checker: checkSecretsCB, NeedsTargetCache: true},
-		{TargetType: "codeartifact", DisplayName: "CodeArtifact Domains", Checker: checkSecretsCodeArtifact},
-		{TargetType: "eb", DisplayName: "Elastic Beanstalk", Checker: checkSecretsEB, NeedsTargetCache: true},
-		{TargetType: "ecs-task", DisplayName: "ECS Tasks", Checker: checkSecretsECSTask, NeedsTargetCache: true},
-		{TargetType: "logs", DisplayName: "Log Groups", Checker: checkSecretsLogs},
-		{TargetType: "role", DisplayName: "IAM Roles", Checker: checkSecretsRole},
-		{TargetType: "sns", DisplayName: "SNS Topics", Checker: checkSecretsSNS},
-	})
-
-	// smtypes.SecretListEntry: KmsKeyId (full ARN — UI resolves UUID suffix to kms cache),
-	// RotationLambdaARN (full ARN — UI resolves function name suffix to lambda cache)
-	resource.RegisterDefaultNavFields("secrets", []resource.NavigableField{
-		{FieldPath: "KmsKeyId", TargetType: "kms"},
-		{FieldPath: "RotationLambdaARN", TargetType: "lambda"},
-	})
-}
-
 // checkSecretsKMS returns the KMS key used to encrypt this secret (Pattern F).
 // KmsKeyId is a full ARN (arn:aws:kms:region:account:key/{uuid}); we extract the
 // UUID after the last "/" and search the kms cache for a matching resource ID.

--- a/internal/aws/ssm.go
+++ b/internal/aws/ssm.go
@@ -12,25 +12,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("ssm", []string{"name", "type", "version", "last_modified", "description", "risk"})
-	resource.RegisterRevealFetcher("ssm", func(ctx context.Context, clients any, resourceID string) (string, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return "", fmt.Errorf("AWS clients not initialized")
-		}
-		return RevealSSMParameter(ctx, c.SSM, resourceID)
-	})
-
-	resource.RegisterPaginated("ssm", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchSSMParametersPage(ctx, c.SSM, continuationToken)
-	})
-}
-
 // FetchSSMParameters calls the SSM DescribeParameters API and returns all pages
 // of parameters. Used by tests; the production path uses the per-page fetcher for pagination.
 func FetchSSMParameters(ctx context.Context, api SSMDescribeParametersAPI) ([]resource.Resource, error) {

--- a/internal/aws/ssm_related.go
+++ b/internal/aws/ssm_related.go
@@ -9,17 +9,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterRelated("ssm", []resource.RelatedDef{
-		{TargetType: "kms", DisplayName: "KMS Key", Checker: checkSSMKMS, NeedsTargetCache: true},
-	})
-
-	// ssmtypes.ParameterMetadata: KeyId (present for SecureString parameters)
-	resource.RegisterDefaultNavFields("ssm", []resource.NavigableField{
-		{FieldPath: "KeyId", TargetType: "kms"},
-	})
-}
-
 // checkSSMKMS checks the KMS cache for the key used to encrypt this SecureString parameter.
 // Pattern C: extracts KeyId from RawStruct, then scans the kms cache for a match.
 func checkSSMKMS(ctx context.Context, clients any, res resource.Resource, cache resource.ResourceCache) resource.RelatedCheckResult {


### PR DESCRIPTION
## Summary

Migrates the **secrets** category's per-type wiring from `init()` bodies in `internal/aws/<svc>.go` (and matching `*_related.go`) into the catalog struct literal in `internal/aws/catalog_secrets.go`. Per-category PR after AS-807 (compute), AS-808 (containers), AS-810 (databases), AS-811 (monitoring), AS-812 (messaging). Spec: [`docs/refactor/AS-795-init-cycle-break.md`](../blob/main/docs/refactor/AS-795-init-cycle-break.md) §3 + §5.2.

Catalog entries populated for the 3 top-level secrets types named in `catalog_secrets.go`: **secrets**, **ssm**, **kms**. Each gains `Fetcher`, `FieldKeys`, and `Related` (with an explicit `ct-events` entry so the `aws.Install()` bridge does not clobber `zzz_ct_events_all_related.go`'s init append — same precedent as AS-810/AS-811/AS-812).

Type-specific fields populated:

| Type | Wave 2 | Reveal | FetchByIDs | Navigable | IssueEnricherFieldKeys |
|------|--------|--------|------------|-----------|------------------------|
| secrets | nil (NoOp) | GetSecretValue | — | KmsKeyId, RotationLambdaARN | — |
| ssm | nil (NoOp) | GetParameter (WithDecryption) | — | KeyId | — |
| kms | EnrichKMSRotation (prio 100) | — | FetchKMSKeysByIDs | — | ["rotation_enabled"] |

## Files changed

- `internal/aws/catalog_secrets.go` — populated 3 entries with full per-type wiring.
- `internal/aws/secrets.go`, `kms.go`, `ssm.go` — deleted `init()` bodies.
- `internal/aws/secrets_related.go`, `ssm_related.go` — deleted `init()` bodies (Related/Navigable now in catalog). `kms_related.go` has no init() — only checker helpers — and is unchanged.

## Out of scope per sibling precedent

`internal/aws/acm.go` and `internal/aws/ses.go` appear in this issue's acceptance grep, but their catalog entries live in `catalog_dns_cdn.go` (acm) and `catalog_messaging.go` (ses), not `catalog_secrets.go`. **AS-812** (PR #402) migrated ses; **AS-814** (PR #399, open) migrates acm. Touching them here would edit out-of-category catalog files and overlap with sibling PRs. Interpreted as a spec drafting artifact — same precedent AS-812 used for its eb.go reference.

## Retained init() bodies (legacy bridge — AS-795n cleans up)

- `secrets_issue_enrichment.go`, `ssm_issue_enrichment.go` — register NoOp Wave 2 so `TestConformance_EveryResourceTypeHasWave2Registration` sees an explicit entry. Wave2 stays nil per spec §5.2.
- `kms_issue_enrichment.go` — registers `EnrichKMSRotation` and `RegisterIssueEnricherFieldKeys("kms", …)` into the legacy registries still iterated by `BuildEnrichQueue` / `runtime_adapter_navigate` / `probe_adapter` / `TestAttentionSignalsDoc`.

## Test plan

- [x] `go build ./...` — green
- [x] `go test ./tests/unit/ -count=1` — green (31s)
- [x] `go test -tags integration ./tests/integration/ -count=1` — green (51s)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `govulncheck ./...` — no vulnerabilities
- [x] `go fix -inline -diff ./...` — no unfixed inline directives
- [x] verify-readonly grep — no write API calls introduced
- [x] `go test ./tests/unit/ -run 'Golden|Scenario'` + `go test -tags integration ./tests/integration/ -run 'Visual|Scenario'` — green
- [x] `./a9s --demo` boots; `--help` shows version OK
- [ ] `make test-race` — blocked by missing cgo/gcc in pod (AS-149)
- [ ] `make mdlint` — `markdownlint-cli2` not installed in pod; no .md files modified by this PR

## Acceptance grep

```
rg '^func init\(\)' internal/aws/{secrets,kms,ssm}.go internal/aws/{secrets,ssm}_related.go   → zero hits
rg 'Fetcher:' internal/aws/catalog_secrets.go                                                  → 3 hits
```

Parent: AS-805 (umbrella).
Depends on: AS-795a / PR #392 (merged).

Refs AS-813.

🤖 Generated with [Claude Code](https://claude.com/claude-code)