### PR TITLE
feat(refactor): AS-817 data category init() → catalog migration

### DIFF
--- a/internal/aws/athena.go
+++ b/internal/aws/athena.go
@@ -10,26 +10,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("athena", []string{"workgroup_name", "state", "description", "engine_version", "result_output_location"})
-
-	resource.RegisterPaginated("athena", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchAthenaWorkgroupsPage(ctx, c.Athena, continuationToken)
-	})
-
-	resource.RegisterRelated("athena", []resource.RelatedDef{
-		{TargetType: "s3", DisplayName: "S3 Buckets (results)", Checker: checkAthenaS3},
-		{TargetType: "kms", DisplayName: "KMS Keys", Checker: checkAthenaKMS},
-		{TargetType: "glue", DisplayName: "Glue Data Catalog", Checker: checkAthenaGlue},
-		{TargetType: "logs", DisplayName: "Log Groups", Checker: checkAthenaLogs},
-		{TargetType: "role", DisplayName: "IAM Roles", Checker: checkAthenaRole},
-	})
-}
-
 // FetchAthenaWorkgroups calls the Athena ListWorkGroups API and converts the
 // response into a slice of generic Resource structs.
 func FetchAthenaWorkgroups(ctx context.Context, api AthenaListWorkGroupsAPI) ([]resource.Resource, error) {

--- a/internal/aws/catalog_compute.go
+++ b/internal/aws/catalog_compute.go
@@ -801,6 +801,28 @@ var computeTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // stati
 			{Key: "created", Title: "Created", Width: 18, Sortable: true},
 		},
 		Color: colorEBS,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchEBSVolumesPage(ctx, c.EC2, continuationToken)
+		},
+		Wave2:     IssueEnricher{Fn: EnrichEBSVolumeStatus, Priority: 10},
+		FieldKeys: []string{"volume_id", "name", "state", "size", "type", "iops", "encrypted", "attached_to", "az", "created"},
+		Related: []domain.RelatedDef{
+			{TargetType: "ec2", DisplayName: "EC2 Instance", Checker: checkEBSEC2, NeedsTargetCache: false},
+			{TargetType: "ebs-snap", DisplayName: "EBS Snapshots", Checker: checkEBSSnap, NeedsTargetCache: true},
+			{TargetType: "kms", DisplayName: "KMS Key", Checker: checkEBSKMS, NeedsTargetCache: false},
+			{TargetType: "alarm", DisplayName: "CW Alarms", Checker: checkEBSAlarm, NeedsTargetCache: true},
+			{TargetType: "backup", DisplayName: "Backup", Checker: checkEBSBackup},
+			{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkEBSCFN, NeedsTargetCache: true},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("ebs")},
+		},
+		Navigable: []domain.NavigableField{
+			{FieldPath: "Attachments.InstanceId", TargetType: "ec2"},
+			{FieldPath: "KmsKeyId", TargetType: "kms"},
+		},
 	},
 	{
 		Name:          "EBS Snapshots",
@@ -820,6 +842,33 @@ var computeTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // stati
 			{Key: "progress", Title: "Progress", Width: 10, Sortable: false},
 		},
 		Color: colorEBSSnap,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchEBSSnapshotsPage(ctx, c.EC2, continuationToken)
+		},
+		FieldKeys: []string{"snapshot_id", "name", "state", "volume_id", "size", "encrypted", "description", "started", "progress"},
+		FetchByIDs: func(ctx context.Context, clients any, ids []string) ([]resource.Resource, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return nil, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchEBSSnapshotsByIDs(ctx, c.EC2, ids)
+		},
+		Related: []domain.RelatedDef{
+			{TargetType: "ami", DisplayName: "AMIs", Checker: checkEBSSnapAMI, NeedsTargetCache: true},
+			{TargetType: "ebs", DisplayName: "EBS Volume", Checker: checkEBSSnapEBS, NeedsTargetCache: false},
+			{TargetType: "ec2", DisplayName: "EC2 Instance", Checker: checkEBSSnapEC2, NeedsTargetCache: false},
+			{TargetType: "kms", DisplayName: "KMS Key", Checker: checkEBSSnapKMS, NeedsTargetCache: false},
+			{TargetType: "backup", DisplayName: "Backup", Checker: checkEBSSnapBackup},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("ebs-snap")},
+		},
+		Navigable: []domain.NavigableField{
+			{FieldPath: "VolumeId", TargetType: "ebs"},
+			{FieldPath: "KmsKeyId", TargetType: "kms"},
+		},
 	},
 	{
 		Name:          "AMIs",

--- a/internal/aws/catalog_data.go
+++ b/internal/aws/catalog_data.go
@@ -1,8 +1,12 @@
 package aws
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/domain"
+	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 func colorGlue(_ domain.Resource) domain.Color { return domain.ColorHealthy }
@@ -38,6 +42,30 @@ var dataTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // static c
 			DisplayNameKey: "job_name",
 		}},
 		Color: colorGlue,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchGlueJobsPage(ctx, c.Glue, continuationToken)
+		},
+		Wave2:     IssueEnricher{Fn: EnrichGlueJobStatus, Priority: 10},
+		FieldKeys: []string{"job_name", "glue_version", "worker_type", "num_workers", "last_modified"},
+		Related: []domain.RelatedDef{
+			{TargetType: "role", DisplayName: "IAM Roles", Checker: checkGlueRole, NeedsTargetCache: true},
+			{TargetType: "alarm", DisplayName: "CW Alarms", Checker: checkGlueAlarms, NeedsTargetCache: true},
+			{TargetType: "logs", DisplayName: "Log Groups", Checker: checkGlueLogs, NeedsTargetCache: true},
+			{TargetType: "cfn", DisplayName: "CloudFormation Stacks", Checker: checkGlueCFN},
+			{TargetType: "s3", DisplayName: "S3 (script bucket)", Checker: checkGlueS3},
+			{TargetType: "kms", DisplayName: "KMS Key", Checker: checkGlueKMS},
+			{TargetType: "athena", DisplayName: "Athena WorkGroups", Checker: checkGlueAthena},
+			{TargetType: "secrets", DisplayName: "Secrets Manager", Checker: checkGlueSecrets},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("glue")},
+		},
+		Navigable: []domain.NavigableField{
+			{FieldPath: "Role", TargetType: "role"},
+		},
+		IssueEnricherFieldKeys: []string{"last_run"},
 	},
 	{
 		Name:          "Athena Workgroups",
@@ -52,5 +80,22 @@ var dataTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // static c
 			{Key: "engine_version", Title: "Engine", Width: 28, Sortable: true},
 		},
 		Color: colorAthena,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			return FetchAthenaWorkgroupsPage(ctx, c.Athena, continuationToken)
+		},
+		Wave2:     IssueEnricher{Fn: EnrichAthenaWorkGroup, Priority: 100},
+		FieldKeys: []string{"workgroup_name", "state", "description", "engine_version", "result_output_location"},
+		Related: []domain.RelatedDef{
+			{TargetType: "s3", DisplayName: "S3 Buckets (results)", Checker: checkAthenaS3},
+			{TargetType: "kms", DisplayName: "KMS Keys", Checker: checkAthenaKMS},
+			{TargetType: "glue", DisplayName: "Glue Data Catalog", Checker: checkAthenaGlue},
+			{TargetType: "logs", DisplayName: "Log Groups", Checker: checkAthenaLogs},
+			{TargetType: "role", DisplayName: "IAM Roles", Checker: checkAthenaRole},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("athena")},
+		},
 	},
 }

--- a/internal/aws/catalog_databases.go
+++ b/internal/aws/catalog_databases.go
@@ -355,6 +355,47 @@ var databasesTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // sta
 			DisplayNameKey: "bucket",
 		}},
 		Color: colorS3,
+		Fetcher: func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
+			c, ok := clients.(*ServiceClients)
+			if !ok || c == nil {
+				return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+			}
+			// Related-panel contract (docs/resources/s3.md §2): lambda/sns/sqs
+			// pivots must resolve non-zero when this bucket has a matching
+			// notification target. Those checkers read Fields["notification_*"],
+			// which can only be populated by GetBucketNotificationConfiguration
+			// — so the list path must run it per-bucket. Accepts N+1 per page
+			// (cheap API, typically ≤50 buckets per AWS account) in exchange
+			// for having the notification pivots actually work.
+			return FetchS3BucketsPageWithNotifications(ctx, c.S3, c.S3, continuationToken)
+		},
+		Wave2: IssueEnricher{Fn: EnrichS3PublicAccessBlock, Priority: 100},
+		FieldKeys: []string{
+			"name",
+			"bucket_name",
+			"creation_date",
+			"notification_lambda",
+			"notification_sqs",
+			"notification_sns",
+		},
+		Related: []domain.RelatedDef{
+			{TargetType: "trail", DisplayName: "CloudTrail Trails", Checker: checkS3Trail, NeedsTargetCache: true},
+			{TargetType: "cf", DisplayName: "CloudFront", Checker: checkS3CF, NeedsTargetCache: true},
+			{TargetType: "lambda", DisplayName: "Lambda (notifications)", Checker: checkS3Lambda},
+			{TargetType: "sns", DisplayName: "SNS (notifications)", Checker: checkS3SNS},
+			{TargetType: "sqs", DisplayName: "SQS (notifications)", Checker: checkS3SQS},
+			{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkS3CFN},
+			{TargetType: "kms", DisplayName: "KMS Key", Checker: checkS3KMS},
+			{TargetType: "s3", DisplayName: "Access Log Bucket", Checker: checkS3Logs},
+			{TargetType: "athena", DisplayName: "Athena WorkGroups", Checker: checkS3Athena},
+			{TargetType: "glue", DisplayName: "Glue Jobs", Checker: checkS3Glue},
+			{TargetType: "backup", DisplayName: "Backup", Checker: checkS3Backup},
+			{TargetType: "eb-rule", DisplayName: "EventBridge Rules", Checker: checkS3EBRule},
+			{TargetType: "r53", DisplayName: "Route 53", Checker: checkS3R53},
+			{TargetType: "role", DisplayName: "IAM Roles", Checker: checkS3Role},
+			{TargetType: "ct-events", DisplayName: "CloudTrail Events", Checker: ctEventsCheckerFor("s3")},
+		},
+		IssueEnricherFieldKeys: []string{"status"},
 	},
 	{
 		Name:          "ElastiCache Redis",

--- a/internal/aws/ebs.go
+++ b/internal/aws/ebs.go
@@ -13,59 +13,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("ebs", []string{"volume_id", "name", "state", "size", "type", "iops", "encrypted", "attached_to", "az", "created"})
-	resource.RegisterPaginated("ebs", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchEBSVolumesPage(ctx, c.EC2, continuationToken)
-	})
-
-	resource.RegisterFieldKeys("ebs-snap", []string{"snapshot_id", "name", "state", "volume_id", "size", "encrypted", "description", "started", "progress"})
-	resource.RegisterPaginated("ebs-snap", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchEBSSnapshotsPage(ctx, c.EC2, continuationToken)
-	})
-
-	resource.RegisterFetchByIDs("ebs-snap", func(ctx context.Context, clients any, ids []string) ([]resource.Resource, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return nil, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchEBSSnapshotsByIDs(ctx, c.EC2, ids)
-	})
-
-	resource.RegisterRelated("ebs", []resource.RelatedDef{
-		{TargetType: "ec2", DisplayName: "EC2 Instance", Checker: checkEBSEC2, NeedsTargetCache: false},
-		{TargetType: "ebs-snap", DisplayName: "EBS Snapshots", Checker: checkEBSSnap, NeedsTargetCache: true},
-		{TargetType: "kms", DisplayName: "KMS Key", Checker: checkEBSKMS, NeedsTargetCache: false},
-		{TargetType: "alarm", DisplayName: "CW Alarms", Checker: checkEBSAlarm, NeedsTargetCache: true},
-		{TargetType: "backup", DisplayName: "Backup", Checker: checkEBSBackup},
-		{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkEBSCFN, NeedsTargetCache: true},
-	})
-	resource.RegisterDefaultNavFields("ebs", []resource.NavigableField{
-		{FieldPath: "Attachments.InstanceId", TargetType: "ec2"},
-		{FieldPath: "KmsKeyId", TargetType: "kms"},
-	})
-
-	resource.RegisterRelated("ebs-snap", []resource.RelatedDef{
-		{TargetType: "ami", DisplayName: "AMIs", Checker: checkEBSSnapAMI, NeedsTargetCache: true},
-		{TargetType: "ebs", DisplayName: "EBS Volume", Checker: checkEBSSnapEBS, NeedsTargetCache: false},
-		{TargetType: "ec2", DisplayName: "EC2 Instance", Checker: checkEBSSnapEC2, NeedsTargetCache: false},
-		{TargetType: "kms", DisplayName: "KMS Key", Checker: checkEBSSnapKMS, NeedsTargetCache: false},
-		{TargetType: "backup", DisplayName: "Backup", Checker: checkEBSSnapBackup},
-	})
-	resource.RegisterDefaultNavFields("ebs-snap", []resource.NavigableField{
-		{FieldPath: "VolumeId", TargetType: "ebs"},
-		{FieldPath: "KmsKeyId", TargetType: "kms"},
-	})
-}
-
 // FetchEBSVolumes calls the EC2 DescribeVolumes API and returns all pages
 // of volumes. Used by tests; the production path uses the per-page fetcher for pagination.
 func FetchEBSVolumes(ctx context.Context, api EC2DescribeVolumesAPI) ([]resource.Resource, error) {

--- a/internal/aws/glue.go
+++ b/internal/aws/glue.go
@@ -11,33 +11,6 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-func init() {
-	resource.RegisterFieldKeys("glue", []string{"job_name", "glue_version", "worker_type", "num_workers", "last_modified"})
-
-	resource.RegisterPaginated("glue", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchGlueJobsPage(ctx, c.Glue, continuationToken)
-	})
-
-	resource.RegisterDefaultNavFields("glue", []resource.NavigableField{
-		{FieldPath: "Role", TargetType: "role"},
-	})
-
-	resource.RegisterRelated("glue", []resource.RelatedDef{
-		{TargetType: "role", DisplayName: "IAM Roles", Checker: checkGlueRole, NeedsTargetCache: true},
-		{TargetType: "alarm", DisplayName: "CW Alarms", Checker: checkGlueAlarms, NeedsTargetCache: true},
-		{TargetType: "logs", DisplayName: "Log Groups", Checker: checkGlueLogs, NeedsTargetCache: true},
-		{TargetType: "cfn", DisplayName: "CloudFormation Stacks", Checker: checkGlueCFN},
-		{TargetType: "s3", DisplayName: "S3 (script bucket)", Checker: checkGlueS3},
-		{TargetType: "kms", DisplayName: "KMS Key", Checker: checkGlueKMS},
-		{TargetType: "athena", DisplayName: "Athena WorkGroups", Checker: checkGlueAthena},
-		{TargetType: "secrets", DisplayName: "Secrets Manager", Checker: checkGlueSecrets},
-	})
-}
-
 // FetchGlueJobs calls the Glue GetJobs API and converts the response
 // into a slice of generic Resource structs.
 func FetchGlueJobs(ctx context.Context, api GlueGetJobsAPI) ([]resource.Resource, error) {

--- a/internal/aws/s3.go
+++ b/internal/aws/s3.go
@@ -3,91 +3,12 @@ package aws
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
-
-func init() {
-	resource.RegisterFieldKeys("s3", []string{
-		"name",
-		"bucket_name",
-		"creation_date",
-		"notification_lambda",
-		"notification_sqs",
-		"notification_sns",
-	})
-
-	resource.RegisterFieldKeys("s3_objects", []string{
-		"key",
-		"size",
-		"last_modified",
-		"storage_class",
-	})
-
-	resource.RegisterPaginated("s3", func(ctx context.Context, clients any, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		// Related-panel contract (docs/resources/s3.md §2): lambda/sns/sqs
-		// pivots must resolve non-zero when this bucket has a matching
-		// notification target. Those checkers read Fields["notification_*"],
-		// which can only be populated by GetBucketNotificationConfiguration
-		// — so the list path must run it per-bucket. Accepts N+1 per page
-		// (cheap API, typically ≤50 buckets per AWS account) in exchange
-		// for having the notification pivots actually work.
-		return FetchS3BucketsPageWithNotifications(ctx, c.S3, c.S3, continuationToken)
-	})
-
-	// Register S3 objects as a child type with its own fetcher.
-	resource.RegisterPaginatedChild("s3_objects", func(ctx context.Context, clients any, parentCtx resource.ParentContext, continuationToken string) (resource.FetchResult, error) {
-		c, ok := clients.(*ServiceClients)
-		if !ok || c == nil {
-			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
-		}
-		return FetchS3Objects(ctx, c.S3, parentCtx["bucket"], parentCtx["prefix"], continuationToken)
-	})
-	resource.RegisterChildType(resource.ResourceTypeDef{
-		Name:      "S3 Objects",
-		ShortName: "s3_objects",
-		Columns:   resource.S3ObjectColumns(),
-		Children: []resource.ChildViewDef{{
-			ChildType:      "s3_objects",
-			Key:            "enter",
-			ContextKeys:    map[string]string{"bucket": "@parent.bucket", "prefix": "ID"},
-			DisplayNameKey: "bucket",
-			DrillCondition: func(r resource.Resource) bool { return r.Status == "folder" },
-		}},
-		// RelatedContextFromIDs extracts the bucket name from related IDs encoded as
-		// "bucket|key". Used when navigating to s3_objects from the related panel
-		// (e.g., from a CloudTrail event detail view).
-		RelatedContextFromIDs: func(relatedIDs []string) map[string]string {
-			for _, id := range relatedIDs {
-				parts := strings.SplitN(id, "|", 2)
-				if len(parts) != 2 || parts[0] == "" {
-					continue
-				}
-				bucket := parts[0]
-				key := parts[1]
-				// Derive the prefix (folder path) from the key so the child view
-				// lands on the folder containing the object, not the bucket root.
-				// Example: key="prod/config.json" → prefix="prod/"
-				// Example: key="landing/2026/04/07/x.parquet" → prefix="landing/2026/04/07/"
-				// Example: key="build-4821.tar.gz" → prefix=""
-				prefix := ""
-				if idx := strings.LastIndex(key, "/"); idx >= 0 {
-					prefix = key[:idx+1]
-				}
-				return map[string]string{"bucket": bucket, "prefix": prefix}
-			}
-			return map[string]string{"bucket": "", "prefix": ""}
-		},
-	})
-}
 
 // FetchS3Buckets calls the S3 ListBuckets API and returns all pages of buckets.
 // Used by tests; the production path uses the per-page fetcher for pagination.

--- a/internal/aws/s3_objects.go
+++ b/internal/aws/s3_objects.go
@@ -1,0 +1,70 @@
+// s3_objects.go — child-type registration for S3 Objects (the per-bucket
+// drill-down). Split out of s3.go in AS-817 so s3.go can have its init() body
+// removed (per the data-category init()→catalog migration). The child-type
+// migration to catalog.SetChildTypes lands in AS-795n (the Wave 2 / child
+// infrastructure sweep); until then this init() body keeps the s3_objects
+// child type registered via the legacy internal/resource registries — same
+// rationale as asg_activities.go / ecs_svc_logs.go / etc.
+package aws
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+func init() {
+	resource.RegisterFieldKeys("s3_objects", []string{
+		"key",
+		"size",
+		"last_modified",
+		"storage_class",
+	})
+
+	resource.RegisterPaginatedChild("s3_objects", func(ctx context.Context, clients any, parentCtx resource.ParentContext, continuationToken string) (resource.FetchResult, error) {
+		c, ok := clients.(*ServiceClients)
+		if !ok || c == nil {
+			return resource.FetchResult{}, fmt.Errorf("AWS clients not initialized")
+		}
+		return FetchS3Objects(ctx, c.S3, parentCtx["bucket"], parentCtx["prefix"], continuationToken)
+	})
+
+	resource.RegisterChildType(resource.ResourceTypeDef{
+		Name:      "S3 Objects",
+		ShortName: "s3_objects",
+		Columns:   resource.S3ObjectColumns(),
+		Children: []resource.ChildViewDef{{
+			ChildType:      "s3_objects",
+			Key:            "enter",
+			ContextKeys:    map[string]string{"bucket": "@parent.bucket", "prefix": "ID"},
+			DisplayNameKey: "bucket",
+			DrillCondition: func(r resource.Resource) bool { return r.Status == "folder" },
+		}},
+		// RelatedContextFromIDs extracts the bucket name from related IDs encoded as
+		// "bucket|key". Used when navigating to s3_objects from the related panel
+		// (e.g., from a CloudTrail event detail view).
+		RelatedContextFromIDs: func(relatedIDs []string) map[string]string {
+			for _, id := range relatedIDs {
+				parts := strings.SplitN(id, "|", 2)
+				if len(parts) != 2 || parts[0] == "" {
+					continue
+				}
+				bucket := parts[0]
+				key := parts[1]
+				// Derive the prefix (folder path) from the key so the child view
+				// lands on the folder containing the object, not the bucket root.
+				// Example: key="prod/config.json" → prefix="prod/"
+				// Example: key="landing/2026/04/07/x.parquet" → prefix="landing/2026/04/07/"
+				// Example: key="build-4821.tar.gz" → prefix=""
+				prefix := ""
+				if idx := strings.LastIndex(key, "/"); idx >= 0 {
+					prefix = key[:idx+1]
+				}
+				return map[string]string{"bucket": bucket, "prefix": prefix}
+			}
+			return map[string]string{"bucket": "", "prefix": ""}
+		},
+	})
+}

--- a/internal/aws/s3_related.go
+++ b/internal/aws/s3_related.go
@@ -614,21 +614,3 @@ func s3RelatedResources(ctx context.Context, clients any, cache resource.Resourc
 	return resources, isTruncated, err
 }
 
-func init() {
-	resource.RegisterRelated("s3", []resource.RelatedDef{
-		{TargetType: "trail", DisplayName: "CloudTrail Trails", Checker: checkS3Trail, NeedsTargetCache: true},
-		{TargetType: "cf", DisplayName: "CloudFront", Checker: checkS3CF, NeedsTargetCache: true},
-		{TargetType: "lambda", DisplayName: "Lambda (notifications)", Checker: checkS3Lambda},
-		{TargetType: "sns", DisplayName: "SNS (notifications)", Checker: checkS3SNS},
-		{TargetType: "sqs", DisplayName: "SQS (notifications)", Checker: checkS3SQS},
-		{TargetType: "cfn", DisplayName: "CloudFormation", Checker: checkS3CFN},
-		{TargetType: "kms", DisplayName: "KMS Key", Checker: checkS3KMS},
-		{TargetType: "s3", DisplayName: "Access Log Bucket", Checker: checkS3Logs},
-		{TargetType: "athena", DisplayName: "Athena WorkGroups", Checker: checkS3Athena},
-		{TargetType: "glue", DisplayName: "Glue Jobs", Checker: checkS3Glue},
-		{TargetType: "backup", DisplayName: "Backup", Checker: checkS3Backup},
-		{TargetType: "eb-rule", DisplayName: "EventBridge Rules", Checker: checkS3EBRule},
-		{TargetType: "r53", DisplayName: "Route 53", Checker: checkS3R53},
-		{TargetType: "role", DisplayName: "IAM Roles", Checker: checkS3Role},
-	})
-}


### PR DESCRIPTION
## Summary

Migrates the **data** category's per-type wiring from `init()` bodies in `internal/aws/<svc>.go` (and matching `*_related.go`) into the catalog struct literals in `internal/aws/catalog_{data,databases,compute}.go`. Per-category PR after AS-807 (compute), AS-808 (containers), AS-810 (databases), AS-811 (monitoring), AS-812 (messaging), AS-813 (secrets).

Spec: [`docs/refactor/AS-795-init-cycle-break.md`](../blob/main/docs/refactor/AS-795-init-cycle-break.md) §3 + §5.2.

### What changed

Catalog entries populated for the 5 top-level data resource types in AS-795l scope:

| Type | Catalog file | Fields populated |
| ---- | ------------ | ---------------- |
| `glue` | `catalog_data.go` | Fetcher, FieldKeys, Related (+ct-events), Navigable, Wave2 (`EnrichGlueJobStatus`/p10), IssueEnricherFieldKeys |
| `athena` | `catalog_data.go` | Fetcher, FieldKeys, Related (+ct-events), Wave2 (`EnrichAthenaWorkGroup`/p100) |
| `s3` | `catalog_databases.go` (identity-only since AS-810) | Fetcher (`FetchS3BucketsPageWithNotifications` — preserves the notification N+1 contract for lambda/sns/sqs pivots), FieldKeys, Related (+ct-events), Wave2 (`EnrichS3PublicAccessBlock`/p100), IssueEnricherFieldKeys |
| `ebs` | `catalog_compute.go` (identity-only since AS-807) | Fetcher, FieldKeys, Related (+ct-events), Navigable, Wave2 (`EnrichEBSVolumeStatus`/p10) |
| `ebs-snap` | `catalog_compute.go` (identity-only since AS-807) | Fetcher, FieldKeys, FetchByIDs (related-panel lazy-add path), Related (+ct-events), Navigable. Wave2 stays nil — only NoOp registered (matches AS-810 redis/redshift, AS-813 secrets/ssm precedent: spec §5.2 template) |

The cross-category file edits (`catalog_databases.go` for `s3`; `catalog_compute.go` for `ebs`/`ebs-snap`) are justified by the explicit AS-807/AS-810 commit messages, which deferred those identity-only entries to "a later sibling" / "a later PR" — this is that sibling.

### `func init()` removed

- `internal/aws/{athena,glue,ebs,s3}.go` — Fetcher / FieldKeys / Related / Navigable / FetchByIDs all now in catalog.
- `internal/aws/s3_related.go` — `RegisterRelated("s3", …)` moved to the catalog `s3` entry.

### `s3_objects` child type extracted

`s3.go`'s init() body owned both the top-level `s3` registrations and the `s3_objects` child-type registration. To let `s3.go` drop its init() per the AS-817 acceptance grep while keeping `s3_objects` functional until AS-795n migrates child types into `catalog.SetChildTypes`, the s3_objects bits move into a new file:

- **New file**: `internal/aws/s3_objects.go` — owns `RegisterFieldKeys("s3_objects", …)` + `RegisterPaginatedChild` + `RegisterChildType`.

Sibling precedent: this mirrors how `asg_activities.go` / `ecs_svc_logs.go` / `lambda_invocations.go` / `cb_builds.go` etc. already live in their own files separate from the parent svc file.

### `_issue_enrichment.go` retained (sibling precedent)

Files with init() body retained for legacy consumers (same rationale as AS-807/AS-810/AS-811/AS-812/AS-813):

- `internal/aws/{athena,glue,ebs,s3}_issue_enrichment.go` — real `Enrich*` registered into the legacy `IssueEnricherRegistry`. Still iterated by `BuildEnrichQueue` / `runtime_adapter_navigate` / `probe_adapter` / `TestAttentionSignalsDoc`; AS-795n migrates those consumers and deletes the legacy registry. `glue_issue_enrichment.go` and `s3_issue_enrichment.go` also still own `RegisterIssueEnricherFieldKeys` (the install.go bridge does not yet wire that catalog field — also AS-795n scope).
- `internal/aws/ebs_snap_issue_enrichment.go` — registers `NoOpIssueEnricher` so `TestConformance_EveryResourceTypeHasWave2Registration` sees an explicit entry for `ebs-snap`; `Wave2` stays nil per template.

### Out of scope (judgment calls — flag for reviewer)

1. **`glue_runs.go` (child type)** — keeps its init(). Child types still register via `internal/resource`; `install.go` has no bridge for `ChildFetcher` yet. **AS-795n** (the Wave 2 / child infrastructure cleanup PR per spec line 188) migrates `ecs_svc_logs` / `ecs_svc_tasks` / `lambda_invocations` / `asg_activities` / `glue_runs` / `s3_objects` / `cb_builds` / etc. in one sweep with the matching install.go bridge and consumer updates. The AS-817 issue body's literal acceptance grep lists `glue_runs.go`, but AS-812 PR #402 called out the same shape for `eb_rule_targets.go` as out-of-scope for a per-category PR — same interpretation here.
2. **`ebs_snap.go`** — does not exist as a file; `ebs` and `ebs-snap` registrations both lived in `ebs.go` (which had init() removed). Spec drafting artifact in the AS-817 acceptance grep.

Either call can land in a tiny follow-up PR or in AS-795n if reviewers disagree.

## Acceptance checks

```text
$ rg '^func init\(\)' internal/aws/s3.go internal/aws/athena.go internal/aws/glue.go internal/aws/ebs.go internal/aws/s3_related.go
# zero hits ✔

$ rg 'Fetcher:' internal/aws/catalog_data.go | wc -l
2  ✔  (glue, athena)

$ rg 'Fetcher:' internal/aws/catalog_databases.go | wc -l
9  ✔  (was 8 in AS-810; +1 = s3)

$ rg 'Fetcher:' internal/aws/catalog_compute.go | wc -l
8  ✔  (was 6 in AS-807; +2 = ebs, ebs-snap)
```

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./tests/unit/ -count=1` — green (26.3s)
- [x] `go test -tags integration ./tests/integration/ -count=1` — green (52.4s, AS-827 gate)
- [x] `go test ./tests/unit/ -run 'Golden|Scenario' -count=1` — green (snapshot)
- [x] `go test -tags integration ./tests/integration/ -run 'Visual|Scenario' -count=1` — green (21.9s)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `govulncheck ./...` — no vulnerabilities
- [x] `go fix -inline -diff ./...` — clean
- [x] `verify-readonly` grep — clean
- [ ] `go test -race` — blocked by missing cgo/gcc in this pod (documented under AS-149); CI exercises it
- [ ] `mdlint` / `check-readme` — N/A, no doc changes

Parent: AS-805 (umbrella). Depends on AS-795a / PR #392 (merged), AS-807 / PR #393 (merged), AS-810 / PR #396 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)