### PR TITLE
feat(refactor): AS-820 / AS-795o acceptance guards (verify-zero-init + catalog smoke test)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install test test-budget test-race lint gofix fmt run clean cover integration security coverage verify-readonly demo readme check-readme mdlint snapshot snapshot-update ready-to-push ready-to-release generate
+.PHONY: build install test test-budget test-race lint gofix fmt run clean cover integration security coverage verify-readonly verify-zero-init demo readme check-readme mdlint snapshot snapshot-update ready-to-push ready-to-release generate
 
 BINARY   = a9s
 CMD      = ./cmd/a9s
@@ -91,6 +91,19 @@ verify-readonly:
 		echo "PASS: All API calls are read-only"; \
 	fi
 
+# AS-820: lock in AS-795 invariant. init() bodies must not return to
+# internal/aws/ or internal/catalog/ after the AS-795b..p migration.
+# internal/resource/projection_init.go is excluded — AS-731 removes that
+# package wholesale.
+verify-zero-init:
+	@echo "Checking for init() bodies in internal/aws/ and internal/catalog/..."
+	@if grep -rln '^func init()' internal/aws/ internal/catalog/ 2>/dev/null; then \
+		echo "FAIL: init() bodies found in internal/aws/ or internal/catalog/ — AS-795 invariant is migrated catalog literals, not package init()"; \
+		exit 1; \
+	else \
+		echo "PASS: no init() bodies in internal/aws/ or internal/catalog/"; \
+	fi
+
 demo:
 	vhs docs/demos/demo.tape
 
@@ -119,7 +132,7 @@ snapshot-update:
 
 # Stage 6 — Pre-push gate. The single command every PR must pass before push.
 # See docs/development-process.md.
-ready-to-push: test-race lint security gofix verify-readonly check-readme snapshot mdlint
+ready-to-push: test-race lint security gofix verify-readonly verify-zero-init check-readme snapshot mdlint
 	@echo "PASS: ready-to-push gate green"
 
 # Stage 7 — Pre-release gate. Run before tagging a release. Subsumes ready-to-push

--- a/tests/unit/catalog_install_test.go
+++ b/tests/unit/catalog_install_test.go
@@ -130,6 +130,9 @@ func TestCatalogInstall_GoldenParity(t *testing.T) {
 			if got.Category != g.category {
 				t.Errorf("Category: got %q, want %q", got.Category, g.category)
 			}
+			if got.Fetcher == nil {
+				t.Errorf("Fetcher: got nil, want non-nil (AS-795 acceptance: every top-level catalog entry must have a populated Fetcher after the AS-795b..p init() cleanup)")
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

AS-820 deliverables #1 and #2 — two regression guards that lock in the AS-947 / AS-795b..p init() cleanup so the catalog-cycle-break invariant cannot regress.

- **Makefile**: new `verify-zero-init` target greps `internal/aws/` and `internal/catalog/` for `^func init()` bodies and fails if any remain. Wired into `ready-to-push`. `internal/resource/projection_init.go` is intentionally excluded — AS-731 removes that package wholesale.
- **tests/unit/catalog_install_test.go**: `TestCatalogInstall_GoldenParity` now asserts `Fetcher != nil` for every one of the 12 representative top-level types (per-category coverage). `TestCatalogInstall_AS795_MigrationShape` is intentionally left alone — its `Fetcher == nil` branch is still load-bearing defensive coverage during catalog growth.

`git diff --stat` against `main` is exactly the two files in scope.

## Continuation of #408

Original PR #408 was stacked on `feat/as-947-wave2-5-init-leakage`. That branch was deleted when #407 merged to main (08:33Z on 2026-05-22), which auto-closed #408 with `mergeStateStatus=DIRTY`. GitHub does not allow reopening a PR whose base branch was deleted — this PR is the same commit content (`384d756`) rebased onto `main`.

Original CXR NEEDS CHANGES verdict on #408: https://github.com/k2m30/a9s/pull/408#issuecomment-4516840498 — the fix is the rebase itself (the verdict was "rebase onto main and re-run gate").

## Acceptance gates (run locally on this branch)

- `verify-zero-init` — PASS
- `TestCatalogInstall_GoldenParity` — all 12 subtests pass with the new Fetcher assertion
- `lint` / `security` / `gofix` / `verify-readonly` / `check-readme` / `snapshot` / `mdlint` — all PASS
- `test` — PASS (pod lacks gcc → `-race` deferred to CI; CI runs full Stage 6 gate)

## Spec

- AS-820 issue body, deliverables #1 + #2
- `docs/refactor/AS-795-init-cycle-break.md` §3 (PR row AS-795o) + §4 (Exit criteria)

## Linked

- Parent: AS-820 (closed)
- Umbrella: AS-805 (closed)
- Predecessor: AS-947 (PR #407, merged)
- Replaces: PR #408 (auto-closed by base-branch deletion)
- Fix-up issue: AS-959

## Stage 5 routing

Per AS-808 board ruling: per-cat / mechanical S-PR — CR + CXR only, no Architect Stage 2 round trip.

Co-Authored-By: Paperclip <noreply@paperclip.ing>