### PR TITLE
AS-963 / PR-05a-h4-c — final internal/session + internal/aws import elimination from internal/tui

### DIFF
--- a/internal/domain/resource_cache.go
+++ b/internal/domain/resource_cache.go
@@ -1,0 +1,43 @@
+// Package domain — see contracts.go for the package overview.
+//
+// resource_cache.go owns the platform-agnostic list-view cache entry shape
+// used to restore a top-level resource list when the user re-enters it
+// from the main menu. The concrete map (`Session.ResourceCache`) lives in
+// internal/session and is mutated by runtime handlers; this file owns the
+// per-entry value type so renderer adapters and the session package can
+// both reference it without an import cycle.
+//
+// ListViewCacheEntry — moved from internal/session/session.go in
+// PR-05a-h4-c (AS-963). The original session.ResourceCacheEntry is now
+// a type alias to this struct (see internal/session/session.go) so the
+// existing read paths (resource.ResourceCache snapshots,
+// runtime.HandleResourcesLoaded, etc.) keep compiling. The intentional
+// name change from ResourceCacheEntry → ListViewCacheEntry disambiguates
+// against the pre-existing domain.ResourceCacheEntry above (related-
+// checker cache snapshot — different shape, different purpose).
+//
+// Field set mirrors the original session.ResourceCacheEntry verbatim:
+// Resources / Pagination drive the next render; FilterText, AttentionOnly,
+// SortColIdx, SortAsc, CursorPos, HScrollOffset preserve the list view's
+// interactive state across re-entry.
+package domain
+
+// ListViewCacheEntry stores the state of a previously-viewed resource list.
+// Used to restore the list when the user re-enters the same resource type
+// from the main menu, avoiding redundant API calls. Moved from
+// internal/session/session.go in PR-05a-h4-c (AS-963) so renderer adapters
+// can construct entries without importing internal/session.
+//
+// The session-side type alias (`type ResourceCacheEntry = domain.ListViewCacheEntry`)
+// keeps the existing `session.ResourceCacheEntry` name available for
+// callers (tests, runtime handlers) that already reference it.
+type ListViewCacheEntry struct {
+	Resources     []Resource
+	Pagination    *PaginationMeta
+	FilterText    string
+	AttentionOnly bool // §7.3: ctrl+z toggle persisted across view re-entry
+	SortColIdx    int
+	SortAsc       bool
+	CursorPos     int
+	HScrollOffset int
+}

--- a/internal/runtime/accessors.go
+++ b/internal/runtime/accessors.go
@@ -1,0 +1,87 @@
+// accessors.go — PR-05a-h4-c (AS-963) typed Core accessors.
+//
+// Exports a small set of typed read/write methods on *Core that lift the
+// session-state reads the renderer adapters previously did via
+// `m.core.Session().<Field>`. The Session() accessor on tui.Model goes
+// away in this PR — these methods, the ServiceClients alias in
+// transport.go, and the related-cache helpers in relatedcache.go are the
+// renderer-facing surface that replaces direct session imports.
+//
+// The accessor list is the spec-mandated minimum (docs/refactor/05-pr-05a-h4.md
+// lines 525–535, 549–554). Convenience constructors that internalise
+// session.New() also live here so the renderer's Model construction path
+// does not need to import internal/session.
+package runtime
+
+import (
+	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/catalog"
+	"github.com/k2m30/a9s/v3/internal/domain"
+	"github.com/k2m30/a9s/v3/internal/session"
+)
+
+// Bootstrap constructs a fresh *Core seeded with a new session.Session
+// configured for the given profile/region pair. Used by the renderer's
+// model constructor (tui.New) so it can build the Core without importing
+// internal/session.
+func Bootstrap(profile, region string, types []catalog.ResourceTypeDef) *Core {
+	s := session.New()
+	s.Profile = profile
+	s.Region = region
+	return New(s, types)
+}
+
+// Profile returns the active session profile.
+func (c *Core) Profile() string { return c.session.Profile }
+
+// Region returns the active session region.
+func (c *Core) Region() string { return c.session.Region }
+
+// ConnectGen returns the staleness counter for AWS connect attempts.
+func (c *Core) ConnectGen() domain.Gen { return c.session.ConnectGen }
+
+// Identity returns the renderer-shaped domain mirror of the session's
+// caller identity, or nil if no identity has been resolved yet. The
+// awsclient-typed pointer stays inside Core; the adapter renders only
+// the domain fields exposed here.
+func (c *Core) Identity() *domain.CallerIdentity {
+	if c.session.Identity == nil {
+		return nil
+	}
+	return domainCallerIdentityFrom(c.session.Identity)
+}
+
+// SetIdentityFetching sets the session-wide IdentityFetching latch.
+func (c *Core) SetIdentityFetching(v bool) { c.session.IdentityFetching = v }
+
+// ClearCommand clears the one-shot -c CLI flag command after the first
+// ClientsReady has consumed it.
+func (c *Core) ClearCommand() { c.session.Command = "" }
+
+// ResourceCache returns the cached top-level resource-list entry for the
+// given resource short name, or (nil, false) when no entry is cached.
+// Renderer adapters use this in place of indexing the session map
+// directly. The return type is the list-view cache entry shape, distinct
+// from the related-checker snapshot's domain.ResourceCacheEntry.
+func (c *Core) ResourceCache(rt string) (*domain.ListViewCacheEntry, bool) {
+	e, ok := c.session.ResourceCache[rt]
+	return e, ok
+}
+
+// LazyResourceCache returns the lazy-cache slice for the given resource
+// short name (resources pulled via FetchByIDs for filtered-target
+// drills). The bool reports whether any lazy-cache entry exists for
+// the type — distinct from a non-nil empty slice.
+func (c *Core) LazyResourceCache(rt string) ([]domain.Resource, bool) {
+	rows, ok := c.session.LazyResourceCache[rt]
+	return rows, ok
+}
+
+// HasIssueEnricher reports whether a Wave-2 issue enricher is registered
+// for the given resource short name. Renderer adapters use this in place
+// of probing awsclient.Wave2EnricherFor / awsclient.IssueEnricherRegistry
+// directly.
+func (c *Core) HasIssueEnricher(shortName string) bool {
+	_, ok := awsclient.Wave2EnricherFor(shortName)
+	return ok
+}

--- a/internal/runtime/accessors.go
+++ b/internal/runtime/accessors.go
@@ -1,22 +1,27 @@
 // accessors.go — PR-05a-h4-c (AS-963) typed Core accessors.
 //
-// Exports a small set of typed read/write methods on *Core that lift the
-// session-state reads the renderer adapters previously did via
-// `m.core.Session().<Field>`. The Session() accessor on tui.Model goes
-// away in this PR — these methods, the ServiceClients alias in
-// transport.go, and the related-cache helpers in relatedcache.go are the
-// renderer-facing surface that replaces direct session imports.
+// Exports a typed read/write surface on *Core that lifts every session-state
+// read or mutation the renderer used to do via `m.core.Session().<Field>`.
+// After h4-c the renderer never reaches through Core into Session — the
+// accessors here, the ServiceClients alias in transport.go, and the
+// related-cache helpers in relatedcache.go are the entire renderer-facing
+// surface that replaces direct session-shape coupling.
 //
-// The accessor list is the spec-mandated minimum (docs/refactor/05-pr-05a-h4.md
-// lines 525–535, 549–554). Convenience constructors that internalise
-// session.New() also live here so the renderer's Model construction path
-// does not need to import internal/session.
+// The accessor list covers the field set the renderer actually touches
+// (see docs/refactor/05-pr-05a-h4.md §2 and CodeReviewer's AS-963 verdict).
+// Convenience constructors that internalise session.New() also live here so
+// the renderer's Model construction path does not need to import
+// internal/session.
 package runtime
 
 import (
+	"maps"
+
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/catalog"
 	"github.com/k2m30/a9s/v3/internal/domain"
+	"github.com/k2m30/a9s/v3/internal/resource"
+	"github.com/k2m30/a9s/v3/internal/runtime/messages"
 	"github.com/k2m30/a9s/v3/internal/session"
 )
 
@@ -31,14 +36,142 @@ func Bootstrap(profile, region string, types []catalog.ResourceTypeDef) *Core {
 	return New(s, types)
 }
 
+// CurrentGenFor implements messages.GenSource by delegating to the
+// session. Lets `messages.IsStale(ev, m.core)` work without the renderer
+// reaching through Core into Session.
+func (c *Core) CurrentGenFor(a messages.Aspect) domain.Gen {
+	return c.session.CurrentGenFor(a)
+}
+
 // Profile returns the active session profile.
 func (c *Core) Profile() string { return c.session.Profile }
+
+// SetProfile sets the active session profile. Used by the WithProfile
+// constructor option only.
+func (c *Core) SetProfile(p string) { c.session.Profile = p }
 
 // Region returns the active session region.
 func (c *Core) Region() string { return c.session.Region }
 
+// SetRegion sets the active session region. Used by the WithRegion
+// constructor option only.
+func (c *Core) SetRegion(r string) { c.session.Region = r }
+
+// NoCache reports whether the --no-cache / --demo CLI flags disabled
+// on-disk availability caching and background probes.
+func (c *Core) NoCache() bool { return c.session.NoCache }
+
+// SetNoCache sets the NoCache policy flag. Constructor-option only.
+func (c *Core) SetNoCache(v bool) { c.session.NoCache = v }
+
+// Command returns the one-shot resource short name to navigate to on the
+// first ClientsReady (from the -c CLI flag).
+func (c *Core) Command() string { return c.session.Command }
+
+// SetCommand sets the one-shot -c CLI flag command. Constructor-option only.
+func (c *Core) SetCommand(s string) { c.session.Command = s }
+
+// ClearCommand clears the one-shot -c CLI flag command after the first
+// ClientsReady has consumed it.
+func (c *Core) ClearCommand() { c.session.Command = "" }
+
+// Clients returns the active session-scoped AWS transport (set by
+// HandleClientsReady). The return type is the runtime-exported alias so
+// renderer adapters need not import internal/aws.
+func (c *Core) Clients() *ServiceClients { return c.session.Clients }
+
+// PreSuppliedClients returns the bootstrap-channel transport supplied by
+// tests or demo mode via WithClients.
+func (c *Core) PreSuppliedClients() *ServiceClients { return c.session.PreSuppliedClients }
+
+// SetPreSuppliedClients sets the bootstrap-channel transport. Used by the
+// WithClients constructor option only.
+func (c *Core) SetPreSuppliedClients(s *ServiceClients) { c.session.PreSuppliedClients = s }
+
 // ConnectGen returns the staleness counter for AWS connect attempts.
 func (c *Core) ConnectGen() domain.Gen { return c.session.ConnectGen }
+
+// AvailabilityGen returns the Wave-1 availability staleness counter.
+func (c *Core) AvailabilityGen() domain.Gen { return c.session.AvailabilityGen }
+
+// BumpAvailabilityGen increments the Wave-1 availability counter so
+// in-flight stale probes are rejected by the gen guard.
+func (c *Core) BumpAvailabilityGen() { c.session.AvailabilityGen++ }
+
+// EnrichmentGen returns the session-wide Wave-2 enrichment counter.
+func (c *Core) EnrichmentGen() domain.Gen { return c.session.EnrichmentGen }
+
+// BumpEnrichmentGen increments the Wave-2 enrichment counter.
+func (c *Core) BumpEnrichmentGen() { c.session.EnrichmentGen++ }
+
+// RelatedGen returns the related-cache staleness counter.
+func (c *Core) RelatedGen() domain.Gen { return c.session.RelatedGen }
+
+// BumpRelatedGen increments the related-cache counter so in-flight
+// related-check results from the prior batch are discarded.
+func (c *Core) BumpRelatedGen() { c.session.RelatedGen++ }
+
+// EnrichGen returns the detail-enrichment staleness counter.
+func (c *Core) EnrichGen() domain.Gen { return c.session.EnrichGen }
+
+// BumpEnrichGen increments the detail-enrichment counter.
+func (c *Core) BumpEnrichGen() { c.session.EnrichGen++ }
+
+// EnrichResKey returns the "resourceType:resourceID" of the last
+// detail-enrichment dispatch.
+func (c *Core) EnrichResKey() string { return c.session.EnrichResKey }
+
+// ClearEnrichResKey clears the last-dispatched detail-enrichment key so the
+// next enrichment dispatch is forced to bump.
+func (c *Core) ClearEnrichResKey() { c.session.EnrichResKey = "" }
+
+// EnrichmentTypeGen returns the per-type Wave-2 enrichment counter for the
+// given resource short name. Zero when no enrichment has run yet for the
+// type.
+func (c *Core) EnrichmentTypeGen(rt string) domain.Gen { return c.session.EnrichmentTypeGen[rt] }
+
+// BumpEnrichmentTypeGen increments the per-type Wave-2 counter and returns
+// the new value. Used by the refresh path to invalidate the prior batch's
+// per-type findings before re-dispatching.
+func (c *Core) BumpEnrichmentTypeGen(rt string) domain.Gen {
+	c.session.EnrichmentTypeGen[rt]++
+	return c.session.EnrichmentTypeGen[rt]
+}
+
+// DeleteEnrichmentRan clears the per-type enrichment-ran latch so the next
+// enrichment dispatch for the type re-runs from scratch.
+func (c *Core) DeleteEnrichmentRan(rt string) { delete(c.session.EnrichmentRan, rt) }
+
+// EnrichmentTruncatedIDs returns the truncated-ID set for the given
+// resource type, or nil when no enrichment has retained truncation data
+// for the type.
+func (c *Core) EnrichmentTruncatedIDs(rt string) map[string]bool {
+	return c.session.EnrichmentTruncatedIDs[rt]
+}
+
+// DeleteEnrichmentTruncatedIDs clears the per-type truncated-ID set.
+func (c *Core) DeleteEnrichmentTruncatedIDs(rt string) {
+	delete(c.session.EnrichmentTruncatedIDs, rt)
+}
+
+// ResetEnrichmentMaps clears the per-type enrichment latches and counters
+// in one shot. Used by the global refresh path (Ctrl+R from main menu)
+// where every type must re-enrich from scratch.
+func (c *Core) ResetEnrichmentMaps() {
+	c.session.EnrichmentRan = make(map[string]bool)
+	c.session.EnrichmentTypeGen = make(map[string]domain.Gen)
+	c.session.EnrichmentTruncatedIDs = make(map[string]map[string]bool)
+}
+
+// ResetProbeMaps clears the Wave-1 retained-probe maps. Used by the global
+// refresh path so the next probe round populates fresh.
+func (c *Core) ResetProbeMaps() {
+	c.session.ProbeResources = make(map[string][]resource.Resource)
+	c.session.ProbeTruncated = make(map[string]bool)
+}
+
+// SetIdentityFetching sets the session-wide IdentityFetching latch.
+func (c *Core) SetIdentityFetching(v bool) { c.session.IdentityFetching = v }
 
 // Identity returns the renderer-shaped domain mirror of the session's
 // caller identity, or nil if no identity has been resolved yet. The
@@ -51,13 +184,6 @@ func (c *Core) Identity() *domain.CallerIdentity {
 	return domainCallerIdentityFrom(c.session.Identity)
 }
 
-// SetIdentityFetching sets the session-wide IdentityFetching latch.
-func (c *Core) SetIdentityFetching(v bool) { c.session.IdentityFetching = v }
-
-// ClearCommand clears the one-shot -c CLI flag command after the first
-// ClientsReady has consumed it.
-func (c *Core) ClearCommand() { c.session.Command = "" }
-
 // ResourceCache returns the cached top-level resource-list entry for the
 // given resource short name, or (nil, false) when no entry is cached.
 // Renderer adapters use this in place of indexing the session map
@@ -68,6 +194,50 @@ func (c *Core) ResourceCache(rt string) (*domain.ListViewCacheEntry, bool) {
 	return e, ok
 }
 
+// SetResourceCache stores the cached top-level resource-list entry for the
+// given resource short name. nil entries are stored as-is (callers wishing
+// to drop an entry should use DeleteResourceCache).
+func (c *Core) SetResourceCache(rt string, e *domain.ListViewCacheEntry) {
+	c.session.ResourceCache[rt] = e
+}
+
+// DeleteResourceCache drops the cached resource-list entry for the given
+// resource short name, so the next list-open re-fetches.
+func (c *Core) DeleteResourceCache(rt string) { delete(c.session.ResourceCache, rt) }
+
+// HasResourceCache reports whether a non-nil cached entry exists for the
+// given resource short name (without exposing the entry itself or any
+// other type). Renderer adapters that only need the existence signal use
+// this in place of `m.core.ResourceCache(rt)` to avoid binding to the
+// entry shape.
+func (c *Core) HasResourceCache(rt string) bool {
+	e, ok := c.session.ResourceCache[rt]
+	return ok && e != nil
+}
+
+// ResourceCacheKeys returns the set of resource short names that currently
+// have a cached top-level list entry. Snapshot semantics — the returned
+// slice is decoupled from the underlying map.
+func (c *Core) ResourceCacheKeys() []string {
+	keys := make([]string, 0, len(c.session.ResourceCache))
+	for k := range c.session.ResourceCache {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// ForEachResourceCache invokes fn for every non-nil cached resource-list
+// entry. The entry pointer is passed by reference; the callback may mutate
+// the entry's slice elements in-place (used by Ctrl+R wave2 cleanup).
+func (c *Core) ForEachResourceCache(fn func(rt string, entry *domain.ListViewCacheEntry)) {
+	for rt, entry := range c.session.ResourceCache {
+		if entry == nil {
+			continue
+		}
+		fn(rt, entry)
+	}
+}
+
 // LazyResourceCache returns the lazy-cache slice for the given resource
 // short name (resources pulled via FetchByIDs for filtered-target
 // drills). The bool reports whether any lazy-cache entry exists for
@@ -76,6 +246,54 @@ func (c *Core) LazyResourceCache(rt string) ([]domain.Resource, bool) {
 	rows, ok := c.session.LazyResourceCache[rt]
 	return rows, ok
 }
+
+// ForEachLazyResourceCache invokes fn for every lazy-cache slice. The slice
+// is passed by value but the underlying array is shared, so the callback
+// may mutate rows[i] fields in-place.
+func (c *Core) ForEachLazyResourceCache(fn func(rt string, rows []resource.Resource)) {
+	for rt, rows := range c.session.LazyResourceCache {
+		fn(rt, rows)
+	}
+}
+
+// ExtendLazyResourceCache merges the given per-type rows into the lazy
+// cache. Used by the PatchLazyResourceCache intent dispatcher in place of
+// `maps.Copy(m.core.Session().LazyResourceCache, ...)`.
+func (c *Core) ExtendLazyResourceCache(adds map[string][]resource.Resource) {
+	maps.Copy(c.session.LazyResourceCache, adds)
+}
+
+// ProbeResources returns the Wave-1 retained first-page resources for the
+// given resource short name. ok reports whether an entry exists in the
+// retained map.
+func (c *Core) ProbeResources(rt string) ([]resource.Resource, bool) {
+	rows, ok := c.session.ProbeResources[rt]
+	return rows, ok
+}
+
+// ForEachProbeResources invokes fn for every retained Wave-1 probe slice.
+// The slice underlying array is shared, so the callback may mutate rows[i]
+// fields in-place.
+func (c *Core) ForEachProbeResources(fn func(rt string, rows []resource.Resource)) {
+	for rt, rows := range c.session.ProbeResources {
+		fn(rt, rows)
+	}
+}
+
+// RelatedCacheGet returns the cached related-check results for the given
+// cache key (built via RelatedCacheKey).
+func (c *Core) RelatedCacheGet(key string) ([]RelatedCacheResult, bool) {
+	return c.session.RelatedCache.Get(key)
+}
+
+// RelatedCacheSet stores the related-check results for the given key.
+func (c *Core) RelatedCacheSet(key string, results []RelatedCacheResult) {
+	c.session.RelatedCache.Set(key, results)
+}
+
+// RelatedCacheDelete drops the cached related-check results for the given
+// key so the next related-fanout re-runs the checkers.
+func (c *Core) RelatedCacheDelete(key string) { c.session.RelatedCache.Delete(key) }
 
 // HasIssueEnricher reports whether a Wave-2 issue enricher is registered
 // for the given resource short name. Renderer adapters use this in place

--- a/internal/runtime/intent.go
+++ b/internal/runtime/intent.go
@@ -259,7 +259,7 @@ func (PatchResourceCache) isIntent() {}
 // PatchRelatedCache appends one resolved related-check result to the
 // session-owned RelatedCache. Emitted by HandleRelatedCheckResult after
 // resolving the source resource ID; the adapter applies by appending to
-// any existing slice under the session.RelatedCacheKey.
+// any existing slice under the runtime.RelatedCacheKey.
 type PatchRelatedCache struct {
 	ResourceType   string
 	SourceID       string

--- a/internal/runtime/relatedcache.go
+++ b/internal/runtime/relatedcache.go
@@ -1,0 +1,44 @@
+// relatedcache.go — PR-05a-h4-c (AS-963) related-cache helpers.
+//
+// RelatedCacheKey and RelatedCacheReplay are free functions moved verbatim
+// from internal/session/related_cache.go so renderer adapters can call them
+// via internal/runtime instead of internal/session. RelatedCacheResult is
+// re-exported as a type alias so callers can construct cache entries using
+// the runtime name; the underlying type still lives in internal/session
+// because *session.RelatedCacheLRU stores it and session.Session.New
+// initialises the cache field.
+package runtime
+
+import (
+	"github.com/k2m30/a9s/v3/internal/runtime/messages"
+	"github.com/k2m30/a9s/v3/internal/session"
+)
+
+// RelatedCacheResult is the per-row payload stored in the related-cache
+// LRU. Alias for session.RelatedCacheResult so renderer adapters need not
+// import internal/session to construct cache entries.
+type RelatedCacheResult = session.RelatedCacheResult
+
+// RelatedCacheKey builds the map key for RelatedCache lookups, using the
+// same `<resourceType>:<resourceID>` format as the session-side helper.
+// Moved here so renderer adapters can resolve cache keys without importing
+// internal/session.
+func RelatedCacheKey(resourceType, resourceID string) string {
+	return resourceType + ":" + resourceID
+}
+
+// RelatedCacheReplay converts cached related-check results into the
+// RelatedCheckResultMsg form the detail view expects, preserving both the
+// resourceType and the per-row DefDisplayName so rightcolumn replay can
+// match the correct row on detail re-entry.
+func RelatedCacheReplay(resourceType string, cached []RelatedCacheResult) []messages.RelatedCheckResult {
+	out := make([]messages.RelatedCheckResult, len(cached))
+	for i, c := range cached {
+		out[i] = messages.RelatedCheckResult{
+			ResourceType:   resourceType,
+			DefDisplayName: c.DefDisplayName,
+			Result:         c.Result,
+		}
+	}
+	return out
+}

--- a/internal/runtime/transport.go
+++ b/internal/runtime/transport.go
@@ -1,0 +1,19 @@
+// transport.go — PR-05a-h4-c (AS-963) tui→runtime transport alias.
+//
+// The TUI used to expose `WithClients(*awsclient.ServiceClients)` as its
+// AWS bootstrap option, forcing internal/tui to import internal/aws. After
+// h4-c the option signature reads `*runtime.ServiceClients` — a transparent
+// alias for the AWS-typed ServiceClients struct. internal/runtime owns the
+// alias because runtime already legitimately imports internal/aws; the TUI
+// only sees the runtime-exported name so its production-side import set
+// drops the awsclient package entirely.
+package runtime
+
+import awsclient "github.com/k2m30/a9s/v3/internal/aws"
+
+// ServiceClients is the runtime-exported alias for *awsclient.ServiceClients.
+// Renderer adapters reference this name in option signatures and accessor
+// returns so they stay independent of internal/aws. The alias is intentional:
+// any *awsclient.ServiceClients value flows through transparently with no
+// conversion at the boundary.
+type ServiceClients = awsclient.ServiceClients

--- a/internal/session/related_cache.go
+++ b/internal/session/related_cache.go
@@ -1,7 +1,13 @@
-// related_cache.go — LRU cache and replay helpers for related-resource check
-// results, keyed by `<resourceType>:<resourceID>`. Hits replay each row's
-// RelatedCheckResultMsg into the rightcolumn view on detail re-entry so the
-// pivot table re-paints without re-issuing AWS describe calls.
+// related_cache.go — LRU cache for related-resource check results.
+//
+// The bounded LRU and the per-row payload type live here because
+// session.Session owns the cache instance (RelatedCacheLRU field). The
+// `RelatedCacheKey` / `RelatedCacheReplay` free helpers used to live here
+// too; PR-05a-h4-c (AS-963) moved them to internal/runtime so renderer
+// adapters can resolve cache keys without importing internal/session.
+// Tests and runtime code reach the helpers via runtime.RelatedCacheKey /
+// runtime.RelatedCacheReplay; there is no session-side re-export to keep
+// drift between two copies impossible.
 //
 // Moved from internal/tui/related_cache.go as part of Phase 02 session owner migration.
 package session
@@ -10,29 +16,7 @@ import (
 	"container/list"
 
 	"github.com/k2m30/a9s/v3/internal/resource"
-	"github.com/k2m30/a9s/v3/internal/runtime/messages"
 )
-
-// RelatedCacheKey builds the map key for RelatedCache lookups.
-func RelatedCacheKey(resourceType, resourceID string) string {
-	return resourceType + ":" + resourceID
-}
-
-// RelatedCacheReplay converts cached related-check results into the
-// RelatedCheckResultMsg form the detail view expects, preserving both the
-// resourceType and the per-row DefDisplayName so rightcolumn replay can
-// match the correct row on detail re-entry.
-func RelatedCacheReplay(resourceType string, cached []RelatedCacheResult) []messages.RelatedCheckResult {
-	out := make([]messages.RelatedCheckResult, len(cached))
-	for i, c := range cached {
-		out[i] = messages.RelatedCheckResult{
-			ResourceType:   resourceType,
-			DefDisplayName: c.DefDisplayName,
-			Result:         c.Result,
-		}
-	}
-	return out
-}
 
 // RelatedCacheLRU is a simple LRU cache for related-resource check results.
 // It caps at MaxRelatedCacheEntries entries; the least-recently-used entry

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -37,16 +37,13 @@ import (
 // ResourceCacheEntry stores the state of a previously-viewed resource list.
 // Used to restore the list when the user re-enters the same resource type
 // from the main menu, avoiding redundant API calls.
-type ResourceCacheEntry struct {
-	Resources     []resource.Resource
-	Pagination    *resource.PaginationMeta
-	FilterText    string
-	AttentionOnly bool // §7.3: ctrl+z toggle persisted across view re-entry
-	SortColIdx    int
-	SortAsc       bool
-	CursorPos     int
-	HScrollOffset int
-}
+//
+// Defined as an alias to domain.ListViewCacheEntry in PR-05a-h4-c (AS-963)
+// so renderer adapters can construct entries without importing
+// internal/session. The existing `session.ResourceCacheEntry` name stays
+// available for callers (tests, runtime handlers) that already reference
+// it. Field set is unchanged.
+type ResourceCacheEntry = domain.ListViewCacheEntry
 
 // Session owns the in-memory orchestration state for the active
 // profile/region session.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -46,10 +46,13 @@ type errorEntry struct {
 // Model is the root Bubble Tea model. It owns the view stack, header state,
 // AWS clients, and routes all messages to the active child view.
 //
-// Session state is owned exclusively by core via core.Session(). Call
-// m.core.Session() at each use site. See the internal/session package for
-// the ownership contract. handleProfileSelected / handleRegionSelected call
-// m.core.Session().Rotate() to invalidate in-flight async results on switch.
+// Session state is owned exclusively by core via *runtime.Core. The renderer
+// reads and mutates session-scoped state through the typed accessors in
+// internal/runtime/accessors.go (m.core.Profile(), m.core.ResourceCache(rt),
+// m.core.BumpRelatedGen(), etc.) — internal/session's struct shape is no
+// longer visible to the tui package. handleProfileSelected /
+// handleRegionSelected call runtime.Core.Rotate (via the orchestrator) to
+// invalidate in-flight async results on profile/region switch.
 type Model struct {
 	core    *runtime.Core    // platform-agnostic app core
 
@@ -154,9 +157,9 @@ func (m Model) Cancel() {
 // When pre-supplied clients are present (demo mode or tests), emits a synthetic
 // ClientsReadyMsg immediately. Otherwise initiates the live AWS connection flow.
 func (m Model) Init() tea.Cmd {
-	if m.core.Session().PreSuppliedClients != nil {
+	if m.core.PreSuppliedClients() != nil {
 		preCmd := func() tea.Msg {
-			return messages.ClientsReady{Clients: m.core.Session().PreSuppliedClients}
+			return messages.ClientsReady{Clients: m.core.PreSuppliedClients()}
 		}
 		if m.configErr != nil {
 			return tea.Batch(preCmd, func() tea.Msg {
@@ -170,8 +173,8 @@ func (m Model) Init() tea.Cmd {
 	}
 	connectCmd := func() tea.Msg {
 		return messages.InitConnect{
-			Profile: m.core.Session().Profile,
-			Region:  m.core.Session().Region,
+			Profile: m.core.Profile(),
+			Region:  m.core.Region(),
 		}
 	}
 	if m.configErr != nil {
@@ -230,7 +233,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case messages.ClearFlash:
 		return m.handleClearFlash(msg)
 	case messages.InitConnect:
-		cmd := m.connectAWS(msg.Profile, msg.Region, m.core.Session().ConnectGen)
+		cmd := m.connectAWS(msg.Profile, msg.Region, m.core.ConnectGen())
 		return m, cmd
 	case messages.ClientsReady:
 		return m.handleClientsReady(msg)
@@ -245,7 +248,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case profilesLoadedMsg:
 		return m.handleProfilesLoaded(msg)
 	case messages.ValueRevealed:
-		if messages.IsStale(msg, m.core.Session()) {
+		if messages.IsStale(msg, m.core) {
 			return m, nil
 		}
 		return m.handleValueRevealed(msg)
@@ -256,14 +259,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if len(msg.ParentContext) > 0 {
 			cmd = m.fetchChildResources(msg.ResourceType, msg.ParentContext)
 		} else {
-			cmd = m.fetchResources(msg.ResourceType, m.core.Session().AvailabilityGen)
+			cmd = m.fetchResources(msg.ResourceType, m.core.AvailabilityGen())
 		}
 		return m, cmd
 	case messages.LoadMore:
 		cmd := m.fetchMoreResources(msg)
 		return m, cmd
 	case messages.APIError:
-		if messages.IsStale(msg, m.core.Session()) {
+		if messages.IsStale(msg, m.core) {
 			return m, nil
 		}
 		return m.handleAPIError(msg)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3,23 +3,17 @@ package tui
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
-	"charm.land/lipgloss/v2"
 
-	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/config"
 	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/runtime"
-	"github.com/k2m30/a9s/v3/internal/session"
-	"github.com/k2m30/a9s/v3/internal/tui/keys"
-	"github.com/k2m30/a9s/v3/internal/tui/layout"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
-	"github.com/k2m30/a9s/v3/internal/tui/styles"
+	"github.com/k2m30/a9s/v3/internal/tui/keys"
 	"github.com/k2m30/a9s/v3/internal/tui/views"
 )
 
@@ -53,8 +47,8 @@ type errorEntry struct {
 // AWS clients, and routes all messages to the active child view.
 //
 // Session state is owned exclusively by core via core.Session(). Call
-// m.core.Session() at each use site. See internal/session/session.go for the
-// ownership contract. handleProfileSelected / handleRegionSelected call
+// m.core.Session() at each use site. See the internal/session package for
+// the ownership contract. handleProfileSelected / handleRegionSelected call
 // m.core.Session().Rotate() to invalidate in-flight async results on switch.
 type Model struct {
 	core    *runtime.Core    // platform-agnostic app core
@@ -107,56 +101,6 @@ type Model struct {
 // Option configures the root Model.
 type Option func(*Model)
 
-// WithProfile overrides the profile field on the session. Used in tests that need
-// a specific profile string without going through the live AWS bootstrap path.
-func WithProfile(profile string) Option {
-	return func(m *Model) { m.core.Session().Profile = profile }
-}
-
-// WithRegion overrides the region field on the session. Used in tests that need
-// a specific region string without going through the live AWS bootstrap path.
-func WithRegion(region string) Option {
-	return func(m *Model) { m.core.Session().Region = region }
-}
-
-// WithIsDemo marks the session as demo mode, which skips Wave 2 enrichment.
-// Set by the --demo CLI bootstrap path. Distinct from WithNoCache which only
-// disables disk persistence.
-func WithIsDemo(demo bool) Option {
-	return func(m *Model) {
-		m.isDemo = demo
-	}
-}
-
-// WithNoCache disables resource availability caching and background checks.
-func WithNoCache(disabled bool) Option {
-	return func(m *Model) {
-		m.core.Session().NoCache = disabled
-	}
-}
-
-// WithClients pre-supplies a set of service clients so that Init() emits a
-// synthetic ClientsReadyMsg instead of initiating a live AWS connection.
-func WithClients(clients *awsclient.ServiceClients) Option {
-	return func(m *Model) {
-		m.core.Session().PreSuppliedClients = clients
-	}
-}
-
-// WithActiveTheme sets the initial active theme filename for the selector's
-// "(current)" indicator. main.go passes the validated theme after loading it.
-func WithActiveTheme(name string) Option {
-	return func(m *Model) { m.activeTheme = name }
-}
-
-// WithCommand sets the initial resource short name to navigate to on the first
-// ClientsReadyMsg. Used by the -c/--command CLI flag to open a resource list
-// directly on startup instead of the main menu. The caller is responsible for
-// resolving the input via resource.FindResourceType.
-func WithCommand(name string) Option {
-	return func(m *Model) { m.core.Session().Command = name }
-}
-
 // New constructs the initial Model.
 func New(profile, region string, opts ...Option) Model {
 	ti := textinput.New()
@@ -175,11 +119,8 @@ func New(profile, region string, opts ...Option) Model {
 	// construction and threaded through all fetchers.
 	ctx, cancel := context.WithCancel(context.Background())
 
-	sess := session.New()
-	sess.Profile = profile
-	sess.Region = region
 	m := Model{
-		core:        runtime.New(sess, resource.AllResourceTypes()),
+		core:        runtime.Bootstrap(profile, region, resource.AllResourceTypes()),
 		keys:        k,
 		stack:       []views.View{&menu},
 		cmdInput:    ti,
@@ -209,7 +150,7 @@ func (m Model) Cancel() {
 	}
 }
 
-// Init implements tea.Model. Fires a command to establish the AWS session.
+// Init implements tea.Model. Fires a command to establish the live AWS connection.
 // When pre-supplied clients are present (demo mode or tests), emits a synthetic
 // ClientsReadyMsg immediately. Otherwise initiates the live AWS connection flow.
 func (m Model) Init() tea.Cmd {
@@ -365,304 +306,3 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m.updateActiveView(msg)
 }
 
-// View implements tea.Model. Composes header + frame around active view content.
-func (m Model) View() tea.View {
-	alt := func(s string) tea.View {
-		v := tea.NewView(s)
-		v.AltScreen = true
-		return v
-	}
-	if m.width == 0 {
-		return alt("")
-	}
-	if m.width < layout.MinTerminalWidth {
-		return alt("Terminal too narrow (min 60 columns)")
-	}
-	if m.height < 7 {
-		return alt("Terminal too short (min 7 lines)")
-	}
-
-	active := m.activeView()
-
-	headerProfile := m.core.Session().Profile
-	headerRegion := m.core.Session().Region
-	if sel, ok := active.(*views.SelectorModel); ok {
-		if sel.Title() == "aws-regions" {
-			headerRegion = "..."
-		} else if sel.Title() == "aws-profiles" {
-			headerProfile = "..."
-		}
-	}
-	rightContent := m.headerRight()
-	badge := m.accountBadge()
-	role := m.identityRoleName()
-	// §7.4: when stack depth exceeds 4, show "[N]" in place of the version string.
-	displayVersion := Version
-	if len(m.stack) > 4 {
-		displayVersion = fmt.Sprintf("[%d]", len(m.stack))
-	}
-	cacheKey := headerProfile + ":" + headerRegion + ":" + displayVersion + ":" + rightContent + ":" + badge + ":" + role + ":" + fmt.Sprintf("%d", m.width)
-	header := m.headerCache
-	if cacheKey != m.headerCacheKey {
-		header = layout.RenderHeader(headerProfile, headerRegion, displayVersion, m.width, rightContent, badge, role)
-		m.headerCache = header
-		m.headerCacheKey = cacheKey
-	}
-
-	content := active.View()
-	var lines []string
-	if content != "" {
-		lines = strings.Split(content, "\n")
-	}
-	frameHeight := max(m.height-1, 3)
-	frameTitle := active.FrameTitle()
-	if d, ok := active.(*views.DetailModel); ok {
-		src := d.SourceResource()
-		if src.ID != "" {
-			if src.Name != "" {
-				frameTitle = fmt.Sprintf("detail -- %s (%s)", src.ID, src.Name)
-			} else {
-				frameTitle = "detail -- " + src.ID
-			}
-		}
-	}
-	var hints []layout.KeyHint
-	if h, ok := active.(views.Hintable); ok {
-		hints = h.BottomHints()
-	}
-	frame := layout.RenderFrameWithHints(lines, frameTitle, hints, m.width, frameHeight)
-
-	v := tea.NewView(header + "\n" + frame)
-	v.AltScreen = true
-	return v
-}
-
-// activeView returns the top of the view stack.
-func (m *Model) activeView() views.View {
-	return m.stack[len(m.stack)-1]
-}
-
-// pushView adds a new view to the stack.
-func (m *Model) pushView(v views.View) {
-	m.stack = append(m.stack, v)
-}
-
-// popView removes the top view. Returns false if only one entry remains.
-func (m *Model) popView() bool {
-	if len(m.stack) <= 1 {
-		return false
-	}
-	// Sync list count back to main menu when popping directly from list → menu.
-	// Only depth 2 (menu → list) triggers this. Related lists (pushed from a detail
-	// view at depth 3+) are marked escPops=true because they show filtered subsets
-	// of a resource type, not the global population — syncing their count back to
-	// the menu badge would overwrite the real global count with a filter result.
-	// See app_related.go for related-list construction.
-	if len(m.stack) == 2 {
-		if rl, ok := m.stack[1].(*views.ResourceListModel); ok {
-			if menu, ok := m.stack[0].(*views.MainMenuModel); ok {
-				shortName := rl.ShortName()
-				if shortName != "" {
-					newCount := rl.LoadedCount()
-					newTrunc := rl.IsTruncated()
-					curCount, known := menu.GetAvailability()[shortName]
-					if !newTrunc || !known || newCount > curCount {
-						menu.SetAvailability(shortName, newCount)
-						menu.SetTruncated(shortName, newTrunc)
-					}
-					// Sync-back issue count with only-increase guard (T036, FR-022).
-					// The list's Status-based issueCount may be lower than the menu's
-					// enriched count. Never overwrite a higher enriched count.
-					newIssues := rl.IssueCount()
-					curIssues := menu.GetIssueCounts()[shortName]
-					curIssueTrunc := menu.GetIssueTruncated()[shortName]
-					switch {
-					case newIssues > curIssues:
-						// higher enriched count from rl: take it
-						menu.SetIssues(shortName, newIssues, newTrunc)
-					case newIssues == curIssues && curIssueTrunc && !newTrunc:
-						// count confirmed but stale "+" must clear
-						menu.SetIssues(shortName, newIssues, false)
-					}
-				}
-			}
-		}
-	}
-	m.stack = m.stack[:len(m.stack)-1]
-	return true
-}
-
-// innerSize returns the content area dimensions inside the frame.
-func (m *Model) innerSize() (int, int) {
-	w := m.width - 2
-	h := m.height - 3
-	if w < 1 {
-		w = 1
-	}
-	if h < 1 {
-		h = 1
-	}
-	return w, h
-}
-
-// propagateSize calls SetSize on every view in the stack with inner dimensions.
-func (m *Model) propagateSize() {
-	w, h := m.innerSize()
-	for _, v := range m.stack {
-		v.SetSize(w, h)
-	}
-}
-
-// updateActiveView delegates a message to the active view and merges the result.
-func (m Model) updateActiveView(msg tea.Msg) (tea.Model, tea.Cmd) {
-	active := m.activeView()
-	switch v := active.(type) {
-	case *views.MainMenuModel:
-		updated, cmd := v.Update(msg)
-		m.stack[len(m.stack)-1] = &updated
-		return m, cmd
-	case *views.ResourceListModel:
-		updated, cmd := v.Update(msg)
-		m.stack[len(m.stack)-1] = &updated
-		m.cacheTopLevelResourceList(updated)
-		return m, cmd
-	case *views.DetailModel:
-		updated, cmd := v.Update(msg)
-		m.stack[len(m.stack)-1] = &updated
-		return m, cmd
-	case *views.YAMLModel:
-		updated, cmd := v.Update(msg)
-		m.stack[len(m.stack)-1] = &updated
-		return m, cmd
-	case *views.JSONModel:
-		updated, cmd := v.Update(msg)
-		m.stack[len(m.stack)-1] = &updated
-		return m, cmd
-	case *views.RevealModel:
-		updated, cmd := v.Update(msg)
-		m.stack[len(m.stack)-1] = &updated
-		return m, cmd
-	case *views.SelectorModel:
-		updated, cmd := v.Update(msg)
-		m.stack[len(m.stack)-1] = &updated
-		return m, cmd
-	case *views.HelpModel:
-		updated, cmd := v.Update(msg)
-		m.stack[len(m.stack)-1] = &updated
-		return m, cmd
-	case *views.IdentityModel:
-		updated, cmd := v.Update(msg)
-		m.stack[len(m.stack)-1] = &updated
-		return m, cmd
-	}
-	return m, nil
-}
-
-func (m *Model) cacheTopLevelResourceList(rl views.ResourceListModel) {
-	if rl.ParentContext() != nil || rl.EscPops() {
-		return
-	}
-	rt := rl.ResourceType()
-	sortColIdx, sortAsc := rl.SortState()
-	m.core.Session().ResourceCache[rt] = &session.ResourceCacheEntry{
-		Resources:     rl.AllResources(),
-		Pagination:    rl.PaginationState(),
-		FilterText:    rl.FilterText(),
-		AttentionOnly: rl.AttentionOnly(),
-		SortColIdx:    sortColIdx,
-		SortAsc:       sortAsc,
-		CursorPos:     rl.CursorPosition(),
-		HScrollOffset: rl.HScrollOffset(),
-	}
-}
-
-// helpContext determines the HelpContext from the current active view.
-func (m *Model) helpContext() views.HelpContext {
-	return m.activeView().GetHelpContext()
-}
-
-// headerRight returns the pre-rendered right-side string for the header.
-func (m Model) headerRight() string {
-	switch m.inputMode {
-	case modeFilter:
-		return styles.FilterActive.Render("/" + m.cmdInput.Value())
-	case modeCommand:
-		return styles.FilterActive.Render(":" + m.cmdInput.Value())
-	}
-	// Show search state from active view.
-	if s, ok := m.activeView().(views.Searchable); ok && s.IsSearchActive() {
-		info := s.SearchInfo()
-		if info != "" {
-			return styles.FilterActive.Render(info)
-		}
-	}
-	if m.flash.active {
-		text := m.flash.text
-		// Truncate to prevent header wrapping (fixes #84).
-		// Reserve ~40 chars for the left side (a9s + version + profile:region + padding).
-		// Errors get more header width; reserve 6 chars minimum for the brand + gap.
-		maxFlash := max(m.width-40, 20)
-		if m.flash.isError {
-			maxFlash = max(m.width-6, 20) // errors get wider display; 6 = innerPad(2)+minLeft(3)+gap(1)
-		}
-		if lipgloss.Width(text) > maxFlash {
-			// Truncate by runes to handle Unicode safely.
-			runes := []rune(text)
-			if len(runes) > maxFlash-3 {
-				text = string(runes[:maxFlash-3]) + "..."
-			}
-		}
-		if m.flash.isError {
-			return styles.FlashError.Render(text)
-		}
-		return styles.FlashSuccess.Render(text)
-	}
-	if rv, ok := m.activeView().(*views.RevealModel); ok {
-		return rv.HeaderWarning()
-	}
-	if m.showErrorHint && len(m.errorHistory) > 0 {
-		return styles.FlashError.Render("! for errors")
-	}
-	return styles.DimText.Render("? for help")
-}
-
-// accountBadge returns the account alias (preferred) or account ID for the header.
-func (m Model) accountBadge() string {
-	if m.core.Session().Identity == nil {
-		return ""
-	}
-	if m.core.Session().Identity.AccountAlias != "" {
-		return m.core.Session().Identity.AccountAlias
-	}
-	return m.core.Session().Identity.AccountID
-}
-
-// identityRoleName returns the identity name (role or user) for the header.
-func (m Model) identityRoleName() string {
-	if m.core.Session().Identity == nil {
-		return ""
-	}
-	return m.core.Session().Identity.IdentityName
-}
-
-// identityToViewData converts the session-cached awsclient.CallerIdentity
-// to a view-layer IdentityData. Used at IdentityModel construction time
-// (the `i` key press) to seed the view from current session state
-// before the in-flight identity fetch returns. The post-h4-b
-// SetIdentityIntent updates the IdentityModel via applyIntents using
-// the *domain.CallerIdentity mirror — this helper covers the construction
-// path that runs before any intent fires.
-func (m Model) identityToViewData() views.IdentityData {
-	if m.core.Session().Identity == nil {
-		return views.IdentityData{}
-	}
-	return views.IdentityData{
-		AccountID:     m.core.Session().Identity.AccountID,
-		AccountAlias:  m.core.Session().Identity.AccountAlias,
-		ARN:           m.core.Session().Identity.Arn,
-		RoleName:      m.core.Session().Identity.RoleName,
-		UserName:      m.core.Session().Identity.UserName,
-		SessionName:   m.core.Session().Identity.SessionName,
-		IsAssumedRole: m.core.Session().Identity.IsAssumedRole,
-	}
-}

--- a/internal/tui/app_accessors.go
+++ b/internal/tui/app_accessors.go
@@ -3,6 +3,13 @@
 // These methods live outside _test.go so that tests in tests/unit/ (package
 // unit_test) can reach them without being in the same package. Production code
 // does not call them.
+//
+// PR-05a-h4-c (AS-963) deleted the Session() accessor (its return type
+// was the last production-side leak of the session package into the tui
+// package). Callers in tests must go through m.Core().Session() instead.
+// Core() returns the platform-agnostic *runtime.Core so the boundary
+// check (`go list .Imports` against internal/tui) no longer reports the
+// session package.
 package tui
 
 import (
@@ -10,14 +17,16 @@ import (
 
 	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
-	"github.com/k2m30/a9s/v3/internal/session"
+	"github.com/k2m30/a9s/v3/internal/runtime"
 	"github.com/k2m30/a9s/v3/internal/tui/views"
 )
 
-// Session returns the underlying *session.Session owned by core.
-// Test-only accessor — production code uses m.core.Session() directly.
-func (m Model) Session() *session.Session {
-	return m.core.Session()
+// Core returns the runtime-owned *runtime.Core handle. Test-only accessor
+// — production code uses m.core directly. Replaces the prior Session()
+// accessor whose session-typed return value forced the tui package to
+// import the internal/session package.
+func (m Model) Core() *runtime.Core {
+	return m.core
 }
 
 // EnrichmentGen returns the current session-wide enrichment generation counter.

--- a/internal/tui/app_accessors.go
+++ b/internal/tui/app_accessors.go
@@ -32,7 +32,7 @@ func (m Model) Core() *runtime.Core {
 // EnrichmentGen returns the current session-wide enrichment generation counter.
 // Test-only accessor.
 func (m Model) EnrichmentGen() domain.Gen {
-	return m.core.Session().EnrichmentGen
+	return m.core.EnrichmentGen()
 }
 
 // FlashGen returns the current tui-adapter flash generation counter.

--- a/internal/tui/app_dispatch.go
+++ b/internal/tui/app_dispatch.go
@@ -9,9 +9,12 @@
 // The five new h4-b intents — PatchResourceCache, PatchRelatedCache,
 // PatchLazyResourceCache, SetIdentityIntent, HeaderInvalidateIntent —
 // each land as a case in applyIntents below. They cross-write
-// session-state owned by Core via the *session.Session pointer that
-// runtime.Core and tui.Model both reference (no separate sync needed —
-// the session is the same instance, not a copy).
+// session-state owned by Core via the handle returned by
+// m.core.Session() (no separate sync needed — the session is the same
+// instance, not a copy). PR-05a-h4-c (AS-963) routed the related-cache
+// key + result type through the internal/runtime package so the
+// renderer-side dispatcher no longer imports the internal/session
+// package.
 package tui
 
 import (
@@ -21,7 +24,6 @@ import (
 
 	"github.com/k2m30/a9s/v3/internal/runtime"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
-	"github.com/k2m30/a9s/v3/internal/session"
 	"github.com/k2m30/a9s/v3/internal/tui/styles"
 	"github.com/k2m30/a9s/v3/internal/tui/views"
 )
@@ -127,9 +129,9 @@ func (m *Model) applyIntents(intents []runtime.UIIntent) []tea.Cmd {
 			// production but keeps the intent set complete for tests
 			// and future emitters that may surface this branch).
 			if v.SourceID != "" {
-				key := session.RelatedCacheKey(v.ResourceType, v.SourceID)
+				key := runtime.RelatedCacheKey(v.ResourceType, v.SourceID)
 				existing, _ := m.core.Session().RelatedCache.Get(key)
-				m.core.Session().RelatedCache.Set(key, append(existing, session.RelatedCacheResult{
+				m.core.Session().RelatedCache.Set(key, append(existing, runtime.RelatedCacheResult{
 					DefDisplayName: v.DefDisplayName,
 					Result:         v.Result,
 				}))

--- a/internal/tui/app_dispatch.go
+++ b/internal/tui/app_dispatch.go
@@ -9,17 +9,15 @@
 // The five new h4-b intents — PatchResourceCache, PatchRelatedCache,
 // PatchLazyResourceCache, SetIdentityIntent, HeaderInvalidateIntent —
 // each land as a case in applyIntents below. They cross-write
-// session-state owned by Core via the handle returned by
-// m.core.Session() (no separate sync needed — the session is the same
-// instance, not a copy). PR-05a-h4-c (AS-963) routed the related-cache
-// key + result type through the internal/runtime package so the
-// renderer-side dispatcher no longer imports the internal/session
-// package.
+// session-state owned by Core via the typed accessors in
+// internal/runtime/accessors.go (SetResourceCache, RelatedCacheSet,
+// ExtendLazyResourceCache). PR-05a-h4-c (AS-963) routed the related-cache
+// key + result type through the internal/runtime package and migrated
+// every session-field access in the renderer onto those typed accessors,
+// so the dispatcher no longer reaches into the session struct shape.
 package tui
 
 import (
-	"maps"
-
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/k2m30/a9s/v3/internal/runtime"
@@ -33,6 +31,10 @@ import (
 // each intent to the TUI view tree + session state. Returns any
 // follow-up tea.Cmds the intents themselves require (flash re-emit,
 // screen-builder closures, theme-apply errors).
+//
+// Session-state mutations land through m.core's typed accessors
+// (SetResourceCache, RelatedCacheSet, ExtendLazyResourceCache) so the
+// dispatcher never reaches through Core into the session struct.
 func (m *Model) applyIntents(intents []runtime.UIIntent) []tea.Cmd {
 	var cmds []tea.Cmd
 	for _, intent := range intents {
@@ -120,7 +122,7 @@ func (m *Model) applyIntents(intents []runtime.UIIntent) []tea.Cmd {
 				m.popView()
 			}
 		case runtime.PatchResourceCache:
-			m.core.Session().ResourceCache[v.ResourceType] = v.Entry
+			m.core.SetResourceCache(v.ResourceType, v.Entry)
 		case runtime.PatchRelatedCache:
 			// PR-05a-h4-b: kept as an applyIntents case for forward-
 			// compatibility, even though Core today writes the
@@ -130,14 +132,14 @@ func (m *Model) applyIntents(intents []runtime.UIIntent) []tea.Cmd {
 			// and future emitters that may surface this branch).
 			if v.SourceID != "" {
 				key := runtime.RelatedCacheKey(v.ResourceType, v.SourceID)
-				existing, _ := m.core.Session().RelatedCache.Get(key)
-				m.core.Session().RelatedCache.Set(key, append(existing, runtime.RelatedCacheResult{
+				existing, _ := m.core.RelatedCacheGet(key)
+				m.core.RelatedCacheSet(key, append(existing, runtime.RelatedCacheResult{
 					DefDisplayName: v.DefDisplayName,
 					Result:         v.Result,
 				}))
 			}
 		case runtime.PatchLazyResourceCache:
-			maps.Copy(m.core.Session().LazyResourceCache, v.Adds)
+			m.core.ExtendLazyResourceCache(v.Adds)
 		case runtime.SetIdentityIntent:
 			if v.Identity == nil {
 				continue
@@ -223,12 +225,12 @@ func (m *Model) tasksToCmd(tasks []runtime.TaskRequest) tea.Cmd {
 	for _, req := range tasks {
 		switch req.Key.Kind {
 		case runtime.TaskKindProbeAvailability:
-			cmd := m.probeResourceAvailability(req.Key.Scope, m.core.Session().AvailabilityGen)
+			cmd := m.probeResourceAvailability(req.Key.Scope, m.core.AvailabilityGen())
 			if cmd != nil {
 				cmds = append(cmds, cmd)
 			}
 		case runtime.TaskKindProbeEnrich:
-			cmd := m.probeEnrichment(req.Key.Scope, m.core.Session().EnrichmentGen)
+			cmd := m.probeEnrichment(req.Key.Scope, m.core.EnrichmentGen())
 			if cmd != nil {
 				cmds = append(cmds, cmd)
 			}

--- a/internal/tui/app_enrich_fold.go
+++ b/internal/tui/app_enrich_fold.go
@@ -47,13 +47,13 @@ func (m *Model) applyEnrichment(resourceType string, findings map[string]resourc
 		}
 	}
 
-	if entry, ok := m.core.Session().ResourceCache[canon]; ok {
+	if entry, ok := m.core.ResourceCache(canon); ok && entry != nil {
 		apply(entry.Resources)
 	}
-	if rows, ok := m.core.Session().LazyResourceCache[canon]; ok {
+	if rows, ok := m.core.LazyResourceCache(canon); ok {
 		apply(rows)
 	}
-	if rows, ok := m.core.Session().ProbeResources[canon]; ok {
+	if rows, ok := m.core.ProbeResources(canon); ok {
 		apply(rows)
 	}
 }
@@ -157,26 +157,23 @@ func stripWave2(findings []domain.Finding) []domain.Finding {
 // cache. Used by main-menu Ctrl+R to ensure the next list-open doesn't
 // rehydrate stale wave2 attention state via findingsFromRows.
 func clearAllWave2(m *Model) {
-	for _, entry := range m.core.Session().ResourceCache {
-		if entry == nil {
-			continue
-		}
+	m.core.ForEachResourceCache(func(_ string, entry *domain.ListViewCacheEntry) {
 		for i := range entry.Resources {
 			entry.Resources[i].Findings = stripWave2(entry.Resources[i].Findings)
 			entry.Resources[i].AttentionDetails = nil
 		}
-	}
-	for _, rows := range m.core.Session().LazyResourceCache {
+	})
+	m.core.ForEachLazyResourceCache(func(_ string, rows []resource.Resource) {
 		for i := range rows {
 			rows[i].Findings = stripWave2(rows[i].Findings)
 			rows[i].AttentionDetails = nil
 		}
-	}
-	for _, rows := range m.core.Session().ProbeResources {
+	})
+	m.core.ForEachProbeResources(func(_ string, rows []resource.Resource) {
 		for i := range rows {
 			rows[i].Findings = stripWave2(rows[i].Findings)
 			rows[i].AttentionDetails = nil
 		}
-	}
+	})
 }
 

--- a/internal/tui/app_input.go
+++ b/internal/tui/app_input.go
@@ -59,16 +59,16 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if _, ok := m.activeView().(*views.IdentityModel); ok {
 			return m.updateActiveView(msg)
 		}
-		id := views.NewIdentity(m.core.Session().Profile, m.core.Session().Region, m.keys)
-		if m.core.Session().Identity != nil {
+		id := views.NewIdentity(m.core.Profile(), m.core.Region(), m.keys)
+		if m.core.Identity() != nil {
 			data := m.identityToViewData()
 			id.SetIdentity(data)
 		}
 		id.SetSize(m.innerSize())
 		m.pushView(&id)
 		// Always re-fetch on i press
-		m.core.Session().IdentityFetching = true
-		cmd := m.fetchIdentity(m.core.Session().ConnectGen)
+		m.core.SetIdentityFetching(true)
+		cmd := m.fetchIdentity(m.core.ConnectGen())
 		return m, cmd
 	}
 	if key.Matches(msg, m.keys.ErrorLog) {

--- a/internal/tui/app_options.go
+++ b/internal/tui/app_options.go
@@ -1,0 +1,70 @@
+// app_options.go — PR-05a-h4-c (AS-963) tui.Model option setters.
+//
+// Split out of app.go so the option surface (WithProfile, WithRegion,
+// WithIsDemo, WithNoCache, WithClients, WithActiveTheme, WithCommand)
+// lives next to its sibling option setters and app.go stays inside the
+// 300–400 LOC budget that the spec acceptance check enforces
+// (`wc -l internal/tui/app.go`).
+//
+// Each option is a tiny closure that mutates the renderer-side Model or
+// pokes a typed setter on m.core. WithClients accepts the runtime-side
+// ServiceClients alias so the package never imports the AWS-client
+// package directly (post-h4-c boundary contract).
+package tui
+
+import "github.com/k2m30/a9s/v3/internal/runtime"
+
+// WithProfile overrides the profile field on the active session — used in
+// tests that need a specific profile string without going through the live
+// AWS bootstrap path.
+func WithProfile(profile string) Option {
+	return func(m *Model) { m.core.Session().Profile = profile }
+}
+
+// WithRegion overrides the region field on the active session — used in
+// tests that need a specific region string without going through the live
+// AWS bootstrap path.
+func WithRegion(region string) Option {
+	return func(m *Model) { m.core.Session().Region = region }
+}
+
+// WithIsDemo marks the session as demo mode, which skips Wave 2 enrichment.
+// Set by the --demo CLI bootstrap path. Distinct from WithNoCache which only
+// disables disk persistence.
+func WithIsDemo(demo bool) Option {
+	return func(m *Model) {
+		m.isDemo = demo
+	}
+}
+
+// WithNoCache disables resource availability caching and background checks.
+func WithNoCache(disabled bool) Option {
+	return func(m *Model) {
+		m.core.Session().NoCache = disabled
+	}
+}
+
+// WithClients pre-supplies a set of service clients so that Init() emits a
+// synthetic ClientsReadyMsg instead of initiating a live AWS connection.
+// The parameter type is a runtime-side ServiceClients alias (transparent
+// re-export of the AWS-typed value) so the TUI package never imports the
+// AWS-client package directly.
+func WithClients(clients *runtime.ServiceClients) Option {
+	return func(m *Model) {
+		m.core.Session().PreSuppliedClients = clients
+	}
+}
+
+// WithActiveTheme sets the initial active theme filename for the selector's
+// "(current)" indicator. main.go passes the validated theme after loading it.
+func WithActiveTheme(name string) Option {
+	return func(m *Model) { m.activeTheme = name }
+}
+
+// WithCommand sets the initial resource short name to navigate to on the first
+// ClientsReadyMsg. Used by the -c/--command CLI flag to open a resource list
+// directly on startup instead of the main menu. The caller is responsible for
+// resolving the input via resource.FindResourceType.
+func WithCommand(name string) Option {
+	return func(m *Model) { m.core.Session().Command = name }
+}

--- a/internal/tui/app_options.go
+++ b/internal/tui/app_options.go
@@ -18,14 +18,14 @@ import "github.com/k2m30/a9s/v3/internal/runtime"
 // tests that need a specific profile string without going through the live
 // AWS bootstrap path.
 func WithProfile(profile string) Option {
-	return func(m *Model) { m.core.Session().Profile = profile }
+	return func(m *Model) { m.core.SetProfile(profile) }
 }
 
 // WithRegion overrides the region field on the active session — used in
 // tests that need a specific region string without going through the live
 // AWS bootstrap path.
 func WithRegion(region string) Option {
-	return func(m *Model) { m.core.Session().Region = region }
+	return func(m *Model) { m.core.SetRegion(region) }
 }
 
 // WithIsDemo marks the session as demo mode, which skips Wave 2 enrichment.
@@ -40,7 +40,7 @@ func WithIsDemo(demo bool) Option {
 // WithNoCache disables resource availability caching and background checks.
 func WithNoCache(disabled bool) Option {
 	return func(m *Model) {
-		m.core.Session().NoCache = disabled
+		m.core.SetNoCache(disabled)
 	}
 }
 
@@ -51,7 +51,7 @@ func WithNoCache(disabled bool) Option {
 // AWS-client package directly.
 func WithClients(clients *runtime.ServiceClients) Option {
 	return func(m *Model) {
-		m.core.Session().PreSuppliedClients = clients
+		m.core.SetPreSuppliedClients(clients)
 	}
 }
 
@@ -66,5 +66,5 @@ func WithActiveTheme(name string) Option {
 // directly on startup instead of the main menu. The caller is responsible for
 // resolving the input via resource.FindResourceType.
 func WithCommand(name string) Option {
-	return func(m *Model) { m.core.Session().Command = name }
+	return func(m *Model) { m.core.SetCommand(name) }
 }

--- a/internal/tui/app_stack.go
+++ b/internal/tui/app_stack.go
@@ -1,0 +1,171 @@
+// app_stack.go — PR-05a-h4-c (AS-963) tui.Model view-stack helpers.
+//
+// Split out of app.go so the view-stack manipulation surface
+// (activeView, pushView, popView, innerSize, propagateSize,
+// updateActiveView, cacheTopLevelResourceList, helpContext) lives in
+// its own file and app.go stays inside the 300–400 LOC budget that the
+// spec acceptance check enforces (`wc -l internal/tui/app.go`).
+//
+// All eight functions are pure renderer-side view-stack manipulation:
+// they update the m.stack slice or read state from the active view.
+// updateActiveView is the per-view-kind switch that delegates a
+// tea.Msg to the right concrete view model and writes the updated
+// model back into the stack.
+package tui
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/k2m30/a9s/v3/internal/domain"
+	"github.com/k2m30/a9s/v3/internal/tui/views"
+)
+
+// activeView returns the top of the view stack.
+func (m *Model) activeView() views.View {
+	return m.stack[len(m.stack)-1]
+}
+
+// pushView adds a new view to the stack.
+func (m *Model) pushView(v views.View) {
+	m.stack = append(m.stack, v)
+}
+
+// popView removes the top view. Returns false if only one entry remains.
+func (m *Model) popView() bool {
+	if len(m.stack) <= 1 {
+		return false
+	}
+	// Sync list count back to main menu when popping directly from list → menu.
+	// Only depth 2 (menu → list) triggers this. Related lists (pushed from a detail
+	// view at depth 3+) are marked escPops=true because they show filtered subsets
+	// of a resource type, not the global population — syncing their count back to
+	// the menu badge would overwrite the real global count with a filter result.
+	// See app_related.go for related-list construction.
+	if len(m.stack) == 2 {
+		if rl, ok := m.stack[1].(*views.ResourceListModel); ok {
+			if menu, ok := m.stack[0].(*views.MainMenuModel); ok {
+				shortName := rl.ShortName()
+				if shortName != "" {
+					newCount := rl.LoadedCount()
+					newTrunc := rl.IsTruncated()
+					curCount, known := menu.GetAvailability()[shortName]
+					if !newTrunc || !known || newCount > curCount {
+						menu.SetAvailability(shortName, newCount)
+						menu.SetTruncated(shortName, newTrunc)
+					}
+					// Sync-back issue count with only-increase guard (T036, FR-022).
+					// The list's Status-based issueCount may be lower than the menu's
+					// enriched count. Never overwrite a higher enriched count.
+					newIssues := rl.IssueCount()
+					curIssues := menu.GetIssueCounts()[shortName]
+					curIssueTrunc := menu.GetIssueTruncated()[shortName]
+					switch {
+					case newIssues > curIssues:
+						// higher enriched count from rl: take it
+						menu.SetIssues(shortName, newIssues, newTrunc)
+					case newIssues == curIssues && curIssueTrunc && !newTrunc:
+						// count confirmed but stale "+" must clear
+						menu.SetIssues(shortName, newIssues, false)
+					}
+				}
+			}
+		}
+	}
+	m.stack = m.stack[:len(m.stack)-1]
+	return true
+}
+
+// innerSize returns the content area dimensions inside the frame.
+func (m *Model) innerSize() (int, int) {
+	w := m.width - 2
+	h := m.height - 3
+	if w < 1 {
+		w = 1
+	}
+	if h < 1 {
+		h = 1
+	}
+	return w, h
+}
+
+// propagateSize calls SetSize on every view in the stack with inner dimensions.
+func (m *Model) propagateSize() {
+	w, h := m.innerSize()
+	for _, v := range m.stack {
+		v.SetSize(w, h)
+	}
+}
+
+// updateActiveView delegates a message to the active view and merges the result.
+func (m Model) updateActiveView(msg tea.Msg) (tea.Model, tea.Cmd) {
+	active := m.activeView()
+	switch v := active.(type) {
+	case *views.MainMenuModel:
+		updated, cmd := v.Update(msg)
+		m.stack[len(m.stack)-1] = &updated
+		return m, cmd
+	case *views.ResourceListModel:
+		updated, cmd := v.Update(msg)
+		m.stack[len(m.stack)-1] = &updated
+		m.cacheTopLevelResourceList(updated)
+		return m, cmd
+	case *views.DetailModel:
+		updated, cmd := v.Update(msg)
+		m.stack[len(m.stack)-1] = &updated
+		return m, cmd
+	case *views.YAMLModel:
+		updated, cmd := v.Update(msg)
+		m.stack[len(m.stack)-1] = &updated
+		return m, cmd
+	case *views.JSONModel:
+		updated, cmd := v.Update(msg)
+		m.stack[len(m.stack)-1] = &updated
+		return m, cmd
+	case *views.RevealModel:
+		updated, cmd := v.Update(msg)
+		m.stack[len(m.stack)-1] = &updated
+		return m, cmd
+	case *views.SelectorModel:
+		updated, cmd := v.Update(msg)
+		m.stack[len(m.stack)-1] = &updated
+		return m, cmd
+	case *views.HelpModel:
+		updated, cmd := v.Update(msg)
+		m.stack[len(m.stack)-1] = &updated
+		return m, cmd
+	case *views.IdentityModel:
+		updated, cmd := v.Update(msg)
+		m.stack[len(m.stack)-1] = &updated
+		return m, cmd
+	}
+	return m, nil
+}
+
+// cacheTopLevelResourceList writes the active ResourceListModel's
+// interactive state (resources, pagination, filter, sort, cursor,
+// h-scroll) into the session's resource-list cache so that re-entering
+// the same top-level resource list restores the view exactly. Child
+// (parentContext != nil) and EscPops lists are skipped because they
+// are filtered subsets and would pollute the global cache.
+func (m *Model) cacheTopLevelResourceList(rl views.ResourceListModel) {
+	if rl.ParentContext() != nil || rl.EscPops() {
+		return
+	}
+	rt := rl.ResourceType()
+	sortColIdx, sortAsc := rl.SortState()
+	m.core.Session().ResourceCache[rt] = &domain.ListViewCacheEntry{
+		Resources:     rl.AllResources(),
+		Pagination:    rl.PaginationState(),
+		FilterText:    rl.FilterText(),
+		AttentionOnly: rl.AttentionOnly(),
+		SortColIdx:    sortColIdx,
+		SortAsc:       sortAsc,
+		CursorPos:     rl.CursorPosition(),
+		HScrollOffset: rl.HScrollOffset(),
+	}
+}
+
+// helpContext determines the HelpContext from the current active view.
+func (m *Model) helpContext() views.HelpContext {
+	return m.activeView().GetHelpContext()
+}

--- a/internal/tui/app_stack.go
+++ b/internal/tui/app_stack.go
@@ -153,7 +153,7 @@ func (m *Model) cacheTopLevelResourceList(rl views.ResourceListModel) {
 	}
 	rt := rl.ResourceType()
 	sortColIdx, sortAsc := rl.SortState()
-	m.core.Session().ResourceCache[rt] = &domain.ListViewCacheEntry{
+	m.core.SetResourceCache(rt, &domain.ListViewCacheEntry{
 		Resources:     rl.AllResources(),
 		Pagination:    rl.PaginationState(),
 		FilterText:    rl.FilterText(),
@@ -162,7 +162,7 @@ func (m *Model) cacheTopLevelResourceList(rl views.ResourceListModel) {
 		SortAsc:       sortAsc,
 		CursorPos:     rl.CursorPosition(),
 		HScrollOffset: rl.HScrollOffset(),
-	}
+	})
 }
 
 // helpContext determines the HelpContext from the current active view.

--- a/internal/tui/app_view.go
+++ b/internal/tui/app_view.go
@@ -42,8 +42,8 @@ func (m Model) View() tea.View {
 
 	active := m.activeView()
 
-	headerProfile := m.core.Session().Profile
-	headerRegion := m.core.Session().Region
+	headerProfile := m.core.Profile()
+	headerRegion := m.core.Region()
 	if sel, ok := active.(*views.SelectorModel); ok {
 		if sel.Title() == "aws-regions" {
 			headerRegion = "..."
@@ -142,41 +142,45 @@ func (m Model) headerRight() string {
 
 // accountBadge returns the account alias (preferred) or account ID for the header.
 func (m Model) accountBadge() string {
-	if m.core.Session().Identity == nil {
+	id := m.core.Identity()
+	if id == nil {
 		return ""
 	}
-	if m.core.Session().Identity.AccountAlias != "" {
-		return m.core.Session().Identity.AccountAlias
+	if id.AccountAlias != "" {
+		return id.AccountAlias
 	}
-	return m.core.Session().Identity.AccountID
+	return id.AccountID
 }
 
 // identityRoleName returns the identity name (role or user) for the header.
 func (m Model) identityRoleName() string {
-	if m.core.Session().Identity == nil {
+	id := m.core.Identity()
+	if id == nil {
 		return ""
 	}
-	return m.core.Session().Identity.IdentityName
+	return id.IdentityName
 }
 
-// identityToViewData converts the session-cached caller identity (the AWS
-// SDK form) to a view-layer IdentityData. Used at IdentityModel
-// construction time (the `i` key press) to seed the view from current
-// session state before the in-flight identity fetch returns. The post-h4-b
-// SetIdentityIntent updates the IdentityModel via applyIntents using
-// the *domain.CallerIdentity mirror — this helper covers the construction
-// path that runs before any intent fires.
+// identityToViewData converts the session-cached caller identity (mirrored
+// to the renderer-shaped *domain.CallerIdentity by m.core.Identity()) to a
+// view-layer IdentityData. Used at IdentityModel construction time (the
+// `i` key press) to seed the view from current session state before the
+// in-flight identity fetch returns. The post-h4-b SetIdentityIntent
+// updates the IdentityModel via applyIntents using the same domain mirror —
+// this helper covers the construction path that runs before any intent
+// fires.
 func (m Model) identityToViewData() views.IdentityData {
-	if m.core.Session().Identity == nil {
+	id := m.core.Identity()
+	if id == nil {
 		return views.IdentityData{}
 	}
 	return views.IdentityData{
-		AccountID:     m.core.Session().Identity.AccountID,
-		AccountAlias:  m.core.Session().Identity.AccountAlias,
-		ARN:           m.core.Session().Identity.Arn,
-		RoleName:      m.core.Session().Identity.RoleName,
-		UserName:      m.core.Session().Identity.UserName,
-		SessionName:   m.core.Session().Identity.SessionName,
-		IsAssumedRole: m.core.Session().Identity.IsAssumedRole,
+		AccountID:     id.AccountID,
+		AccountAlias:  id.AccountAlias,
+		ARN:           id.Arn,
+		RoleName:      id.RoleName,
+		UserName:      id.UserName,
+		SessionName:   id.SessionName,
+		IsAssumedRole: id.IsAssumedRole,
 	}
 }

--- a/internal/tui/app_view.go
+++ b/internal/tui/app_view.go
@@ -1,0 +1,182 @@
+// app_view.go — PR-05a-h4-c (AS-963) tui.Model render-path helpers.
+//
+// Split out of app.go so the View() composition + header-right /
+// account-badge / identity-role / identity-to-view-data helpers live in
+// their own file and app.go stays inside the 300–400 LOC budget that the
+// spec acceptance check enforces (`wc -l internal/tui/app.go`).
+//
+// All five functions here are pure renderer-side composition: they read
+// view-stack state plus a small slice of session metadata (profile,
+// region, identity) and produce strings or tea.View values for the
+// renderer to display. No runtime / handler logic lives here.
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/k2m30/a9s/v3/internal/tui/layout"
+	"github.com/k2m30/a9s/v3/internal/tui/styles"
+	"github.com/k2m30/a9s/v3/internal/tui/views"
+)
+
+// View implements tea.Model. Composes header + frame around active view content.
+func (m Model) View() tea.View {
+	alt := func(s string) tea.View {
+		v := tea.NewView(s)
+		v.AltScreen = true
+		return v
+	}
+	if m.width == 0 {
+		return alt("")
+	}
+	if m.width < layout.MinTerminalWidth {
+		return alt("Terminal too narrow (min 60 columns)")
+	}
+	if m.height < 7 {
+		return alt("Terminal too short (min 7 lines)")
+	}
+
+	active := m.activeView()
+
+	headerProfile := m.core.Session().Profile
+	headerRegion := m.core.Session().Region
+	if sel, ok := active.(*views.SelectorModel); ok {
+		if sel.Title() == "aws-regions" {
+			headerRegion = "..."
+		} else if sel.Title() == "aws-profiles" {
+			headerProfile = "..."
+		}
+	}
+	rightContent := m.headerRight()
+	badge := m.accountBadge()
+	role := m.identityRoleName()
+	// §7.4: when stack depth exceeds 4, show "[N]" in place of the version string.
+	displayVersion := Version
+	if len(m.stack) > 4 {
+		displayVersion = fmt.Sprintf("[%d]", len(m.stack))
+	}
+	cacheKey := headerProfile + ":" + headerRegion + ":" + displayVersion + ":" + rightContent + ":" + badge + ":" + role + ":" + fmt.Sprintf("%d", m.width)
+	header := m.headerCache
+	if cacheKey != m.headerCacheKey {
+		header = layout.RenderHeader(headerProfile, headerRegion, displayVersion, m.width, rightContent, badge, role)
+		m.headerCache = header
+		m.headerCacheKey = cacheKey
+	}
+
+	content := active.View()
+	var lines []string
+	if content != "" {
+		lines = strings.Split(content, "\n")
+	}
+	frameHeight := max(m.height-1, 3)
+	frameTitle := active.FrameTitle()
+	if d, ok := active.(*views.DetailModel); ok {
+		src := d.SourceResource()
+		if src.ID != "" {
+			if src.Name != "" {
+				frameTitle = fmt.Sprintf("detail -- %s (%s)", src.ID, src.Name)
+			} else {
+				frameTitle = "detail -- " + src.ID
+			}
+		}
+	}
+	var hints []layout.KeyHint
+	if h, ok := active.(views.Hintable); ok {
+		hints = h.BottomHints()
+	}
+	frame := layout.RenderFrameWithHints(lines, frameTitle, hints, m.width, frameHeight)
+
+	v := tea.NewView(header + "\n" + frame)
+	v.AltScreen = true
+	return v
+}
+
+// headerRight returns the pre-rendered right-side string for the header.
+func (m Model) headerRight() string {
+	switch m.inputMode {
+	case modeFilter:
+		return styles.FilterActive.Render("/" + m.cmdInput.Value())
+	case modeCommand:
+		return styles.FilterActive.Render(":" + m.cmdInput.Value())
+	}
+	// Show search state from active view.
+	if s, ok := m.activeView().(views.Searchable); ok && s.IsSearchActive() {
+		info := s.SearchInfo()
+		if info != "" {
+			return styles.FilterActive.Render(info)
+		}
+	}
+	if m.flash.active {
+		text := m.flash.text
+		// Truncate to prevent header wrapping (fixes #84).
+		// Reserve ~40 chars for the left side (a9s + version + profile:region + padding).
+		// Errors get more header width; reserve 6 chars minimum for the brand + gap.
+		maxFlash := max(m.width-40, 20)
+		if m.flash.isError {
+			maxFlash = max(m.width-6, 20) // errors get wider display; 6 = innerPad(2)+minLeft(3)+gap(1)
+		}
+		if lipgloss.Width(text) > maxFlash {
+			// Truncate by runes to handle Unicode safely.
+			runes := []rune(text)
+			if len(runes) > maxFlash-3 {
+				text = string(runes[:maxFlash-3]) + "..."
+			}
+		}
+		if m.flash.isError {
+			return styles.FlashError.Render(text)
+		}
+		return styles.FlashSuccess.Render(text)
+	}
+	if rv, ok := m.activeView().(*views.RevealModel); ok {
+		return rv.HeaderWarning()
+	}
+	if m.showErrorHint && len(m.errorHistory) > 0 {
+		return styles.FlashError.Render("! for errors")
+	}
+	return styles.DimText.Render("? for help")
+}
+
+// accountBadge returns the account alias (preferred) or account ID for the header.
+func (m Model) accountBadge() string {
+	if m.core.Session().Identity == nil {
+		return ""
+	}
+	if m.core.Session().Identity.AccountAlias != "" {
+		return m.core.Session().Identity.AccountAlias
+	}
+	return m.core.Session().Identity.AccountID
+}
+
+// identityRoleName returns the identity name (role or user) for the header.
+func (m Model) identityRoleName() string {
+	if m.core.Session().Identity == nil {
+		return ""
+	}
+	return m.core.Session().Identity.IdentityName
+}
+
+// identityToViewData converts the session-cached caller identity (the AWS
+// SDK form) to a view-layer IdentityData. Used at IdentityModel
+// construction time (the `i` key press) to seed the view from current
+// session state before the in-flight identity fetch returns. The post-h4-b
+// SetIdentityIntent updates the IdentityModel via applyIntents using
+// the *domain.CallerIdentity mirror — this helper covers the construction
+// path that runs before any intent fires.
+func (m Model) identityToViewData() views.IdentityData {
+	if m.core.Session().Identity == nil {
+		return views.IdentityData{}
+	}
+	return views.IdentityData{
+		AccountID:     m.core.Session().Identity.AccountID,
+		AccountAlias:  m.core.Session().Identity.AccountAlias,
+		ARN:           m.core.Session().Identity.Arn,
+		RoleName:      m.core.Session().Identity.RoleName,
+		UserName:      m.core.Session().Identity.UserName,
+		SessionName:   m.core.Session().Identity.SessionName,
+		IsAssumedRole: m.core.Session().Identity.IsAssumedRole,
+	}
+}

--- a/internal/tui/fetch_adapter.go
+++ b/internal/tui/fetch_adapter.go
@@ -10,8 +10,8 @@
 // IdentityError / ValueRevealed now captures the dispatch-time generation counter
 // (gen domain.Gen) at the call site. The gen is stamped onto the returned message
 // so the app.go handler can discard stale results after a profile/region switch
-// (messages.IsStale guard). Callers pass m.core.Session().AvailabilityGen (for
-// resource fetches) or m.core.Session().ConnectGen (for identity/reveal fetches).
+// (messages.IsStale guard). Callers pass m.core.AvailabilityGen() (for
+// resource fetches) or m.core.ConnectGen() (for identity/reveal fetches).
 package tui
 
 import (
@@ -33,7 +33,7 @@ type profilesLoadedMsg struct {
 // gen is the AvailabilityGen captured at dispatch time; it is stamped onto the
 // returned message so the handler can discard stale results after a switch.
 func (m *Model) fetchResources(resourceType string, gen domain.Gen) tea.Cmd {
-	ctx, clients := m.appCtx, m.core.Session().Clients
+	ctx, clients := m.appCtx, m.core.Clients()
 	return func() tea.Msg {
 		res, err := m.core.FetchResources(ctx, clients, resourceType)
 		// Partial-success contract: fetchers may return BOTH a non-empty
@@ -56,7 +56,7 @@ func (m *Model) fetchResources(resourceType string, gen domain.Gen) tea.Cmd {
 // fetchResourcesFiltered returns a tea.Cmd for a server-side filtered fetch.
 // gen is the AvailabilityGen captured at dispatch time.
 func (m *Model) fetchResourcesFiltered(resourceType string, filter map[string]string, gen domain.Gen) tea.Cmd {
-	ctx, clients := m.appCtx, m.core.Session().Clients
+	ctx, clients := m.appCtx, m.core.Clients()
 	return func() tea.Msg {
 		res, err := m.core.FetchResourcesFiltered(ctx, clients, resourceType, filter)
 		if err != nil && len(res.Resources) == 0 {
@@ -75,7 +75,7 @@ func (m *Model) fetchResourcesFiltered(resourceType string, filter map[string]st
 // fetchAMIDetail returns a tea.Cmd that fetches a single AMI by ID and
 // navigates to its detail view.
 func (m *Model) fetchAMIDetail(imageID string) tea.Cmd {
-	ctx, clients := m.appCtx, m.core.Session().Clients
+	ctx, clients := m.appCtx, m.core.Clients()
 	return func() tea.Msg {
 		res, err := m.core.FetchAMIDetail(ctx, clients, imageID)
 		if err != nil {
@@ -93,8 +93,8 @@ func (m *Model) fetchAMIDetail(imageID string) tea.Cmd {
 // Child resource fetches use AvailabilityGen so stale results from prior
 // profile/region are discarded along with top-level fetches.
 func (m *Model) fetchChildResources(childType string, parentCtx map[string]string) tea.Cmd {
-	ctx, clients := m.appCtx, m.core.Session().Clients
-	gen := m.core.Session().AvailabilityGen
+	ctx, clients := m.appCtx, m.core.Clients()
+	gen := m.core.AvailabilityGen()
 	return func() tea.Msg {
 		res, err := m.core.FetchChildResources(ctx, clients, childType, parentCtx)
 		if err != nil {
@@ -113,8 +113,8 @@ func (m *Model) fetchChildResources(childType string, parentCtx map[string]strin
 // paginated resource list using the continuation token from LoadMoreMsg.
 // gen is the AvailabilityGen captured at dispatch time.
 func (m *Model) fetchMoreResources(msg messages.LoadMore) tea.Cmd {
-	ctx, clients := m.appCtx, m.core.Session().Clients
-	gen := m.core.Session().AvailabilityGen
+	ctx, clients := m.appCtx, m.core.Clients()
+	gen := m.core.AvailabilityGen()
 	p := runtime.FetchMoreParams{
 		ResourceType: msg.ResourceType,
 		Token:        msg.ContinuationToken,
@@ -141,7 +141,7 @@ func (m *Model) fetchMoreResources(msg messages.LoadMore) tea.Cmd {
 // gen is the ConnectGen captured at dispatch time; it is stamped onto the
 // returned message so the handler can discard stale results after a switch.
 func (m *Model) fetchIdentity(gen domain.Gen) tea.Cmd {
-	ctx, clients := m.appCtx, m.core.Session().Clients
+	ctx, clients := m.appCtx, m.core.Clients()
 	return func() tea.Msg {
 		identity, err := m.core.FetchIdentity(ctx, clients)
 		if err != nil {
@@ -166,7 +166,7 @@ func (m *Model) fetchProfiles() tea.Cmd {
 // gen is the ConnectGen captured at dispatch time; it is stamped onto the
 // returned message so the handler can discard stale results after a switch.
 func (m *Model) fetchRevealValue(resourceType, resourceID string, gen domain.Gen) tea.Cmd {
-	ctx, clients := m.appCtx, m.core.Session().Clients
+	ctx, clients := m.appCtx, m.core.Clients()
 	return func() tea.Msg {
 		value, err := m.core.FetchRevealValue(ctx, clients, resourceType, resourceID)
 		if err != nil {

--- a/internal/tui/lru_test.go
+++ b/internal/tui/lru_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/k2m30/a9s/v3/internal/resource"
+	"github.com/k2m30/a9s/v3/internal/runtime"
 	"github.com/k2m30/a9s/v3/internal/session"
 )
 
@@ -93,7 +94,7 @@ func TestRelatedCacheLRU_Clear(t *testing.T) {
 // for the shared TargetType="ct-events".
 func TestRelatedCacheReplay_PreservesDefDisplayName(t *testing.T) {
 	c := session.NewRelatedCacheLRU(10)
-	key := session.RelatedCacheKey("ct-events", "src-evt-0001")
+	key := runtime.RelatedCacheKey("ct-events", "src-evt-0001")
 
 	in := []session.RelatedCacheResult{
 		{DefDisplayName: "CT events by AccessKeyId", Result: resource.RelatedCheckResult{TargetType: "ct-events", Count: 3, ResourceIDs: []string{"e1"}}},
@@ -111,9 +112,9 @@ func TestRelatedCacheReplay_PreservesDefDisplayName(t *testing.T) {
 		t.Fatalf("len(cached) = %d, want %d", len(got), len(in))
 	}
 
-	// session.RelatedCacheReplay must project cached entries back into messages
+	// runtime.RelatedCacheReplay must project cached entries back into messages
 	// carrying the original DefDisplayName so every row resolves.
-	msgs := session.RelatedCacheReplay("ct-events", got)
+	msgs := runtime.RelatedCacheReplay("ct-events", got)
 	if len(msgs) != len(in) {
 		t.Fatalf("len(replay) = %d, want %d", len(msgs), len(in))
 	}

--- a/internal/tui/probe_adapter.go
+++ b/internal/tui/probe_adapter.go
@@ -10,7 +10,6 @@ package tui
 import (
 	tea "charm.land/bubbletea/v2"
 
-	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/cache"
 	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
@@ -170,7 +169,7 @@ func (m *Model) probeEnrichment(shortName string, gen domain.Gen) tea.Cmd {
 	}
 	ctx, clients := m.appCtx, m.core.Session().Clients
 	typeGen := m.core.Session().EnrichmentTypeGen[shortName]
-	if _, ok := awsclient.Wave2EnricherFor(shortName); !ok {
+	if !m.core.HasIssueEnricher(shortName) {
 		return nil
 	}
 	return func() tea.Msg {

--- a/internal/tui/probe_adapter.go
+++ b/internal/tui/probe_adapter.go
@@ -19,8 +19,8 @@ import (
 // loadAvailabilityCache returns a tea.Cmd that reads the availability cache
 // from disk and converts the result to AvailabilityCacheLoadedMsg.
 func (m *Model) loadAvailabilityCache() tea.Cmd {
-	profile := m.core.Session().Profile
-	region := m.core.Session().Region
+	profile := m.core.Profile()
+	region := m.core.Region()
 	return func() tea.Msg {
 		cf, err := m.core.LoadAvailabilityCache(profile, region)
 		if err != nil || cf == nil {
@@ -63,7 +63,7 @@ func (m *Model) loadAvailabilityCache() tea.Cmd {
 // probeResourceAvailability returns a tea.Cmd that runs a Wave-1 availability
 // probe for shortName and converts the result to AvailabilityCheckedMsg.
 func (m *Model) probeResourceAvailability(shortName string, gen domain.Gen) tea.Cmd {
-	ctx, clients := m.appCtx, m.core.Session().Clients
+	ctx, clients := m.appCtx, m.core.Clients()
 	return func() tea.Msg {
 		r := m.core.ProbeResourceAvailability(ctx, clients, shortName)
 		return messages.AvailabilityChecked{
@@ -82,11 +82,11 @@ func (m *Model) probeResourceAvailability(shortName string, gen domain.Gen) tea.
 // saveAvailabilityCache returns a tea.Cmd that persists the current
 // availability state to disk. No-op when caching is disabled (noCache=true).
 func (m *Model) saveAvailabilityCache() tea.Cmd {
-	if m.core.Session().NoCache {
+	if m.core.NoCache() {
 		return nil
 	}
-	profile := m.core.Session().Profile
-	region := m.core.Session().Region
+	profile := m.core.Profile()
+	region := m.core.Region()
 
 	// Collect availability, truncation, and issue counts from main menu.
 	var entries map[string]int
@@ -117,8 +117,8 @@ func (m *Model) saveAvailabilityCache() tea.Cmd {
 // Used when pre-supplied clients are present and no-cache is active so the
 // main menu shows counts immediately without the async probe pipeline.
 func (m *Model) demoPrefetchCounts() tea.Cmd {
-	ctx, clients := m.appCtx, m.core.Session().Clients
-	gen := m.core.Session().AvailabilityGen
+	ctx, clients := m.appCtx, m.core.Clients()
+	gen := m.core.AvailabilityGen()
 	return func() tea.Msg {
 		r := m.core.DemoPrefetchCounts(ctx, clients)
 		return messages.AvailabilityPrefetched{
@@ -167,8 +167,8 @@ func (m *Model) probeEnrichment(shortName string, gen domain.Gen) tea.Cmd {
 	if m.isDemo {
 		return nil
 	}
-	ctx, clients := m.appCtx, m.core.Session().Clients
-	typeGen := m.core.Session().EnrichmentTypeGen[shortName]
+	ctx, clients := m.appCtx, m.core.Clients()
+	typeGen := m.core.EnrichmentTypeGen(shortName)
 	if !m.core.HasIssueEnricher(shortName) {
 		return nil
 	}

--- a/internal/tui/related_helpers.go
+++ b/internal/tui/related_helpers.go
@@ -45,5 +45,5 @@ func (m *Model) newRelatedList(rt resource.ResourceTypeDef, src resource.Resourc
 // buildResourceCacheSnapshot delegates to runtime.Core for the canonical
 // multi-cache merge (ResourceCache + LazyResourceCache + ProbeResources).
 func (m *Model) buildResourceCacheSnapshot() resource.ResourceCache {
-	return runtime.New(m.core.Session(), resource.AllResourceTypes()).BuildResourceCacheSnapshot()
+	return m.core.BuildResourceCacheSnapshot()
 }

--- a/internal/tui/runtime_adapter.go
+++ b/internal/tui/runtime_adapter.go
@@ -23,7 +23,7 @@
 //     fields without parsing TaskKey.Scope or accepting side-channel
 //     arguments. The closure builder stays in the adapter because it
 //     returns tea.Cmd and reads adapter-owned state (m.appCtx,
-//     m.core.Session().Clients, the session owned by core's EnrichGen and PolicyDocCache)
+//     m.core.Clients(), the session owned by core's EnrichGen and PolicyDocCache)
 //     that has not yet migrated to the runtime core.
 package tui
 
@@ -142,7 +142,7 @@ func (m Model) runtimeTasksToCmd(tasks []runtime.TaskRequest) tea.Cmd {
 		case runtime.ConnectPayload:
 			cmds = append(cmds, m.connectAWS(p.Profile, p.Region, p.Gen))
 		case runtime.FetchIdentityPayload:
-			cmds = append(cmds, m.fetchIdentity(m.core.Session().ConnectGen))
+			cmds = append(cmds, m.fetchIdentity(m.core.ConnectGen()))
 		case runtime.LoadAvailCachePayload:
 			cmds = append(cmds, m.loadAvailabilityCache())
 		case runtime.DemoPrefetchCountsPayload:

--- a/internal/tui/runtime_adapter.go
+++ b/internal/tui/runtime_adapter.go
@@ -177,7 +177,7 @@ func (m Model) runtimeTasksToCmd(tasks []runtime.TaskRequest) tea.Cmd {
 // detail enricher and emits an EnrichDetailResultMsg. It reads every
 // runtime-side input (DetailCtx, Generation) from the typed payload —
 // PR-05a-h4-b (AS-962) moved DetailEnrichmentCtx construction onto Core
-// so the adapter no longer touches awsclient.DetailEnrichmentCtx
+// so the adapter no longer touches the AWS-side DetailEnrichmentCtx
 // directly here. The remaining adapter-owned input is m.appCtx (the
 // app-wide cancellation context); ctx still wraps a 10 s per-call
 // timeout the runtime cannot express because tea.Cmd composition

--- a/internal/tui/runtime_adapter_navigate.go
+++ b/internal/tui/runtime_adapter_navigate.go
@@ -15,7 +15,7 @@
 // stack, view-typed methods, flashState, tea.Cmd returns). Their
 // runtime-policy parts (cache-mutation gen bumps, per-type
 // enrichment-rerun bookkeeping) are reads/writes against the session
-// owned by core — same data the runtime sees through c.session.
+// owned by core — same data the runtime sees through its session field.
 //
 // PR-05a-h4-b (AS-962) removed the inline handleIdentityLoaded /
 // handleIdentityError helpers in favour of HandleEvent-routed dispatch
@@ -34,12 +34,10 @@ import (
 
 	"github.com/atotto/clipboard"
 
-	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/config"
 	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/runtime"
-	"github.com/k2m30/a9s/v3/internal/session"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
 	"github.com/k2m30/a9s/v3/internal/tui/views"
 )
@@ -184,9 +182,9 @@ func (m Model) handleNavigate(msg messages.Navigate) (tea.Model, tea.Cmd) {
 			})
 		}
 		if result.DispatchRelated && d.NeedsRelatedCheck() {
-			ck := session.RelatedCacheKey(result.ResolvedType, result.Resource.ID)
+			ck := runtime.RelatedCacheKey(result.ResolvedType, result.Resource.ID)
 			if cached, ok := m.core.Session().RelatedCache.Get(ck); ok && len(cached) > 0 {
-				d.ApplyRelatedResults(session.RelatedCacheReplay(result.ResolvedType, cached))
+				d.ApplyRelatedResults(runtime.RelatedCacheReplay(result.ResolvedType, cached))
 			} else {
 				res := *result.Resource
 				rt := result.ResolvedType
@@ -436,7 +434,7 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 		d.ResetRightColumn()
 		rt := d.ResourceType()
 		srcRes := d.SourceResource()
-		m.core.Session().RelatedCache.Delete(session.RelatedCacheKey(rt, srcRes.ID))
+		m.core.Session().RelatedCache.Delete(runtime.RelatedCacheKey(rt, srcRes.ID))
 		m.core.Session().RelatedGen++      // cancel in-flight results from previous batch
 		m.core.Session().EnrichGen++       // cancel in-flight enrichment from previous batch
 		m.core.Session().EnrichResKey = "" // force gen bump on next enrichment dispatch
@@ -502,7 +500,7 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 	// outgoing ResourcesLoadedMsg so the tail branch in app.go can seed
 	// probeResources and dispatch probeEnrichment on success.
 	if rl.ParentContext() == nil && !rl.EscPops() {
-		if _, hasEnricher := awsclient.Wave2EnricherFor(rt); hasEnricher {
+		if m.core.HasIssueEnricher(rt) {
 			m.core.Session().EnrichmentTypeGen[rt]++
 			tok := m.core.Session().EnrichmentTypeGen[rt]
 			delete(m.core.Session().EnrichmentRan, rt)

--- a/internal/tui/runtime_adapter_navigate.go
+++ b/internal/tui/runtime_adapter_navigate.go
@@ -35,7 +35,6 @@ import (
 	"github.com/atotto/clipboard"
 
 	"github.com/k2m30/a9s/v3/internal/config"
-	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/runtime"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
@@ -129,7 +128,7 @@ func (m Model) handleNavigate(msg messages.Navigate) (tea.Model, tea.Cmd) {
 			issueTrunc = menu.GetIssueTruncated()[canon]
 		}
 		rl.SetEnrichmentState(issueCount, issueTrunc, findingsFromRows(entry.Resources))
-		rl.SetTruncatedIDs(m.core.Session().EnrichmentTruncatedIDs[canon])
+		rl.SetTruncatedIDs(m.core.EnrichmentTruncatedIDs(canon))
 		m.pushView(&rl)
 		return m, nil
 
@@ -156,7 +155,7 @@ func (m Model) handleNavigate(msg messages.Navigate) (tea.Model, tea.Cmd) {
 			issueTrunc = menu.GetIssueTruncated()[canon]
 		}
 		rl.SetEnrichmentState(issueCount, issueTrunc, nil)
-		rl.SetTruncatedIDs(m.core.Session().EnrichmentTruncatedIDs[canon])
+		rl.SetTruncatedIDs(m.core.EnrichmentTruncatedIDs(canon))
 		rl, initCmd := rl.Init()
 		m.pushView(&rl)
 		fetchCmd := navigateTasksToCmd(m, msg, result, tasks)
@@ -183,7 +182,7 @@ func (m Model) handleNavigate(msg messages.Navigate) (tea.Model, tea.Cmd) {
 		}
 		if result.DispatchRelated && d.NeedsRelatedCheck() {
 			ck := runtime.RelatedCacheKey(result.ResolvedType, result.Resource.ID)
-			if cached, ok := m.core.Session().RelatedCache.Get(ck); ok && len(cached) > 0 {
+			if cached, ok := m.core.RelatedCacheGet(ck); ok && len(cached) > 0 {
 				d.ApplyRelatedResults(runtime.RelatedCacheReplay(result.ResolvedType, cached))
 			} else {
 				res := *result.Resource
@@ -242,7 +241,7 @@ func (m Model) handleNavigate(msg messages.Navigate) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case runtime.NavigateKindFetchProfiles:
-		if m.core.Session().PreSuppliedClients != nil {
+		if m.core.PreSuppliedClients() != nil {
 			return m, func() tea.Msg {
 				return messages.Flash{
 					Text:    "context switching is disabled in demo mode",
@@ -253,7 +252,7 @@ func (m Model) handleNavigate(msg messages.Navigate) (tea.Model, tea.Cmd) {
 		return m, navigateTasksToCmd(m, msg, result, tasks)
 
 	case runtime.NavigateKindPushRegion:
-		if m.core.Session().PreSuppliedClients != nil {
+		if m.core.PreSuppliedClients() != nil {
 			return m, func() tea.Msg {
 				return messages.Flash{
 					Text:    "region switching is disabled in demo mode",
@@ -266,7 +265,7 @@ func (m Model) handleNavigate(msg messages.Navigate) (tea.Model, tea.Cmd) {
 		for i, r := range regions {
 			regionCodes[i] = r.Code
 		}
-		rg := views.NewRegion(regionCodes, m.core.Session().Region, m.keys)
+		rg := views.NewRegion(regionCodes, m.core.Region(), m.keys)
 		rg.SetSize(m.innerSize())
 		m.pushView(&rg)
 		return m, nil
@@ -358,12 +357,12 @@ func navigateTasksToCmd(m Model, msg messages.Navigate, result runtime.NavigateR
 			if fetchRT == "" {
 				fetchRT = msg.ResourceType
 			}
-			cmds = append(cmds, m.fetchResources(fetchRT, m.core.Session().AvailabilityGen))
+			cmds = append(cmds, m.fetchResources(fetchRT, m.core.AvailabilityGen()))
 		case runtime.KindFetchProfiles:
 			cmds = append(cmds, m.fetchProfiles())
 		case runtime.KindFetchReveal:
 			if p, ok := t.Payload.(runtime.FetchRevealPayload); ok {
-				cmds = append(cmds, m.fetchRevealValue(p.ResourceType, p.ResourceID, m.core.Session().ConnectGen))
+				cmds = append(cmds, m.fetchRevealValue(p.ResourceType, p.ResourceID, m.core.ConnectGen()))
 			}
 		}
 	}
@@ -403,22 +402,19 @@ func (m Model) handleCopy() (tea.Model, tea.Cmd) {
 func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 	// Main menu: restart availability checks (no-op in no-cache mode).
 	if _, ok := m.activeView().(*views.MainMenuModel); ok {
-		if m.core.Session().NoCache {
+		if m.core.NoCache() {
 			return m, nil
 		}
 		// Increment gen to cancel any in-flight probes and enrichment.
-		m.core.Session().AvailabilityGen++
-		m.core.Session().EnrichmentGen++
-		m.core.Session().EnrichmentRan = make(map[string]bool)
-		m.core.Session().EnrichmentTypeGen = make(map[string]domain.Gen)
-		m.core.Session().EnrichmentTruncatedIDs = make(map[string]map[string]bool)
+		m.core.BumpAvailabilityGen()
+		m.core.BumpEnrichmentGen()
+		m.core.ResetEnrichmentMaps()
 		// Clear stale Wave 2 from all cached rows before resetting ProbeResources.
 		// Without this, opening a cached list before the new enrichment completes
 		// would show the previous run's attention state (PR #310 CodeRabbit
 		// finding B).
 		clearAllWave2(&m)
-		m.core.Session().ProbeResources = make(map[string][]resource.Resource)
-		m.core.Session().ProbeTruncated = make(map[string]bool)
+		m.core.ResetProbeMaps()
 		// Reset the menu's view-side state (availability, issue counts) in
 		// lockstep with the model-side maps above.
 		if menu, ok := m.stack[0].(*views.MainMenuModel); ok {
@@ -434,10 +430,10 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 		d.ResetRightColumn()
 		rt := d.ResourceType()
 		srcRes := d.SourceResource()
-		m.core.Session().RelatedCache.Delete(runtime.RelatedCacheKey(rt, srcRes.ID))
-		m.core.Session().RelatedGen++      // cancel in-flight results from previous batch
-		m.core.Session().EnrichGen++       // cancel in-flight enrichment from previous batch
-		m.core.Session().EnrichResKey = "" // force gen bump on next enrichment dispatch
+		m.core.RelatedCacheDelete(runtime.RelatedCacheKey(rt, srcRes.ID))
+		m.core.BumpRelatedGen() // cancel in-flight results from previous batch
+		m.core.BumpEnrichGen()  // cancel in-flight enrichment from previous batch
+		m.core.ClearEnrichResKey() // force gen bump on next enrichment dispatch
 		// Invalidate the SES v1 receipt rule set cache so Ctrl+R on a detail
 		// view picks up receipt-rule changes without requiring a profile/region
 		// switch. Swap (not Clear) so that any in-flight blocked
@@ -487,7 +483,7 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 		(&m).applyEnrichment(rt, nil)
 	}
 
-	delete(m.core.Session().ResourceCache, rt) // clear cache for refreshed type only
+	m.core.DeleteResourceCache(rt) // clear cache for refreshed type only
 	if rt == "ses" {
 		// Swap (see detail-view path above): protects against in-flight blocked
 		// DescribeActiveReceiptRuleSet fetchers re-poisoning the cache.
@@ -501,12 +497,11 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 	// probeResources and dispatch probeEnrichment on success.
 	if rl.ParentContext() == nil && !rl.EscPops() {
 		if m.core.HasIssueEnricher(rt) {
-			m.core.Session().EnrichmentTypeGen[rt]++
-			tok := m.core.Session().EnrichmentTypeGen[rt]
-			delete(m.core.Session().EnrichmentRan, rt)
+			tok := m.core.BumpEnrichmentTypeGen(rt)
+			m.core.DeleteEnrichmentRan(rt)
 			// Clear per-resource truncation markers too: if the refresh errors
 			// out, stale "?" prefixes must not persist across the rerun.
-			delete(m.core.Session().EnrichmentTruncatedIDs, rt)
+			m.core.DeleteEnrichmentTruncatedIDs(rt)
 			// Wave2 already stripped above (pre-fetch cleanup). Strip any rows
 			// that entered via ProbeResources/LazyResourceCache (those paths
 			// are NOT covered by the pre-fetch cleanup above, which only
@@ -533,7 +528,7 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 // and by other callers in the TUI.
 func (m Model) refreshResourceList(rl views.ResourceListModel) tea.Cmd {
 	rt := rl.ResourceType()
-	gen := m.core.Session().AvailabilityGen
+	gen := m.core.AvailabilityGen()
 
 	// Filtered lists must refresh through the same filtered fetcher so their
 	// pagination token remains valid for subsequent load-more requests.
@@ -564,7 +559,7 @@ func (m Model) handleReveal() (tea.Model, tea.Cmd) {
 	if r == nil {
 		return m, nil
 	}
-	cmd := m.fetchRevealValue(rt, r.ID, m.core.Session().ConnectGen)
+	cmd := m.fetchRevealValue(rt, r.ID, m.core.ConnectGen())
 	return m, cmd
 }
 
@@ -578,7 +573,7 @@ func (m Model) handleReveal() (tea.Model, tea.Cmd) {
 // the stale-gen check up-front so the view-side SetError() does not
 // fire on a stale error from a prior profile/region.
 func (m Model) handleIdentityError(msg messages.IdentityError) (tea.Model, tea.Cmd) {
-	if messages.IsStale(msg, m.core.Session()) {
+	if messages.IsStale(msg, m.core) {
 		return m, nil
 	}
 	updated, cmd := m.coreUpdate(msg)

--- a/internal/tui/runtime_adapter_related.go
+++ b/internal/tui/runtime_adapter_related.go
@@ -16,7 +16,7 @@
 // It asks runtime.Core whether any RelatedDefs are registered for the source
 // type, and if so fans out one checker goroutine per def via relatedCheckCmd
 // (capped by runtime.MaxConcurrentProbes). The actual probe loop stays here in
-// the adapter because it depends on m.core.Session().Clients, m.appCtx, and tea.Cmd —
+// the adapter because it depends on m.core.Clients(), m.appCtx, and tea.Cmd —
 // platform glue that does not belong in internal/runtime.
 //
 // Decision-locus follow-up (PR-05b): a few branches in this adapter still walk
@@ -52,7 +52,6 @@ import (
 // (HandleRelatedNavigate), then builds the view and starts any required fetch
 // based on the returned NavigationResult and TaskRequests.
 func (m Model) handleRelatedNavigate(msg messages.RelatedNavigate) (tea.Model, tea.Cmd) {
-	core := runtime.New(m.core.Session(), resource.AllResourceTypes())
 	ev := runtime.RelatedNavigateEvent{
 		TargetType:     msg.TargetType,
 		SourceResource: msg.SourceResource,
@@ -62,7 +61,7 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigate) (tea.Model, t
 		FetchFilter:    msg.FetchFilter,
 		Checker:        msg.Checker,
 	}
-	result, tasks := core.HandleRelatedNavigate(ev)
+	result, tasks := m.core.HandleRelatedNavigate(ev)
 
 	switch result.Kind {
 	case runtime.NavigationKindFlash:
@@ -81,7 +80,7 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigate) (tea.Model, t
 		if rt == nil {
 			// Fetcher-only type (registered paginated fetcher but no ResourceTypeDef).
 			if len(result.RelatedIDs) > 0 {
-				if lazyRows, hasLazy := m.core.Session().LazyResourceCache[msg.TargetType]; hasLazy {
+				if lazyRows, hasLazy := m.core.LazyResourceCache(msg.TargetType); hasLazy {
 					idSet := make(map[string]bool, len(result.RelatedIDs))
 					for _, id := range result.RelatedIDs {
 						idSet[id] = true
@@ -94,7 +93,7 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigate) (tea.Model, t
 					}
 					// Partial coverage: fall through to fetch so missing IDs are retrieved.
 					if len(filtered) < len(result.RelatedIDs) {
-						fetchCmd := m.fetchResources(msg.TargetType, m.core.Session().AvailabilityGen)
+						fetchCmd := m.fetchResources(msg.TargetType, m.core.AvailabilityGen())
 						return m, fetchCmd
 					}
 				}
@@ -116,18 +115,18 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigate) (tea.Model, t
 			rl.SetSize(m.innerSize())
 			rl, initCmd := rl.Init()
 			m.pushView(&rl)
-			return m, tea.Batch(initCmd, m.fetchResourcesFiltered(msg.TargetType, result.FetchFilter, m.core.Session().AvailabilityGen))
+			return m, tea.Batch(initCmd, m.fetchResourcesFiltered(msg.TargetType, result.FetchFilter, m.core.AvailabilityGen()))
 		}
 
 		// TargetID-based filtered list (cache miss).
 		if result.TargetID != "" {
 			// Exact AMI navigation should fetch by image ID instead of falling
 			// back to the owned-AMI list, which misses public and third-party images.
-			// PR-05b: when m.core.Session().Clients moves into the runtime Core, the runtime will
+			// PR-05b: when m.core.Clients() moves into the runtime Core, the runtime will
 			// emit a typed FetchAMIDetail TaskRequest and this branch collapses
 			// into runtimeTasksToCmd; the adapter override stays for now because
 			// client selection is adapter-owned state.
-			if msg.TargetType == "ami" && m.core.Session().Clients != nil {
+			if msg.TargetType == "ami" && m.core.Clients() != nil {
 				cmd := m.fetchAMIDetail(result.TargetID)
 				return m, cmd
 			}
@@ -148,7 +147,7 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigate) (tea.Model, t
 
 		// RelatedIDs-based filtered list (multi or single cache miss).
 		if len(result.RelatedIDs) > 0 {
-			if entry, ok := m.core.Session().ResourceCache[msg.TargetType]; ok {
+			if entry, ok := m.core.ResourceCache(msg.TargetType); ok && entry != nil {
 				idSet := make(map[string]bool, len(result.RelatedIDs))
 				for _, id := range result.RelatedIDs {
 					idSet[id] = true
@@ -160,7 +159,7 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigate) (tea.Model, t
 					}
 				}
 				// Augment with lazy-cached resources. Prefer ResourceCache on ID collision.
-				if lazyRows, hasLazy := m.core.Session().LazyResourceCache[msg.TargetType]; hasLazy {
+				if lazyRows, hasLazy := m.core.LazyResourceCache(msg.TargetType); hasLazy {
 					found := make(map[string]struct{}, len(filtered))
 					for _, r := range filtered {
 						found[r.ID] = struct{}{}
@@ -247,7 +246,7 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigate) (tea.Model, t
 			// the runtime decision rather than a divergence. PR-05b will route the
 			// lazy-row slice through TaskRequest payload so the adapter no longer
 			// re-walks the cache.
-			if lazyRows, hasLazy := m.core.Session().LazyResourceCache[msg.TargetType]; hasLazy {
+			if lazyRows, hasLazy := m.core.LazyResourceCache(msg.TargetType); hasLazy {
 				idSet := make(map[string]bool, len(result.RelatedIDs))
 				for _, id := range result.RelatedIDs {
 					idSet[id] = true
@@ -320,11 +319,11 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigate) (tea.Model, t
 		}
 		var detailRes resource.Resource
 		var detailFound bool
-		if entry, ok := m.core.Session().ResourceCache[msg.TargetType]; ok {
+		if entry, ok := m.core.ResourceCache(msg.TargetType); ok && entry != nil {
 			detailRes, detailFound = resolveDetailResource(entry.Resources)
 		}
 		if !detailFound {
-			if lazyRows, ok := m.core.Session().LazyResourceCache[msg.TargetType]; ok {
+			if lazyRows, ok := m.core.LazyResourceCache(msg.TargetType); ok {
 				detailRes, detailFound = resolveDetailResource(lazyRows)
 			}
 		}
@@ -348,7 +347,7 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigate) (tea.Model, t
 			m.pushView(&detail)
 			if detail.NeedsRelatedCheck() {
 				ck := runtime.RelatedCacheKey(msg.TargetType, r.ID)
-				if cached, ok := m.core.Session().RelatedCache.Get(ck); ok && len(cached) > 0 {
+				if cached, ok := m.core.RelatedCacheGet(ck); ok && len(cached) > 0 {
 					detail.ApplyRelatedResults(runtime.RelatedCacheReplay(msg.TargetType, cached))
 					return m, nil
 				}
@@ -430,9 +429,9 @@ func relatedNavigateTasksToCmd(m Model, targetType string, result runtime.Naviga
 	for _, t := range tasks {
 		switch t.Key.Kind {
 		case runtime.KindFetchResources:
-			cmds = append(cmds, m.fetchResources(targetType, m.core.Session().AvailabilityGen))
+			cmds = append(cmds, m.fetchResources(targetType, m.core.AvailabilityGen()))
 		case runtime.KindFetchFiltered:
-			cmds = append(cmds, m.fetchResourcesFiltered(targetType, result.FetchFilter, m.core.Session().AvailabilityGen))
+			cmds = append(cmds, m.fetchResourcesFiltered(targetType, result.FetchFilter, m.core.AvailabilityGen()))
 		case runtime.KindFetchMore:
 			// Continuation token is runtime-owned and arrives as a structured
 			// payload (AS-270 / PR-05b). The adapter is a pure pass-through
@@ -468,8 +467,7 @@ func (m Model) handleRelatedCheckStarted(msg messages.RelatedCheckStarted) (tea.
 	if src.Type == "" {
 		src.Type = msg.ResourceType
 	}
-	core := runtime.New(m.core.Session(), resource.AllResourceTypes())
-	_, tasks := core.HandleRelatedCheckStarted(runtime.RelatedCheckStartedEvent{
+	_, tasks := m.core.HandleRelatedCheckStarted(runtime.RelatedCheckStartedEvent{
 		ResourceType:   msg.ResourceType,
 		SourceResource: src,
 	})
@@ -488,13 +486,15 @@ func (m Model) relatedCheckCmd(res resource.Resource) tea.Cmd {
 	}
 
 	cache := m.buildResourceCacheSnapshot()
-	gen := m.core.Session().RelatedGen
+	gen := m.core.RelatedGen()
 
-	mainCacheKeys := make(map[string]struct{}, len(m.core.Session().ResourceCache))
-	for k := range m.core.Session().ResourceCache {
+	keys := m.core.ResourceCacheKeys()
+	mainCacheKeys := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
 		mainCacheKeys[k] = struct{}{}
 	}
 
+	clients := m.core.Clients()
 	sem := make(chan struct{}, runtime.MaxConcurrentProbes)
 	cmds := make([]tea.Cmd, 0, len(defs))
 
@@ -529,7 +529,7 @@ func (m Model) relatedCheckCmd(res resource.Resource) tea.Cmd {
 			if def.NeedsTargetCache {
 				if _, inMainCache := mainCacheKeys[def.TargetType]; !inMainCache {
 					if pf := resource.GetPaginatedFetcher(def.TargetType); pf != nil {
-						if fr, err := pf(ctx, m.core.Session().Clients, ""); err == nil {
+						if fr, err := pf(ctx, clients, ""); err == nil {
 							isTrunc := fr.Pagination != nil && fr.Pagination.IsTruncated
 							if prev, hasPrev := localCache[def.TargetType]; hasPrev && prev.IsTruncated {
 								isTrunc = true
@@ -548,7 +548,7 @@ func (m Model) relatedCheckCmd(res resource.Resource) tea.Cmd {
 					}
 				}
 			}
-			result := def.Checker(ctx, m.core.Session().Clients, res, localCache)
+			result := def.Checker(ctx, clients, res, localCache)
 			result.TargetType = def.TargetType
 			var lazyAdded map[string][]resource.Resource
 			var lazyAddError error
@@ -556,7 +556,7 @@ func (m Model) relatedCheckCmd(res resource.Resource) tea.Cmd {
 				if ff := resource.GetFetchByIDs(def.TargetType); ff != nil {
 					missing := runtime.MissingFromCache(localCache, def.TargetType, result.ResourceIDs)
 					if len(missing) > 0 {
-						extra, fetchErr := ff(ctx, m.core.Session().Clients, missing)
+						extra, fetchErr := ff(ctx, clients, missing)
 						if fetchErr != nil {
 							lazyAddError = fetchErr
 						}

--- a/internal/tui/runtime_adapter_related.go
+++ b/internal/tui/runtime_adapter_related.go
@@ -40,7 +40,6 @@ import (
 
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/runtime"
-	"github.com/k2m30/a9s/v3/internal/session"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
 	"github.com/k2m30/a9s/v3/internal/tui/views"
 )
@@ -348,9 +347,9 @@ func (m Model) handleRelatedNavigate(msg messages.RelatedNavigate) (tea.Model, t
 			detail.SetSize(m.innerSize())
 			m.pushView(&detail)
 			if detail.NeedsRelatedCheck() {
-				ck := session.RelatedCacheKey(msg.TargetType, r.ID)
+				ck := runtime.RelatedCacheKey(msg.TargetType, r.ID)
 				if cached, ok := m.core.Session().RelatedCache.Get(ck); ok && len(cached) > 0 {
-					detail.ApplyRelatedResults(session.RelatedCacheReplay(msg.TargetType, cached))
+					detail.ApplyRelatedResults(runtime.RelatedCacheReplay(msg.TargetType, cached))
 					return m, nil
 				}
 				srcRes := r

--- a/internal/tui/runtime_adapter_resources.go
+++ b/internal/tui/runtime_adapter_resources.go
@@ -50,7 +50,7 @@ func (m Model) handleResourcesLoaded(msg messages.ResourcesLoaded) (tea.Model, t
 	// invoked directly (not via HandleEvent's central GenStamped gate) and the
 	// pre-Core view-side derive + updateActiveView would otherwise mutate state
 	// from a previous profile/region rotation.
-	if messages.IsStale(msg, m.core.Session()) {
+	if messages.IsStale(msg, m.core) {
 		return m, nil
 	}
 	(&m).deriveFindingsForType(msg.ResourceType, msg.Resources)
@@ -83,7 +83,7 @@ func (m Model) handleResourcesLoaded(msg messages.ResourcesLoaded) (tea.Model, t
 // source-resource ID (the original case-body fallback). Core receives
 // the resolved value as authoritative.
 func (m Model) handleRelatedCheckResult(msg messages.RelatedCheckResult) (tea.Model, tea.Cmd) {
-	if messages.IsStale(msg, m.core.Session()) {
+	if messages.IsStale(msg, m.core) {
 		return m, nil
 	}
 	sourceID := msg.SourceResourceID
@@ -138,7 +138,7 @@ func (m Model) handleRelatedCheckResult(msg messages.RelatedCheckResult) (tea.Mo
 // updateActiveView never sees a half-populated EnrichedRes — matches the
 // original case-body's early-return on err.
 func (m Model) handleEnrichDetailResult(msg messages.EnrichDetailResult) (tea.Model, tea.Cmd) {
-	if messages.IsStale(msg, m.core.Session()) {
+	if messages.IsStale(msg, m.core) {
 		return m, nil
 	}
 	intents, tasks := m.core.HandleEnrichDetailResult(runtime.EnrichDetailResultEvent{

--- a/tests/integration/scripted_scenario_helpers_test.go
+++ b/tests/integration/scripted_scenario_helpers_test.go
@@ -240,7 +240,7 @@ func (s *fullIntegrationScenario) OpenDetailResource(resourceType string, res re
 	// Findings or AttentionDetails, so the detail-view Attention section
 	// would render only Wave-1 entries. Swap in the cached row when one
 	// exists so detail rendering matches what `./a9s --demo` shows on screen.
-	if entry, ok := s.model.Session().ResourceCache[resourceType]; ok && entry != nil {
+	if entry, ok := s.model.Core().ResourceCache(resourceType); ok && entry != nil {
 		for i := range entry.Resources {
 			if entry.Resources[i].ID == res.ID {
 				res = entry.Resources[i]

--- a/tests/unit/app_error_surfacing_test.go
+++ b/tests/unit/app_error_surfacing_test.go
@@ -87,7 +87,7 @@ func TestAvailabilityPrefetchedMsg_PrefetchErrEmitsFlash(t *testing.T) {
 		Resources:      map[string][]resource.Resource{},
 		// Stamp the live AvailabilityGen — AS-657/AS-659 staleness guard
 		// drops zero-stamped prefetches (AcceptZeroGen=false).
-		Gen:         m.Session().AvailabilityGen,
+		Gen:         m.Core().Session().AvailabilityGen,
 		PrefetchErr: errors.New("eks: access denied, ng: throttled"),
 	}
 
@@ -118,7 +118,7 @@ func TestAvailabilityPrefetchedMsg_NilPrefetchErrNoFlash(t *testing.T) {
 		Resources:      map[string][]resource.Resource{},
 		// Stamp the live AvailabilityGen — AS-657/AS-659 staleness guard
 		// drops zero-stamped prefetches (AcceptZeroGen=false).
-		Gen: m.Session().AvailabilityGen,
+		Gen: m.Core().Session().AvailabilityGen,
 		// PrefetchErr left nil — happy path.
 	}
 

--- a/tests/unit/app_fetchers_dispatchers_test.go
+++ b/tests/unit/app_fetchers_dispatchers_test.go
@@ -513,7 +513,7 @@ func TestSaveAvailabilityCache_NoCacheMode(t *testing.T) {
 		ResourceType: "ec2",
 		HasResources: true,
 		Count:        3,
-		Gen:          m.Session().AvailabilityGen,
+		Gen:          m.Core().Session().AvailabilityGen,
 	})
 	// With noCache=true, saveAvailabilityCache returns nil.
 	// No panic is the key assertion.
@@ -591,7 +591,7 @@ func TestDemoPrefetchCounts_AvailabilityPrefetchedHandler(t *testing.T) {
 		Entries:     map[string]int{"ec2": 7, "s3": 3},
 		Truncated:   map[string]bool{},
 		IssueCounts: map[string]int{"ec2": 1},
-		Gen:         m.Session().AvailabilityGen,
+		Gen:         m.Core().Session().AvailabilityGen,
 		Resources:   map[string][]resource.Resource{},
 	})
 	// Handler should not crash.
@@ -705,14 +705,14 @@ func TestFetchAdapter_CapturesGenAtDispatchTime(t *testing.T) {
 
 	t.Run("fetchResources", func(t *testing.T) {
 		m := newRootSizedModel()
-		dispatchGen := m.Session().AvailabilityGen
+		dispatchGen := m.Core().Session().AvailabilityGen
 
 		// Build the cmd at dispatch time with the captured gen.
 		cmd := m.FetchResourcesCmdForTest("ec2", dispatchGen)
 
 		// Rotate AFTER dispatch: the closure must carry dispatchGen, not the new gen.
-		m.Session().Rotate()
-		if m.Session().AvailabilityGen == dispatchGen {
+		m.Core().Session().Rotate()
+		if m.Core().Session().AvailabilityGen == dispatchGen {
 			t.Fatal("Rotate() did not bump AvailabilityGen — test precondition broken")
 		}
 
@@ -734,12 +734,12 @@ func TestFetchAdapter_CapturesGenAtDispatchTime(t *testing.T) {
 
 	t.Run("fetchIdentity", func(t *testing.T) {
 		m := newRootSizedModel()
-		dispatchGen := m.Session().ConnectGen
+		dispatchGen := m.Core().Session().ConnectGen
 
 		cmd := m.FetchIdentityCmdForTest(dispatchGen)
 
-		m.Session().Rotate()
-		if m.Session().ConnectGen == dispatchGen {
+		m.Core().Session().Rotate()
+		if m.Core().Session().ConnectGen == dispatchGen {
 			t.Fatal("Rotate() did not bump ConnectGen — test precondition broken")
 		}
 
@@ -760,12 +760,12 @@ func TestFetchAdapter_CapturesGenAtDispatchTime(t *testing.T) {
 
 	t.Run("fetchRevealValue", func(t *testing.T) {
 		m := newRootSizedModel()
-		dispatchGen := m.Session().ConnectGen
+		dispatchGen := m.Core().Session().ConnectGen
 
 		cmd := m.FetchRevealValueCmdForTest("secrets", "prod/api/key", dispatchGen)
 
-		m.Session().Rotate()
-		if m.Session().ConnectGen == dispatchGen {
+		m.Core().Session().Rotate()
+		if m.Core().Session().ConnectGen == dispatchGen {
 			t.Fatal("Rotate() did not bump ConnectGen — test precondition broken")
 		}
 

--- a/tests/unit/enrich_queue_test.go
+++ b/tests/unit/enrich_queue_test.go
@@ -58,7 +58,7 @@ func seedAllEnricherTypes(m tui.Model) (tui.Model, tea.Cmd) {
 		Resources: allResources,
 		// Stamp the live AvailabilityGen so the AS-657/AS-659 staleness guard
 		// accepts the message (AcceptZeroGen=false after AS-659).
-		Gen: m.Session().AvailabilityGen,
+		Gen: m.Core().Session().AvailabilityGen,
 	})
 	return m, cmd
 }
@@ -77,7 +77,7 @@ func seedEnricherSubset(m tui.Model, names []string) (tui.Model, tea.Cmd) {
 		Resources: subset,
 		// Stamp the live AvailabilityGen so the AS-657/AS-659 staleness guard
 		// accepts the message (AcceptZeroGen=false after AS-659).
-		Gen: m.Session().AvailabilityGen,
+		Gen: m.Core().Session().AvailabilityGen,
 	})
 	return m, cmd
 }

--- a/tests/unit/generation_stamping_fetch_test.go
+++ b/tests/unit/generation_stamping_fetch_test.go
@@ -48,7 +48,7 @@ func TestResourcesLoaded_Stale_Dropped(t *testing.T) {
 
 	// Rotate once so AvailabilityGen becomes non-zero (starts at 0).
 	// This ensures staleGen > 0, bypassing AcceptZeroGen=true.
-	m.Session().Rotate()
+	m.Core().Session().Rotate()
 
 	// Navigate to ec2 list and load sentinel resources with the current (non-zero) gen.
 	m, _ = rootApplyMsg(m, messages.Navigate{
@@ -61,7 +61,7 @@ func TestResourcesLoaded_Stale_Dropped(t *testing.T) {
 	m, _ = rootApplyMsg(m, messages.ResourcesLoaded{
 		ResourceType: "ec2",
 		Resources:    sentinel,
-		Gen:          m.Session().AvailabilityGen, // current non-zero gen — matches
+		Gen:          m.Core().Session().AvailabilityGen, // current non-zero gen — matches
 	})
 	// Verify baseline: sentinel resource is present.
 	if got := m.ActiveListResources(); len(got) == 0 || got[0].ID != "i-before-rotate" {
@@ -69,12 +69,12 @@ func TestResourcesLoaded_Stale_Dropped(t *testing.T) {
 	}
 
 	// Capture stale gen (non-zero) BEFORE the second Rotate.
-	staleGen := m.Session().AvailabilityGen
+	staleGen := m.Core().Session().AvailabilityGen
 	if staleGen == 0 {
 		t.Fatal("precondition failed: staleGen must be non-zero to test IsStale guard (AcceptZeroGen=true would pass zero)")
 	}
 	// Second Rotate bumps AvailabilityGen to staleGen+1.
-	m.Session().Rotate()
+	m.Core().Session().Rotate()
 
 	// Dispatch a stale ResourcesLoaded (Gen == staleGen, current is staleGen+1).
 	staleMsg := messages.ResourcesLoaded{
@@ -109,18 +109,18 @@ func TestIdentityLoaded_Stale_Dropped(t *testing.T) {
 	m := newRootSizedModel()
 
 	// First Rotate: ConnectGen becomes non-zero.
-	m.Session().Rotate()
+	m.Core().Session().Rotate()
 
 	// Capture stale ConnectGen (non-zero) BEFORE the second Rotate.
-	staleGen := m.Session().ConnectGen
+	staleGen := m.Core().Session().ConnectGen
 	if staleGen == 0 {
 		t.Fatal("precondition failed: staleGen must be non-zero to test IsStale guard")
 	}
 	// Second Rotate: ConnectGen becomes staleGen+1, Identity cleared.
-	m.Session().Rotate()
+	m.Core().Session().Rotate()
 
 	// Session.Identity is nil after Rotate() (per session.go:233).
-	if m.Session().Identity != nil {
+	if m.Core().Session().Identity != nil {
 		t.Fatal("precondition failed: Session.Identity should be nil after Rotate()")
 	}
 
@@ -133,8 +133,8 @@ func TestIdentityLoaded_Stale_Dropped(t *testing.T) {
 	m, _ = rootApplyMsg(m, staleMsg)
 
 	// Session.Identity must still be nil — the stale message was dropped.
-	if m.Session().Identity != nil {
-		t.Errorf("stale IdentityLoaded was NOT dropped: Session.Identity = %+v, expected nil — guard regression", m.Session().Identity)
+	if m.Core().Session().Identity != nil {
+		t.Errorf("stale IdentityLoaded was NOT dropped: Session.Identity = %+v, expected nil — guard regression", m.Core().Session().Identity)
 	}
 }
 
@@ -154,15 +154,15 @@ func TestValueRevealed_Stale_Dropped(t *testing.T) {
 	m := newRootSizedModel()
 
 	// First Rotate: ConnectGen becomes non-zero.
-	m.Session().Rotate()
+	m.Core().Session().Rotate()
 
 	// Capture stale ConnectGen (non-zero) BEFORE the second Rotate.
-	staleGen := m.Session().ConnectGen
+	staleGen := m.Core().Session().ConnectGen
 	if staleGen == 0 {
 		t.Fatal("precondition failed: staleGen must be non-zero to test IsStale guard")
 	}
 	// Second Rotate: ConnectGen becomes staleGen+1.
-	m.Session().Rotate()
+	m.Core().Session().Rotate()
 
 	// The secret value from a previous profile that must NOT appear.
 	const staleSecret = "PREV_ACCOUNT_SECRET_VALUE_xyzzy_42"
@@ -194,7 +194,7 @@ func TestHappyPath_MatchingGen_ResourcesLoaded(t *testing.T) {
 		Target:       messages.TargetResourceList,
 		ResourceType: "ec2",
 	})
-	currentGen := m.Session().AvailabilityGen
+	currentGen := m.Core().Session().AvailabilityGen
 	m, _ = rootApplyMsg(m, messages.ResourcesLoaded{
 		ResourceType: "ec2",
 		Resources:    []resource.Resource{{ID: "i-fresh", Name: "fresh-server"}},
@@ -217,17 +217,17 @@ func TestHappyPath_MatchingGen_ResourcesLoaded(t *testing.T) {
 // Gen == current ConnectGen sets Session.Identity.
 func TestHappyPath_MatchingGen_IdentityLoaded(t *testing.T) {
 	m := newRootSizedModel()
-	currentGen := m.Session().ConnectGen
+	currentGen := m.Core().Session().ConnectGen
 	freshIdentity := &awsclient.CallerIdentity{AccountID: "999988887777"}
 	m, _ = rootApplyMsg(m, messages.IdentityLoaded{
 		Identity: freshIdentity,
 		Gen:      currentGen,
 	})
-	if m.Session().Identity == nil {
+	if m.Core().Session().Identity == nil {
 		t.Fatal("happy-path IdentityLoaded with matching gen was not applied: Session.Identity is nil")
 	}
-	if m.Session().Identity.AccountID != "999988887777" {
-		t.Errorf("Session.Identity.AccountID = %q, want 999988887777", m.Session().Identity.AccountID)
+	if m.Core().Session().Identity.AccountID != "999988887777" {
+		t.Errorf("Session.Identity.AccountID = %q, want 999988887777", m.Core().Session().Identity.AccountID)
 	}
 }
 
@@ -235,7 +235,7 @@ func TestHappyPath_MatchingGen_IdentityLoaded(t *testing.T) {
 // Gen == current ConnectGen pushes the reveal view.
 func TestHappyPath_MatchingGen_ValueRevealed(t *testing.T) {
 	m := newRootSizedModel()
-	currentGen := m.Session().ConnectGen
+	currentGen := m.Core().Session().ConnectGen
 	const freshSecret = "FRESH_CURRENT_SESSION_SECRET_abc123"
 	m, _ = rootApplyMsg(m, messages.ValueRevealed{
 		ResourceType: "secrets",
@@ -260,7 +260,7 @@ func TestHappyPath_MatchingGen_ValueRevealed(t *testing.T) {
 // "stamp == 0 && AcceptZeroGen()" branch (messages/messages.go:71) rather
 // than the trivial "stamp == currentGen" path.
 //
-// Note: the prior version of this test gated on `m.Session().AvailabilityGen
+// Note: the prior version of this test gated on `m.Core().Session().AvailabilityGen
 // == 0` on a fresh session. The AS-659 seed `AvailabilityGen=1` in
 // `session.New()` (this same PR) makes that precondition unsatisfiable, which
 // would silently skip the entire test post-merge.
@@ -269,8 +269,8 @@ func TestHappyPath_ZeroGen_AcceptedByAllThree(t *testing.T) {
 		m := newRootSizedModel()
 		// Force AvailabilityGen non-zero so a Gen=0 dispatch can only succeed
 		// via the AcceptZeroGen=true branch in IsStale.
-		m.Session().Rotate()
-		if got := m.Session().AvailabilityGen; got == 0 {
+		m.Core().Session().Rotate()
+		if got := m.Core().Session().AvailabilityGen; got == 0 {
 			t.Fatalf("precondition: AvailabilityGen must be non-zero, got 0")
 		}
 
@@ -300,8 +300,8 @@ func TestHappyPath_ZeroGen_AcceptedByAllThree(t *testing.T) {
 		m := newRootSizedModel()
 		// Force ConnectGen non-zero so the AcceptZeroGen branch is the only
 		// path that admits a Gen=0 IdentityLoaded.
-		m.Session().Rotate()
-		if got := m.Session().ConnectGen; got == 0 {
+		m.Core().Session().Rotate()
+		if got := m.Core().Session().ConnectGen; got == 0 {
 			t.Fatalf("precondition: ConnectGen must be non-zero, got 0")
 		}
 
@@ -310,7 +310,7 @@ func TestHappyPath_ZeroGen_AcceptedByAllThree(t *testing.T) {
 			Identity: freshID,
 			Gen:      domain.Gen(0),
 		})
-		if m.Session().Identity == nil {
+		if m.Core().Session().Identity == nil {
 			t.Error("IdentityLoaded with Gen=0 was dropped while ConnectGen!=0 — AcceptZeroGen=true regression")
 		}
 	})
@@ -318,8 +318,8 @@ func TestHappyPath_ZeroGen_AcceptedByAllThree(t *testing.T) {
 	t.Run("ValueRevealed", func(t *testing.T) {
 		m := newRootSizedModel()
 		// Force ConnectGen non-zero (ValueRevealed uses AspectConnect).
-		m.Session().Rotate()
-		if got := m.Session().ConnectGen; got == 0 {
+		m.Core().Session().Rotate()
+		if got := m.Core().Session().ConnectGen; got == 0 {
 			t.Fatalf("precondition: ConnectGen must be non-zero, got 0")
 		}
 
@@ -352,7 +352,7 @@ func TestAPIError_Stale_NoFlash(t *testing.T) {
 	m := newRootSizedModel()
 
 	// First Rotate: AvailabilityGen becomes non-zero.
-	m.Session().Rotate()
+	m.Core().Session().Rotate()
 
 	// Establish baseline flash.gen (non-zero) via a legitimate flash.
 	m, _ = rootApplyMsg(m, messages.Flash{Text: "baseline flash"})
@@ -362,11 +362,11 @@ func TestAPIError_Stale_NoFlash(t *testing.T) {
 	}
 
 	// Capture stale gen (non-zero) and rotate a second time.
-	staleGen := m.Session().AvailabilityGen
+	staleGen := m.Core().Session().AvailabilityGen
 	if staleGen == 0 {
 		t.Fatal("precondition failed: staleGen must be non-zero to test IsStale guard")
 	}
-	m.Session().Rotate()
+	m.Core().Session().Rotate()
 
 	// Dispatch stale APIError.
 	staleErr := messages.APIError{
@@ -396,18 +396,18 @@ func TestIdentityError_Stale_DoesNotClearFetching(t *testing.T) {
 	m := newRootSizedModel()
 
 	// First Rotate: ConnectGen becomes non-zero.
-	m.Session().Rotate()
+	m.Core().Session().Rotate()
 
 	// Capture stale ConnectGen (non-zero) and rotate a second time so a new
 	// identity fetch could be in flight for the post-rotate session.
-	staleGen := m.Session().ConnectGen
+	staleGen := m.Core().Session().ConnectGen
 	if staleGen == 0 {
 		t.Fatal("precondition failed: staleGen must be non-zero to test IsStale guard")
 	}
-	m.Session().Rotate()
+	m.Core().Session().Rotate()
 
 	// Simulate: a new identity fetch is in flight for the post-rotate session.
-	m.Session().IdentityFetching = true
+	m.Core().Session().IdentityFetching = true
 
 	// Dispatch stale IdentityError from the pre-rotate session.
 	staleErr := messages.IdentityError{
@@ -417,7 +417,7 @@ func TestIdentityError_Stale_DoesNotClearFetching(t *testing.T) {
 	m, _ = rootApplyMsg(m, staleErr)
 
 	// IdentityFetching must still be true — the stale error must not clear it.
-	if !m.Session().IdentityFetching {
+	if !m.Core().Session().IdentityFetching {
 		t.Errorf("stale IdentityError cleared Session.IdentityFetching for the new session — guard regression: post-rotate spinner would disappear while real fetch still in flight")
 	}
 }
@@ -430,7 +430,7 @@ func TestAPIError_Fresh_DoesFlash(t *testing.T) {
 	m := newRootSizedModel()
 
 	genBefore := m.FlashGen()
-	currentGen := m.Session().AvailabilityGen
+	currentGen := m.Core().Session().AvailabilityGen
 
 	m, _ = rootApplyMsg(m, messages.APIError{
 		ResourceType: "ec2",
@@ -448,8 +448,8 @@ func TestAPIError_Fresh_DoesFlash(t *testing.T) {
 func TestIdentityError_Fresh_DoesProcess(t *testing.T) {
 	m := newRootSizedModel()
 
-	m.Session().IdentityFetching = true
-	currentGen := m.Session().ConnectGen
+	m.Core().Session().IdentityFetching = true
+	currentGen := m.Core().Session().ConnectGen
 
 	m, _ = rootApplyMsg(m, messages.IdentityError{
 		Err: "some identity error",
@@ -457,7 +457,7 @@ func TestIdentityError_Fresh_DoesProcess(t *testing.T) {
 	})
 
 	// handleIdentityError clears IdentityFetching.
-	if m.Session().IdentityFetching {
+	if m.Core().Session().IdentityFetching {
 		t.Error("fresh IdentityError was dropped or did not clear IdentityFetching — guard too broad")
 	}
 }
@@ -483,17 +483,17 @@ func TestAvailabilityPrefetched_Stale_Dropped(t *testing.T) {
 	m := newRootSizedModel()
 
 	// AvailabilityGen seeded at 1 by session.New(); rotate once so staleGen > 1.
-	m.Session().Rotate()
+	m.Core().Session().Rotate()
 
 	// Capture stale gen (non-zero) BEFORE the second Rotate.
-	staleGen := m.Session().AvailabilityGen
+	staleGen := m.Core().Session().AvailabilityGen
 	if staleGen == 0 {
 		t.Fatal("precondition failed: staleGen must be non-zero to test IsStale guard (AcceptZeroGen=false rejects zero unconditionally)")
 	}
 
 	// Second Rotate bumps AvailabilityGen past staleGen and clears caches.
-	m.Session().Rotate()
-	if m.Session().AvailabilityGen == staleGen {
+	m.Core().Session().Rotate()
+	if m.Core().Session().AvailabilityGen == staleGen {
 		t.Fatalf("precondition failed: Rotate() must advance AvailabilityGen past staleGen=%d", staleGen)
 	}
 
@@ -512,7 +512,7 @@ func TestAvailabilityPrefetched_Stale_Dropped(t *testing.T) {
 	m, _ = rootApplyMsg(m, staleMsg)
 
 	// ResourceCache must NOT have been seeded — the stale prefetch was dropped.
-	if entry, ok := m.Session().ResourceCache[targetType]; ok {
+	if entry, ok := m.Core().Session().ResourceCache[targetType]; ok {
 		t.Errorf("stale AvailabilityPrefetched was NOT dropped: ResourceCache[%q]=%+v — post-rotate session contaminated by pre-rotate prefetch (AS-648-h4 regression)", targetType, entry)
 	}
 }
@@ -527,7 +527,7 @@ func TestAvailabilityPrefetched_ZeroGen_Dropped(t *testing.T) {
 	m := newRootSizedModel()
 
 	// Fresh session: AvailabilityGen is seeded at 1 (AS-648-h4 / AS-659).
-	if got := m.Session().AvailabilityGen; got != 1 {
+	if got := m.Core().Session().AvailabilityGen; got != 1 {
 		t.Fatalf("precondition failed: fresh AvailabilityGen = %d, want 1 (session.New seed)", got)
 	}
 
@@ -539,7 +539,7 @@ func TestAvailabilityPrefetched_ZeroGen_Dropped(t *testing.T) {
 	}
 	m, _ = rootApplyMsg(m, zeroMsg)
 
-	if entry, ok := m.Session().ResourceCache[targetType]; ok {
+	if entry, ok := m.Core().Session().ResourceCache[targetType]; ok {
 		t.Errorf("zero-stamped AvailabilityPrefetched was NOT dropped: ResourceCache[%q]=%+v — guard regression: AcceptZeroGen() must remain false", targetType, entry)
 	}
 }

--- a/tests/unit/phase03_fold_test.go
+++ b/tests/unit/phase03_fold_test.go
@@ -13,7 +13,7 @@
 // ── Red-light expectations (before PR-03a-fold) ─────────────────────────────
 //
 //	Test 1/ProbeResources: fails because the handler's "all-enrichment-done"
-//	    cleanup (m.Session().EnrichChecked >= m.Session().EnrichTotal → m.Session().ProbeResources = nil) runs
+//	    cleanup (m.Core().Session().EnrichChecked >= m.Core().Session().EnrichTotal → m.Core().Session().ProbeResources = nil) runs
 //	    before the test can inspect the cache. After fold, applyEnrichment
 //	    must run BEFORE cleanup AND tests seed EnrichTotal=2 to keep ProbeResources
 //	    alive for inspection. Without EnrichTotal=2, this subtest ALWAYS fails.
@@ -132,7 +132,7 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 		t.Run(tc.name+"/ResourceCache", func(t *testing.T) {
 			m := newShimModel()
 
-			m.Session().ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
+			m.Core().Session().ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
 				Resources: []resource.Resource{
 					{ID: rid, Name: "test-" + tc.canonShort, Status: "running"},
 				},
@@ -145,7 +145,7 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 				TypeGen:      0,
 			})
 
-			entry, ok := m.Session().ResourceCache[tc.canonShort]
+			entry, ok := m.Core().Session().ResourceCache[tc.canonShort]
 			if !ok || len(entry.Resources) == 0 {
 				t.Fatalf("ResourceCache[%q] is empty after EnrichmentCheckedMsg", tc.canonShort)
 			}
@@ -185,7 +185,7 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 		t.Run(tc.name+"/LazyResourceCache", func(t *testing.T) {
 			m := newShimModel()
 
-			m.Session().LazyResourceCache[tc.canonShort] = []resource.Resource{
+			m.Core().Session().LazyResourceCache[tc.canonShort] = []resource.Resource{
 				{ID: rid, Name: "lazy-" + tc.canonShort, Status: "running"},
 			}
 
@@ -196,7 +196,7 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 				TypeGen:      0,
 			})
 
-			lazySlice, ok := m.Session().LazyResourceCache[tc.canonShort]
+			lazySlice, ok := m.Core().Session().LazyResourceCache[tc.canonShort]
 			if !ok || len(lazySlice) == 0 {
 				t.Fatalf("LazyResourceCache[%q] is empty after EnrichmentCheckedMsg", tc.canonShort)
 			}
@@ -215,19 +215,19 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 			m := newShimModel()
 
 			// Prevent the "all enrichment done" cleanup path (app_handlers_availability.go:
-			// if m.Session().EnrichChecked >= m.Session().EnrichTotal { m.Session().ProbeResources = nil }).
+			// if m.Core().Session().EnrichChecked >= m.Core().Session().EnrichTotal { m.Core().Session().ProbeResources = nil }).
 			// After EnrichChecked++ fires (0→1), we need 1 < EnrichTotal to avoid
 			// the cleanup so ProbeResources remains inspectable. Setting EnrichTotal=2
 			// simulates "one type still pending", keeping the cache alive.
-			m.Session().EnrichTotal = 2
+			m.Core().Session().EnrichTotal = 2
 
 			// ProbeResources is initialized via AvailabilityCheckedMsg in real usage,
 			// but for the fold test we set it directly — the fold must walk ProbeResources
 			// just as it walks the other two caches.
-			if m.Session().ProbeResources == nil {
-				m.Session().ProbeResources = make(map[string][]resource.Resource)
+			if m.Core().Session().ProbeResources == nil {
+				m.Core().Session().ProbeResources = make(map[string][]resource.Resource)
 			}
-			m.Session().ProbeResources[tc.canonShort] = []resource.Resource{
+			m.Core().Session().ProbeResources[tc.canonShort] = []resource.Resource{
 				{ID: rid, Name: "probe-" + tc.canonShort, Status: "running"},
 			}
 
@@ -238,7 +238,7 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 				TypeGen:      0,
 			})
 
-			probeSlice, ok := m.Session().ProbeResources[tc.canonShort]
+			probeSlice, ok := m.Core().Session().ProbeResources[tc.canonShort]
 			if !ok || len(probeSlice) == 0 {
 				t.Fatalf("ProbeResources[%q] is empty after EnrichmentCheckedMsg (fold path must update ProbeResources before cleanup)", tc.canonShort)
 			}
@@ -314,7 +314,7 @@ func TestFold_RepeatedEnrichmentReplacesWave2(t *testing.T) {
 			}
 
 			m := newShimModel()
-			m.Session().ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
+			m.Core().Session().ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
 				Resources: []resource.Resource{
 					{ID: rid, Name: "test-" + tc.canonShort, Status: "impaired"},
 				},
@@ -336,7 +336,7 @@ func TestFold_RepeatedEnrichmentReplacesWave2(t *testing.T) {
 				TypeGen:      0,
 			})
 
-			entry, ok := m.Session().ResourceCache[tc.canonShort]
+			entry, ok := m.Core().Session().ResourceCache[tc.canonShort]
 			if !ok || len(entry.Resources) == 0 {
 				t.Fatalf("ResourceCache[%q] is empty", tc.canonShort)
 			}
@@ -424,7 +424,7 @@ func TestFold_EmptyEnrichmentClearsWave2(t *testing.T) {
 			}
 
 			m := newShimModel()
-			m.Session().ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
+			m.Core().Session().ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
 				Resources: []resource.Resource{
 					{ID: rid, Name: "test-" + tc.canonShort, Status: "impaired"},
 				},
@@ -440,7 +440,7 @@ func TestFold_EmptyEnrichmentClearsWave2(t *testing.T) {
 
 			// Verify wave2 was set before clearing.
 			{
-				entry := m.Session().ResourceCache[tc.canonShort]
+				entry := m.Core().Session().ResourceCache[tc.canonShort]
 				if entry == nil || len(entry.Resources) == 0 {
 					t.Fatalf("ResourceCache[%q] empty after initial enrichment", tc.canonShort)
 				}
@@ -464,7 +464,7 @@ func TestFold_EmptyEnrichmentClearsWave2(t *testing.T) {
 				TypeGen:      0,
 			})
 
-			entry, ok := m.Session().ResourceCache[tc.canonShort]
+			entry, ok := m.Core().Session().ResourceCache[tc.canonShort]
 			if !ok || len(entry.Resources) == 0 {
 				t.Fatalf("ResourceCache[%q] is empty after empty EnrichmentCheckedMsg", tc.canonShort)
 			}
@@ -526,7 +526,7 @@ func TestFold_EnrichmentFindingsFieldDeleted(t *testing.T) {
 //
 // The pre-fix bug (PR #310 CodeRabbit finding A):
 //
-//	handleRefresh calls delete(m.Session().ResourceCache[rt]) BEFORE applyEnrichment(rt, nil).
+//	handleRefresh calls delete(m.Core().Session().ResourceCache[rt]) BEFORE applyEnrichment(rt, nil).
 //	applyEnrichment walks ResourceCache[rt] to find rows to clear — but the entry
 //	was just deleted, so it finds nothing. The ResourceListModel was constructed
 //	from entry.Resources when NavigateMsg was handled; the rl's internal slice
@@ -560,7 +560,7 @@ func TestFold_CtrlROnList_ClearsActiveRowFindings(t *testing.T) {
 
 	// Step 1: seed ResourceCache so NavigateMsg gets a cache hit and creates
 	// a ResourceListModel holding this slice.
-	m.Session().ResourceCache["ec2"] = &session.ResourceCacheEntry{
+	m.Core().Session().ResourceCache["ec2"] = &session.ResourceCacheEntry{
 		Resources: []resource.Resource{
 			{ID: rid, Name: "test-ec2", Status: "running"},
 		},
@@ -602,7 +602,7 @@ func TestFold_CtrlROnList_ClearsActiveRowFindings(t *testing.T) {
 
 	// Assertion: after Ctrl+R, no wave2 entry should remain on the rows
 	// visible in the active ResourceListModel. The fix requires applyEnrichment
-	// to run BEFORE delete(m.Session().ResourceCache[rt]), so that rl's internal slice
+	// to run BEFORE delete(m.Core().Session().ResourceCache[rt]), so that rl's internal slice
 	// has its wave2 findings cleared before the cache entry is removed.
 	postResources := m.ActiveListResources()
 	if len(postResources) == 0 {
@@ -614,7 +614,7 @@ func TestFold_CtrlROnList_ClearsActiveRowFindings(t *testing.T) {
 			if f.Source == wantSource {
 				t.Errorf(
 					"resource %q still has stale wave2 finding after Ctrl+R: Source=%q Phrase=%q; "+
-						"fix: call applyEnrichment(rt, nil) BEFORE delete(m.Session().ResourceCache[rt]) in handleRefresh",
+						"fix: call applyEnrichment(rt, nil) BEFORE delete(m.Core().Session().ResourceCache[rt]) in handleRefresh",
 					r.ID, f.Source, f.Phrase,
 				)
 			}
@@ -631,7 +631,7 @@ func TestFold_CtrlROnList_ClearsActiveRowFindings(t *testing.T) {
 // The pre-fix bug (PR #310 CodeRabbit finding B):
 //
 //	handleRefresh on the main-menu path resets side maps (ProbeResources,
-//	EnrichmentRan, etc.) but never touches m.Session().ResourceCache. Rows in ResourceCache
+//	EnrichmentRan, etc.) but never touches m.Core().Session().ResourceCache. Rows in ResourceCache
 //	retain stale r.Findings from the previous enrichment wave. When the user
 //	navigates back to a list, they see stale wave2 markers until a fresh
 //	EnrichmentCheckedMsg arrives and overwrites them.
@@ -664,12 +664,12 @@ func TestFold_MainMenuCtrlR_ClearsAllCachedWave2(t *testing.T) {
 	m = shimApplyMsg(m, messages.ClientsReady{Clients: nil})
 
 	// Step 1: seed ResourceCache for ec2 and s3 with running resources.
-	m.Session().ResourceCache[ec2Short] = &session.ResourceCacheEntry{
+	m.Core().Session().ResourceCache[ec2Short] = &session.ResourceCacheEntry{
 		Resources: []resource.Resource{
 			{ID: ec2ID, Name: "test-ec2", Status: "running"},
 		},
 	}
-	m.Session().ResourceCache[s3Short] = &session.ResourceCacheEntry{
+	m.Core().Session().ResourceCache[s3Short] = &session.ResourceCacheEntry{
 		Resources: []resource.Resource{
 			{ID: s3ID, Name: "test-bucket", Status: "running"},
 		},
@@ -698,7 +698,7 @@ func TestFold_MainMenuCtrlR_ClearsAllCachedWave2(t *testing.T) {
 		{ec2Short, ec2ID, "wave2:" + ec2Short},
 		{s3Short, s3ID, "wave2:" + s3Short},
 	} {
-		entry, ok := m.Session().ResourceCache[tc.short]
+		entry, ok := m.Core().Session().ResourceCache[tc.short]
 		if !ok || len(entry.Resources) == 0 {
 			t.Fatalf("pre-Ctrl+R: ResourceCache[%q] empty — enrichment not wired", tc.short)
 		}
@@ -728,7 +728,7 @@ func TestFold_MainMenuCtrlR_ClearsAllCachedWave2(t *testing.T) {
 		{ec2Short, "wave2:" + ec2Short},
 		{s3Short, "wave2:" + s3Short},
 	} {
-		entry, ok := m.Session().ResourceCache[tc.short]
+		entry, ok := m.Core().Session().ResourceCache[tc.short]
 		if !ok {
 			// Cache entry deleted on Ctrl+R is also acceptable — no stale wave2.
 			continue
@@ -824,7 +824,7 @@ func TestFold_AttentionDetailsCarryAcrossEntryPoints(t *testing.T) {
 
 			// Verify entry-point wave1 was set (shim site #4 must be wired for this to hold).
 			{
-				entry := m.Session().ResourceCache[tc.canonShort]
+				entry := m.Core().Session().ResourceCache[tc.canonShort]
 				if entry == nil || len(entry.Resources) == 0 {
 					t.Fatalf("ResourceCache[%q] empty after RelatedCheckResultMsg — site 4 shim not wired", tc.canonShort)
 				}
@@ -841,7 +841,7 @@ func TestFold_AttentionDetailsCarryAcrossEntryPoints(t *testing.T) {
 				TypeGen:      0,
 			})
 
-			entry, ok := m.Session().ResourceCache[tc.canonShort]
+			entry, ok := m.Core().Session().ResourceCache[tc.canonShort]
 			if !ok || len(entry.Resources) == 0 {
 				t.Fatalf("ResourceCache[%q] is empty after EnrichmentCheckedMsg", tc.canonShort)
 			}

--- a/tests/unit/phase03_shim_wireups_test.go
+++ b/tests/unit/phase03_shim_wireups_test.go
@@ -32,7 +32,7 @@
 //	   scaffolding. Covered by grep-audit.
 //
 //	#7 app_enrich.go — EnrichDetailResultMsg updates only the active DetailModel's
-//	   internal m.res field, not m.Session().ResourceCache. That field is unexported and
+//	   internal m.res field, not m.Core().Session().ResourceCache. That field is unexported and
 //	   inaccessible from this external test package. The wire-up will be verified
 //	   by the coder's grep-audit (exactly 7 sites).
 //
@@ -55,7 +55,7 @@
 //	   are missed. Pre-fix: only wave1 finding returned. Post-fix: 2 findings.
 //
 //	TestShim_NavigateAliasHitsCanonicalCache:
-//	   handleNavigate does m.Session().ResourceCache[msg.ResourceType] — alias misses canonical
+//	   handleNavigate does m.Core().Session().ResourceCache[msg.ResourceType] — alias misses canonical
 //	   cache key, bypasses deriveFindingsForType, leaving Findings empty. Pre-fix:
 //	   empty. Post-fix: Findings populated.
 //
@@ -100,11 +100,11 @@ func newShimModel() tui.Model {
 }
 
 // TestShim_ProbeResourcesPopulatesFindings verifies that when
-// AvailabilityCheckedMsg is handled the retained resources in m.Session().ProbeResources
+// AvailabilityCheckedMsg is handled the retained resources in m.Core().Session().ProbeResources
 // have their Findings field populated by DeriveFindings.
 //
 // Wire-up site: app_handlers_availability.go (~line 215), the
-// m.Session().ProbeResources[msg.ResourceType] = msg.Resources assignment.
+// m.Core().Session().ProbeResources[msg.ResourceType] = msg.Resources assignment.
 //
 // Table-driven: every row exercises a distinct resource type to ensure no
 // type is special-cased and aliases are handled correctly.
@@ -148,13 +148,13 @@ func TestShim_ProbeResourcesPopulatesFindings(t *testing.T) {
 				Truncated:    false,
 				// session.New seeds AvailabilityGen=1 (AS-659) — stamp the live
 				// value so the AvailabilityChecked stale guard accepts it.
-				Gen:       m.Session().AvailabilityGen,
+				Gen:       m.Core().Session().AvailabilityGen,
 				Issues:    1,
 				Resources: []resource.Resource{res},
 			})
 
 			// The cache lookup must use the canonical short name, NOT the alias.
-			probeSlice, ok := m.Session().ProbeResources[tc.canonShort]
+			probeSlice, ok := m.Core().Session().ProbeResources[tc.canonShort]
 			if !ok || len(probeSlice) == 0 {
 				t.Fatalf("ProbeResources[%q] is empty — handler did not retain resources (alias=%q)", tc.canonShort, effective)
 			}
@@ -185,7 +185,7 @@ func TestShim_ProbeResourcesPopulatesFindings(t *testing.T) {
 
 // TestShim_EnrichmentCheckedBridgesWave2Findings is the critical Wave-2 bridge test.
 //
-// The test pre-seeds m.Session().ResourceCache[tc.canonShort] with a resource that has
+// The test pre-seeds m.Core().Session().ResourceCache[tc.canonShort] with a resource that has
 // tc.status, sends EnrichmentCheckedMsg (using alias if present), and asserts
 // the first finding is populated correctly.
 //
@@ -224,7 +224,7 @@ func TestShim_EnrichmentCheckedBridgesWave2Findings(t *testing.T) {
 			}
 
 			// Seed the cache under the canonical short name.
-			m.Session().ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
+			m.Core().Session().ResourceCache[tc.canonShort] = &session.ResourceCacheEntry{
 				Resources: []resource.Resource{res},
 			}
 
@@ -238,7 +238,7 @@ func TestShim_EnrichmentCheckedBridgesWave2Findings(t *testing.T) {
 				TypeGen:      0,
 			})
 
-			entry, ok := m.Session().ResourceCache[tc.canonShort]
+			entry, ok := m.Core().Session().ResourceCache[tc.canonShort]
 			if !ok || len(entry.Resources) == 0 {
 				t.Fatalf("ResourceCache[%q] is empty after EnrichmentCheckedMsg", tc.canonShort)
 			}
@@ -268,10 +268,10 @@ func TestShim_EnrichmentCheckedBridgesWave2Findings(t *testing.T) {
 }
 
 // TestShim_CachedPagesPopulatesFindings verifies that when RelatedCheckResultMsg
-// carries a CachedPages entry, the resources written to m.Session().ResourceCache have
+// carries a CachedPages entry, the resources written to m.Core().Session().ResourceCache have
 // their Findings field populated by DeriveFindings.
 //
-// Wire-up site: app.go (~line 489), the m.Session().ResourceCache[shortName] = ... assignment
+// Wire-up site: app.go (~line 489), the m.Core().Session().ResourceCache[shortName] = ... assignment
 // inside the CachedPages loop.
 //
 // Table-driven: aliased rows (rds-aliased, redis-aliased) are expected to fail
@@ -325,7 +325,7 @@ func TestShim_CachedPagesPopulatesFindings(t *testing.T) {
 			})
 
 			// After handling, the cache must be stored under the canonical key.
-			entry, ok := m.Session().ResourceCache[tc.canonShort]
+			entry, ok := m.Core().Session().ResourceCache[tc.canonShort]
 			if !ok || len(entry.Resources) == 0 {
 				t.Fatalf("ResourceCache[%q] is empty — CachedPages was not written (alias=%q)", tc.canonShort, effective)
 			}
@@ -355,10 +355,10 @@ func TestShim_CachedPagesPopulatesFindings(t *testing.T) {
 }
 
 // TestShim_LazyAddedPopulatesFindings verifies that when RelatedCheckResultMsg
-// carries a LazyAddedResources entry, the resources merged into m.Session().LazyResourceCache
+// carries a LazyAddedResources entry, the resources merged into m.Core().Session().LazyResourceCache
 // have their Findings field populated by DeriveFindings.
 //
-// Wire-up site: app.go (~line 517), the m.Session().LazyResourceCache[shortName] = existing
+// Wire-up site: app.go (~line 517), the m.Core().Session().LazyResourceCache[shortName] = existing
 // assignment inside the LazyAddedResources loop.
 //
 // Table-driven: aliased rows (rds-aliased, redis-aliased) are expected to fail
@@ -409,7 +409,7 @@ func TestShim_LazyAddedPopulatesFindings(t *testing.T) {
 			})
 
 			// The lazy cache must be stored under the canonical short name.
-			lazySlice, ok := m.Session().LazyResourceCache[tc.canonShort]
+			lazySlice, ok := m.Core().Session().LazyResourceCache[tc.canonShort]
 			if !ok || len(lazySlice) == 0 {
 				t.Fatalf("LazyResourceCache[%q] is empty — LazyAddedResources was not written (alias=%q)", tc.canonShort, effective)
 			}
@@ -481,7 +481,7 @@ func TestShim_DeriveHelpersResolveAlias(t *testing.T) {
 		Truncated:    false,
 		// session.New seeds AvailabilityGen=1 (AS-659) — stamp the live
 		// value so the AvailabilityChecked stale guard accepts it.
-		Gen:       m.Session().AvailabilityGen,
+		Gen:       m.Core().Session().AvailabilityGen,
 		Issues:    1,
 		Resources: []resource.Resource{res},
 	})
@@ -493,7 +493,7 @@ func TestShim_DeriveHelpersResolveAlias(t *testing.T) {
 	// Set EnrichTotal > 1 so the "all enrichment done" branch (EnrichChecked >= EnrichTotal)
 	// does not fire after processing this single message, which would nil out ProbeResources
 	// before we can inspect it.
-	m.Session().EnrichTotal = 2
+	m.Core().Session().EnrichTotal = 2
 	m = shimApplyMsg(m, messages.EnrichmentChecked{
 		ResourceType: "dbi",
 		Findings: map[string]resource.EnrichmentFinding{
@@ -503,7 +503,7 @@ func TestShim_DeriveHelpersResolveAlias(t *testing.T) {
 		TypeGen: 0,
 	})
 
-	probeSlice, ok := m.Session().ProbeResources["dbi"]
+	probeSlice, ok := m.Core().Session().ProbeResources["dbi"]
 	if !ok || len(probeSlice) == 0 {
 		t.Fatal("ProbeResources[\"dbi\"] is empty after AvailabilityCheckedMsg with alias \"rds\"")
 	}
@@ -582,7 +582,7 @@ func TestShim_DeriveHelpersResolveAlias_SingleResource(t *testing.T) {
 		Truncated:    false,
 		// session.New seeds AvailabilityGen=1 (AS-659) — stamp the live
 		// value so the AvailabilityChecked stale guard accepts it.
-		Gen:       m.Session().AvailabilityGen,
+		Gen:       m.Core().Session().AvailabilityGen,
 		Issues:    1,
 		Resources: []resource.Resource{res},
 	})
@@ -595,7 +595,7 @@ func TestShim_DeriveHelpersResolveAlias_SingleResource(t *testing.T) {
 	// Set EnrichTotal > 1 so the "all enrichment done" branch (EnrichChecked >= EnrichTotal)
 	// does not fire after processing this single message, which would nil out ProbeResources
 	// before we can inspect it.
-	m.Session().EnrichTotal = 2
+	m.Core().Session().EnrichTotal = 2
 	m = shimApplyMsg(m, messages.EnrichmentChecked{
 		ResourceType: "rds", // alias — exercises alias normalization in handleEnrichmentChecked
 		Findings: map[string]resource.EnrichmentFinding{
@@ -605,7 +605,7 @@ func TestShim_DeriveHelpersResolveAlias_SingleResource(t *testing.T) {
 		TypeGen: 0,
 	})
 
-	probeSlice, ok := m.Session().ProbeResources["dbi"]
+	probeSlice, ok := m.Core().Session().ProbeResources["dbi"]
 	if !ok || len(probeSlice) == 0 {
 		t.Fatal("ProbeResources[\"dbi\"] is empty after AvailabilityCheckedMsg with alias \"rds\"")
 	}
@@ -685,16 +685,16 @@ func TestShim_DeriveHelpersResolveAlias_SingleResource(t *testing.T) {
 // ──────────────────────────────────────────────────────────────────────────
 
 // TestShim_NavigateAliasHitsCanonicalCache verifies that handleNavigate resolves
-// an alias to the canonical ShortName before looking up m.Session().ResourceCache.
+// an alias to the canonical ShortName before looking up m.Core().Session().ResourceCache.
 //
-// Bug: app_handlers_navigate.go:49 does m.Session().ResourceCache[msg.ResourceType] —
+// Bug: app_handlers_navigate.go:49 does m.Core().Session().ResourceCache[msg.ResourceType] —
 // when msg.ResourceType is "rds" (alias) but the cache is keyed under "dbi"
 // (canonical), the lookup misses. deriveFindingsForType is never called on the
 // cached resources, so Findings remain empty.
 //
-// Setup: seed m.Session().ResourceCache["dbi"] with one resource (Status="impaired").
+// Setup: seed m.Core().Session().ResourceCache["dbi"] with one resource (Status="impaired").
 // Drive NavigateMsg{Target: TargetResourceList, ResourceType: "rds"}.
-// Post-fix: m.Session().ResourceCache["dbi"].Resources[0].Findings is populated.
+// Post-fix: m.Core().Session().ResourceCache["dbi"].Resources[0].Findings is populated.
 // Pre-fix: Findings is empty (cache entry found only after canonical lookup is wired).
 func TestShim_NavigateAliasHitsCanonicalCache(t *testing.T) {
 	m := newShimModel()
@@ -707,7 +707,7 @@ func TestShim_NavigateAliasHitsCanonicalCache(t *testing.T) {
 	}
 
 	// Seed the cache under the canonical key "dbi".
-	m.Session().ResourceCache["dbi"] = &session.ResourceCacheEntry{
+	m.Core().Session().ResourceCache["dbi"] = &session.ResourceCacheEntry{
 		Resources: []resource.Resource{res},
 	}
 
@@ -719,7 +719,7 @@ func TestShim_NavigateAliasHitsCanonicalCache(t *testing.T) {
 	})
 
 	// The cache under "dbi" must now have Findings populated.
-	entry, ok := m.Session().ResourceCache["dbi"]
+	entry, ok := m.Core().Session().ResourceCache["dbi"]
 	if !ok || len(entry.Resources) == 0 {
 		t.Fatal("ResourceCache[\"dbi\"] is empty after NavigateMsg — unexpected state")
 	}
@@ -799,10 +799,10 @@ func TestShim_ResourcesLoadedPopulatesFindings(t *testing.T) {
 			// an alias). The canonical test: check both canonical and alias keys to
 			// find where the entry landed, then assert Findings.
 			var entry *session.ResourceCacheEntry
-			if e, ok := m.Session().ResourceCache[tc.canonShort]; ok {
+			if e, ok := m.Core().Session().ResourceCache[tc.canonShort]; ok {
 				entry = e
 			} else if tc.alias != "" {
-				if e, ok := m.Session().ResourceCache[effective]; ok {
+				if e, ok := m.Core().Session().ResourceCache[effective]; ok {
 					entry = e
 				}
 			}

--- a/tests/unit/qa_clients_ready_flash_gen_test.go
+++ b/tests/unit/qa_clients_ready_flash_gen_test.go
@@ -48,7 +48,7 @@ func TestHandleClientsReady_SuccessNoPendingRefresh_FlashGenUnchanged(t *testing
 	m, _ = rootApplyMsg(m, messages.ClientsReady{
 		Clients: &awsclient.ServiceClients{},
 		Region:  "us-east-1",
-		Gen:     m.Session().ConnectGen, // matches session → non-stale
+		Gen:     m.Core().Session().ConnectGen, // matches session → non-stale
 	})
 
 	if got := m.FlashGen(); got != genBefore {
@@ -76,7 +76,7 @@ func TestHandleClientsReady_StaleGen_FlashGenUnchanged(t *testing.T) {
 	m, _ = rootApplyMsg(m, messages.ClientsReady{
 		Clients: &awsclient.ServiceClients{},
 		Region:  "us-east-1",
-		Gen:     m.Session().ConnectGen + 5,
+		Gen:     m.Core().Session().ConnectGen + 5,
 	})
 
 	if got := m.FlashGen(); got != genBefore {

--- a/tests/unit/qa_enrich_pipeline_dispatch_test.go
+++ b/tests/unit/qa_enrich_pipeline_dispatch_test.go
@@ -102,7 +102,7 @@ func TestBuildEnrichQueue_DispatchesCodePipeline(t *testing.T) {
 		ResourceType: "pipeline",
 		Count:        1,
 		Truncated:    false,
-		Gen:          m.Session().AvailabilityGen,
+		Gen:          m.Core().Session().AvailabilityGen,
 		Resources:    pipelineProbeResources(),
 	})
 

--- a/tests/unit/qa_partial_success_handlers_test.go
+++ b/tests/unit/qa_partial_success_handlers_test.go
@@ -67,7 +67,7 @@ func TestHandleAvailabilityChecked_PartialErrAppliesState(t *testing.T) {
 		Resources:    partialResources,
 		Issues:       0,
 		Truncated:    false,
-		Gen:          m.Session().AvailabilityGen,
+		Gen:          m.Core().Session().AvailabilityGen,
 	})
 
 	// CONTRACT 1: A FlashMsg with IsError=true must be emitted.
@@ -100,7 +100,7 @@ func TestHandleAvailabilityChecked_PartialErrAppliesState(t *testing.T) {
 	// retained, buildEnrichQueue includes "ec2" → enrichment is dispatched.
 	_, enrichCmd := rootApplyMsg(m, messages.AvailabilityChecked{
 		ResourceType: "dummy-for-finalize",
-		Gen:          m.Session().AvailabilityGen,
+		Gen:          m.Core().Session().AvailabilityGen,
 		Count:        0,
 		HasResources: false,
 	})
@@ -139,13 +139,13 @@ func TestHandleAvailabilityChecked_HardErr_NoStateApplied(t *testing.T) {
 		HasResources: false,
 		Count:        0,
 		Resources:    nil,
-		Gen:          m.Session().AvailabilityGen,
+		Gen:          m.Core().Session().AvailabilityGen,
 	})
 
 	// Hard failure: wave 2 must NOT be dispatched for lambda (no probe resources).
 	_, enrichCmd := rootApplyMsg(m, messages.AvailabilityChecked{
 		ResourceType: "dummy-finalize",
-		Gen:          m.Session().AvailabilityGen,
+		Gen:          m.Core().Session().AvailabilityGen,
 	})
 	if enrichCmd != nil {
 		enrichMsgs := collectEnrichmentMsgs(enrichCmd)
@@ -188,7 +188,7 @@ func TestHandleEnrichmentChecked_PartialErrAppliesState(t *testing.T) {
 	// Seed probeResources["ec2"] so the handler can merge FieldUpdates.
 	m, _ = rootApplyMsg(m, messages.AvailabilityChecked{
 		ResourceType: "ec2",
-		Gen:          m.Session().AvailabilityGen,
+		Gen:          m.Core().Session().AvailabilityGen,
 		Count:        1,
 		HasResources: true,
 		Resources: []resource.Resource{

--- a/tests/unit/qa_partial_success_probe_test.go
+++ b/tests/unit/qa_partial_success_probe_test.go
@@ -179,7 +179,7 @@ func TestProbeEnrichment_PartialSuccess(t *testing.T) {
 	// availTotal=0 → availChecked(1) >= 0 → finalize → startEnrichment.
 	_, enrichCmd := rootApplyMsg(m, messages.AvailabilityChecked{
 		ResourceType: shortName,
-		Gen:          m.Session().AvailabilityGen,
+		Gen:          m.Core().Session().AvailabilityGen,
 		Count:        len(probeRes),
 		HasResources: true,
 		Resources:    probeRes,

--- a/tests/unit/qa_prefetch_pagination_seed_test.go
+++ b/tests/unit/qa_prefetch_pagination_seed_test.go
@@ -57,10 +57,10 @@ func TestPrefetchPaginationSeed_PreservesNextToken(t *testing.T) {
 		Pagination:     map[string]*resource.PaginationMeta{targetType: wantMeta},
 		// Stamp the live AvailabilityGen so the AS-657/AS-659 staleness guard
 		// accepts the message (AcceptZeroGen=false after AS-659).
-		Gen: m.Session().AvailabilityGen,
+		Gen: m.Core().Session().AvailabilityGen,
 	})
 
-	entry, ok := m.Session().ResourceCache[targetType]
+	entry, ok := m.Core().Session().ResourceCache[targetType]
 	if !ok {
 		t.Fatalf("expected ResourceCache entry for %q after prefetch seed; got nil", targetType)
 	}
@@ -103,10 +103,10 @@ func TestPrefetchPaginationSeed_FallbackWhenPaginationOmitted(t *testing.T) {
 		// Pagination intentionally nil — pre-fix shape.
 		// Stamp the live AvailabilityGen so the AS-657/AS-659 staleness guard
 		// accepts the message (AcceptZeroGen=false after AS-659).
-		Gen: m.Session().AvailabilityGen,
+		Gen: m.Core().Session().AvailabilityGen,
 	})
 
-	entry, ok := m.Session().ResourceCache[targetType]
+	entry, ok := m.Core().Session().ResourceCache[targetType]
 	if !ok {
 		t.Fatalf("expected ResourceCache entry for %q after fallback prefetch seed; got nil", targetType)
 	}

--- a/tests/unit/qa_probe_truncation_per_type_test.go
+++ b/tests/unit/qa_probe_truncation_per_type_test.go
@@ -96,7 +96,7 @@ func TestBuildResourceCacheSnapshot_ProbeAuthoritative_SinglePageComplete(t *tes
 		Resources:      map[string][]resource.Resource{targetType: {probeResource}},
 		// Stamp the live AvailabilityGen so the AS-657/AS-659 staleness guard
 		// accepts the message (AcceptZeroGen=false after AS-659).
-		Gen: m.Session().AvailabilityGen,
+		Gen: m.Core().Session().AvailabilityGen,
 	})
 
 	// Navigate to src detail view so RelatedCheckStartedMsg is handled.
@@ -200,7 +200,7 @@ func TestBuildResourceCacheSnapshot_ProbeTruncated_StampsTrue(t *testing.T) {
 		Resources:      map[string][]resource.Resource{targetType: {probeResource}},
 		// Stamp the live AvailabilityGen so the AS-657/AS-659 staleness guard
 		// accepts the message (AcceptZeroGen=false after AS-659).
-		Gen: m.Session().AvailabilityGen,
+		Gen: m.Core().Session().AvailabilityGen,
 	})
 
 	srcRes := resource.Resource{ID: "pt2-src-001", Name: "pt2-src-001"}

--- a/tests/unit/qa_unified_issue_count_test.go
+++ b/tests/unit/qa_unified_issue_count_test.go
@@ -375,7 +375,7 @@ func TestUnifiedIssueCount_IgnoresTildeSeverityFindings(t *testing.T) {
 			Count:        3,
 			Resources:    resources,
 			Issues:       0,
-			Gen:          m.Session().AvailabilityGen,
+			Gen:          m.Core().Session().AvailabilityGen,
 		})
 
 		m = navigateToEC2List(m)
@@ -419,7 +419,7 @@ func TestUnifiedIssueCount_IgnoresTildeSeverityFindings(t *testing.T) {
 			Count:        3,
 			Resources:    resources,
 			Issues:       0,
-			Gen:          m.Session().AvailabilityGen,
+			Gen:          m.Core().Session().AvailabilityGen,
 		})
 
 		m = navigateToEC2List(m)
@@ -466,7 +466,7 @@ func TestUnifiedIssueCount_IgnoresTildeSeverityFindings(t *testing.T) {
 			Count:        1,
 			Resources:    []resource.Resource{brokenResource},
 			Issues:       1, // Wave-1 issue
-			Gen:          m.Session().AvailabilityGen,
+			Gen:          m.Core().Session().AvailabilityGen,
 		})
 
 		m = navigateToEC2List(m)

--- a/tests/unit/tui_wiring_test.go
+++ b/tests/unit/tui_wiring_test.go
@@ -380,7 +380,7 @@ func TestWiring_AvailabilityComplete_ClearsFlash(t *testing.T) {
 	var lastCmd tea.Cmd
 	// session.New seeds AvailabilityGen=1 (AS-659) — capture and reuse so the
 	// AvailabilityChecked stale guard (AcceptZeroGen=false) accepts each msg.
-	gen := m.Session().AvailabilityGen
+	gen := m.Core().Session().AvailabilityGen
 	for _, name := range allNames {
 		m, lastCmd = rootApplyMsg(m, messages.AvailabilityChecked{
 			ResourceType: name,


### PR DESCRIPTION
## Summary

The 5a-extract Stage 2 exit gate. After this merges, [`docs/refactor/05-boundary.md`](https://github.com/k2m30/a9s/blob/main/docs/refactor/05-boundary.md):230-264 passes for the first time — `internal/tui`'s production import set no longer references `internal/aws` or `internal/session`.

Parent tracker: AS-960. Predecessor: AS-962 (h4-b, PR #411). Spec authority: AS-650.

## Files added

- `internal/runtime/transport.go` — `type ServiceClients = awsclient.ServiceClients` alias (spec line 558).
- `internal/runtime/relatedcache.go` — `RelatedCacheKey`, `RelatedCacheReplay` free functions + `RelatedCacheResult` type alias so renderer adapters can construct cache entries without importing `internal/session` (spec line 559).
- `internal/domain/resource_cache.go` — `ListViewCacheEntry` value type moved from `internal/session` (spec line 560). Renamed from `ResourceCacheEntry` because the existing `domain.ResourceCacheEntry` (related-checker snapshot) has a different shape and name collision would be a compile error. `session.ResourceCacheEntry` stays available as a type alias to `domain.ListViewCacheEntry` so all existing callers compile unchanged.
- `internal/runtime/accessors.go` — typed Core accessors per spec lines 525-535, 549-554: `Profile`, `Region`, `ConnectGen`, `Identity` (returns `*domain.CallerIdentity`), `ResourceCache(rt)` (returns `(*domain.ListViewCacheEntry, bool)`), `LazyResourceCache(rt)`, `SetIdentityFetching`, `ClearCommand`, `HasIssueEnricher(shortName) bool`. Plus `Bootstrap(profile, region, types) *Core` so `tui.New` no longer imports `internal/session`.
- `internal/tui/app_options.go`, `internal/tui/app_view.go`, `internal/tui/app_stack.go` — extracted from `app.go` to honour the spec 300-400 LOC budget on `app.go`.

## Files modified

- `internal/session/session.go` — `ResourceCacheEntry` becomes a type alias to `domain.ListViewCacheEntry`. All existing callers (tests, runtime handlers) compile unchanged.
- `internal/tui/app.go` — dropped `internal/aws` and `internal/session` imports; `WithClients` signature now takes `*runtime.ServiceClients`; the residual `&session.ResourceCacheEntry{}` literal in `cacheTopLevelResourceList` is now `&domain.ListViewCacheEntry{}`; `session.New()` replaced by `runtime.Bootstrap(...)`. Shrunk from **668 → 308 LOC** by splitting into the three new helper files.
- `internal/tui/app_accessors.go` — deleted the `Session() *session.Session` accessor that was the last production-side leak of `internal/session` into `internal/tui`. Added `Core() *runtime.Core` so test sites can reach the runtime handle. Test sites migrated from `m.Session()` to `m.Core().Session()` across 14 test files.
- `internal/tui/probe_adapter.go`, `runtime_adapter_navigate.go` — `awsclient.Wave2EnricherFor(shortName)` replaced by `m.core.HasIssueEnricher(shortName)`.
- `internal/tui/app_dispatch.go`, `runtime_adapter_navigate.go`, `runtime_adapter_related.go` — `session.RelatedCacheKey/RelatedCacheReplay/RelatedCacheResult` references switched to `runtime.*` equivalents.
- `internal/tui/runtime_adapter.go` — historical comment scrub so the `\bsession\.` / `awsclient\.` grep gates pass on the literal text too.

## Spec acceptance (all gates green locally)

```bash
$ go list -f '{{.Imports}}' github.com/k2m30/a9s/v3/internal/tui \
    | tr ' ' '\n' | grep -E 'internal/session|internal/aws$'
# zero hits — THE boundary check

$ wc -l internal/tui/app.go
308 internal/tui/app.go      # 300-400 budget: PASS

$ rg 'func \(m Model\) Session\(\)' internal/tui/
# zero hits

$ rg 'awsclient\.' internal/tui/ --type go | grep -v _test
# zero hits

$ rg '\bsession\.' internal/tui/ --type go | grep -v _test
# zero hits

$ go list -f '{{.Imports}}' github.com/k2m30/a9s/v3/internal/runtime \
    | grep -E 'bubbletea|lipgloss|bubbles'
# zero hits — runtime still Bubble Tea-free
```

`make ready-to-push` sub-targets run locally: lint (0 issues), security (govulncheck — no vulns), gofix (PASS), verify-readonly (PASS), verify-zero-init (PASS), check-readme (PASS), snapshot (PASS), mdlint (0 errors), `go test ./...` (PASS).

**Note on `test-race`**: the harness sandbox has no C compiler (cgo unavailable), so `go test -race` cannot run here. CI runs with cgo and will exercise the race detector. The race-relevant code (related-cache key + replay) was a verbatim move — no new concurrency surface introduced.

## Behavior verification

Mechanical move — h4-a and h4-b already shifted the runtime logic. The exit gate is the import-boundary check above plus a full `./a9s --demo` regression pass (list → detail → YAML, child views, profile switch, region switch, Ctrl+R, Wave-2 attention column) which is the Stage 5 reviewer responsibility.

## Out of scope

- Phase-04 catalog/init() work (AS-651/AS-731 program).
- The selector package (AS-649 / PR #380).
- Anything spec lines 615-622 calls out: `handleKeyMsg`, `app_flash.go`, Cmd/Event split, `domain.Gen` collapse, `internal/aws/` rename, new capability screens, future desktop-shell adapter.

## Test plan

- [x] Boundary grep returns zero hits
- [x] `wc -l internal/tui/app.go` in 300-400 range
- [x] `Session()` accessor deleted
- [x] No bare `awsclient.` / `session.` in tui production
- [x] Runtime still Bubble Tea-free
- [x] `go build ./...` clean
- [x] `go test ./...` PASS
- [x] golangci-lint / govulncheck / gofix / verify-readonly / verify-zero-init / check-readme / snapshot / mdlint all PASS
- [ ] CI race detector (`test-race`) — exercised in GitHub Actions (cgo unavailable locally)
- [ ] Stage 5 reviewer `./a9s --demo` smoke

## References

- Parent tracker: AS-960.
- Spec: [`docs/refactor/05-pr-05a-h4.md`](https://github.com/k2m30/a9s/blob/main/docs/refactor/05-pr-05a-h4.md):496-611.
- Boundary contract: [`docs/refactor/05-boundary.md`](https://github.com/k2m30/a9s/blob/main/docs/refactor/05-boundary.md):230-264 — exit criteria pass for the first time when this PR merges.
- Predecessor (h4-b): AS-962 / PR #411.

Stage 5 reviewers per AS-960 owner + size L: **CodeReviewer + CodexReviewer + Architect (AS-960 owner) → CTO**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)