### PR TITLE
AS-768 fix(test): stamp main.version ldflag in integration TestMain

### DIFF
--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -23,10 +23,13 @@ func TestMain(m *testing.M) {
 	aws.Install()
 	resource.WireProjection()
 
-	// Build the binary once for all CLI tests.
+	// Build the binary once for all CLI tests. Stamp main.version via
+	// ldflags so TestQA_012_VersionFlag's X.Y.Z assertion holds — without
+	// ldflags, buildinfo.ResolveVersion falls back to "dev" and `--version`
+	// prints "a9s dev" with no "." in it (AS-768).
 	tmpDir := os.TempDir()
 	testBinary = filepath.Join(tmpDir, "a9s-test")
-	cmd := exec.Command("go", "build", "-o", testBinary, "./cmd/a9s/")
+	cmd := exec.Command("go", "build", "-ldflags", "-X main.version=test-0.0.0", "-o", testBinary, "./cmd/a9s/")
 	cmd.Dir = findProjectRoot()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		panic("failed to build test binary: " + string(out) + ": " + err.Error())


### PR DESCRIPTION
## Summary

Fixes AS-768 — `TestQA_012_VersionFlag` fails on unstamped `go build` because TestMain builds the test binary without ldflags, so `main.version` stays `"dev"` and `--version` prints `"a9s dev"` (no `.`, assertion fails).

Adds `-ldflags=-X main.version=test-0.0.0` to the test build. Restores the X.Y.Z pattern assertion as a meaningful gate.

Note on issue's suggested ldflag target: AS-768 description proposed `-X github.com/k2m30/a9s/v3/internal/buildinfo.Version=...`, but `buildinfo` exposes no `Version` variable — the version string is `cmd/a9s/main.go::version` (package `main`). This PR uses `main.version`, matching the production Makefile.

## Test plan

- [x] `go test -tags integration ./tests/integration/ -run TestQA_012_VersionFlag -count=1 -v` → PASS
- [x] `go test -tags integration ./tests/integration/ -v -count=1 -timeout 300s` → all PASS (23.3s)
- [x] `go test ./tests/unit/ -count=1 -timeout 120s` → PASS
- [x] `golangci-lint run ./...` → 0 issues (4 pre-existing integration-tag `noctx` warnings unchanged, same lines)
- [ ] CI: `make ready-to-push` (test-race + lint + security + gofix + verify-readonly + verify-zero-init + check-readme + snapshot + mdlint)

## Risk

Test-harness only. No production code touched. Worst case is the harness binary now identifies as `test-0.0.0` instead of `dev` in any future test that reads `--version`.

Closes AS-768.

🤖 Generated with [Claude Code](https://claude.com/claude-code)