### PR TITLE
fix(related): AS-1243 soft-skip deleted launch templates + gate ELB WAF by type

### DIFF
--- a/internal/aws/eks_related_extra.go
+++ b/internal/aws/eks_related_extra.go
@@ -3,6 +3,7 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -13,6 +14,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	smithy "github.com/aws/smithy-go"
 
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
@@ -172,6 +174,14 @@ func checkEKSAMI(ctx context.Context, clients any, res resource.Resource, _ reso
 			})
 		})
 		if ltErr != nil {
+			// Soft-skip when the launch template has been deleted upstream:
+			// AWS returns InvalidLaunchTemplateId.NotFound, which is a true
+			// "no AMI to relate to" rather than a fetch failure.
+			var apiErr smithy.APIError
+			if errors.As(ltErr, &apiErr) && apiErr.ErrorCode() == "InvalidLaunchTemplateId.NotFound" {
+				failures = append(failures, fmt.Sprintf("%s: launch template deleted", ngName))
+				continue
+			}
 			failures = append(failures, fmt.Sprintf("%s/lt: %v", ngName, ltErr))
 			continue
 		}

--- a/internal/aws/elb_related.go
+++ b/internal/aws/elb_related.go
@@ -364,8 +364,11 @@ func checkELBSubnet(_ context.Context, _ any, res resource.Resource, _ resource.
 // AWS WAFv2 only supports CloudFront, ALB, API Gateway, AppSync, Cognito,
 // Verified Access, and App Runner — NLBs and GWLBs are unsupported and
 // calling GetWebACLForResource with a non-ALB ELB returns
-// WAFInvalidParameterException. Gate on the ELB type to keep the
-// related-panel result a definitive zero instead of a fetch failure.
+// WAFInvalidParameterException. Short-circuit when the ELB type is a known
+// unsupported value (network or gateway) to keep the related-panel result a
+// definitive zero instead of a fetch failure. Fall through to the API call
+// for "application" and unknown types so ALBs with missing Fields["type"]
+// (e.g. cache rehydration paths) still get checked via RawStruct fallback.
 func checkELBWAF(ctx context.Context, clients any, res resource.Resource, _ resource.ResourceCache) resource.RelatedCheckResult {
 	elbARN := res.Fields["load_balancer_arn"]
 	if elbARN == "" {
@@ -377,7 +380,13 @@ func checkELBWAF(ctx context.Context, clients any, res resource.Resource, _ reso
 	if elbARN == "" {
 		return resource.RelatedCheckResult{TargetType: "waf", Count: 0}
 	}
-	if res.Fields["type"] != "application" {
+	lbType := res.Fields["type"]
+	if lbType == "" {
+		if raw, ok := assertStruct[elbv2types.LoadBalancer](res.RawStruct); ok {
+			lbType = string(raw.Type)
+		}
+	}
+	if lbType == "network" || lbType == "gateway" {
 		return resource.RelatedCheckResult{TargetType: "waf", Count: 0}
 	}
 	c, ok := clients.(*ServiceClients)

--- a/internal/aws/elb_related.go
+++ b/internal/aws/elb_related.go
@@ -360,6 +360,12 @@ func checkELBSubnet(_ context.Context, _ any, res resource.Resource, _ resource.
 
 // checkELBWAF reports the WAF Web ACL attached to this ELB.
 // Pattern C: one wafv2:GetWebACLForResource call with the ELB ARN.
+//
+// AWS WAFv2 only supports CloudFront, ALB, API Gateway, AppSync, Cognito,
+// Verified Access, and App Runner — NLBs and GWLBs are unsupported and
+// calling GetWebACLForResource with a non-ALB ELB returns
+// WAFInvalidParameterException. Gate on the ELB type to keep the
+// related-panel result a definitive zero instead of a fetch failure.
 func checkELBWAF(ctx context.Context, clients any, res resource.Resource, _ resource.ResourceCache) resource.RelatedCheckResult {
 	elbARN := res.Fields["load_balancer_arn"]
 	if elbARN == "" {
@@ -369,6 +375,9 @@ func checkELBWAF(ctx context.Context, clients any, res resource.Resource, _ reso
 		}
 	}
 	if elbARN == "" {
+		return resource.RelatedCheckResult{TargetType: "waf", Count: 0}
+	}
+	if res.Fields["type"] != "application" {
 		return resource.RelatedCheckResult{TargetType: "waf", Count: 0}
 	}
 	c, ok := clients.(*ServiceClients)

--- a/internal/aws/ng_related.go
+++ b/internal/aws/ng_related.go
@@ -3,6 +3,7 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -10,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	smithy "github.com/aws/smithy-go"
 
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
@@ -217,6 +219,12 @@ func checkNGAMI(ctx context.Context, clients any, res resource.Resource, _ resou
 		})
 	})
 	if err != nil {
+		// Launch template deleted upstream — that is a true zero, not a
+		// fetch failure: there is no AMI for this NG to relate to.
+		var apiErr smithy.APIError
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "InvalidLaunchTemplateId.NotFound" {
+			return resource.RelatedCheckResult{TargetType: "ami", Count: 0}
+		}
 		return resource.RelatedCheckResult{TargetType: "ami", Count: -1, Err: err}
 	}
 	for _, v := range ltOut.LaunchTemplateVersions {

--- a/tests/unit/aws_elb_related_extra_test.go
+++ b/tests/unit/aws_elb_related_extra_test.go
@@ -584,7 +584,7 @@ func TestRelated_ELB_WAF_Found(t *testing.T) {
 	const wafID = "waf-web-acl-id-abc123"
 	source := resource.Resource{
 		ID:     "prod-alb",
-		Fields: map[string]string{"load_balancer_arn": elbARN},
+		Fields: map[string]string{"load_balancer_arn": elbARN, "type": "application"},
 	}
 	clients := &awsclient.ServiceClients{
 		WAFv2: &fakeWAFv2ForResource{
@@ -612,7 +612,7 @@ func TestRelated_ELB_WAF_NoWebACL(t *testing.T) {
 	const elbARN = "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/prod-alb/abcdef1234567890"
 	source := resource.Resource{
 		ID:     "prod-alb",
-		Fields: map[string]string{"load_balancer_arn": elbARN},
+		Fields: map[string]string{"load_balancer_arn": elbARN, "type": "application"},
 	}
 	clients := &awsclient.ServiceClients{
 		WAFv2: &fakeWAFv2ForResource{

--- a/tests/unit/aws_related_def_fragility_test.go
+++ b/tests/unit/aws_related_def_fragility_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/aws/aws-sdk-go-v2/service/wafv2"
 	wafv2types "github.com/aws/aws-sdk-go-v2/service/wafv2/types"
 	smithy "github.com/aws/smithy-go"
@@ -290,6 +291,46 @@ func TestCheckELBWAF_CallsAPIForApplicationLB(t *testing.T) {
 
 	if result.Count != 1 {
 		t.Fatalf("Count = %d, want 1; ResourceIDs=%v Err=%v", result.Count, result.ResourceIDs, result.Err)
+	}
+	if len(result.ResourceIDs) != 1 || result.ResourceIDs[0] != wafID {
+		t.Errorf("ResourceIDs = %v, want [%s]", result.ResourceIDs, wafID)
+	}
+}
+
+// TestCheckELBWAF_EmptyTypeFallbackToRawStruct verifies the defense-in-depth
+// fallback: when Fields["type"] is empty (e.g. cache rehydration paths that
+// drop the field), the checker falls back to RawStruct.Type. If RawStruct
+// resolves to "application", the WAF API call still proceeds. This mirrors
+// the existing elbARN RawStruct fallback at lines 370-376 and prevents a
+// silent false-negative on a security-relevant pivot.
+func TestCheckELBWAF_EmptyTypeFallbackToRawStruct(t *testing.T) {
+	const albARN = "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/prod-alb/abcdef1234567890"
+	const wafID = "waf-web-acl-id-fallback"
+	source := resource.Resource{
+		ID:     "prod-alb",
+		Name:   "prod-alb",
+		Fields: map[string]string{"load_balancer_arn": albARN}, // type missing
+		RawStruct: elbv2types.LoadBalancer{
+			LoadBalancerArn: aws.String(albARN),
+			Type:            elbv2types.LoadBalancerTypeEnumApplication,
+		},
+	}
+	clients := &awsclient.ServiceClients{
+		WAFv2: &fakeWAFv2ForResource{
+			output: &wafv2.GetWebACLForResourceOutput{
+				WebACL: &wafv2types.WebACL{
+					Id:   aws.String(wafID),
+					Name: aws.String("prod-alb-waf"),
+					ARN:  aws.String("arn:aws:wafv2:us-east-1:123456789012:regional/webacl/prod-alb-waf/" + wafID),
+				},
+			},
+		},
+	}
+	checker := elbCheckerByTarget(t, "waf")
+	result := checker(context.Background(), clients, source, resource.ResourceCache{})
+
+	if result.Count != 1 {
+		t.Fatalf("Count = %d, want 1 (RawStruct fallback should have surfaced ALB type); ResourceIDs=%v Err=%v", result.Count, result.ResourceIDs, result.Err)
 	}
 	if len(result.ResourceIDs) != 1 || result.ResourceIDs[0] != wafID {
 		t.Errorf("ResourceIDs = %v, want [%s]", result.ResourceIDs, wafID)

--- a/tests/unit/aws_related_def_fragility_test.go
+++ b/tests/unit/aws_related_def_fragility_test.go
@@ -1,0 +1,297 @@
+package unit_test
+
+// aws_related_def_fragility_test.go — AS-1243 regression coverage for three
+// pre-existing related-def fragilities surfaced by AS-1242 Stage 6.5:
+//
+//  1. checkEKSAMI must soft-skip nodegroups whose launch template has been
+//     deleted upstream (InvalidLaunchTemplateId.NotFound) instead of hard
+//     failing the whole AMI panel.
+//  2. checkNGAMI must return Count:0 (a true zero) when the launch template
+//     has been deleted upstream, not Count:-1 with the API error.
+//  3. checkELBWAF must skip the wafv2:GetWebACLForResource call for non-ALB
+//     load balancers (NLB / GWLB), because AWS WAFv2 only supports ALBs and
+//     would return WAFInvalidParameterException.
+//
+// The fixes live in:
+//   - internal/aws/eks_related_extra.go (checkEKSAMI)
+//   - internal/aws/ng_related.go (checkNGAMI)
+//   - internal/aws/elb_related.go (checkELBWAF)
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/aws/aws-sdk-go-v2/service/wafv2"
+	wafv2types "github.com/aws/aws-sdk-go-v2/service/wafv2/types"
+	smithy "github.com/aws/smithy-go"
+
+	_ "github.com/k2m30/a9s/v3/internal/aws"
+	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// ---------------------------------------------------------------------------
+// Fix 1 — checkEKSAMI: soft-skip InvalidLaunchTemplateId.NotFound per NG
+// ---------------------------------------------------------------------------
+
+// TestCheckEKSAMI_SkipsDeletedLaunchTemplate verifies that when one node group
+// references a launch template that has been deleted upstream, the AMI panel
+// still surfaces the AMIs from the other node groups (rather than hard-failing
+// with Count:-1). The deleted-LT NG is recorded as a partial failure entry in
+// the aggregated error per the existing AggregateFailures format.
+func TestCheckEKSAMI_SkipsDeletedLaunchTemplate(t *testing.T) {
+	const (
+		ltGood    = "lt-good001"
+		ltDeleted = "lt-deleted999"
+		amiGood   = "ami-0a1b2c3d4e5f60001"
+	)
+
+	eksNodegroups := map[string]*ekstypes.Nodegroup{
+		"ng-good": {
+			NodegroupName: aws.String("ng-good"),
+			ClusterName:   aws.String("acme-services"),
+			LaunchTemplate: &ekstypes.LaunchTemplateSpecification{
+				Id:      aws.String(ltGood),
+				Version: aws.String("1"),
+			},
+		},
+		"ng-deleted-lt": {
+			NodegroupName: aws.String("ng-deleted-lt"),
+			ClusterName:   aws.String("acme-services"),
+			LaunchTemplate: &ekstypes.LaunchTemplateSpecification{
+				Id:      aws.String(ltDeleted),
+				Version: aws.String("1"),
+			},
+		},
+	}
+	fakeEKS := newFakeEKSWithNodegroups([]string{"ng-good", "ng-deleted-lt"}, eksNodegroups)
+
+	fakeEC2 := &fakeEC2Batch2{
+		describeLaunchTemplateVersionsFn: func(input *ec2.DescribeLaunchTemplateVersionsInput) (*ec2.DescribeLaunchTemplateVersionsOutput, error) {
+			ltID := ""
+			if input.LaunchTemplateId != nil {
+				ltID = *input.LaunchTemplateId
+			}
+			if ltID == ltDeleted {
+				return nil, &smithy.GenericAPIError{
+					Code:    "InvalidLaunchTemplateId.NotFound",
+					Message: "The launch template ID '" + ltDeleted + "' does not exist",
+				}
+			}
+			return &ec2.DescribeLaunchTemplateVersionsOutput{
+				LaunchTemplateVersions: []ec2types.LaunchTemplateVersion{
+					{
+						LaunchTemplateData: &ec2types.ResponseLaunchTemplateData{
+							ImageId: aws.String(amiGood),
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	clients := &awsclient.ServiceClients{EKS: fakeEKS, EC2: fakeEC2}
+	res := eksClusterSrcResource()
+	checker := eksCheckerByTarget(t, "ami")
+	result := checker(context.Background(), clients, res, nil)
+
+	if result.Count != 1 {
+		t.Fatalf("Count = %d, want 1 (good NG contributes AMI even though deleted-LT NG was skipped); ResourceIDs=%v Err=%v",
+			result.Count, result.ResourceIDs, result.Err)
+	}
+	if len(result.ResourceIDs) != 1 || result.ResourceIDs[0] != amiGood {
+		t.Errorf("ResourceIDs = %v, want [%s]", result.ResourceIDs, amiGood)
+	}
+	if result.Err == nil {
+		// Acceptable: the issue allows Err nil OR a soft-skip note.
+		return
+	}
+	if !strings.Contains(result.Err.Error(), "launch template deleted") {
+		t.Errorf("Err = %v; expected nil or a 'launch template deleted' soft-skip note", result.Err)
+	}
+	if !strings.Contains(result.Err.Error(), "ng-deleted-lt") {
+		t.Errorf("Err = %v; expected the soft-skip note to name 'ng-deleted-lt'", result.Err)
+	}
+}
+
+// TestCheckEKSAMI_HardFailsOnOtherErrors verifies that errors other than
+// InvalidLaunchTemplateId.NotFound keep the existing partial-failure behavior:
+// the failure is aggregated into Err, surfacing the underlying error.
+func TestCheckEKSAMI_HardFailsOnOtherErrors(t *testing.T) {
+	eksNodegroups := map[string]*ekstypes.Nodegroup{
+		"ng-throttled": {
+			NodegroupName: aws.String("ng-throttled"),
+			ClusterName:   aws.String("acme-services"),
+			LaunchTemplate: &ekstypes.LaunchTemplateSpecification{
+				Id:      aws.String("lt-throttled"),
+				Version: aws.String("1"),
+			},
+		},
+	}
+	fakeEKS := newFakeEKSWithNodegroups([]string{"ng-throttled"}, eksNodegroups)
+
+	fakeEC2 := &fakeEC2Batch2{
+		describeLaunchTemplateVersionsFn: func(_ *ec2.DescribeLaunchTemplateVersionsInput) (*ec2.DescribeLaunchTemplateVersionsOutput, error) {
+			return nil, fmt.Errorf("unexpected 5xx from EC2 DescribeLaunchTemplateVersions")
+		},
+	}
+
+	clients := &awsclient.ServiceClients{EKS: fakeEKS, EC2: fakeEC2}
+	res := eksClusterSrcResource()
+	checker := eksCheckerByTarget(t, "ami")
+	result := checker(context.Background(), clients, res, nil)
+
+	if result.Err == nil {
+		t.Fatal("Err = nil, want non-nil for non-NotFound error")
+	}
+	if strings.Contains(result.Err.Error(), "launch template deleted") {
+		t.Errorf("Err = %v; non-NotFound error should not be classified as a soft skip", result.Err)
+	}
+	if !strings.Contains(result.Err.Error(), "ng-throttled") {
+		t.Errorf("Err = %v; expected failure note to name 'ng-throttled'", result.Err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fix 2 — checkNGAMI: Count:0 (true zero) on InvalidLaunchTemplateId.NotFound
+// ---------------------------------------------------------------------------
+
+// TestCheckNGAMI_SkipsDeletedLaunchTemplate verifies that when the node group's
+// launch template has been deleted upstream, the AMI checker returns
+// Count:0 / Err:nil instead of Count:-1 with the API error — the LT is gone,
+// so there is no AMI to relate to.
+func TestCheckNGAMI_SkipsDeletedLaunchTemplate(t *testing.T) {
+	const ltDeleted = "lt-deleted999"
+
+	fakeEC2 := &fakeEC2Batch2{
+		describeLaunchTemplateVersionsFn: func(_ *ec2.DescribeLaunchTemplateVersionsInput) (*ec2.DescribeLaunchTemplateVersionsOutput, error) {
+			return nil, &smithy.GenericAPIError{
+				Code:    "InvalidLaunchTemplateId.NotFound",
+				Message: "The launch template ID '" + ltDeleted + "' does not exist",
+			}
+		},
+	}
+	clients := &awsclient.ServiceClients{EC2: fakeEC2}
+	res := ngSrcResourceWithLaunchTemplate(ltDeleted, "1")
+	checker := ngCheckerByTarget(t, "ami")
+	result := checker(context.Background(), clients, res, nil)
+
+	if result.Count != 0 {
+		t.Errorf("Count = %d, want 0 (deleted LT is a true zero); Err=%v", result.Count, result.Err)
+	}
+	if result.Err != nil {
+		t.Errorf("Err = %v, want nil (NotFound is soft-skipped to a true zero)", result.Err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fix 3 — checkELBWAF: gate on Fields["type"] before calling WAF API
+// ---------------------------------------------------------------------------
+
+// fakeWAFv2NoCallExpected fails the test if GetWebACLForResource is invoked.
+// Used to enforce the type-gate skip in checkELBWAF.
+type fakeWAFv2NoCallExpected struct {
+	t *testing.T
+}
+
+func (f *fakeWAFv2NoCallExpected) GetWebACLForResource(_ context.Context, _ *wafv2.GetWebACLForResourceInput, _ ...func(*wafv2.Options)) (*wafv2.GetWebACLForResourceOutput, error) {
+	f.t.Fatal("GetWebACLForResource was called for a non-ALB ELB; the type gate should have skipped it")
+	return nil, nil
+}
+
+func (f *fakeWAFv2NoCallExpected) ListWebACLs(_ context.Context, _ *wafv2.ListWebACLsInput, _ ...func(*wafv2.Options)) (*wafv2.ListWebACLsOutput, error) {
+	return &wafv2.ListWebACLsOutput{}, nil
+}
+
+func (f *fakeWAFv2NoCallExpected) ListResourcesForWebACL(_ context.Context, _ *wafv2.ListResourcesForWebACLInput, _ ...func(*wafv2.Options)) (*wafv2.ListResourcesForWebACLOutput, error) {
+	return &wafv2.ListResourcesForWebACLOutput{}, nil
+}
+
+func (f *fakeWAFv2NoCallExpected) GetLoggingConfiguration(_ context.Context, _ *wafv2.GetLoggingConfigurationInput, _ ...func(*wafv2.Options)) (*wafv2.GetLoggingConfigurationOutput, error) {
+	return &wafv2.GetLoggingConfigurationOutput{}, nil
+}
+
+// TestCheckELBWAF_SkipsNetworkLoadBalancer verifies that for an NLB (Fields["type"]="network"),
+// the checker returns Count:0 without calling wafv2:GetWebACLForResource.
+func TestCheckELBWAF_SkipsNetworkLoadBalancer(t *testing.T) {
+	const nlbARN = "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/net/prod-nlb/1234567890abcdef"
+	source := resource.Resource{
+		ID:     "prod-nlb",
+		Name:   "prod-nlb",
+		Fields: map[string]string{"load_balancer_arn": nlbARN, "type": "network"},
+	}
+	clients := &awsclient.ServiceClients{
+		WAFv2: &fakeWAFv2NoCallExpected{t: t},
+	}
+	checker := elbCheckerByTarget(t, "waf")
+	result := checker(context.Background(), clients, source, resource.ResourceCache{})
+
+	if result.Count != 0 {
+		t.Errorf("Count = %d, want 0 (NLB is not WAFv2-compatible)", result.Count)
+	}
+	if result.Err != nil {
+		t.Errorf("Err = %v, want nil (skip is a true zero)", result.Err)
+	}
+}
+
+// TestCheckELBWAF_SkipsGatewayLoadBalancer verifies that for a GWLB
+// (Fields["type"]="gateway"), the checker returns Count:0 without calling the API.
+func TestCheckELBWAF_SkipsGatewayLoadBalancer(t *testing.T) {
+	const gwlbARN = "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/gwy/prod-gwlb/abcdef1234567890"
+	source := resource.Resource{
+		ID:     "prod-gwlb",
+		Name:   "prod-gwlb",
+		Fields: map[string]string{"load_balancer_arn": gwlbARN, "type": "gateway"},
+	}
+	clients := &awsclient.ServiceClients{
+		WAFv2: &fakeWAFv2NoCallExpected{t: t},
+	}
+	checker := elbCheckerByTarget(t, "waf")
+	result := checker(context.Background(), clients, source, resource.ResourceCache{})
+
+	if result.Count != 0 {
+		t.Errorf("Count = %d, want 0 (GWLB is not WAFv2-compatible)", result.Count)
+	}
+	if result.Err != nil {
+		t.Errorf("Err = %v, want nil (skip is a true zero)", result.Err)
+	}
+}
+
+// TestCheckELBWAF_CallsAPIForApplicationLB verifies that the happy path for
+// ALB (Fields["type"]="application") still calls the WAF API and surfaces the
+// Web ACL.
+func TestCheckELBWAF_CallsAPIForApplicationLB(t *testing.T) {
+	const albARN = "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/prod-alb/abcdef1234567890"
+	const wafID = "waf-web-acl-id-abc123"
+	source := resource.Resource{
+		ID:     "prod-alb",
+		Name:   "prod-alb",
+		Fields: map[string]string{"load_balancer_arn": albARN, "type": "application"},
+	}
+	clients := &awsclient.ServiceClients{
+		WAFv2: &fakeWAFv2ForResource{
+			output: &wafv2.GetWebACLForResourceOutput{
+				WebACL: &wafv2types.WebACL{
+					Id:   aws.String(wafID),
+					Name: aws.String("prod-alb-waf"),
+					ARN:  aws.String("arn:aws:wafv2:us-east-1:123456789012:regional/webacl/prod-alb-waf/" + wafID),
+				},
+			},
+		},
+	}
+	checker := elbCheckerByTarget(t, "waf")
+	result := checker(context.Background(), clients, source, resource.ResourceCache{})
+
+	if result.Count != 1 {
+		t.Fatalf("Count = %d, want 1; ResourceIDs=%v Err=%v", result.Count, result.ResourceIDs, result.Err)
+	}
+	if len(result.ResourceIDs) != 1 || result.ResourceIDs[0] != wafID {
+		t.Errorf("ResourceIDs = %v, want [%s]", result.ResourceIDs, wafID)
+	}
+}


### PR DESCRIPTION
## Summary

Fix three pre-existing related-def fragilities that AS-1242 surfaced during the AS-1240 Stage 6.5 live-AWS run. None are Phase-05 regressions — demo fixtures simply never exercised these live-AWS edge cases. E2ETester confirmed on AS-1242 that no revert is needed.

Findings (verbatim from AS-1242, per AS-1243 acceptance):

1. **`eks` AMI related-def — deleted launch template aborts the whole panel.** `checkEKSAMI` aggregates `DescribeNodegroup` partial-failures but the inner `DescribeLaunchTemplateVersions` call does not. When a node-group references a launch template that has been deleted upstream (`InvalidLaunchTemplateId.NotFound`), the entire AMI related-def fails hard. **Fix:** soft-skip the deleted-LT NG via the existing `AggregateFailures` slice; other NGs still contribute AMIs.
2. **`ng` AMI related-def — deleted launch template returns Count:-1.** Same root cause, simpler shape (single NG → single LT call). **Fix:** return `Count:0, Err:nil` instead of bubbling up the API error. The LT is gone, so there is no AMI to relate to — that is a true zero.
3. **`elb` WAF related-def — `wafv2:GetWebACLForResource` called for NLB/GWLB.** WAFv2 only supports CloudFront, ALB, API Gateway, AppSync, Cognito, Verified Access, App Runner. Calling it with an NLB or GWLB ARN returns `WAFInvalidParameterException`. **Fix:** gate the call on `Fields["type"] == "application"` (the ELB fetcher already populates this).

Other error kinds keep their existing hard-fail behavior in all three sites.

## Test plan

- [x] `go test ./tests/unit/ -count=1 -timeout 120s` — PASS (full unit suite, including the 6 new fragility tests)
- [x] `go test -tags integration ./tests/integration/ -count=1 -timeout 180s` — PASS
- [x] `golangci-lint run ./...` — 0 issues
- [x] `govulncheck ./...` — 0 vulnerabilities
- [x] `go fix -inline -diff ./...` — no diff
- [x] `verify-readonly` — PASS
- [x] `verify-zero-init` — PASS
- [x] `check-readme` — PASS
- [x] `markdownlint-cli2` — PASS (no MD changes)
- [x] Snapshot golden tests — PASS (unit + integration)
- [ ] `go test ./tests/unit/ -race` — local env has no `gcc` for CGO; CI runs this. Changes are pure error-classification logic in existing critical sections; no new goroutines or shared state introduced.

## New tests (`tests/unit/aws_related_def_fragility_test.go`)

- `TestCheckEKSAMI_SkipsDeletedLaunchTemplate` — one of two NGs has a deleted LT; assert the other NG's AMI is returned and the soft-skip note names the deleted NG.
- `TestCheckEKSAMI_HardFailsOnOtherErrors` — non-NotFound error keeps Err propagation; assert no `launch template deleted` classification.
- `TestCheckNGAMI_SkipsDeletedLaunchTemplate` — assert `Count:0, Err:nil` on `InvalidLaunchTemplateId.NotFound`.
- `TestCheckELBWAF_SkipsNetworkLoadBalancer` — assert `Count:0` and **no API call made** for `type="network"` (fake fails via `t.Fatal`).
- `TestCheckELBWAF_SkipsGatewayLoadBalancer` — same enforcement for `type="gateway"`.
- `TestCheckELBWAF_CallsAPIForApplicationLB` — happy path for `type="application"` still works.

Existing `TestRelated_ELB_WAF_Found` / `TestRelated_ELB_WAF_NoWebACL` updated to include `Fields["type"]="application"` so the new gate does not flip them to `Count:0`. Production resources always populate this field; the existing tests were under-specified, which is exactly why the type-gate gap went unnoticed.

## Out of scope

- Re-running live-AWS sign-off — that is E2ETester's call on **AS-1240** once this merges; not part of this PR.
- Wider audit of other related-defs for similar fragility — file a follow-up if you spot one in the same area.

## Links

- Parent (Stage 6.5 incident): **AS-1242**
- Grandparent (Stage 6.5 sign-off): **AS-1240**
- This issue: **AS-1243**