### PR TITLE
fix(release): AS-1246 migrate goreleaser brews → homebrew_casks for v2.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
               # must re-run the gate, otherwise an unvalidated change to the
               # enforcement path can merge with the test-budget job skipped.
               - 'scripts/test-budget-gate.sh'
+              # AS-1246: .goreleaser.yaml is validated inside the Build job
+              # (`goreleaser check`). Without it in this filter, a goreleaser
+              # config regression can land via a docs-classified PR with the
+              # Build job stubbed — the exact gap that let AS-1243/PR #414 sit
+              # broken when goreleaser v2.16 escalated the brews deprecation.
+              - '.goreleaser.yaml'
             md:
               - '**/*.md'
             not_docs:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,17 +34,17 @@ archives:
         formats:
           - zip
 
-brews:
-  - repository:
+homebrew_casks:
+  - name: a9s
+    binaries:
+      - a9s
+    repository:
       owner: k2m30
       name: homebrew-a9s
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    directory: Formula
+    directory: Casks
     homepage: https://github.com/k2m30/a9s
     description: Terminal UI AWS Resource Manager
-    license: GPL-3.0-or-later
-    test: |
-      system "#{bin}/a9s", "--version"
 
 scoops:
   - repository:


### PR DESCRIPTION
## Summary

Unblocks CI Build → Validate goreleaser config on every PR by migrating the deprecated `brews:` block to `homebrew_casks:` per goreleaser v2.16's hard-fail, and closes the CI path-filter gap that masked the regression on docs-classified PRs.

## Why

Goreleaser v2.16.0 escalated the `brews` deprecation to a hard error. First observed at AS-1243 / PR #414 build run [`26383012463`](https://github.com/k2m30/a9s/actions/runs/26383012463/job/77655808946):

```
DEPRECATED: brews should not be used anymore, check https://goreleaser.com/deprecations#brews for more info
.goreleaser.yaml                                 error=configuration is valid, but uses deprecated properties
check failed                                     error=1 out of 1 configuration file(s) have issues
```

Affects every PR going forward — high-priority infra unblock per AS-1242 Stage 6.5 incident audit.

## Changes

**Commit 1 — `.goreleaser.yaml`** (the actual migration):

- `brews:` → `homebrew_casks:` per [goreleaser deprecation docs](https://goreleaser.com/deprecations#brews). v2.16 unifies pre-compiled binary distribution under `homebrew_casks` regardless of whether the binary is GUI or CLI.
- `binaries:` (plural) per current cask schema (`binary` singular is itself deprecated since v2.12.6).
- `directory: Formula` → `directory: Casks` (cask default).
- `license:` and `test:` removed — formula-only fields, not valid in cask schema.

**Commit 2 — `.github/workflows/ci.yml`** (the validation enabler):

- Add `.goreleaser.yaml` to the `dorny/paths-filter` `go:` predicate.
- Root cause of why AS-1243/PR #414 was the *first* PR to surface this: a PR that only touches `.goreleaser.yaml` is classified as docs by the filter, so the Build job runs the docs-only stub and the `goreleaser check` step never executes. A goreleaser regression can land via a docs-classified PR with no actual validation. Adding `.goreleaser.yaml` here means any future edit to release config triggers a real `goreleaser check` — including this PR, which is the only way to actually prove the migration in commit 1.

`scoops:` block is not deprecated, left unchanged.

## Tap impact

`k2m30/homebrew-a9s` will now receive PRs landing in `Casks/a9s.rb` instead of `Formula/a9s.rb`. Install path for users is unchanged: `brew install k2m30/a9s/a9s`. Homebrew transparently resolves casks from a tap. A `tap_migrations.json` to auto-upgrade existing installs is out of scope per the issue scope (single-file release config).

## Stage 5 routing

XS — single-file infra fix + 6-line CI filter addition. CR + CXR per the size matrix; no Architect.

## Test plan

- [x] `homebrew_casks` schema verified against https://goreleaser.com/customization/homebrew_casks/ — `binaries` (plural), `directory: Casks`, no `license`/`test` fields
- [x] Replacement key verified against https://goreleaser.com/deprecations#brews
- [ ] CI Build → Validate goreleaser config runs and goes green on this PR (requires commit 2's filter expansion — verified via this PR run after the second push)
- [ ] No other goreleaser deprecation warnings remain in build output
- [ ] After merge, rebase PR #414 (AS-1243) — confirm its Build job recovers

## Linked

- Closes AS-1246
- Unblocks PR #414 (AS-1243) and all future PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)