### PR TITLE
refactor(aws): AS-1394 W1.2 drop BumpFindingSuffix from dbi-snap/ddb/ses enrichers

### DIFF
--- a/internal/aws/backup_issue_enrichment.go
+++ b/internal/aws/backup_issue_enrichment.go
@@ -24,8 +24,8 @@ const (
 // Severity "!" for FAILED/ABORTED/EXPIRED, "~" for PARTIAL.
 // IssueCount counts only "!" findings.
 //
-// Rule-7 suffix machinery (BumpFindingSuffix) is N/A for backup — spec §3.1 has zero
-// Wave-1 signals so there are no coexisting Wave-1 warnings to apply the (+N) arithmetic.
+// Rule-7 (+N) stacking is N/A for backup — spec §3.1 has zero Wave-1 signals so
+// there are no coexisting Wave-1 warnings to stack with the Wave-2 finding.
 func EnrichBackupJobs(ctx context.Context, clients *ServiceClients, _ []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
 	result := IssueEnricherResult{
 		Findings:     make(map[string]domain.Finding),

--- a/internal/aws/dbi_snap.go
+++ b/internal/aws/dbi_snap.go
@@ -56,16 +56,14 @@ func isSnapUnencrypted(snap rdstypes.DBSnapshot) bool {
 	return snap.Encrypted != nil && !*snap.Encrypted
 }
 
-// buildStatusFromIssues returns the top phrase with a (+N) suffix when there
-// are multiple issues, or empty string when there are none.
+// buildStatusFromIssues returns the top phrase, or empty string when there
+// are no issues. Multi-finding (+N) stacking is now computed at render time
+// by phraseFromFindings(r.Findings) — not by string-suffix algebra here.
 func buildStatusFromIssues(issues []string) string {
 	if len(issues) == 0 {
 		return ""
 	}
-	if len(issues) == 1 {
-		return issues[0]
-	}
-	return resource.BumpFindingSuffix(issues[0])
+	return issues[0]
 }
 
 // FetchDBISnapshots calls the RDS DescribeDBSnapshots API and converts the

--- a/internal/aws/ddb_issue_enrichment.go
+++ b/internal/aws/ddb_issue_enrichment.go
@@ -58,20 +58,10 @@ func EnrichDynamoDBPITR(ctx context.Context, clients *ServiceClients, resources 
 		}
 		pitrEnabled := string(pitr.PointInTimeRecoveryStatus) == "ENABLED"
 		if !pitrEnabled {
-			// Compute the new status value: if the table already has a non-empty
-			// status phrase (e.g. "archived: kms key lost"), bump the suffix so the
-			// operator sees there is an additional finding. Otherwise the phrase is
-			// "PITR off" itself.
-			existingStatus := r.Fields["status"]
-			var newStatus string
-			if existingStatus != "" {
-				newStatus = resource.BumpFindingSuffix(existingStatus)
-			} else {
-				newStatus = "PITR off"
-			}
-			result.FieldUpdates[r.ID] = map[string]string{
-				"status": newStatus,
-			}
+			// AS-140 / AS-1394: emit only the Finding entry. The merged display
+			// phrase (e.g. "archived: kms key lost") is computed at render time
+			// by phraseFromFindings(r.Findings) — not by writing
+			// FieldUpdates["status"] here.
 			setWave2Finding(&result, r.ID, ddbCodePITROff, "PITR off", "~", "ddb", nil)
 		}
 	}

--- a/tests/unit/aws_ddb_issue_enrichment_test.go
+++ b/tests/unit/aws_ddb_issue_enrichment_test.go
@@ -4,11 +4,12 @@ package unit
 //
 // Tests drive EnrichDynamoDBPITR and assert:
 //   - PITR enabled  → no finding, no FieldUpdates["status"].
-//   - PITR disabled on Healthy row → FieldUpdates[id]["status"] == "PITR off",
-//     Findings[id].Severity == "~", Findings[id].Summary == "PITR off".
+//   - PITR disabled on Healthy row → Findings[id].Severity == "~",
+//     Findings[id].Summary == "PITR off". AS-140 (W1.2 of AS-1390): no
+//     FieldUpdates["status"] is written — the merged display phrase is
+//     computed at render time by phraseFromFindings(r.Findings).
 //   - PITR disabled on non-Healthy row (e.g. "archived: kms key lost") →
-//     FieldUpdates[id]["status"] == resource.BumpFindingSuffix(existing),
-//     Finding still Severity "~", Summary "PITR off".
+//     same as above; no (+N) suffix is applied by this enricher.
 //   - Summary/Rows contract (U11): Summary is "PITR off"; Row values must
 //     NOT be substrings of Summary.
 //   - Error path: DescribeContinuousBackups errors → table skipped,
@@ -149,7 +150,9 @@ func TestDDB_Enrich_PITREnabled_NoFinding(t *testing.T) {
 }
 
 // TestDDB_Enrich_PITRDisabled_HealthyRow verifies a Healthy ACTIVE table with
-// PITR disabled produces the correct finding and FieldUpdates["status"] == "PITR off".
+// PITR disabled produces the correct EnrichmentFinding. AS-140 (W1.2 of
+// AS-1390): no FieldUpdates["status"] is written — the display phrase is
+// computed at render time by phraseFromFindings(r.Findings).
 func TestDDB_Enrich_PITRDisabled_HealthyRow(t *testing.T) {
 	fake := &ddbContinuousBackupsFake{
 		responses: map[string]*dynamodb.DescribeContinuousBackupsOutput{
@@ -176,12 +179,10 @@ func TestDDB_Enrich_PITRDisabled_HealthyRow(t *testing.T) {
 		t.Errorf("Phrase = %q, want %q", finding.Phrase, "PITR off")
 	}
 
-	updates, ok := result.FieldUpdates[fixtures.AuditPITROffID]
-	if !ok {
-		t.Fatalf("FieldUpdates missing entry for %q", fixtures.AuditPITROffID)
-	}
-	if updates["status"] != "PITR off" {
-		t.Errorf("FieldUpdates[%q][status] = %q, want %q", fixtures.AuditPITROffID, updates["status"], "PITR off")
+	// AS-140: FieldUpdates must be empty for this resource — the merged
+	// display phrase is now computed at render time by phraseFromFindings.
+	if updates, ok := result.FieldUpdates[fixtures.AuditPITROffID]; ok && len(updates) != 0 {
+		t.Errorf("AS-140: expected empty FieldUpdates for %q (status overlay removed); got %v", fixtures.AuditPITROffID, updates)
 	}
 
 	if result.IssueCount != 0 {
@@ -189,10 +190,12 @@ func TestDDB_Enrich_PITRDisabled_HealthyRow(t *testing.T) {
 	}
 }
 
-// TestDDB_Enrich_PITRDisabled_NonHealthyRow verifies that a table already carrying
-// "archived: kms key lost" (Wave-2 fetcher phrase) gets a bumped suffix
-// "archived: kms key lost (+1)" when PITR is also disabled.
-// Finding is still emitted with Severity "~" and Summary "PITR off".
+// TestDDB_Enrich_PITRDisabled_NonHealthyRow verifies that a table already
+// carrying "archived: kms key lost" (Wave-1 fetcher phrase) still gets the
+// Wave-2 EnrichmentFinding emitted when PITR is disabled. AS-140 (W1.2 of
+// AS-1390): no FieldUpdates["status"] is written and no (+N) suffix is
+// applied; the merged display phrase is computed at render time by
+// phraseFromFindings(r.Findings).
 func TestDDB_Enrich_PITRDisabled_NonHealthyRow(t *testing.T) {
 	// legacy-archived: fetcher sets Status="archived: kms key lost"
 	existingStatus := "archived: kms key lost"
@@ -220,13 +223,11 @@ func TestDDB_Enrich_PITRDisabled_NonHealthyRow(t *testing.T) {
 		t.Errorf("Phrase = %q, want %q", finding.Phrase, "PITR off")
 	}
 
-	updates, ok := result.FieldUpdates[fixtures.LegacyArchivedID]
-	if !ok {
-		t.Fatalf("FieldUpdates missing entry for %q", fixtures.LegacyArchivedID)
-	}
-	wantStatus := "archived: kms key lost (+1)"
-	if updates["status"] != wantStatus {
-		t.Errorf("FieldUpdates[%q][status] = %q, want %q (BumpFindingSuffix)", fixtures.LegacyArchivedID, updates["status"], wantStatus)
+	// AS-140: FieldUpdates must be empty for this resource — the merged
+	// Wave-1 + Wave-2 display phrase is computed at render time by
+	// phraseFromFindings(r.Findings).
+	if updates, ok := result.FieldUpdates[fixtures.LegacyArchivedID]; ok && len(updates) != 0 {
+		t.Errorf("AS-140: expected empty FieldUpdates for %q (status overlay removed); got %v", fixtures.LegacyArchivedID, updates)
 	}
 
 	if result.IssueCount != 0 {
@@ -296,10 +297,14 @@ func TestDDB_Enrich_ErrorPath_TruncatedID(t *testing.T) {
 	}
 }
 
-// TestDDB_Enrich_BumpFindingSuffix_ExistingPlusSuffix verifies that when the
-// existing status already carries a suffix (e.g. "kms key inaccessible (+2)"),
-// the enricher increments it to "(+3)" — not producing double suffixes.
-func TestDDB_Enrich_BumpFindingSuffix_ExistingPlusSuffix(t *testing.T) {
+// TestDDB_Enrich_PITRDisabled_NoFieldUpdates_WithStackedWave1 verifies AS-140
+// (W1.2 of AS-1390): when the existing status already carries a stacked
+// Wave-1 phrase (e.g. "kms key inaccessible (+2)"), the enricher must NOT
+// write FieldUpdates["status"] — no suffix-bump arithmetic happens here.
+// The merged display phrase is computed at render time by
+// phraseFromFindings(r.Findings), which aggregates Wave-1 findings on the
+// resource with this enricher's Wave-2 "PITR off" finding.
+func TestDDB_Enrich_PITRDisabled_NoFieldUpdates_WithStackedWave1(t *testing.T) {
 	id := "inline-bump-ddb-test"
 	existingStatus := "kms key inaccessible (+2)"
 	fake := &ddbContinuousBackupsFake{
@@ -322,13 +327,13 @@ func TestDDB_Enrich_BumpFindingSuffix_ExistingPlusSuffix(t *testing.T) {
 		t.Fatalf("EnrichDynamoDBPITR error: %v", err)
 	}
 
-	updates, ok := result.FieldUpdates[id]
-	if !ok {
-		t.Fatalf("FieldUpdates missing entry for %q", id)
+	// The Wave-2 PITR finding must still be emitted.
+	if _, ok := result.Findings[id]; !ok {
+		t.Errorf("expected PITR-off Finding for %q even when row carries stacked Wave-1 phrase", id)
 	}
-	wantStatus := "kms key inaccessible (+3)"
-	if updates["status"] != wantStatus {
-		t.Errorf("FieldUpdates[%q][status] = %q, want %q (must increment counter, not double-suffix)", id, updates["status"], wantStatus)
+	// AS-140: no FieldUpdates write — no suffix-bump arithmetic from this enricher.
+	if updates, ok := result.FieldUpdates[id]; ok && len(updates) != 0 {
+		t.Errorf("AS-140: expected empty FieldUpdates for %q (status overlay removed); got %v", id, updates)
 	}
 }
 

--- a/tests/unit/aws_ses_test.go
+++ b/tests/unit/aws_ses_test.go
@@ -196,7 +196,8 @@ func TestFetchSESIdentitiesPage_StatusPhraseMapping(t *testing.T) {
 
 // TestFetchSESIdentitiesPage_MultipleIssuesSuffixBumped verifies that an identity
 // with FAILED verification AND sending disabled produces a Status phrase with the
-// "(+N)" suffix (BumpFindingSuffix behavior from computeSESStatusAndIssues).
+// "(+N)" suffix. The suffix is built by sesTopPhrase in the fetcher — not by
+// resource.BumpFindingSuffix (which W1.2 of AS-1390 removed from all enrichers).
 func TestFetchSESIdentitiesPage_MultipleIssuesSuffixBumped(t *testing.T) {
 	mock := &mockSESv2Client{
 		output: &sesv2.ListEmailIdentitiesOutput{


### PR DESCRIPTION
## Summary

W1.2 of Phase-03 finding-model cleanup (AS-1390 family, 2 of 4 W1 children). Stops three call sites of `resource.BumpFindingSuffix(...)` so no Wave-2 enricher mutates `Resource.Status` by string-suffix algebra. After this PR, the suffix machinery in `internal/resource/finding_suffix.go` is reachable only from itself, ready for deletion by **W1.4**.

May proceed in parallel with W1.1 (AS-1393, PR #417) and W1.3. **W1.4 is blocked by this PR.**

## Production changes

| File | Change |
|---|---|
| `internal/aws/dbi_snap.go` | `buildStatusFromIssues` no longer applies the `(+N)` bump on multi-issue input; returns top phrase. Multi-finding stacking is now built at render time by `phraseFromFindings`. (Helper shared with dbc_snap/dbc_snap_rds.) |
| `internal/aws/ddb_issue_enrichment.go` | `EnrichDynamoDBPITR` no longer writes `FieldUpdates[\"status\"]` — emits only the `EnrichmentFinding` entry (AS-140 shape). |
| `internal/aws/ses_issue_enrichment.go` | `EnrichSESAccount` drops the else-branch `BumpFindingSuffix` call; always sets `FieldUpdates[\"status\"] = finding.Summary`. W5 deletes the overlay write entirely. |
| `internal/aws/backup_issue_enrichment.go` | Updated stale comment that referenced `BumpFindingSuffix` as the suffix mechanism. |

## Test changes

- `aws_ddb_issue_enrichment_test.go`
  - `PITRDisabled_HealthyRow` → asserts no FieldUpdates entry (AS-140 pattern).
  - `PITRDisabled_NonHealthyRow` → asserts no FieldUpdates entry instead of bumped suffix.
  - `TestDDB_Enrich_BumpFindingSuffix_ExistingPlusSuffix` → renamed to `TestDDB_Enrich_PITRDisabled_NoFieldUpdates_WithStackedWave1`; verifies no FieldUpdates write and finding still emitted.
- `aws_ses_issue_enrichment_test.go`
  - `FieldUpdatesNonHealthyRowBumped` → renamed to `FieldUpdatesNonHealthyRowSetToSummary`; asserts `finding.Summary` instead of `\"verification failed (+1)\"`.
- `aws_ses_test.go`
  - Updated stale comment that misattributed `sesTopPhrase` (+N) formatting to `BumpFindingSuffix`.

## Acceptance gates (from AS-1394)

```bash
$ grep -rn 'BumpFindingSuffix' internal/aws/
# 0 hits ✓

$ grep -rn 'BumpFindingSuffix' internal/
internal/resource/finding_suffix.go:33:// BumpFindingSuffix ...
internal/resource/finding_suffix.go:40:func BumpFindingSuffix(s string) string {
# 1 file only — to be deleted by W1.4 ✓
```

Local pre-push gate (`make ready-to-push` equivalents) green:
- ✅ `go build ./...`
- ✅ `go test ./tests/unit/`
- ✅ `golangci-lint run ./...` (0 issues)
- ✅ `govulncheck ./...` (0 vulns in called code)
- ✅ `go fix -inline -diff ./...` (no unfixed directives)
- ✅ `verify-readonly` / `verify-zero-init`
- ✅ `check-readme` (in sync)
- ✅ `snapshot` (unit + integration goldens)
- ✅ `markdownlint-cli2` (0 errors)

`make test-race` not runnable in sandbox (no gcc/cgo). CI exercises it on push.

## Test plan

- [x] Unit tests pass (`go test ./tests/unit/`).
- [x] Integration snapshot tests pass (`go test -tags integration ./tests/integration/ -run 'Visual|Scenario'`).
- [x] Acceptance grep gates verified.
- [ ] CI green on push (covered by Stage 5 reviewers).
- [ ] Manual `./a9s --demo` verification — Coder run sandbox cannot render TUI; reviewers should confirm dbi/ddb/ses rows on stacked Wave-1+Wave-2 cases display the Wave-1 phrase only (no `(+N)` suffix from these enrichers).

Parent: AS-1390 · Sibling: AS-1393 (PR #417, W1.1) · Blocks: W1.4 final cleanup.

Co-Authored-By: Paperclip <noreply@paperclip.ing>