### PR TITLE
refactor(findings): AS-1395 W1.3 migrate EnrichmentFinding → domain.Finding

### DIFF
--- a/internal/aws/acm_issue_enrichment.go
+++ b/internal/aws/acm_issue_enrichment.go
@@ -10,7 +10,14 @@ import (
 	acmsvc "github.com/aws/aws-sdk-go-v2/service/acm"
 	acmtypes "github.com/aws/aws-sdk-go-v2/service/acm/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// acm canonical FindingCodes.
+const (
+	acmCodeExpiresSoon domain.FindingCode = "acm.expires-soon"
+	acmCodeOrphan      domain.FindingCode = "acm.orphan"
 )
 
 // EnrichACMCertificate calls DescribeCertificate per ACM certificate (cap EnrichmentCap)
@@ -21,10 +28,12 @@ import (
 // IssueCount counts only "!" severity findings — "~" (informational) are excluded from the badge.
 // Skip if clients.ACM == nil. Per-cert errors → Truncated.
 func EnrichACMCertificate(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+	}
 	if clients.ACM == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	now := time.Now()
@@ -45,7 +54,7 @@ func EnrichACMCertificate(ctx context.Context, clients *ServiceClients, resource
 		})
 		if err != nil {
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 		if out.Certificate == nil {
@@ -64,22 +73,18 @@ func EnrichACMCertificate(ctx context.Context, clients *ServiceClients, resource
 					days := int(remaining.Hours() / 24)
 					summary = fmt.Sprintf("expires in %d days", days)
 				}
-				findings[r.ID] = resource.EnrichmentFinding{
-					Severity: "!",
-					Summary:  summary,
-				}
+				setWave2Finding(&result, r.ID, acmCodeExpiresSoon, summary, "!", "acm", nil)
 				bangCount++
 				continue
 			}
 		}
 		// Orphan check — only for ISSUED certs not already flagged.
 		if cert.Status == acmtypes.CertificateStatusIssued && len(cert.InUseBy) == 0 {
-			findings[r.ID] = resource.EnrichmentFinding{
-				Severity: "~",
-				Summary:  "certificate not in use (orphan)",
-			}
+			setWave2Finding(&result, r.ID, acmCodeOrphan, "certificate not in use (orphan)", "~", "acm", nil)
 			// "~" is informational — not counted in IssueCount.
 		}
 	}
-	return IssueEnricherResult{IssueCount: bangCount, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings}, nil
+	result.IssueCount = bangCount
+	result.Truncated = truncated
+	return result, nil
 }

--- a/internal/aws/apigw_issue_enrichment.go
+++ b/internal/aws/apigw_issue_enrichment.go
@@ -9,7 +9,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	apigatewayv2types "github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// apigw canonical FindingCodes.
+const (
+	apigwCodeNoDeployedStages   domain.FindingCode = "apigw.no-deployed-stages"
+	apigwCodeStageConfigIssues  domain.FindingCode = "apigw.stage-config-issues"
 )
 
 // EnrichAPIGatewayStage calls GetStages per API (cap EnrichmentCap)
@@ -23,11 +30,13 @@ import (
 // Findings are aggregated per API (one finding per API, covering all stages).
 // Skip if clients.APIGatewayV2 == nil. Per-API errors → truncated.
 func EnrichAPIGatewayStage(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		FieldUpdates: make(map[string]map[string]string),
+		TruncatedIDs: make(map[string]bool),
+	}
 	if clients.APIGatewayV2 == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	for i, r := range resources {
@@ -45,7 +54,7 @@ func EnrichAPIGatewayStage(ctx context.Context, clients *ServiceClients, resourc
 		for {
 			if stagePages >= PerParentPageCap {
 				stagesTruncated = true
-				truncatedIDs[r.ID] = true
+				result.TruncatedIDs[r.ID] = true
 				break
 			}
 			out, err := clients.APIGatewayV2.GetStages(ctx, &apigatewayv2.GetStagesInput{
@@ -55,7 +64,7 @@ func EnrichAPIGatewayStage(ctx context.Context, clients *ServiceClients, resourc
 			stagePages++
 			if err != nil {
 				truncated = true
-				truncatedIDs[r.ID] = true
+				result.TruncatedIDs[r.ID] = true
 				break
 			}
 			stages = append(stages, out.Items...)
@@ -69,9 +78,9 @@ func EnrichAPIGatewayStage(ctx context.Context, clients *ServiceClients, resourc
 		if stagesTruncated {
 			stagesCountStr = resource.FormatApproximate(len(stages))
 		}
-		fieldUpdates[apiID] = map[string]string{"stages_count": stagesCountStr}
+		result.FieldUpdates[apiID] = map[string]string{"stages_count": stagesCountStr}
 		var summaries []string
-		var rows []resource.FindingRow
+		var rows []domain.DetailRow
 
 		for _, stage := range stages {
 			stageName := stage.StageName
@@ -85,12 +94,12 @@ func EnrichAPIGatewayStage(ctx context.Context, clients *ServiceClients, resourc
 					(drs.ThrottlingRateLimit != nil && *drs.ThrottlingRateLimit == 0)
 				if noThrottle {
 					summaries = append(summaries, "no throttling configured (DoS risk)")
-					rows = append(rows, resource.FindingRow{
+					rows = append(rows, domain.DetailRow{
 						Label: "Stage",
 						Value: *stageName,
 						Tier:  "~",
 					})
-					rows = append(rows, resource.FindingRow{
+					rows = append(rows, domain.DetailRow{
 						Label: "Issue",
 						Value: "no throttling configured (DoS risk)",
 						Tier:  "~",
@@ -101,12 +110,12 @@ func EnrichAPIGatewayStage(ctx context.Context, clients *ServiceClients, resourc
 			// Check access log settings.
 			if stage.AccessLogSettings == nil {
 				summaries = append(summaries, "access logs disabled")
-				rows = append(rows, resource.FindingRow{
+				rows = append(rows, domain.DetailRow{
 					Label: "Stage",
 					Value: *stageName,
 					Tier:  "~",
 				})
-				rows = append(rows, resource.FindingRow{
+				rows = append(rows, domain.DetailRow{
 					Label: "Issue",
 					Value: "access logs disabled",
 					Tier:  "~",
@@ -115,18 +124,14 @@ func EnrichAPIGatewayStage(ctx context.Context, clients *ServiceClients, resourc
 		}
 
 		stagesCount := len(stages)
-		if stagesCount == 0 && !stagesTruncated && !truncatedIDs[r.ID] {
+		if stagesCount == 0 && !stagesTruncated && !result.TruncatedIDs[r.ID] {
 			// No deployed stages — surface as an informational finding.
 			// Only emitted when stage fetch succeeded (no error, no page cap).
-			findings[apiID] = resource.EnrichmentFinding{
-				Severity: "~",
-				Summary:  "no deployed stages",
-				Rows: []resource.FindingRow{{
-					Label: "Issue",
-					Value: "no deployed stages",
-					Tier:  "~",
-				}},
-			}
+			setWave2Finding(&result, apiID, apigwCodeNoDeployedStages, "no deployed stages", "~", "apigw", []domain.DetailRow{{
+				Label: "Issue",
+				Value: "no deployed stages",
+				Tier:  "~",
+			}})
 			continue
 		}
 		if len(summaries) == 0 {
@@ -141,13 +146,11 @@ func EnrichAPIGatewayStage(ctx context.Context, clients *ServiceClients, resourc
 				uniqueSummaries = append(uniqueSummaries, s)
 			}
 		}
-		findings[apiID] = resource.EnrichmentFinding{
-			Severity: "~",
-			Summary:  strings.Join(uniqueSummaries, "; "),
-			Rows:     rows,
-		}
+		setWave2Finding(&result, apiID, apigwCodeStageConfigIssues, strings.Join(uniqueSummaries, "; "), "~", "apigw", rows)
 	}
 	// All API Gateway findings are severity "~" (informational).
 	// IssueCount counts only "!" severity findings; "~" do not contribute.
-	return IssueEnricherResult{IssueCount: 0, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates}, nil
+	result.IssueCount = 0
+	result.Truncated = truncated
+	return result, nil
 }

--- a/internal/aws/asg_issue_enrichment.go
+++ b/internal/aws/asg_issue_enrichment.go
@@ -9,17 +9,25 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	asgtypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// asg canonical FindingCodes.
+const (
+	asgCodeScalingActivityFailed domain.FindingCode = "asg.scaling-activity-failed"
 )
 
 // EnrichASGScalingActivities calls DescribeScalingActivities(MaxRecords=1) for each ASG
 // (cap EnrichmentCap) and returns a Finding when the latest activity StatusCode == Failed.
 // Severity is "!" (broken/degraded). Summary: "latest scaling activity failed: <statusMessage>".
 func EnrichASGScalingActivities(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+	}
 	if clients.AutoScaling == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	var failures []string
@@ -42,7 +50,7 @@ func EnrichASGScalingActivities(ctx context.Context, clients *ServiceClients, re
 		if err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", r.ID, err))
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 		if len(out.Activities) == 0 {
@@ -60,24 +68,21 @@ func EnrichASGScalingActivities(ctx context.Context, clients *ServiceClients, re
 		if statusMsg != "" {
 			summary = fmt.Sprintf("latest scaling activity failed: %s", statusMsg)
 		}
-		rows := []resource.FindingRow{
+		rows := []domain.DetailRow{
 			{Label: "Status", Value: string(act.StatusCode), Tier: "!"},
 		}
 		if statusMsg != "" {
-			rows = append(rows, resource.FindingRow{Label: "Message", Value: statusMsg, Tier: "!"})
+			rows = append(rows, domain.DetailRow{Label: "Message", Value: statusMsg, Tier: "!"})
 		}
 		if act.Cause != nil && *act.Cause != "" {
-			rows = append(rows, resource.FindingRow{Label: "Cause", Value: *act.Cause})
+			rows = append(rows, domain.DetailRow{Label: "Cause", Value: *act.Cause})
 		}
 		if act.StartTime != nil {
-			rows = append(rows, resource.FindingRow{Label: "Started", Value: act.StartTime.Format("2006-01-02")})
+			rows = append(rows, domain.DetailRow{Label: "Started", Value: act.StartTime.Format("2006-01-02")})
 		}
-		findings[r.ID] = resource.EnrichmentFinding{
-			Severity: "!",
-			Summary:  summary,
-			Rows:     rows,
-		}
+		setWave2Finding(&result, r.ID, asgCodeScalingActivityFailed, summary, "!", "asg", rows)
 	}
-	return IssueEnricherResult{IssueCount: len(findings), Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings},
-		AggregateFailures("asg-enrich: DescribeScalingActivities", failures, total)
+	result.IssueCount = len(result.Findings)
+	result.Truncated = truncated
+	return result, AggregateFailures("asg-enrich: DescribeScalingActivities", failures, total)
 }

--- a/internal/aws/athena_issue_enrichment.go
+++ b/internal/aws/athena_issue_enrichment.go
@@ -8,7 +8,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/athena"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// athena canonical FindingCodes.
+const (
+	athenaCodeGovernanceMisconfigured domain.FindingCode = "athena.governance-misconfigured"
 )
 
 // EnrichAthenaWorkGroup calls GetWorkGroup per workgroup (capped at EnrichmentCap) to
@@ -23,10 +29,12 @@ import (
 // Per-WG errors mark Truncated=true and are skipped.
 // Skip when clients.Athena == nil.
 func EnrichAthenaWorkGroup(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+	}
 	if clients.Athena == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	for i, r := range resources {
@@ -45,7 +53,7 @@ func EnrichAthenaWorkGroup(ctx context.Context, clients *ServiceClients, resourc
 		})
 		if err != nil {
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 		if out.WorkGroup == nil || out.WorkGroup.Configuration == nil {
@@ -56,10 +64,10 @@ func EnrichAthenaWorkGroup(ctx context.Context, clients *ServiceClients, resourc
 		if key == "" {
 			key = wgName
 		}
-		var rows []resource.FindingRow
+		var rows []domain.DetailRow
 		// EnforceWorkGroupConfiguration defaults to true; false means callers can bypass settings.
 		if cfg.EnforceWorkGroupConfiguration != nil && !*cfg.EnforceWorkGroupConfiguration {
-			rows = append(rows, resource.FindingRow{
+			rows = append(rows, domain.DetailRow{
 				Label: "EnforceWorkGroupConfiguration",
 				Value: "false",
 				Tier:  "~",
@@ -67,7 +75,7 @@ func EnrichAthenaWorkGroup(ctx context.Context, clients *ServiceClients, resourc
 		}
 		// Missing encryption on result configuration is a security concern.
 		if cfg.ResultConfiguration == nil || cfg.ResultConfiguration.EncryptionConfiguration == nil {
-			rows = append(rows, resource.FindingRow{
+			rows = append(rows, domain.DetailRow{
 				Label: "ResultConfiguration.EncryptionConfiguration",
 				Value: "nil",
 				Tier:  "~",
@@ -80,12 +88,10 @@ func EnrichAthenaWorkGroup(ctx context.Context, clients *ServiceClients, resourc
 		if len(rows) > 1 {
 			summary = fmt.Sprintf("%s (%d findings)", rows[0].Label, len(rows))
 		}
-		findings[key] = resource.EnrichmentFinding{
-			Severity: "~",
-			Summary:  summary,
-			Rows:     rows,
-		}
+		setWave2Finding(&result, key, athenaCodeGovernanceMisconfigured, summary, "~", "athena", rows)
 		// "~" severity does not contribute to IssueCount.
 	}
-	return IssueEnricherResult{Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings}, nil
+	result.IssueCount = 0
+	result.Truncated = truncated
+	return result, nil
 }

--- a/internal/aws/backup_issue_enrichment.go
+++ b/internal/aws/backup_issue_enrichment.go
@@ -9,7 +9,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/backup"
 	backuptypes "github.com/aws/aws-sdk-go-v2/service/backup/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// backup canonical FindingCodes.
+const (
+	backupCodeJobFailed  domain.FindingCode = "backup.job-failed"
+	backupCodeJobPartial domain.FindingCode = "backup.job-partial"
 )
 
 // EnrichBackupJobs calls ListBackupJobs (account-wide, paginated) and returns a Finding
@@ -20,11 +27,13 @@ import (
 // Rule-7 suffix machinery (BumpFindingSuffix) is N/A for backup — spec §3.1 has zero
 // Wave-1 signals so there are no coexisting Wave-1 warnings to apply the (+N) arithmetic.
 func EnrichBackupJobs(ctx context.Context, clients *ServiceClients, _ []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients.Backup == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 
 	var allJobs []backuptypes.BackupJob
@@ -109,9 +118,9 @@ func EnrichBackupJobs(ctx context.Context, clients *ServiceClients, _ []resource
 
 			// Cap displayed failed jobs at 5.
 			cap := min(failedCount, 5)
-			var rows []resource.FindingRow
+			var rows []domain.DetailRow
 			for _, job := range b.failedJobs[:cap] {
-				rows = append(rows, resource.FindingRow{
+				rows = append(rows, domain.DetailRow{
 					Label: "State",
 					Value: string(job.State),
 					Tier:  "!",
@@ -125,7 +134,7 @@ func EnrichBackupJobs(ctx context.Context, clients *ServiceClients, _ []resource
 				}
 			}
 			if mostRecent != nil {
-				rows = append(rows, resource.FindingRow{
+				rows = append(rows, domain.DetailRow{
 					Label: "Most recent",
 					Value: mostRecent.UTC().Format("2006-01-02 15:04 UTC"),
 					Tier:  "!",
@@ -133,50 +142,38 @@ func EnrichBackupJobs(ctx context.Context, clients *ServiceClients, _ []resource
 			}
 			// If there are also partial jobs, append a partial row so nothing silently disappears.
 			if partialCount > 0 {
-				rows = append(rows, resource.FindingRow{
+				rows = append(rows, domain.DetailRow{
 					Label: "Partial jobs",
 					Value: fmt.Sprintf("%d", partialCount),
 					Tier:  "~",
 				})
 			}
 
-			findings[planID] = resource.EnrichmentFinding{
-				Severity: "!",
-				Summary:  summary,
-				Rows:     rows,
+			setWave2Finding(&result, planID, backupCodeJobFailed, summary, "!", "backup", rows)
+			if result.FieldUpdates[planID] == nil {
+				result.FieldUpdates[planID] = make(map[string]string)
 			}
-			if _, ok := fieldUpdates[planID]; !ok {
-				fieldUpdates[planID] = make(map[string]string)
-			}
-			fieldUpdates[planID]["status"] = summary
+			result.FieldUpdates[planID]["status"] = summary
 			issueCount++
 		} else if partialCount >= 1 {
 			summary := fmt.Sprintf("partial: %d of %d resources skipped", partialCount, totalCount)
-			rows := []resource.FindingRow{
+			rows := []domain.DetailRow{
 				{Label: "Partial jobs", Value: fmt.Sprintf("%d", partialCount), Tier: "~"},
 				{Label: "Total jobs", Value: fmt.Sprintf("%d", totalCount), Tier: "~"},
 			}
-			findings[planID] = resource.EnrichmentFinding{
-				Severity: "~",
-				Summary:  summary,
-				Rows:     rows,
+			setWave2Finding(&result, planID, backupCodeJobPartial, summary, "~", "backup", rows)
+			if result.FieldUpdates[planID] == nil {
+				result.FieldUpdates[planID] = make(map[string]string)
 			}
-			if _, ok := fieldUpdates[planID]; !ok {
-				fieldUpdates[planID] = make(map[string]string)
-			}
-			fieldUpdates[planID]["status"] = summary
+			result.FieldUpdates[planID]["status"] = summary
 			// "~" findings do not count toward issueCount.
 		}
 		// Else: only COMPLETED jobs — no finding, no FieldUpdate.
 	}
 
-	return IssueEnricherResult{
-		IssueCount:   issueCount,
-		Truncated:    truncated,
-		TruncatedIDs: truncatedIDs,
-		Findings:     findings,
-		FieldUpdates: fieldUpdates,
-	}, AggregateFailures("backup-enrich: ListBackupJobs", failures, pages)
+	result.IssueCount = issueCount
+	result.Truncated = truncated
+	return result, AggregateFailures("backup-enrich: ListBackupJobs", failures, pages)
 }
 
 // plural returns "s" when n != 1, "" otherwise.

--- a/internal/aws/cb_issue_enrichment.go
+++ b/internal/aws/cb_issue_enrichment.go
@@ -10,18 +10,26 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/codebuild"
 	cbtypes "github.com/aws/aws-sdk-go-v2/service/codebuild/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// cb canonical FindingCodes.
+const (
+	cbCodeLatestBuildFailed domain.FindingCode = "cb.latest-build-failed"
 )
 
 // EnrichCodeBuildStatus calls BatchGetBuilds for the latest build of each project
 // and returns a Finding for every project whose latest build is not SUCCEEDED.
 // Severity is "!" (broken/degraded). Summary: "latest build FAILED (<date>)".
 func EnrichCodeBuildStatus(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients.CodeBuild == nil || len(resources) == 0 {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	names := make([]string, 0, len(resources))
 	for _, r := range resources {
@@ -30,7 +38,7 @@ func EnrichCodeBuildStatus(ctx context.Context, clients *ServiceClients, resourc
 		}
 	}
 	if len(names) == 0 {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	buildIDToProject := make(map[string]string, len(names))
 	var buildIDs []string
@@ -45,7 +53,7 @@ func EnrichCodeBuildStatus(ctx context.Context, clients *ServiceClients, resourc
 		})
 		if err != nil {
 			truncated = true
-			truncatedIDs[name] = true
+			result.TruncatedIDs[name] = true
 			continue
 		}
 		if len(out.Ids) > 0 {
@@ -55,13 +63,14 @@ func EnrichCodeBuildStatus(ctx context.Context, clients *ServiceClients, resourc
 		}
 	}
 	if len(buildIDs) == 0 {
-		return IssueEnricherResult{Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings}, nil
+		result.Truncated = truncated
+		return result, nil
 	}
 	builds, err := clients.CodeBuild.BatchGetBuilds(ctx, &codebuild.BatchGetBuildsInput{
 		Ids: buildIDs,
 	})
 	if err != nil {
-		return IssueEnricherResult{TruncatedIDs: truncatedIDs}, err
+		return IssueEnricherResult{TruncatedIDs: result.TruncatedIDs}, err
 	}
 	for _, b := range builds.Builds {
 		if b.Id == nil {
@@ -73,7 +82,7 @@ func EnrichCodeBuildStatus(ctx context.Context, clients *ServiceClients, resourc
 		}
 		switch b.BuildStatus {
 		case cbtypes.StatusTypeSucceeded, cbtypes.StatusTypeInProgress, cbtypes.StatusTypeStopped:
-			fieldUpdates[projectName] = map[string]string{"last_build": "OK"}
+			result.FieldUpdates[projectName] = map[string]string{"last_build": "OK"}
 			continue
 		}
 		statusVal := string(b.BuildStatus)
@@ -83,23 +92,23 @@ func EnrichCodeBuildStatus(ctx context.Context, clients *ServiceClients, resourc
 			hours := int(elapsed.Hours())
 			lastBuildVal = fmt.Sprintf("%s %dh ago", statusVal, hours)
 		}
-		rows := []resource.FindingRow{
+		rows := []domain.DetailRow{
 			{Label: "Status", Value: statusVal, Tier: "!"},
 		}
 		if b.EndTime != nil {
-			rows = append(rows, resource.FindingRow{Label: "Ended", Value: b.EndTime.Format("2006-01-02")})
+			rows = append(rows, domain.DetailRow{Label: "Ended", Value: b.EndTime.Format("2006-01-02")})
 		}
 		// Append the latest failed phase if build is not complete.
 		if !b.BuildComplete {
 			if b.CurrentPhase != nil && *b.CurrentPhase != "" {
-				rows = append(rows, resource.FindingRow{Label: "Current Phase", Value: *b.CurrentPhase, Tier: "~"})
+				rows = append(rows, domain.DetailRow{Label: "Current Phase", Value: *b.CurrentPhase, Tier: "~"})
 			}
 		} else {
 			// Find the latest failed phase.
 			for i := len(b.Phases) - 1; i >= 0; i-- {
 				ph := b.Phases[i]
 				if ph.PhaseStatus == cbtypes.StatusTypeFailed {
-					rows = append(rows, resource.FindingRow{Label: "Phase", Value: string(ph.PhaseType), Tier: "!"})
+					rows = append(rows, domain.DetailRow{Label: "Phase", Value: string(ph.PhaseType), Tier: "!"})
 					break
 				}
 			}
@@ -108,12 +117,10 @@ func EnrichCodeBuildStatus(ctx context.Context, clients *ServiceClients, resourc
 		if b.EndTime != nil {
 			summary = fmt.Sprintf("latest build %s (%s)", statusVal, b.EndTime.Format("2006-01-02"))
 		}
-		findings[projectName] = resource.EnrichmentFinding{
-			Severity: "!",
-			Summary:  summary,
-			Rows:     rows,
-		}
-		fieldUpdates[projectName] = map[string]string{"last_build": lastBuildVal}
+		setWave2Finding(&result, projectName, cbCodeLatestBuildFailed, summary, "!", "cb", rows)
+		result.FieldUpdates[projectName] = map[string]string{"last_build": lastBuildVal}
 	}
-	return IssueEnricherResult{IssueCount: len(findings), Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates}, nil
+	result.IssueCount = len(result.Findings)
+	result.Truncated = truncated
+	return result, nil
 }

--- a/internal/aws/cf_issue_enrichment.go
+++ b/internal/aws/cf_issue_enrichment.go
@@ -9,7 +9,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
 	cftypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// cf canonical FindingCodes.
+const (
+	cfCodeInsecureProtocol domain.FindingCode = "cf.insecure-protocol"
 )
 
 // EnrichCloudFrontDistribution calls GetDistributionConfig per distribution (cap EnrichmentCap)
@@ -21,10 +27,12 @@ import (
 //
 // Skip if clients.CloudFront == nil. Per-distribution errors → truncated.
 func EnrichCloudFrontDistribution(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+	}
 	if clients.CloudFront == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	for i, r := range resources {
@@ -40,21 +48,21 @@ func EnrichCloudFrontDistribution(ctx context.Context, clients *ServiceClients, 
 		})
 		if err != nil {
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 		if out.DistributionConfig == nil {
 			continue
 		}
 		cfg := out.DistributionConfig
-		var rows []resource.FindingRow
+		var rows []domain.DetailRow
 		var summaries []string
 
 		// Check viewer protocol policy on default cache behavior.
 		if cfg.DefaultCacheBehavior != nil &&
 			cfg.DefaultCacheBehavior.ViewerProtocolPolicy == cftypes.ViewerProtocolPolicyAllowAll {
 			summaries = append(summaries, "no HTTPS redirect (insecure)")
-			rows = append(rows, resource.FindingRow{
+			rows = append(rows, domain.DetailRow{
 				Label: "ViewerProtocolPolicy",
 				Value: "allow-all",
 				Tier:  "~",
@@ -71,12 +79,12 @@ func EnrichCloudFrontDistribution(ctx context.Context, clients *ServiceClients, 
 						originID = *origin.Id
 					}
 					summaries = append(summaries, "origin without TLS")
-					rows = append(rows, resource.FindingRow{
+					rows = append(rows, domain.DetailRow{
 						Label: "Origin",
 						Value: originID,
 						Tier:  "~",
 					})
-					rows = append(rows, resource.FindingRow{
+					rows = append(rows, domain.DetailRow{
 						Label: "OriginProtocolPolicy",
 						Value: "http-only",
 						Tier:  "~",
@@ -89,13 +97,11 @@ func EnrichCloudFrontDistribution(ctx context.Context, clients *ServiceClients, 
 			continue
 		}
 		summary := strings.Join(summaries, "; ")
-		findings[distID] = resource.EnrichmentFinding{
-			Severity: "~",
-			Summary:  summary,
-			Rows:     rows,
-		}
+		setWave2Finding(&result, distID, cfCodeInsecureProtocol, summary, "~", "cf", rows)
 	}
 	// All CloudFront findings are severity "~" (informational).
 	// IssueCount counts only "!" severity findings; "~" do not contribute.
-	return IssueEnricherResult{IssueCount: 0, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings}, nil
+	result.IssueCount = 0
+	result.Truncated = truncated
+	return result, nil
 }

--- a/internal/aws/cfn_issue_enrichment.go
+++ b/internal/aws/cfn_issue_enrichment.go
@@ -10,7 +10,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// cfn canonical FindingCodes.
+const (
+	cfnCodeRecentResourceFailure domain.FindingCode = "cfn.recent-resource-failure"
+	cfnCodeStackDrifted          domain.FindingCode = "cfn.stack-drifted"
 )
 
 // EnrichCFNStackEvents calls DescribeStackEvents for each stack (first page only,
@@ -19,10 +26,12 @@ import (
 // a "!" finding: "recent resource failure: <ResourceType>/<LogicalResourceId>".
 // This surfaces hidden failures that are not reflected in the top-level StackStatus.
 func EnrichCFNStackEvents(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+	}
 	if clients.CloudFormation == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	var failures []string
@@ -47,13 +56,13 @@ func EnrichCFNStackEvents(ctx context.Context, clients *ServiceClients, resource
 		if err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", r.ID, err))
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 		// Scan events from the first page for any resource with a _FAILED status.
 		// The API returns events in reverse-chronological order; we inspect all
 		// events on the first page to catch recent failures.
-		var failedRows []resource.FindingRow
+		var failedRows []domain.DetailRow
 		for _, ev := range out.StackEvents {
 			status := string(ev.ResourceStatus)
 			if !strings.HasSuffix(status, "_FAILED") {
@@ -77,10 +86,10 @@ func EnrichCFNStackEvents(ctx context.Context, clients *ServiceClients, resource
 			} else if logicalID != "" {
 				label = resourceType + "/" + logicalID
 			}
-			row := resource.FindingRow{Label: label, Value: status, Tier: "!"}
+			row := domain.DetailRow{Label: label, Value: status, Tier: "!"}
 			failedRows = append(failedRows, row)
 			if reason != "" {
-				failedRows = append(failedRows, resource.FindingRow{Label: "Reason", Value: reason, Tier: "~"})
+				failedRows = append(failedRows, domain.DetailRow{Label: "Reason", Value: reason, Tier: "~"})
 			}
 		}
 		if len(failedRows) == 0 {
@@ -90,14 +99,12 @@ func EnrichCFNStackEvents(ctx context.Context, clients *ServiceClients, resource
 		if key == "" {
 			key = stackName
 		}
-		findings[key] = resource.EnrichmentFinding{
-			Severity: "!",
-			Summary:  fmt.Sprintf("recent resource failure: %s", failedRows[0].Label),
-			Rows:     failedRows,
-		}
+		setWave2Finding(&result, key, cfnCodeRecentResourceFailure,
+			fmt.Sprintf("recent resource failure: %s", failedRows[0].Label), "!", "cfn", failedRows)
 	}
-	return IssueEnricherResult{IssueCount: len(findings), Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings},
-		AggregateFailures("cfn-enrich: DescribeStackEvents", failures, total)
+	result.IssueCount = len(result.Findings)
+	result.Truncated = truncated
+	return result, AggregateFailures("cfn-enrich: DescribeStackEvents", failures, total)
 }
 
 // EnrichCFNCombined merges findings from EnrichCFNStackEvents and EnrichCFNDrift.
@@ -121,7 +128,7 @@ func EnrichCFNCombined(ctx context.Context, clients *ServiceClients, resources [
 		combinedErr = driftErr
 	}
 
-	merged := make(map[string]resource.EnrichmentFinding, len(eventsResult.Findings)+len(driftResult.Findings))
+	merged := make(map[string]domain.Finding, len(eventsResult.Findings)+len(driftResult.Findings))
 	// Drift findings go in first; stack-events findings overwrite on conflict.
 	maps.Copy(merged, driftResult.Findings)
 	maps.Copy(merged, eventsResult.Findings)
@@ -156,11 +163,13 @@ func EnrichCFNCombined(ctx context.Context, clients *ServiceClients, resources [
 // "stack drifted from template". IN_SYNC and NOT_CHECKED stacks produce no finding.
 // Severity "~" findings do not contribute to IssueCount.
 func EnrichCFNDrift(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients.CloudFormation == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	var failures []string
@@ -185,7 +194,7 @@ func EnrichCFNDrift(ctx context.Context, clients *ServiceClients, resources []re
 		if err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", r.ID, err))
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 		if len(out.Stacks) == 0 {
@@ -198,21 +207,19 @@ func EnrichCFNDrift(ctx context.Context, clients *ServiceClients, resources []re
 		}
 		if stack.DriftInformation != nil {
 			driftStatus := string(stack.DriftInformation.StackDriftStatus)
-			fieldUpdates[key] = map[string]string{
+			result.FieldUpdates[key] = map[string]string{
 				"drift_status": driftStatus,
 			}
 			if driftStatus == "DRIFTED" {
-				findings[key] = resource.EnrichmentFinding{
-					Severity: "~",
-					Summary:  "stack drifted from template",
-					Rows: []resource.FindingRow{
+				setWave2Finding(&result, key, cfnCodeStackDrifted, "stack drifted from template", "~", "cfn",
+					[]domain.DetailRow{
 						{Label: "Drift Status", Value: driftStatus, Tier: "~"},
-					},
-				}
+					})
 			}
 		}
 	}
 	// "~" findings do not contribute to IssueCount per the IssueEnricherResult contract.
-	return IssueEnricherResult{IssueCount: 0, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates},
-		AggregateFailures("cfn-enrich: DescribeStacks", failures, total)
+	result.IssueCount = 0
+	result.Truncated = truncated
+	return result, AggregateFailures("cfn-enrich: DescribeStacks", failures, total)
 }

--- a/internal/aws/codeartifact_issue_enrichment.go
+++ b/internal/aws/codeartifact_issue_enrichment.go
@@ -10,7 +10,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/codeartifact"
 	codeartifacttypes "github.com/aws/aws-sdk-go-v2/service/codeartifact/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// codeartifact canonical FindingCodes.
+const (
+	codeartifactCodePublicAccessPolicy domain.FindingCode = "codeartifact.public-access-policy"
+	codeartifactCodeNoPermissionsPolicy domain.FindingCode = "codeartifact.no-permissions-policy"
 )
 
 // EnrichCodeArtifactRepository calls GetRepositoryPermissionsPolicy per repository (capped at
@@ -23,11 +30,13 @@ import (
 // Per-repo errors other than ResourceNotFoundException mark Truncated=true and are skipped.
 // Skip when clients.CodeArtifact == nil.
 func EnrichCodeArtifactRepository(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients.CodeArtifact == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	issueCount := 0
@@ -82,7 +91,7 @@ func EnrichCodeArtifactRepository(ctx context.Context, clients *ServiceClients, 
 				nextToken = pkgOut.NextToken
 			}
 			if total >= 0 {
-				fieldUpdates[key] = map[string]string{"package_count": resource.FormatExact(total)}
+				result.FieldUpdates[key] = map[string]string{"package_count": resource.FormatExact(total)}
 			}
 		}
 		input := &codeartifact.GetRepositoryPermissionsPolicyInput{
@@ -96,16 +105,13 @@ func EnrichCodeArtifactRepository(ctx context.Context, clients *ServiceClients, 
 		if err != nil {
 			if _, ok := errors.AsType[*codeartifacttypes.ResourceNotFoundException](err); ok {
 				// No policy set — default open within the domain.
-				findings[key] = resource.EnrichmentFinding{
-					Severity: "~",
-					Summary:  "no permissions policy",
-				}
+				setWave2Finding(&result, key, codeartifactCodeNoPermissionsPolicy, "no permissions policy", "~", "codeartifact", nil)
 				// "~" does not contribute to IssueCount.
 				continue
 			}
 			// Any other error — skip this repo but flag truncation.
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 		if out.Policy == nil || out.Policy.Document == nil {
@@ -113,15 +119,14 @@ func EnrichCodeArtifactRepository(ctx context.Context, clients *ServiceClients, 
 		}
 		doc := *out.Policy.Document
 		if strings.Contains(doc, `"Principal":"*"`) || strings.Contains(doc, `"Principal": "*"`) {
-			findings[key] = resource.EnrichmentFinding{
-				Severity: "!",
-				Summary:  "public access policy",
-				Rows: []resource.FindingRow{
+			setWave2Finding(&result, key, codeartifactCodePublicAccessPolicy, "public access policy", "!", "codeartifact",
+				[]domain.DetailRow{
 					{Label: "Principal", Value: "*", Tier: "!"},
-				},
-			}
+				})
 			issueCount++
 		}
 	}
-	return IssueEnricherResult{IssueCount: issueCount, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates}, nil
+	result.IssueCount = issueCount
+	result.Truncated = truncated
+	return result, nil
 }

--- a/internal/aws/dbc_issue_enrichment.go
+++ b/internal/aws/dbc_issue_enrichment.go
@@ -9,12 +9,18 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/docdb"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
 // nowFunc is the time source for overdue-date checks. Tests override it to a
 // fixed past/future anchor via package-level replacement.
 var nowFunc = time.Now
+
+// dbc canonical FindingCodes.
+const (
+	dbcCodeMaintenanceOverdue domain.FindingCode = "dbc.maintenance-overdue"
+)
 
 // EnrichDBCMaintenance calls DescribePendingMaintenanceActions (account-wide,
 // paginated) and emits one Finding per dbc cluster with overdue maintenance.
@@ -27,11 +33,14 @@ var nowFunc = time.Now
 // "stopped (+1)" stacked over a Wave-1 finding) is computed at render time
 // from r.Findings via phraseFromFindings; this enricher only emits Findings.
 func EnrichDBCMaintenance(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 
 	if clients == nil || clients.DocDB == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs, FieldUpdates: make(map[string]map[string]string)}, nil
+		return result, nil
 	}
 
 	// Deterministic ARN-suffix matching via ordered probeIDs. AS-140 removed
@@ -106,29 +115,25 @@ func EnrichDBCMaintenance(ctx context.Context, clients *ServiceClients, resource
 			// Build rows. Summary is the short S5 phrase; every concrete fact
 			// (Action, Description, Earliest Target, Apply Method) lives only in
 			// Rows so the Attention section does not render duplicated content (U11).
-			var rows []resource.FindingRow
+			var rows []domain.DetailRow
 			for _, pa := range action.PendingMaintenanceActionDetails {
 				if pa.Action != nil && *pa.Action != "" {
-					rows = append(rows, resource.FindingRow{Label: "Action", Value: *pa.Action, Tier: "!"})
+					rows = append(rows, domain.DetailRow{Label: "Action", Value: *pa.Action, Tier: "!"})
 				}
 				if pa.OptInStatus != nil && *pa.OptInStatus != "" {
-					rows = append(rows, resource.FindingRow{Label: "Apply Method", Value: *pa.OptInStatus})
+					rows = append(rows, domain.DetailRow{Label: "Apply Method", Value: *pa.OptInStatus})
 				}
 				if pa.AutoAppliedAfterDate != nil {
-					rows = append(rows, resource.FindingRow{Label: "Earliest Target", Value: formatDate(pa.AutoAppliedAfterDate), Tier: "!"})
+					rows = append(rows, domain.DetailRow{Label: "Earliest Target", Value: formatDate(pa.AutoAppliedAfterDate), Tier: "!"})
 				} else if pa.ForcedApplyDate != nil {
-					rows = append(rows, resource.FindingRow{Label: "Earliest Target", Value: formatDate(pa.ForcedApplyDate), Tier: "!"})
+					rows = append(rows, domain.DetailRow{Label: "Earliest Target", Value: formatDate(pa.ForcedApplyDate), Tier: "!"})
 				}
 				if pa.Description != nil && *pa.Description != "" {
-					rows = append(rows, resource.FindingRow{Label: "Description", Value: *pa.Description})
+					rows = append(rows, domain.DetailRow{Label: "Description", Value: *pa.Description})
 				}
 			}
 
-			findings[key] = resource.EnrichmentFinding{
-				Severity: "!",
-				Summary:  "maintenance overdue",
-				Rows:     rows,
-			}
+			setWave2Finding(&result, key, dbcCodeMaintenanceOverdue, "maintenance overdue", "!", "dbc", rows)
 			issueCount++
 		}
 
@@ -138,13 +143,9 @@ func EnrichDBCMaintenance(ctx context.Context, clients *ServiceClients, resource
 		marker = out.Marker
 	}
 
-	return IssueEnricherResult{
-		IssueCount:   issueCount, // "!" findings bump the S1 badge
-		Truncated:    truncated,
-		TruncatedIDs: truncatedIDs,
-		Findings:     findings,
-		FieldUpdates: make(map[string]map[string]string),
-	}, AggregateFailures("dbc-enrich: DescribePendingMaintenanceActions", failures, pages)
+	result.IssueCount = issueCount // "!" findings bump the S1 badge
+	result.Truncated = truncated
+	return result, AggregateFailures("dbc-enrich: DescribePendingMaintenanceActions", failures, pages)
 }
 
 // isClusterARN returns true when the ARN's resource-type segment is "cluster".

--- a/internal/aws/dbc_snap_issue_enrichment.go
+++ b/internal/aws/dbc_snap_issue_enrichment.go
@@ -31,6 +31,14 @@ import (
 
 	docdbtypes "github.com/aws/aws-sdk-go-v2/service/docdb/types"
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+
+	"github.com/k2m30/a9s/v3/internal/domain"
+)
+
+// dbc-snap canonical FindingCodes emitted by the cross-ref enricher.
+const (
+	dbcSnapOrphanCode        domain.FindingCode = "dbc-snap.orphan"
+	dbcSnapPastRetentionCode domain.FindingCode = "dbc-snap.past-retention"
 )
 
 // enrichDBCSnapCrossRef is the IssueEnricherFunc registered for dbc-snap.
@@ -45,6 +53,9 @@ var enrichDBCSnapCrossRef = EnrichSnapshotCrossRef(SnapshotCrossRefConfig{
 	RetentionPhrase:    func(d int) string { return fmt.Sprintf("automated, %dd past retention", d) },
 	RetentionEnabled:   true,
 	Severity:           "!",
+	ShortName:          "dbc-snap",
+	OrphanCode:         dbcSnapOrphanCode,
+	PastRetentionCode:  dbcSnapPastRetentionCode,
 })
 
 // dbcSnapParentID extracts DBClusterIdentifier from either a

--- a/internal/aws/dbc_snap_issue_enrichment_internal_test.go
+++ b/internal/aws/dbc_snap_issue_enrichment_internal_test.go
@@ -78,9 +78,9 @@ func TestEnrichDBCSnapCrossRef_FailedPlusOrphan(t *testing.T) {
 	if !hasFinding {
 		t.Fatal("Findings[\"snap-failed\"] missing; want orphan finding from cross-ref enricher")
 	}
-	if finding.Summary != "orphan: source cluster deleted" {
+	if finding.Phrase != "orphan: source cluster deleted" {
 		t.Errorf("Findings[\"snap-failed\"].Summary = %q, want %q",
-			finding.Summary, "orphan: source cluster deleted")
+			finding.Phrase, "orphan: source cluster deleted")
 	}
 
 	// AS-140: FieldUpdates must be empty — the merged "failed (+1)" stack is
@@ -178,8 +178,8 @@ func TestEnrichDBCSnapCrossRef_RDSShape_OrphanAndPastRetention(t *testing.T) {
 		if !ok {
 			t.Fatal("expected orphan finding for rdstypes.DBClusterSnapshot, got none")
 		}
-		if finding.Summary != "orphan: source cluster deleted" {
-			t.Errorf("Summary = %q, want %q", finding.Summary, "orphan: source cluster deleted")
+		if finding.Phrase != "orphan: source cluster deleted" {
+			t.Errorf("Summary = %q, want %q", finding.Phrase, "orphan: source cluster deleted")
 		}
 		// AS-140: FieldUpdates must be empty — merged phrase is computed at
 		// render time by phraseFromFindings(r.Findings).
@@ -225,12 +225,12 @@ func TestEnrichDBCSnapCrossRef_RDSShape_OrphanAndPastRetention(t *testing.T) {
 		if !ok {
 			t.Fatal("expected past-retention finding for rdstypes automated snapshot")
 		}
-		if !strings.Contains(finding.Summary, "automated") || !strings.Contains(finding.Summary, "past retention") {
-			t.Errorf("Summary = %q; want automated + past retention", finding.Summary)
+		if !strings.Contains(finding.Phrase, "automated") || !strings.Contains(finding.Phrase, "past retention") {
+			t.Errorf("Summary = %q; want automated + past retention", finding.Phrase)
 		}
 		// 25 - 7 = 18 days over retention
-		if !strings.Contains(finding.Summary, "18d") {
-			t.Errorf("Summary days-over should be 18 (25 - 7), got %q", finding.Summary)
+		if !strings.Contains(finding.Phrase, "18d") {
+			t.Errorf("Summary days-over should be 18 (25 - 7), got %q", finding.Phrase)
 		}
 	})
 }

--- a/internal/aws/dbi_issue_enrichment.go
+++ b/internal/aws/dbi_issue_enrichment.go
@@ -8,7 +8,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// dbi canonical FindingCodes.
+const (
+	dbiCodePendingMaintenance domain.FindingCode = "dbi.pending-maintenance"
 )
 
 // EnrichDBIMaintenance calls DescribePendingMaintenanceActions (account-wide, paginated)
@@ -18,11 +24,14 @@ import (
 // over a Wave-1 finding) is computed at render time from r.Findings via
 // phraseFromFindings; this enricher only emits Findings.
 func EnrichDBIMaintenance(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 
 	if clients == nil || clients.RDS == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs, FieldUpdates: make(map[string]map[string]string)}, nil
+		return result, nil
 	}
 
 	// Paginate with a cap.
@@ -38,7 +47,7 @@ func EnrichDBIMaintenance(ctx context.Context, clients *ServiceClients, resource
 		out, err := clients.RDS.DescribePendingMaintenanceActions(ctx, &rds.DescribePendingMaintenanceActionsInput{Marker: marker})
 		pages++
 		if err != nil {
-			return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs, FieldUpdates: make(map[string]map[string]string)}, err
+			return result, err
 		}
 		allActions = append(allActions, out.PendingMaintenanceActions...)
 		if out.Marker == nil || *out.Marker == "" {
@@ -79,39 +88,30 @@ func EnrichDBIMaintenance(ctx context.Context, clients *ServiceClients, resource
 
 		// Summary is the short S5 phrase; every concrete fact (Action,
 		// Description, Earliest Target, Apply Method) lives only in Rows so
-		// the Attention section does not render duplicated content. See the
-		// contract on resource.EnrichmentFinding.
-		var rows []resource.FindingRow
+		// the Attention section does not render duplicated content.
+		var rows []domain.DetailRow
 		for _, pa := range action.PendingMaintenanceActionDetails {
 			if pa.Action != nil && *pa.Action != "" {
-				rows = append(rows, resource.FindingRow{Label: "Action", Value: *pa.Action, Tier: "~"})
+				rows = append(rows, domain.DetailRow{Label: "Action", Value: *pa.Action, Tier: "~"})
 			}
 			if pa.OptInStatus != nil && *pa.OptInStatus != "" {
-				rows = append(rows, resource.FindingRow{Label: "Apply Method", Value: *pa.OptInStatus})
+				rows = append(rows, domain.DetailRow{Label: "Apply Method", Value: *pa.OptInStatus})
 			}
 			if pa.AutoAppliedAfterDate != nil {
-				rows = append(rows, resource.FindingRow{Label: "Earliest Target", Value: formatDate(pa.AutoAppliedAfterDate), Tier: "~"})
+				rows = append(rows, domain.DetailRow{Label: "Earliest Target", Value: formatDate(pa.AutoAppliedAfterDate), Tier: "~"})
 			} else if pa.ForcedApplyDate != nil {
-				rows = append(rows, resource.FindingRow{Label: "Earliest Target", Value: formatDate(pa.ForcedApplyDate), Tier: "~"})
+				rows = append(rows, domain.DetailRow{Label: "Earliest Target", Value: formatDate(pa.ForcedApplyDate), Tier: "~"})
 			}
 			if pa.Description != nil && *pa.Description != "" {
-				rows = append(rows, resource.FindingRow{Label: "Description", Value: *pa.Description})
+				rows = append(rows, domain.DetailRow{Label: "Description", Value: *pa.Description})
 			}
 		}
 
-		findings[key] = resource.EnrichmentFinding{
-			Severity: "~",
-			Summary:  "pending maintenance",
-			Rows:     rows,
-		}
+		setWave2Finding(&result, key, dbiCodePendingMaintenance, "pending maintenance", "~", "dbi", rows)
 	}
 
-	return IssueEnricherResult{
-		IssueCount:   0, // "~" findings never bump the S1 badge
-		Truncated:    truncated,
-		TruncatedIDs: truncatedIDs,
-		Findings:     findings,
-		FieldUpdates: make(map[string]map[string]string),
-	}, nil
+	result.IssueCount = 0 // "~" findings never bump the S1 badge
+	result.Truncated = truncated
+	return result, nil
 }
 

--- a/internal/aws/dbi_snap_issue_enrichment.go
+++ b/internal/aws/dbi_snap_issue_enrichment.go
@@ -20,6 +20,14 @@ import (
 	"time"
 
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+
+	"github.com/k2m30/a9s/v3/internal/domain"
+)
+
+// dbi-snap canonical FindingCodes emitted by the cross-ref enricher.
+const (
+	dbiSnapOrphanCode        domain.FindingCode = "dbi-snap.orphan"
+	dbiSnapPastRetentionCode domain.FindingCode = "dbi-snap.past-retention"
 )
 
 // enrichDBISnapCrossRef is the IssueEnricherFunc registered for dbi-snap.
@@ -55,9 +63,12 @@ var enrichDBISnapCrossRef = EnrichSnapshotCrossRef(SnapshotCrossRefConfig{
 		}
 		return *db.BackupRetentionPeriod, true
 	},
-	OrphanPhrase:     "orphan: source DB deleted",
-	ParentRowLabel:   "Source DB",
-	RetentionPhrase:  func(d int) string { return fmt.Sprintf("automated, %dd past retention", d) },
-	RetentionEnabled: true,
-	Severity:         "!",
+	OrphanPhrase:      "orphan: source DB deleted",
+	ParentRowLabel:    "Source DB",
+	RetentionPhrase:   func(d int) string { return fmt.Sprintf("automated, %dd past retention", d) },
+	RetentionEnabled:  true,
+	Severity:          "!",
+	ShortName:         "dbi-snap",
+	OrphanCode:        dbiSnapOrphanCode,
+	PastRetentionCode: dbiSnapPastRetentionCode,
 })

--- a/internal/aws/ddb_issue_enrichment.go
+++ b/internal/aws/ddb_issue_enrichment.go
@@ -7,18 +7,26 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// ddb canonical FindingCodes.
+const (
+	ddbCodePITROff domain.FindingCode = "ddb.pitr-off"
 )
 
 // EnrichDynamoDBPITR calls DescribeContinuousBackups for each table (cap EnrichmentCap)
 // and returns a Finding when PITR is not enabled.
 // Severity is "~" (informational); PITR-disabled findings do not bump the menu badge.
 func EnrichDynamoDBPITR(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients.DynamoDB == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	for i, r := range resources {
@@ -38,7 +46,7 @@ func EnrichDynamoDBPITR(ctx context.Context, clients *ServiceClients, resources 
 		if err != nil {
 			// sub-call error: skip this table, mark truncated to signal incomplete data
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 		if out.ContinuousBackupsDescription == nil {
@@ -61,14 +69,13 @@ func EnrichDynamoDBPITR(ctx context.Context, clients *ServiceClients, resources 
 			} else {
 				newStatus = "PITR off"
 			}
-			fieldUpdates[r.ID] = map[string]string{
+			result.FieldUpdates[r.ID] = map[string]string{
 				"status": newStatus,
 			}
-			findings[r.ID] = resource.EnrichmentFinding{
-				Severity: "~",
-				Summary:  "PITR off",
-			}
+			setWave2Finding(&result, r.ID, ddbCodePITROff, "PITR off", "~", "ddb", nil)
 		}
 	}
-	return IssueEnricherResult{IssueCount: 0, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates}, nil
+	result.IssueCount = 0
+	result.Truncated = truncated
+	return result, nil
 }

--- a/internal/aws/eb_issue_enrichment.go
+++ b/internal/aws/eb_issue_enrichment.go
@@ -9,7 +9,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk"
 	ebtypes "github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// eb canonical FindingCodes.
+const (
+	ebCodeEnvironmentCauses domain.FindingCode = "eb.environment-causes"
 )
 
 // EnrichEBEnvironmentHealth calls DescribeEnvironmentHealth for each Elastic
@@ -18,10 +24,12 @@ import (
 // Summary: "EB causes: <first cause>". IssueCount is always 0 — causes are
 // informational signals, not broken-state indicators.
 func EnrichEBEnvironmentHealth(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+	}
 	if clients.ElasticBeanstalk == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	for i, r := range resources {
@@ -41,19 +49,19 @@ func EnrichEBEnvironmentHealth(ctx context.Context, clients *ServiceClients, res
 		})
 		if err != nil {
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 		if len(out.Causes) == 0 {
 			continue
 		}
 		firstCause := out.Causes[0]
-		rows := []resource.FindingRow{
+		rows := []domain.DetailRow{
 			{Label: "Cause", Value: firstCause, Tier: "~"},
 		}
 		// Record additional causes as extra rows.
 		for _, cause := range out.Causes[1:] {
-			rows = append(rows, resource.FindingRow{Label: "Cause", Value: cause, Tier: "~"})
+			rows = append(rows, domain.DetailRow{Label: "Cause", Value: cause, Tier: "~"})
 		}
 		// Key on resource ID (environment ID) for registry consistency.
 		// Fall back to name if ID is not set.
@@ -61,11 +69,9 @@ func EnrichEBEnvironmentHealth(ctx context.Context, clients *ServiceClients, res
 		if key == "" {
 			key = name
 		}
-		findings[key] = resource.EnrichmentFinding{
-			Severity: "~",
-			Summary:  fmt.Sprintf("EB causes: %s", firstCause),
-			Rows:     rows,
-		}
+		setWave2Finding(&result, key, ebCodeEnvironmentCauses, fmt.Sprintf("EB causes: %s", firstCause), "~", "eb", rows)
 	}
-	return IssueEnricherResult{IssueCount: 0, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings}, nil
+	result.IssueCount = 0
+	result.Truncated = truncated
+	return result, nil
 }

--- a/internal/aws/eb_rule_issue_enrichment.go
+++ b/internal/aws/eb_rule_issue_enrichment.go
@@ -10,7 +10,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
 	eventbridgetypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// eb-rule canonical FindingCodes.
+const (
+	ebRuleCodeTargetIssue domain.FindingCode = "eb-rule.target-issue"
 )
 
 // EnrichEventBridgeRuleTargets is a Wave 2 enricher for EventBridge rules.
@@ -19,11 +25,13 @@ import (
 //   - Rule state == DISABLED AND len(Targets) > 0 → "~" finding (disabled rule still has targets — drift)
 //   - Any target without DeadLetterConfig → "~" finding (no DLQ on target)
 func EnrichEventBridgeRuleTargets(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients.EventBridge == nil || len(resources) == 0 {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 
 	truncated := len(resources) > EnrichmentCap
@@ -54,7 +62,7 @@ func EnrichEventBridgeRuleTargets(ctx context.Context, clients *ServiceClients, 
 			if targetPages >= PerParentPageCap {
 				targetsTruncated = true
 				truncated = true
-				truncatedIDs[r.ID] = true
+				result.TruncatedIDs[r.ID] = true
 				break
 			}
 			pageInput := &eventbridge.ListTargetsByRuleInput{
@@ -68,7 +76,7 @@ func EnrichEventBridgeRuleTargets(ctx context.Context, clients *ServiceClients, 
 			targetPages++
 			if err != nil {
 				truncated = true
-				truncatedIDs[r.ID] = true
+				result.TruncatedIDs[r.ID] = true
 				break
 			}
 			targets = append(targets, out.Targets...)
@@ -83,14 +91,14 @@ func EnrichEventBridgeRuleTargets(ctx context.Context, clients *ServiceClients, 
 		if targetsTruncated {
 			targetCountStr = resource.FormatApproximate(len(targets))
 		}
-		fieldUpdates[ruleName] = map[string]string{
+		result.FieldUpdates[ruleName] = map[string]string{
 			"target_count": targetCountStr,
 		}
-		var rows []resource.FindingRow
+		var rows []domain.DetailRow
 
 		// ENABLED rule with no targets → rule fires but goes nowhere.
 		if state == "ENABLED" && len(targets) == 0 && !targetsTruncated {
-			rows = append(rows, resource.FindingRow{
+			rows = append(rows, domain.DetailRow{
 				Label: "Targets",
 				Value: "enabled rule has no targets (rule matches but goes nowhere)",
 				Tier:  "!",
@@ -99,7 +107,7 @@ func EnrichEventBridgeRuleTargets(ctx context.Context, clients *ServiceClients, 
 
 		// DISABLED rule still has targets → probable drift/oversight.
 		if state == "DISABLED" && len(targets) > 0 {
-			rows = append(rows, resource.FindingRow{
+			rows = append(rows, domain.DetailRow{
 				Label: "Targets",
 				Value: fmt.Sprintf("disabled rule still has %d target(s) (drift)", len(targets)),
 				Tier:  "~",
@@ -113,7 +121,7 @@ func EnrichEventBridgeRuleTargets(ctx context.Context, clients *ServiceClients, 
 				if target.Id != nil {
 					targetID = *target.Id
 				}
-				rows = append(rows, resource.FindingRow{
+				rows = append(rows, domain.DetailRow{
 					Label: "Target",
 					Value: fmt.Sprintf("%s: no dead-letter config", targetID),
 					Tier:  "~",
@@ -134,19 +142,16 @@ func EnrichEventBridgeRuleTargets(ctx context.Context, clients *ServiceClients, 
 			}
 		}
 
-		findings[ruleName] = resource.EnrichmentFinding{
-			Severity: severity,
-			Summary:  rows[0].Value,
-			Rows:     rows,
-		}
+		setWave2Finding(&result, ruleName, ebRuleCodeTargetIssue, rows[0].Value, severity, "eb-rule", rows)
 	}
 
 	issueCount := 0
-	for _, f := range findings {
-		if f.Severity == "!" {
+	for _, f := range result.Findings {
+		if f.Severity == domain.SevBroken {
 			issueCount++
 		}
 	}
-
-	return IssueEnricherResult{IssueCount: issueCount, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates}, nil
+	result.IssueCount = issueCount
+	result.Truncated = truncated
+	return result, nil
 }

--- a/internal/aws/ebs_issue_enrichment.go
+++ b/internal/aws/ebs_issue_enrichment.go
@@ -7,17 +7,25 @@ import (
 	ec2svc "github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// ebs canonical FindingCodes.
+const (
+	ebsCodeVolumeIODegraded domain.FindingCode = "ebs.volume-io-degraded"
 )
 
 // EnrichEBSVolumeStatus calls DescribeVolumeStatus (account-wide, paginated) and returns
 // a Finding for every volume with non-ok status.
 // Severity is "!" (broken/degraded). Walks up to EnrichmentCap pages via NextToken.
 func EnrichEBSVolumeStatus(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+	}
 	if clients.EC2 == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	// Build a set of known resource IDs so we can detect unmatched API returns.
 	knownIDs := make(map[string]bool, len(resources))
@@ -40,7 +48,7 @@ func EnrichEBSVolumeStatus(ctx context.Context, clients *ServiceClients, resourc
 		})
 		pages++
 		if err != nil {
-			return IssueEnricherResult{TruncatedIDs: truncatedIDs}, err
+			return IssueEnricherResult{TruncatedIDs: result.TruncatedIDs}, err
 		}
 		allVolumeStatuses = append(allVolumeStatuses, out.VolumeStatuses...)
 		if out.NextToken == nil {
@@ -61,7 +69,7 @@ func EnrichEBSVolumeStatus(ctx context.Context, clients *ServiceClients, resourc
 			continue
 		}
 		ioState := string(v.VolumeStatus.Status)
-		rows := []resource.FindingRow{
+		rows := []domain.DetailRow{
 			{Label: "I/O State", Value: ioState, Tier: "!"},
 		}
 		// Most recent event (if any).
@@ -75,21 +83,19 @@ func EnrichEBSVolumeStatus(ctx context.Context, clients *ServiceClients, resourc
 				eventVal = *ev.Description
 			}
 			if eventVal != "" {
-				rows = append(rows, resource.FindingRow{Label: "Event", Value: eventVal, Tier: "~"})
+				rows = append(rows, domain.DetailRow{Label: "Event", Value: eventVal, Tier: "~"})
 			}
 		}
 		// Most recent action code (if any).
 		if len(v.Actions) > 0 {
 			ac := v.Actions[0]
 			if ac.Code != nil && *ac.Code != "" {
-				rows = append(rows, resource.FindingRow{Label: "Action Code", Value: *ac.Code})
+				rows = append(rows, domain.DetailRow{Label: "Action Code", Value: *ac.Code})
 			}
 		}
-		findings[volID] = resource.EnrichmentFinding{
-			Severity: "!",
-			Summary:  "volume I/O degraded",
-			Rows:     rows,
-		}
+		setWave2Finding(&result, volID, ebsCodeVolumeIODegraded, "volume I/O degraded", "!", "ebs", rows)
 	}
-	return IssueEnricherResult{IssueCount: len(findings), Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings}, nil
+	result.IssueCount = len(result.Findings)
+	result.Truncated = truncated
+	return result, nil
 }

--- a/internal/aws/ec2_issue_enrichment.go
+++ b/internal/aws/ec2_issue_enrichment.go
@@ -11,7 +11,14 @@ import (
 	ec2svc "github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// ec2 canonical FindingCodes.
+const (
+	ec2CodeInstanceStatusImpaired domain.FindingCode = "ec2.instance-status-impaired"
+	// TODO(W1-future): split scheduled-event branch into a typed constant once ec2 enricher is further split.
 )
 
 // EnrichEC2InstanceStatus calls DescribeInstanceStatus(IncludeAllInstances=true) (account-wide,
@@ -20,10 +27,12 @@ import (
 // Severity "!" for status != ok; "~" for scheduled events. IssueCount counts "!" findings only.
 // Pagination uses NextToken; walks up to EnrichmentCap pages.
 func EnrichEC2InstanceStatus(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+	}
 	if clients.EC2 == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	// Build a set of known resource IDs so we can detect unmatched API returns.
 	knownIDs := make(map[string]bool, len(resources))
@@ -47,7 +56,7 @@ func EnrichEC2InstanceStatus(ctx context.Context, clients *ServiceClients, resou
 		})
 		pages++
 		if err != nil {
-			return IssueEnricherResult{TruncatedIDs: truncatedIDs}, err
+			return IssueEnricherResult{TruncatedIDs: result.TruncatedIDs}, err
 		}
 		allInstanceStatuses = append(allInstanceStatuses, out.InstanceStatuses...)
 		if out.NextToken == nil {
@@ -70,20 +79,20 @@ func EnrichEC2InstanceStatus(ctx context.Context, clients *ServiceClients, resou
 		}
 
 		// Collect rows for this instance.
-		var rows []resource.FindingRow
+		var rows []domain.DetailRow
 		severity := "~" // start informational; upgrade to "!" on real impairment
 
 		// Check instance status.
 		if is.InstanceStatus != nil && is.InstanceStatus.Status != ec2types.SummaryStatusOk {
 			statusStr := string(is.InstanceStatus.Status)
-			rows = append(rows, resource.FindingRow{Label: "Instance Status", Value: statusStr, Tier: "!"})
+			rows = append(rows, domain.DetailRow{Label: "Instance Status", Value: statusStr, Tier: "!"})
 			severity = "!"
 		}
 
 		// Check system status.
 		if is.SystemStatus != nil && is.SystemStatus.Status != ec2types.SummaryStatusOk {
 			statusStr := string(is.SystemStatus.Status)
-			rows = append(rows, resource.FindingRow{Label: "System Status", Value: statusStr, Tier: "!"})
+			rows = append(rows, domain.DetailRow{Label: "System Status", Value: statusStr, Tier: "!"})
 			severity = "!"
 		}
 
@@ -102,7 +111,7 @@ func EnrichEC2InstanceStatus(ctx context.Context, clients *ServiceClients, resou
 			}
 			code := string(ev.Code)
 			dateStr := eventDate.Format("2006-01-02")
-			rows = append(rows, resource.FindingRow{
+			rows = append(rows, domain.DetailRow{
 				Label: "Scheduled Event",
 				Value: fmt.Sprintf("%s at %s", code, dateStr),
 				Tier:  "~",
@@ -125,18 +134,16 @@ func EnrichEC2InstanceStatus(ctx context.Context, clients *ServiceClients, resou
 			summary = fmt.Sprintf("scheduled event: %s", rows[0].Value)
 		}
 
-		findings[id] = resource.EnrichmentFinding{
-			Severity: severity,
-			Summary:  summary,
-			Rows:     rows,
-		}
+		setWave2Finding(&result, id, ec2CodeInstanceStatusImpaired, summary, severity, "ec2", rows)
 	}
 
 	issueCount := 0
-	for _, f := range findings {
-		if f.Severity == "!" {
+	for _, f := range result.Findings {
+		if f.Severity == domain.SevBroken {
 			issueCount++
 		}
 	}
-	return IssueEnricherResult{IssueCount: issueCount, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings}, nil
+	result.IssueCount = issueCount
+	result.Truncated = truncated
+	return result, nil
 }

--- a/internal/aws/ecr_issue_enrichment.go
+++ b/internal/aws/ecr_issue_enrichment.go
@@ -10,7 +10,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// ecr canonical FindingCodes.
+const (
+	ecrCodeVulnerabilities domain.FindingCode = "ecr.vulnerabilities"
 )
 
 // ECRImagesPerRepo caps how many recent images are inspected per repository.
@@ -41,15 +47,17 @@ const ECRImagesPerRepo = 10
 // Repositories without scan data (unscanned images) contribute zero counts
 // silently — AWS returns a nil ImageScanFindingsSummary for those.
 func EnrichECRRepository(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients == nil || clients.ECR == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	describeAPI, ok := clients.ECR.(ECRDescribeImagesAPI)
 	if !ok {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 
 	truncated := len(resources) > EnrichmentCap
@@ -79,7 +87,7 @@ func EnrichECRRepository(ctx context.Context, clients *ServiceClients, resources
 		if err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", r.ID, err))
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 
@@ -102,7 +110,7 @@ func EnrichECRRepository(ctx context.Context, clients *ServiceClients, resources
 			}
 		}
 
-		fieldUpdates[r.ID] = map[string]string{
+		result.FieldUpdates[r.ID] = map[string]string{
 			"critical_vulns": strconv.FormatInt(int64(criticalTotal), 10),
 			"high_vulns":     strconv.FormatInt(int64(highTotal), 10),
 			"images_scanned": strconv.Itoa(scannedCount),
@@ -112,36 +120,33 @@ func EnrichECRRepository(ctx context.Context, clients *ServiceClients, resources
 			continue
 		}
 
-		var rows []resource.FindingRow
+		var rows []domain.DetailRow
 		tier := "~"
 		if criticalTotal > 0 {
 			tier = "!"
-			rows = append(rows, resource.FindingRow{
+			rows = append(rows, domain.DetailRow{
 				Label: "CRITICAL",
 				Value: fmt.Sprintf("%d CRITICAL findings across %d image(s)", criticalTotal, scannedCount),
 				Tier:  "!",
 			})
 		}
 		if highTotal > 0 {
-			rows = append(rows, resource.FindingRow{
+			rows = append(rows, domain.DetailRow{
 				Label: "HIGH",
 				Value: fmt.Sprintf("%d HIGH findings across %d image(s)", highTotal, scannedCount),
 				Tier:  "~",
 			})
 		}
-		findings[r.ID] = resource.EnrichmentFinding{
-			Severity: tier,
-			Summary:  rows[0].Value,
-			Rows:     rows,
-		}
+		setWave2Finding(&result, r.ID, ecrCodeVulnerabilities, rows[0].Value, tier, "ecr", rows)
 	}
 
 	issueCount := 0
-	for _, f := range findings {
-		if f.Severity == "!" {
+	for _, f := range result.Findings {
+		if f.Severity == domain.SevBroken {
 			issueCount++
 		}
 	}
-	return IssueEnricherResult{IssueCount: issueCount, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates},
-		AggregateFailures("ecr-enrich: DescribeImages", failures, total)
+	result.IssueCount = issueCount
+	result.Truncated = truncated
+	return result, AggregateFailures("ecr-enrich: DescribeImages", failures, total)
 }

--- a/internal/aws/ecs_issue_enrichment.go
+++ b/internal/aws/ecs_issue_enrichment.go
@@ -9,7 +9,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// ecs canonical FindingCodes.
+const (
+	ecsCodeClusterIssue domain.FindingCode = "ecs.cluster-issue"
 )
 
 // EnrichECSClusters is a Wave 2 enricher for ECS clusters.
@@ -22,10 +28,12 @@ import (
 // (informational) and do not contribute to the attention menu badge per the
 // IssueEnricherResult contract.
 func EnrichECSClusters(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+	}
 	if clients.ECS == nil || len(resources) == 0 {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 
 	clusterNames := make([]string, 0, len(resources))
@@ -71,11 +79,11 @@ func EnrichECSClusters(ctx context.Context, clients *ServiceClients, resources [
 			running := cluster.RunningTasksCount
 			registered := cluster.RegisteredContainerInstancesCount
 
-			var rows []resource.FindingRow
+			var rows []domain.DetailRow
 			var summaries []string
 
 			if pending > 0 {
-				rows = append(rows, resource.FindingRow{
+				rows = append(rows, domain.DetailRow{
 					Label: "Pending Tasks",
 					Value: fmt.Sprintf("%d tasks pending", pending),
 					Tier:  "~",
@@ -84,7 +92,7 @@ func EnrichECSClusters(ctx context.Context, clients *ServiceClients, resources [
 			}
 
 			if running == 0 && registered > 0 {
-				rows = append(rows, resource.FindingRow{
+				rows = append(rows, domain.DetailRow{
 					Label: "Tasks",
 					Value: fmt.Sprintf("no running tasks (%d container instances registered)", registered),
 					Tier:  "~",
@@ -97,15 +105,13 @@ func EnrichECSClusters(ctx context.Context, clients *ServiceClients, resources [
 			}
 
 			summary := strings.Join(summaries, "; ")
-			findings[name] = resource.EnrichmentFinding{
-				Severity: "~",
-				Summary:  summary,
-				Rows:     rows,
-			}
+			setWave2Finding(&result, name, ecsCodeClusterIssue, summary, "~", "ecs", rows)
 		}
 	}
 
 	// IssueCount is 0: all ECS cluster findings are "~" (informational) and
 	// do not contribute to the attention menu badge.
-	return IssueEnricherResult{IssueCount: 0, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings}, nil
+	result.IssueCount = 0
+	result.Truncated = truncated
+	return result, nil
 }

--- a/internal/aws/ecs_svc_issue_enrichment.go
+++ b/internal/aws/ecs_svc_issue_enrichment.go
@@ -11,7 +11,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// ecs-svc canonical FindingCodes.
+const (
+	ecsSvcCodeDeploymentFailed domain.FindingCode = "ecs-svc.deployment-failed"
 )
 
 // EnrichECSServices is a Wave 2 enricher for ECS services.
@@ -22,10 +28,12 @@ import (
 //   - runningCount < desiredCount with no IN_PROGRESS deployment → "!" finding
 //   - Recent events (last 10m) containing "unable to place" or "ELB health checks failed" → "!" finding
 func EnrichECSServices(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+	}
 	if clients.ECS == nil || len(resources) == 0 {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 
 	// Group service names by cluster name. Both fields are populated by FetchECSServicesPage.
@@ -69,7 +77,7 @@ func EnrichECSServices(ctx context.Context, clients *ServiceClients, resources [
 				for _, svcName := range batch {
 					failures = append(failures, fmt.Sprintf("%s/%s: %v", clusterName, svcName, err))
 					if r, ok := resourceByService[svcName]; ok {
-						truncatedIDs[r.ID] = true
+						result.TruncatedIDs[r.ID] = true
 					}
 				}
 				truncated = true
@@ -136,19 +144,19 @@ func EnrichECSServices(ctx context.Context, clients *ServiceClients, resources [
 					continue
 				}
 
-				var rows []resource.FindingRow
+				var rows []domain.DetailRow
 				for _, issue := range deploymentIssues {
-					rows = append(rows, resource.FindingRow{Label: "Deployment", Value: issue, Tier: "!"})
+					rows = append(rows, domain.DetailRow{Label: "Deployment", Value: issue, Tier: "!"})
 				}
 				if serviceStuck {
-					rows = append(rows, resource.FindingRow{
+					rows = append(rows, domain.DetailRow{
 						Label: "Tasks",
 						Value: fmt.Sprintf("running %d / desired %d (stuck)", svc.RunningCount, svc.DesiredCount),
 						Tier:  "!",
 					})
 				}
 				for _, issue := range eventIssues {
-					rows = append(rows, resource.FindingRow{Label: "Event", Value: issue, Tier: "!"})
+					rows = append(rows, domain.DetailRow{Label: "Event", Value: issue, Tier: "!"})
 				}
 
 				summary := "deployment failed"
@@ -158,15 +166,12 @@ func EnrichECSServices(ctx context.Context, clients *ServiceClients, resources [
 					summary = eventIssues[0]
 				}
 
-				findings[svcName] = resource.EnrichmentFinding{
-					Severity: "!",
-					Summary:  summary,
-					Rows:     rows,
-				}
+				setWave2Finding(&result, svcName, ecsSvcCodeDeploymentFailed, summary, "!", "ecs-svc", rows)
 			}
 		}
 	}
 
-	return IssueEnricherResult{IssueCount: len(findings), Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings},
-		AggregateFailures("ecs-svc-enrich: DescribeServices", failures, total)
+	result.IssueCount = len(result.Findings)
+	result.Truncated = truncated
+	return result, AggregateFailures("ecs-svc-enrich: DescribeServices", failures, total)
 }

--- a/internal/aws/ecs_task_issue_enrichment.go
+++ b/internal/aws/ecs_task_issue_enrichment.go
@@ -10,7 +10,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// ecs-task canonical FindingCodes.
+const (
+	ecsTaskCodeTaskFailed domain.FindingCode = "ecs-task.task-failed"
 )
 
 // EnrichECSTasks is a Wave 2 enricher for ECS tasks.
@@ -22,10 +28,12 @@ import (
 //   - StopCode == EssentialContainerExited → essential container died
 //   - Any container with a non-zero ExitCode → container crash detected
 func EnrichECSTasks(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+	}
 	if clients.ECS == nil || len(resources) == 0 {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 
 	// Group task ARNs by cluster ARN.
@@ -79,18 +87,18 @@ func EnrichECSTasks(ctx context.Context, clients *ServiceClients, resources []re
 					continue
 				}
 
-				var rows []resource.FindingRow
+				var rows []domain.DetailRow
 
 				// Check stop code for known failure modes.
 				switch task.StopCode {
 				case ecstypes.TaskStopCodeTaskFailedToStart:
-					rows = append(rows, resource.FindingRow{
+					rows = append(rows, domain.DetailRow{
 						Label: "Stop Code",
 						Value: "TaskFailedToStart — task never launched",
 						Tier:  "!",
 					})
 				case ecstypes.TaskStopCodeEssentialContainerExited:
-					rows = append(rows, resource.FindingRow{
+					rows = append(rows, domain.DetailRow{
 						Label: "Stop Code",
 						Value: "EssentialContainerExited — essential container died",
 						Tier:  "!",
@@ -104,7 +112,7 @@ func EnrichECSTasks(ctx context.Context, clients *ServiceClients, resources []re
 						if container.Name != nil {
 							name = *container.Name
 						}
-						rows = append(rows, resource.FindingRow{
+						rows = append(rows, domain.DetailRow{
 							Label: "Container",
 							Value: fmt.Sprintf("%s exited with code %d", name, *container.ExitCode),
 							Tier:  "!",
@@ -118,14 +126,12 @@ func EnrichECSTasks(ctx context.Context, clients *ServiceClients, resources []re
 				}
 
 				summary := rows[0].Value
-				findings[taskID] = resource.EnrichmentFinding{
-					Severity: "!",
-					Summary:  summary,
-					Rows:     rows,
-				}
+				setWave2Finding(&result, taskID, ecsTaskCodeTaskFailed, summary, "!", "ecs-task", rows)
 			}
 		}
 	}
 
-	return IssueEnricherResult{IssueCount: len(findings), Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings}, nil
+	result.IssueCount = len(result.Findings)
+	result.Truncated = truncated
+	return result, nil
 }

--- a/internal/aws/efs_issue_enrichment.go
+++ b/internal/aws/efs_issue_enrichment.go
@@ -9,7 +9,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/efs"
 	efstypes "github.com/aws/aws-sdk-go-v2/service/efs/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// efs canonical FindingCodes.
+const (
+	efsCodeMountTargetDown domain.FindingCode = "efs.mount-target-down"
 )
 
 // EnrichEFSMountTargets calls DescribeMountTargets per file system (cap EnrichmentCap, per-FS
@@ -25,10 +31,12 @@ import (
 // S4 phrase ("mount target down" alone, or stacked with Wave-1 findings) is
 // computed at render time from r.Findings via phraseFromFindings.
 func EnrichEFSMountTargets(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+	}
 	if clients.EFS == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	var failures []string
@@ -52,7 +60,7 @@ func EnrichEFSMountTargets(ctx context.Context, clients *ServiceClients, resourc
 			if mtPages >= PerParentPageCap {
 				mtTruncated = true
 				truncated = true
-				truncatedIDs[r.ID] = true
+				result.TruncatedIDs[r.ID] = true
 				break
 			}
 			out, err := RetryOnThrottle(ctx, DefaultRetryConfig(), func() (*efs.DescribeMountTargetsOutput, error) {
@@ -65,7 +73,7 @@ func EnrichEFSMountTargets(ctx context.Context, clients *ServiceClients, resourc
 			if err != nil {
 				failures = append(failures, fmt.Sprintf("%s: %v", r.ID, err))
 				truncated = true
-				truncatedIDs[r.ID] = true
+				result.TruncatedIDs[r.ID] = true
 				pageFailed = true
 				break
 			}
@@ -109,23 +117,15 @@ func EnrichEFSMountTargets(ctx context.Context, clients *ServiceClients, resourc
 		state := string(firstBad.LifeCycleState)
 
 		// Summary must NOT embed any Row value (U11 contract).
-		finding := resource.EnrichmentFinding{
-			Severity: "!",
-			Summary:  "mount target down",
-			Rows: []resource.FindingRow{
-				{Label: "Mount Target", Value: mtID, Tier: "!"},
-				{Label: "AZ", Value: az},
-				{Label: "State", Value: state, Tier: "!"},
-				{Label: "Degraded", Value: fmt.Sprintf("%d/%d", unavailableCount, totalMT)},
-			},
-		}
-		findings[fsID] = finding
+		setWave2Finding(&result, fsID, efsCodeMountTargetDown, "mount target down", "!", "efs", []domain.DetailRow{
+			{Label: "Mount Target", Value: mtID, Tier: "!"},
+			{Label: "AZ", Value: az},
+			{Label: "State", Value: state, Tier: "!"},
+			{Label: "Degraded", Value: fmt.Sprintf("%d/%d", unavailableCount, totalMT)},
+		})
 	}
-	return IssueEnricherResult{
-		IssueCount:   len(findings),
-		Truncated:    truncated,
-		TruncatedIDs: truncatedIDs,
-		Findings:     findings,
-		FieldUpdates: make(map[string]map[string]string),
-	}, AggregateFailures("efs-enrich: DescribeMountTargets", failures, total)
+	result.IssueCount = len(result.Findings)
+	result.Truncated = truncated
+	result.FieldUpdates = make(map[string]map[string]string)
+	return result, AggregateFailures("efs-enrich: DescribeMountTargets", failures, total)
 }

--- a/internal/aws/elb_issue_enrichment.go
+++ b/internal/aws/elb_issue_enrichment.go
@@ -8,7 +8,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// elb canonical FindingCodes.
+const (
+	elbCodeMisconfigured domain.FindingCode = "elb.misconfigured"
 )
 
 // EnrichELBAttributes calls DescribeLoadBalancerAttributes for each load
@@ -22,10 +28,12 @@ import (
 // r.Fields["load_balancer_arn"] — the elb fetcher emits ID = bare LB name
 // and stores the ARN in Fields. Each call is wrapped in RetryOnThrottle.
 func EnrichELBAttributes(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+	}
 	if clients.ELBv2 == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	var failures []string
@@ -53,10 +61,10 @@ func EnrichELBAttributes(ctx context.Context, clients *ServiceClients, resources
 		if err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", r.ID, err))
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
-		var rows []resource.FindingRow
+		var rows []domain.DetailRow
 		for _, attr := range out.Attributes {
 			if attr.Key == nil || attr.Value == nil {
 				continue
@@ -64,11 +72,11 @@ func EnrichELBAttributes(ctx context.Context, clients *ServiceClients, resources
 			switch *attr.Key {
 			case "deletion_protection.enabled":
 				if *attr.Value == "false" {
-					rows = append(rows, resource.FindingRow{Label: "Deletion Protection", Value: "disabled", Tier: "~"})
+					rows = append(rows, domain.DetailRow{Label: "Deletion Protection", Value: "disabled", Tier: "~"})
 				}
 			case "access_logs.s3.enabled":
 				if *attr.Value == "false" {
-					rows = append(rows, resource.FindingRow{Label: "Access Logs", Value: "disabled", Tier: "~"})
+					rows = append(rows, domain.DetailRow{Label: "Access Logs", Value: "disabled", Tier: "~"})
 				}
 			}
 		}
@@ -81,18 +89,15 @@ func EnrichELBAttributes(ctx context.Context, clients *ServiceClients, resources
 		if len(rows) >= 2 {
 			severity = "!"
 		}
-		findings[r.ID] = resource.EnrichmentFinding{
-			Severity: severity,
-			Summary:  rows[0].Label + ": " + rows[0].Value,
-			Rows:     rows,
-		}
+		setWave2Finding(&result, r.ID, elbCodeMisconfigured, rows[0].Label+": "+rows[0].Value, severity, "elb", rows)
 	}
 	issueCount := 0
-	for _, f := range findings {
-		if f.Severity == "!" {
+	for _, f := range result.Findings {
+		if f.Severity == domain.SevBroken {
 			issueCount++
 		}
 	}
-	return IssueEnricherResult{IssueCount: issueCount, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings},
-		AggregateFailures("elb-enrich: DescribeLoadBalancerAttributes", failures, total)
+	result.IssueCount = issueCount
+	result.Truncated = truncated
+	return result, AggregateFailures("elb-enrich: DescribeLoadBalancerAttributes", failures, total)
 }

--- a/internal/aws/glue_issue_enrichment.go
+++ b/internal/aws/glue_issue_enrichment.go
@@ -9,18 +9,26 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/glue"
 	gluetypes "github.com/aws/aws-sdk-go-v2/service/glue/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// glue canonical FindingCodes.
+const (
+	glueCodeLatestRunFailed domain.FindingCode = "glue.latest-run-failed"
 )
 
 // EnrichGlueJobStatus calls GetJobRuns(max:1) for each job (1 per job, cap ~50).
 // Returns a Finding for each job whose latest run is FAILED, ERROR, or TIMEOUT.
 // Severity is "!" (broken/degraded). Summary: "latest run <STATUS>".
 func EnrichGlueJobStatus(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients.Glue == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	for i, r := range resources {
@@ -36,7 +44,7 @@ func EnrichGlueJobStatus(ctx context.Context, clients *ServiceClients, resources
 		})
 		if err != nil {
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 		key := r.ID
@@ -47,25 +55,23 @@ func EnrichGlueJobStatus(ctx context.Context, clients *ServiceClients, resources
 			run := out.JobRuns[0]
 			s := run.JobRunState
 			if s == gluetypes.JobRunStateFailed || s == gluetypes.JobRunStateError || s == gluetypes.JobRunStateTimeout {
-				rows := []resource.FindingRow{
+				rows := []domain.DetailRow{
 					{Label: "State", Value: string(s), Tier: "!"},
 				}
 				if run.CompletedOn != nil {
-					rows = append(rows, resource.FindingRow{Label: "Ended", Value: run.CompletedOn.Format("2006-01-02")})
+					rows = append(rows, domain.DetailRow{Label: "Ended", Value: run.CompletedOn.Format("2006-01-02")})
 				}
 				if run.ErrorMessage != nil && *run.ErrorMessage != "" {
-					rows = append(rows, resource.FindingRow{Label: "Error", Value: *run.ErrorMessage, Tier: "!"})
+					rows = append(rows, domain.DetailRow{Label: "Error", Value: *run.ErrorMessage, Tier: "!"})
 				}
-				findings[key] = resource.EnrichmentFinding{
-					Severity: "!",
-					Summary:  fmt.Sprintf("latest run %s", string(s)),
-					Rows:     rows,
-				}
-				fieldUpdates[key] = map[string]string{"last_run": string(s)}
+				setWave2Finding(&result, key, glueCodeLatestRunFailed, fmt.Sprintf("latest run %s", string(s)), "!", "glue", rows)
+				result.FieldUpdates[key] = map[string]string{"last_run": string(s)}
 			} else {
-				fieldUpdates[key] = map[string]string{"last_run": "OK"}
+				result.FieldUpdates[key] = map[string]string{"last_run": "OK"}
 			}
 		}
 	}
-	return IssueEnricherResult{IssueCount: len(findings), Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates}, nil
+	result.IssueCount = len(result.Findings)
+	result.Truncated = truncated
+	return result, nil
 }

--- a/internal/aws/iam_group_issue_enrichment.go
+++ b/internal/aws/iam_group_issue_enrichment.go
@@ -8,7 +8,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// iam-group canonical FindingCodes.
+const (
+	iamGroupCodeOrphanOrNoop domain.FindingCode = "iam-group.orphan-or-noop"
 )
 
 // EnrichIAMGroup calls GetGroup + ListAttachedGroupPolicies per group
@@ -20,17 +26,19 @@ import (
 //
 // Skip when clients.IAM == nil.
 func EnrichIAMGroup(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients.IAM == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	getGroupAPI, ok1 := clients.IAM.(IAMGetGroupAPI)
 	attachedPoliciesAPI, ok2 := clients.IAM.(IAMListAttachedGroupPoliciesAPI)
 	inlinePoliciesAPI, ok3 := clients.IAM.(IAMListGroupPoliciesAPI)
 	if !ok1 || !ok2 || !ok3 {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 
 	truncated := len(resources) > EnrichmentCap
@@ -55,7 +63,7 @@ func EnrichIAMGroup(ctx context.Context, clients *ServiceClients, resources []re
 		for {
 			if memberPages >= PerParentPageCap {
 				memberTruncated = true
-				truncatedIDs[r.ID] = true
+				result.TruncatedIDs[r.ID] = true
 				break
 			}
 			groupOut, err := getGroupAPI.GetGroup(ctx, &iam.GetGroupInput{
@@ -64,7 +72,7 @@ func EnrichIAMGroup(ctx context.Context, clients *ServiceClients, resources []re
 			})
 			if err != nil {
 				truncated = true
-				truncatedIDs[r.ID] = true
+				result.TruncatedIDs[r.ID] = true
 				if memberPages == 0 {
 					memberFirstCallErrd = true
 				} else {
@@ -90,7 +98,7 @@ func EnrichIAMGroup(ctx context.Context, clients *ServiceClients, resources []re
 		for {
 			if attachedPages >= PerParentPageCap {
 				attachedTruncated = true
-				truncatedIDs[r.ID] = true
+				result.TruncatedIDs[r.ID] = true
 				break
 			}
 			attachedOut, err := attachedPoliciesAPI.ListAttachedGroupPolicies(ctx, &iam.ListAttachedGroupPoliciesInput{
@@ -99,7 +107,7 @@ func EnrichIAMGroup(ctx context.Context, clients *ServiceClients, resources []re
 			})
 			if err != nil {
 				truncated = true
-				truncatedIDs[r.ID] = true
+				result.TruncatedIDs[r.ID] = true
 				if attachedPages == 0 {
 					attachedFirstCallErrd = true
 				} else {
@@ -125,7 +133,7 @@ func EnrichIAMGroup(ctx context.Context, clients *ServiceClients, resources []re
 		for {
 			if inlinePages >= PerParentPageCap {
 				inlineTruncated = true
-				truncatedIDs[r.ID] = true
+				result.TruncatedIDs[r.ID] = true
 				break
 			}
 			inlineOut, err := inlinePoliciesAPI.ListGroupPolicies(ctx, &iam.ListGroupPoliciesInput{
@@ -134,7 +142,7 @@ func EnrichIAMGroup(ctx context.Context, clients *ServiceClients, resources []re
 			})
 			if err != nil {
 				truncated = true
-				truncatedIDs[r.ID] = true
+				result.TruncatedIDs[r.ID] = true
 				if inlinePages == 0 {
 					inlineFirstCallErrd = true
 				} else {
@@ -161,14 +169,14 @@ func EnrichIAMGroup(ctx context.Context, clients *ServiceClients, resources []re
 		if memberTruncated {
 			memberCountStr = resource.FormatApproximate(memberCount)
 		}
-		fieldUpdates[r.ID] = map[string]string{
+		result.FieldUpdates[r.ID] = map[string]string{
 			"member_count": memberCountStr,
 		}
 
-		var rows []resource.FindingRow
+		var rows []domain.DetailRow
 
 		if memberCount == 0 && !memberTruncated {
-			rows = append(rows, resource.FindingRow{
+			rows = append(rows, domain.DetailRow{
 				Label: "Members",
 				Value: "group has no members (orphan)",
 				Tier:  "~",
@@ -176,7 +184,7 @@ func EnrichIAMGroup(ctx context.Context, clients *ServiceClients, resources []re
 		}
 
 		if len(allAttached) == 0 && len(allInline) == 0 && !attachedTruncated && !inlineTruncated {
-			rows = append(rows, resource.FindingRow{
+			rows = append(rows, domain.DetailRow{
 				Label: "Policies",
 				Value: "group has no policies (no-op group)",
 				Tier:  "~",
@@ -186,12 +194,10 @@ func EnrichIAMGroup(ctx context.Context, clients *ServiceClients, resources []re
 		if len(rows) == 0 {
 			continue
 		}
-		findings[r.ID] = resource.EnrichmentFinding{
-			Severity: "~",
-			Summary:  rows[0].Value,
-			Rows:     rows,
-		}
+		setWave2Finding(&result, r.ID, iamGroupCodeOrphanOrNoop, rows[0].Value, "~", "iam-group", rows)
 	}
 	// Group findings are severity "~" (informational); IssueCount stays 0.
-	return IssueEnricherResult{IssueCount: 0, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates}, nil
+	result.IssueCount = 0
+	result.Truncated = truncated
+	return result, nil
 }

--- a/internal/aws/iam_policy_issue_enrichment.go
+++ b/internal/aws/iam_policy_issue_enrichment.go
@@ -7,7 +7,13 @@ import (
 
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// iam-policy canonical FindingCodes.
+const (
+	iamPolicyCodeAdminStar domain.FindingCode = "iam-policy.admin-star"
 )
 
 // EnrichIAMPolicy calls GetPolicy + GetPolicyVersion per customer-managed policy
@@ -19,19 +25,21 @@ import (
 // AWS-managed policies (ARN starts with "arn:aws:iam::aws:policy/") are skipped.
 // Skip when clients.IAM == nil.
 func EnrichIAMPolicy(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients.IAM == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	getPolicyAPI, ok1 := clients.IAM.(IAMGetPolicyAPI)
 	getPolicyVersionAPI, ok2 := clients.IAM.(IAMGetPolicyVersionAPI)
 	if !ok1 || !ok2 {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	issueCount := 0
-	fieldUpdates := make(map[string]map[string]string)
 	for i, r := range resources {
 		if i >= EnrichmentCap {
 			break
@@ -54,7 +62,7 @@ func EnrichIAMPolicy(ctx context.Context, clients *ServiceClients, resources []r
 		doc, err := FetchManagedPolicyDocument(ctx, getPolicyAPI, getPolicyVersionAPI, policyARN)
 		if err != nil {
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 		riskVal := ""
@@ -65,21 +73,19 @@ func EnrichIAMPolicy(ctx context.Context, clients *ServiceClients, resources []r
 		}
 		if isAdminStarPolicy(doc) {
 			riskVal = "ADMIN_ALL"
-			findings[r.ID] = resource.EnrichmentFinding{
-				Severity: "!",
-				Summary:  "admin star (CIS IAM.16)",
-				Rows: []resource.FindingRow{
-					{Label: "Action", Value: "*", Tier: "!"},
-					{Label: "Resource", Value: "*", Tier: "!"},
-				},
-			}
+			setWave2Finding(&result, r.ID, iamPolicyCodeAdminStar, "admin star (CIS IAM.16)", "!", "iam-policy", []domain.DetailRow{
+				{Label: "Action", Value: "*", Tier: "!"},
+				{Label: "Resource", Value: "*", Tier: "!"},
+			})
 			issueCount++
 		}
-		fieldUpdates[r.ID] = map[string]string{
+		result.FieldUpdates[r.ID] = map[string]string{
 			"risk": riskVal,
 		}
 	}
-	return IssueEnricherResult{IssueCount: issueCount, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates}, nil
+	result.IssueCount = issueCount
+	result.Truncated = truncated
+	return result, nil
 }
 
 // extractIAMPolicyARN extracts the ARN from a resource whose RawStruct is an iamtypes.Policy

--- a/internal/aws/iam_role_issue_enrichment.go
+++ b/internal/aws/iam_role_issue_enrichment.go
@@ -9,7 +9,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// iam-role canonical FindingCodes.
+const (
+	iamRoleCodeDormant domain.FindingCode = "iam-role.dormant"
 )
 
 // EnrichIAMRoleLastUsed calls GetRole per role (capped at EnrichmentCap) to detect dormant roles.
@@ -20,14 +26,16 @@ import (
 // AWS service-linked roles (Path starts with "/aws-service-role/") are skipped.
 // Skip when clients.IAM == nil.
 func EnrichIAMRoleLastUsed(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+	}
 	if clients.IAM == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	getRoleAPI, ok := clients.IAM.(IAMGetRoleAPI)
 	if !ok {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	for i, r := range resources {
@@ -50,7 +58,7 @@ func EnrichIAMRoleLastUsed(ctx context.Context, clients *ServiceClients, resourc
 		})
 		if err != nil {
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 		if out.Role == nil {
@@ -63,12 +71,11 @@ func EnrichIAMRoleLastUsed(ctx context.Context, clients *ServiceClients, resourc
 			isDormant = true
 		}
 		if isDormant {
-			findings[r.ID] = resource.EnrichmentFinding{
-				Severity: "~",
-				Summary:  "dormant role (>90d)",
-			}
+			setWave2Finding(&result, r.ID, iamRoleCodeDormant, "dormant role (>90d)", "~", "iam-role", nil)
 		}
 	}
 	// Dormant-role findings are severity "~" (informational); IssueCount stays 0.
-	return IssueEnricherResult{IssueCount: 0, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings}, nil
+	result.IssueCount = 0
+	result.Truncated = truncated
+	return result, nil
 }

--- a/internal/aws/iam_user_issue_enrichment.go
+++ b/internal/aws/iam_user_issue_enrichment.go
@@ -12,7 +12,14 @@ import (
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	smithy "github.com/aws/smithy-go"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// iam-user canonical FindingCodes.
+const (
+	iamUserCodeNoMFA   domain.FindingCode = "iam-user.no-mfa"
+	iamUserCodeOldKey  domain.FindingCode = "iam-user.old-key"
 )
 
 // EnrichIAMUserMFA calls GetLoginProfile + ListMFADevices + ListAccessKeys per user
@@ -24,17 +31,19 @@ import (
 //
 // Skip when clients.IAM == nil.
 func EnrichIAMUserMFA(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients.IAM == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	loginProfileAPI, ok1 := clients.IAM.(IAMGetLoginProfileAPI)
 	mfaAPI, ok2 := clients.IAM.(IAMListMFADevicesAPI)
 	accessKeyAPI, ok3 := clients.IAM.(IAMListAccessKeysAPI)
 	if !ok1 || !ok2 || !ok3 {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 
 	truncated := len(resources) > EnrichmentCap
@@ -64,7 +73,7 @@ func EnrichIAMUserMFA(ctx context.Context, clients *ServiceClients, resources []
 			if !isNoSuchEntity {
 				// Unexpected error — skip this user but flag truncation.
 				truncated = true
-				truncatedIDs[r.ID] = true
+				result.TruncatedIDs[r.ID] = true
 				continue
 			}
 			// NoSuchEntityException means the user has no console password.
@@ -72,7 +81,7 @@ func EnrichIAMUserMFA(ctx context.Context, clients *ServiceClients, resources []
 			hasConsolePassword = true
 		}
 
-		var rows []resource.FindingRow
+		var rows []domain.DetailRow
 		severity := "~"
 		hasMFA := false
 		riskLabel := ""
@@ -84,12 +93,12 @@ func EnrichIAMUserMFA(ctx context.Context, clients *ServiceClients, resources []
 			})
 			if mfaErr != nil {
 				truncated = true
-				truncatedIDs[r.ID] = true
+				result.TruncatedIDs[r.ID] = true
 				continue
 			}
 			hasMFA = len(mfaOut.MFADevices) > 0
 			if !hasMFA {
-				rows = append(rows, resource.FindingRow{
+				rows = append(rows, domain.DetailRow{
 					Label: "MFA",
 					Value: "console user without MFA (CIS IAM.5)",
 					Tier:  "!",
@@ -106,7 +115,7 @@ func EnrichIAMUserMFA(ctx context.Context, clients *ServiceClients, resources []
 		})
 		if keysErr != nil {
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 		hasOldKey := false
@@ -123,7 +132,7 @@ func EnrichIAMUserMFA(ctx context.Context, clients *ServiceClients, resources []
 				if key.AccessKeyId != nil {
 					keyID = *key.AccessKeyId
 				}
-				rows = append(rows, resource.FindingRow{
+				rows = append(rows, domain.DetailRow{
 					Label: "Access Key",
 					Value: fmt.Sprintf("key %s >90d (rotation)", keyID),
 					Tier:  "~",
@@ -140,7 +149,7 @@ func EnrichIAMUserMFA(ctx context.Context, clients *ServiceClients, resources []
 		if hasMFA || !hasConsolePassword {
 			mfaVal = "true"
 		}
-		fieldUpdates[r.ID] = map[string]string{
+		result.FieldUpdates[r.ID] = map[string]string{
 			"mfa":  mfaVal,
 			"risk": riskLabel,
 		}
@@ -148,11 +157,14 @@ func EnrichIAMUserMFA(ctx context.Context, clients *ServiceClients, resources []
 		if len(rows) == 0 {
 			continue
 		}
-		findings[r.ID] = resource.EnrichmentFinding{
-			Severity: severity,
-			Summary:  rows[0].Value,
-			Rows:     rows,
+		// Use the no-mfa code when severity is "!", otherwise old-key code.
+		code := iamUserCodeOldKey
+		if severity == "!" {
+			code = iamUserCodeNoMFA
 		}
+		setWave2Finding(&result, r.ID, code, rows[0].Value, severity, "iam-user", rows)
 	}
-	return IssueEnricherResult{IssueCount: issueCount, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates}, nil
+	result.IssueCount = issueCount
+	result.Truncated = truncated
+	return result, nil
 }

--- a/internal/aws/issue_enrichment.go
+++ b/internal/aws/issue_enrichment.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -47,11 +48,12 @@ type IssueEnricher struct {
 // AS-731 zero-hit grep gate for the prior name in internal/.
 func InFetcherWave2Sentinel(_ context.Context, _ *ServiceClients, _ []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
 	return IssueEnricherResult{
-		Findings:     map[string]resource.EnrichmentFinding{},
-		TruncatedIDs: map[string]bool{},
-		FieldUpdates: map[string]map[string]string{},
-		IssueCount:   0,
-		Truncated:    false,
+		Findings:         map[string]domain.Finding{},
+		AttentionDetails: map[string]domain.AttentionDetail{},
+		TruncatedIDs:     map[string]bool{},
+		FieldUpdates:     map[string]map[string]string{},
+		IssueCount:       0,
+		Truncated:        false,
 	}, nil
 }
 
@@ -79,6 +81,48 @@ func formatDate(t interface{ Format(string) string }) string {
 	return t.Format("2006-01-02")
 }
 
+// setWave2Finding writes a Wave-2 Finding + AttentionDetail pair into the
+// IssueEnricherResult maps. AS-1395 helper that keeps per-file migration
+// uniform: every enricher constructs its emission via this helper rather than
+// re-implementing the glyph→Severity mapping and the AttentionDetail{Rows: …}
+// packing in every file.
+//
+// severityGlyph: "!" → SevBroken, "~" → SevWarn, otherwise → SevDim. Matches
+// the legacy EnrichmentFinding.Severity glyph contract used by per-enricher
+// docstrings — view code now consumes domain.Severity directly.
+//
+// rows MAY be nil; the helper omits the AttentionDetail entry when empty so a
+// nil-row finding does not surface an empty Attention section.
+//
+// shortName stamps Source = "wave2:<shortName>" on the emitted Finding. It is
+// the resource short name the enricher serves (e.g. "acm", "dbi", "tg").
+//
+// The caller is responsible for initialising r.Findings and (when emitting
+// rows) r.AttentionDetails before calling this helper. The IssueEnricherResult
+// godoc requires both reference fields be non-nil on a successful return.
+func setWave2Finding(
+	r *IssueEnricherResult,
+	resourceID string,
+	code domain.FindingCode,
+	phrase string,
+	severityGlyph string,
+	shortName string,
+	rows []domain.DetailRow,
+) {
+	r.Findings[resourceID] = domain.Finding{
+		Code:     code,
+		Phrase:   phrase,
+		Severity: glyphToSeverity(severityGlyph),
+		Source:   "wave2:" + shortName,
+	}
+	if len(rows) > 0 {
+		if r.AttentionDetails == nil {
+			r.AttentionDetails = make(map[string]domain.AttentionDetail)
+		}
+		r.AttentionDetails[resourceID] = domain.AttentionDetail{Rows: rows}
+	}
+}
+
 // IssueEnricherResult is the typed return value of a Wave 2 issue enricher.
 //
 //   - IssueCount: number of resources classified issue-worthy for the menu badge
@@ -95,10 +139,16 @@ func formatDate(t interface{ Format(string) string }) string {
 //     instead of a global banner. An ID appearing here MUST NOT also appear in
 //     Findings unless the partial data was still usable.
 //
-//   - Findings: map from Resource.ID → EnrichmentFinding. May contain entries
-//     for resources NOT in the input slice (account-wide enrichers). Enrichers
-//     that receive API identifiers in a different form (e.g., ARNs) MUST
-//     normalize to Resource.ID before writing to Findings.
+//   - Findings: map from Resource.ID → domain.Finding. The enricher emits ≤1
+//     Finding per Resource.ID. May contain entries for resources NOT in the
+//     input slice (account-wide enrichers). Enrichers that receive API
+//     identifiers in a different form (e.g., ARNs) MUST normalize to
+//     Resource.ID before writing to Findings.
+//
+//   - AttentionDetails: per-resource supporting rows for the Wave-2 Finding,
+//     keyed by Resource.ID. Only entries with non-empty rows are emitted; the
+//     fold layer (runtime.Core.applyEnrichment) re-keys to FindingCode against
+//     the matching Finding when writing onto r.AttentionDetails.
 //
 //   - FieldUpdates: map from Resource.ID → (fieldKey → value). Same normalization
 //     rule applies.
@@ -109,7 +159,13 @@ type IssueEnricherResult struct {
 	IssueCount   int
 	Truncated    bool
 	TruncatedIDs map[string]bool
-	Findings     map[string]resource.EnrichmentFinding
+	Findings     map[string]domain.Finding
+	// AttentionDetails carries per-resource supporting rows for the Wave-2
+	// Finding emitted in Findings. Keyed by Resource.ID until the fold layer
+	// (runtime.Core.applyEnrichment) flips it to FindingCode against the
+	// matching r.Findings entry. Enrichers MAY omit this when no rows accompany
+	// the finding.
+	AttentionDetails map[string]domain.AttentionDetail
 	// FieldUpdates carries per-resource Fields[] mutations the enricher wants
 	// merged into the cached row. Keyed by resource ID, then by field key.
 	// Used by list columns and Color funcs that need access to Wave-2-derived

--- a/internal/aws/kms_issue_enrichment.go
+++ b/internal/aws/kms_issue_enrichment.go
@@ -7,7 +7,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// kms canonical FindingCodes.
+const (
+	kmsCodeRotationDisabled domain.FindingCode = "kms.rotation-disabled"
 )
 
 // EnrichKMSRotation calls GetKeyRotationStatus for each customer-managed key (cap EnrichmentCap)
@@ -16,11 +22,13 @@ import (
 // AWS-managed keys reject GetKeyRotationStatus with AccessDeniedException — that error is
 // silently skipped without marking Truncated. Other per-key errors set Truncated=true.
 func EnrichKMSRotation(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients.KMS == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	for i, r := range resources {
@@ -42,22 +50,21 @@ func EnrichKMSRotation(ctx context.Context, clients *ServiceClients, resources [
 			}
 			// Any other error: skip this key but signal incomplete data via truncated
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 		rotationVal := "false"
 		if out.KeyRotationEnabled {
 			rotationVal = "true"
 		}
-		fieldUpdates[keyID] = map[string]string{
+		result.FieldUpdates[keyID] = map[string]string{
 			"rotation_enabled": rotationVal,
 		}
 		if !out.KeyRotationEnabled {
-			findings[keyID] = resource.EnrichmentFinding{
-				Severity: "~",
-				Summary:  "key rotation disabled (CIS KMS.1)",
-			}
+			setWave2Finding(&result, keyID, kmsCodeRotationDisabled, "key rotation disabled (CIS KMS.1)", "~", "kms", nil)
 		}
 	}
-	return IssueEnricherResult{IssueCount: 0, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates}, nil
+	result.IssueCount = 0
+	result.Truncated = truncated
+	return result, nil
 }

--- a/internal/aws/logs_issue_enrichment.go
+++ b/internal/aws/logs_issue_enrichment.go
@@ -10,7 +10,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	cwlogssvc "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// logs canonical FindingCodes.
+const (
+	logsCodeMissingMetricFilters domain.FindingCode = "logs.missing-metric-filters"
 )
 
 // EnrichLogsMetricFilters calls DescribeMetricFilters per CloudTrail log group
@@ -24,15 +30,17 @@ import (
 // IssueCount stays 0 (severity "~" only).
 // Skip when clients.CloudWatchLogs == nil or does not implement CWLogsDescribeMetricFiltersAPI.
 func EnrichLogsMetricFilters(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients.CloudWatchLogs == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	metricFiltersAPI, ok := clients.CloudWatchLogs.(CWLogsDescribeMetricFiltersAPI)
 	if !ok {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	// CWLogsAPI already embeds CWLogsDescribeLogStreamsAPI, so the type assertion
 	// always succeeds for valid clients. However, test fakes that embed the interface
@@ -76,10 +84,10 @@ func EnrichLogsMetricFilters(ctx context.Context, clients *ServiceClients, resou
 					default:
 						rel = t.Format("2006-01-02")
 					}
-					if fieldUpdates[r.ID] == nil {
-						fieldUpdates[r.ID] = make(map[string]string)
+					if result.FieldUpdates[r.ID] == nil {
+						result.FieldUpdates[r.ID] = make(map[string]string)
 					}
-					fieldUpdates[r.ID]["last_event_at"] = rel
+					result.FieldUpdates[r.ID]["last_event_at"] = rel
 				}
 			}
 		}
@@ -97,7 +105,7 @@ func EnrichLogsMetricFilters(ctx context.Context, clients *ServiceClients, resou
 		if err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", r.ID, err))
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 
@@ -105,17 +113,15 @@ func EnrichLogsMetricFilters(ctx context.Context, clients *ServiceClients, resou
 			continue
 		}
 
-		findings[r.ID] = resource.EnrichmentFinding{
-			Severity: "~",
-			Summary:  "audit log group missing metric filters",
-			Rows: []resource.FindingRow{
-				{Label: "Log Group", Value: logGroupName, Tier: "~"},
-				{Label: "Metric Filters", Value: "none", Tier: "~"},
-			},
-		}
+		setWave2Finding(&result, r.ID, logsCodeMissingMetricFilters, "audit log group missing metric filters", "~", "logs", []domain.DetailRow{
+			{Label: "Log Group", Value: logGroupName, Tier: "~"},
+			{Label: "Metric Filters", Value: "none", Tier: "~"},
+		})
 	}
 	// Metric filter findings are severity "~" (informational); IssueCount stays 0.
-	return IssueEnricherResult{IssueCount: 0, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates},
+	result.IssueCount = 0
+	result.Truncated = truncated
+	return result,
 		AggregateFailures("logs-enrich: DescribeMetricFilters", failures, total)
 }
 

--- a/internal/aws/msk_issue_enrichment.go
+++ b/internal/aws/msk_issue_enrichment.go
@@ -10,7 +10,14 @@ import (
 	kafkasvc "github.com/aws/aws-sdk-go-v2/service/kafka"
 	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// msk canonical FindingCodes.
+const (
+	mskCodeBrokerOutdated    domain.FindingCode = "msk.broker-outdated"
+	mskCodeEncryptionNotTLS  domain.FindingCode = "msk.encryption-not-tls"
 )
 
 // EnrichMSKCluster calls DescribeClusterV2 per provisioned MSK cluster (cap EnrichmentCap)
@@ -21,10 +28,12 @@ import (
 // Serverless clusters (Provisioned==nil) are skipped.
 // Skip if clients.MSK == nil. Per-cluster errors → Truncated.
 func EnrichMSKCluster(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+	}
 	if clients.MSK == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	var failures []string
@@ -49,7 +58,7 @@ func EnrichMSKCluster(ctx context.Context, clients *ServiceClients, resources []
 		if err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", r.ID, err))
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 		if out.ClusterInfo == nil {
@@ -63,27 +72,23 @@ func EnrichMSKCluster(ctx context.Context, clients *ServiceClients, resources []
 		// Check broker software version.
 		if prov.CurrentBrokerSoftwareInfo != nil && prov.CurrentBrokerSoftwareInfo.KafkaVersion != nil {
 			if isMSKVersionOutdated(*prov.CurrentBrokerSoftwareInfo.KafkaVersion) {
-				findings[r.ID] = resource.EnrichmentFinding{
-					Severity: "~",
-					Summary:  "broker software outdated",
-				}
+				setWave2Finding(&result, r.ID, mskCodeBrokerOutdated, "broker software outdated", "~", "msk", nil)
 			}
 		}
 		// Check encryption in transit (only set finding if not already set).
-		if _, alreadyFound := findings[r.ID]; !alreadyFound {
+		if _, alreadyFound := result.Findings[r.ID]; !alreadyFound {
 			if prov.EncryptionInfo != nil &&
 				prov.EncryptionInfo.EncryptionInTransit != nil &&
 				prov.EncryptionInfo.EncryptionInTransit.ClientBroker != kafkatypes.ClientBrokerTls {
-				findings[r.ID] = resource.EnrichmentFinding{
-					Severity: "~",
-					Summary:  "encryption in transit not enforced",
-				}
+				setWave2Finding(&result, r.ID, mskCodeEncryptionNotTLS, "encryption in transit not enforced", "~", "msk", nil)
 			}
 		}
 	}
 	// All MSK findings are severity "~" (informational) and do not contribute to the
 	// attention menu badge. IssueCount is always 0 for this enricher.
-	return IssueEnricherResult{IssueCount: 0, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings},
+	result.IssueCount = 0
+	result.Truncated = truncated
+	return result,
 		AggregateFailures("msk-enrich: DescribeClusterV2", failures, total)
 }
 

--- a/internal/aws/opensearch_issue_enrichment.go
+++ b/internal/aws/opensearch_issue_enrichment.go
@@ -5,10 +5,17 @@ package aws
 import (
 	"context"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-// EnrichOpenSearchDomains emits EnrichmentFindings for background-check signals
+// opensearch canonical FindingCodes.
+const (
+	opensearchCodeUpdateForced   domain.FindingCode = "opensearch.update-forced"
+	opensearchCodeEncryptionOff  domain.FindingCode = "opensearch.encryption-off"
+)
+
+// EnrichOpenSearchDomains emits Findings for background-check signals
 // read from resource Fields populated by FetchOpenSearchDomains:
 //
 //   - service_software_update_available == "true"  → Severity "!", Summary "software update forced soon"
@@ -23,7 +30,10 @@ import (
 // No FieldUpdates — the fetcher is authoritative for Status on opensearch.
 // clients may be nil; no API calls are made.
 func EnrichOpenSearchDomains(_ context.Context, _ *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+	}
 	bangCount := 0
 
 	for _, r := range resources {
@@ -48,48 +58,34 @@ func EnrichOpenSearchDomains(_ context.Context, _ *ServiceClients, resources []r
 			continue
 		}
 
-		var finding resource.EnrichmentFinding
-
 		if updateAvailable {
 			// "!" branch — update forced soon. Include enc-off as additional row
 			// when both signals are active so the "~" finding is not lost.
-			var rows []resource.FindingRow
+			var rows []domain.DetailRow
 			if updateDate := r.Fields["automated_update_date"]; updateDate != "" {
-				rows = append(rows, resource.FindingRow{Label: "Automated Update", Value: updateDate, Tier: "!"})
+				rows = append(rows, domain.DetailRow{Label: "Automated Update", Value: updateDate, Tier: "!"})
 			}
 			if cv := r.Fields["current_version"]; cv != "" {
-				rows = append(rows, resource.FindingRow{Label: "Current Version", Value: cv})
+				rows = append(rows, domain.DetailRow{Label: "Current Version", Value: cv})
 			}
 			if nv := r.Fields["new_version"]; nv != "" {
-				rows = append(rows, resource.FindingRow{Label: "New Version", Value: nv})
+				rows = append(rows, domain.DetailRow{Label: "New Version", Value: nv})
 			}
 			if encOff {
 				// Surface the hidden ~ finding as an additional row (U11 contract:
 				// its value must not appear in Summary).
-				rows = append(rows, resource.FindingRow{Label: "Additional", Value: "encryption at rest off", Tier: "~"})
+				rows = append(rows, domain.DetailRow{Label: "Additional", Value: "encryption at rest off", Tier: "~"})
 			}
-			finding = resource.EnrichmentFinding{
-				Severity: "!",
-				Summary:  "software update forced soon",
-				Rows:     rows,
-			}
+			setWave2Finding(&result, r.ID, opensearchCodeUpdateForced, "software update forced soon", "!", "opensearch", rows)
 			bangCount++
 		} else {
 			// Only enc-off — "~" finding, no rows needed.
-			finding = resource.EnrichmentFinding{
-				Severity: "~",
-				Summary:  "encryption at rest off",
-			}
+			setWave2Finding(&result, r.ID, opensearchCodeEncryptionOff, "encryption at rest off", "~", "opensearch", nil)
 			// "~" never bumps bangCount.
 		}
-
-		findings[r.ID] = finding
 	}
 
-	return IssueEnricherResult{
-		IssueCount:   bangCount,
-		TruncatedIDs: map[string]bool{},
-		Findings:     findings,
-		// FieldUpdates intentionally nil — fetcher is authoritative for Status.
-	}, nil
+	result.IssueCount = bangCount
+	// FieldUpdates intentionally nil — fetcher is authoritative for Status.
+	return result, nil
 }

--- a/internal/aws/pipeline_issue_enrichment.go
+++ b/internal/aws/pipeline_issue_enrichment.go
@@ -9,18 +9,26 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/codepipeline"
 	cptypes "github.com/aws/aws-sdk-go-v2/service/codepipeline/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// pipeline canonical FindingCodes.
+const (
+	pipelineCodeStageFailed domain.FindingCode = "pipeline.stage-failed"
 )
 
 // EnrichCodePipelineStatus calls GetPipelineState for each pipeline (1 per pipeline, cap ~50).
 // Returns a Finding for each pipeline with a failed stage.
 // Severity is "!" (broken/degraded). Summary: "stage <Name> failed".
 func EnrichCodePipelineStatus(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients.CodePipeline == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	var failures []string
@@ -41,7 +49,7 @@ func EnrichCodePipelineStatus(ctx context.Context, clients *ServiceClients, reso
 		if err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", r.ID, err))
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 		key := r.ID
@@ -58,7 +66,7 @@ func EnrichCodePipelineStatus(ctx context.Context, clients *ServiceClients, reso
 				stageName = *stage.StageName
 			}
 			lastStatus = stageName
-			rows := []resource.FindingRow{
+			rows := []domain.DetailRow{
 				{Label: "Failed Stage", Value: stageName, Tier: "!"},
 				{Label: "Status", Value: string(stage.LatestExecution.Status)},
 			}
@@ -73,20 +81,18 @@ func EnrichCodePipelineStatus(ctx context.Context, clients *ServiceClients, reso
 				if action.LatestExecution.ErrorDetails != nil && action.LatestExecution.ErrorDetails.Message != nil {
 					msg := *action.LatestExecution.ErrorDetails.Message
 					if msg != "" {
-						rows = append(rows, resource.FindingRow{Label: "Error", Value: msg, Tier: "!"})
+						rows = append(rows, domain.DetailRow{Label: "Error", Value: msg, Tier: "!"})
 					}
 					break
 				}
 			}
-			findings[key] = resource.EnrichmentFinding{
-				Severity: "!",
-				Summary:  fmt.Sprintf("stage %s failed", stageName),
-				Rows:     rows,
-			}
+			setWave2Finding(&result, key, pipelineCodeStageFailed, fmt.Sprintf("stage %s failed", stageName), "!", "pipeline", rows)
 			break // first failed stage is sufficient
 		}
-		fieldUpdates[key] = map[string]string{"last_status": lastStatus}
+		result.FieldUpdates[key] = map[string]string{"last_status": lastStatus}
 	}
-	return IssueEnricherResult{IssueCount: len(findings), Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates},
+	result.IssueCount = len(result.Findings)
+	result.Truncated = truncated
+	return result,
 		AggregateFailures("pipeline-enrich: GetPipelineState", failures, total)
 }

--- a/internal/aws/r53_issue_enrichment.go
+++ b/internal/aws/r53_issue_enrichment.go
@@ -8,7 +8,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	r53svc "github.com/aws/aws-sdk-go-v2/service/route53"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// r53 canonical FindingCodes.
+const (
+	r53CodeOrphanPrivateZone domain.FindingCode = "r53.orphan-private-zone"
 )
 
 // EnrichRoute53Zone calls GetHostedZone per zone (cap EnrichmentCap) and raises a finding
@@ -20,10 +26,12 @@ import (
 //
 // Skip if clients.Route53 == nil. Per-zone errors → Truncated.
 func EnrichRoute53Zone(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+	}
 	if clients.Route53 == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	var failures []string
@@ -48,7 +56,7 @@ func EnrichRoute53Zone(ctx context.Context, clients *ServiceClients, resources [
 		if err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", r.ID, err))
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 		if out.HostedZone == nil {
@@ -61,16 +69,14 @@ func EnrichRoute53Zone(ctx context.Context, clients *ServiceClients, resources [
 		if len(out.VPCs) > 0 {
 			continue
 		}
-		findings[r.ID] = resource.EnrichmentFinding{
-			Severity: "~",
-			Summary:  "private zone with no VPC associations (orphan)",
-			Rows: []resource.FindingRow{
-				{Label: "Zone ID", Value: zoneID, Tier: "~"},
-				{Label: "Issue", Value: "private zone with no VPC associations (orphan)", Tier: "~"},
-			},
-		}
+		setWave2Finding(&result, r.ID, r53CodeOrphanPrivateZone, "private zone with no VPC associations (orphan)", "~", "r53", []domain.DetailRow{
+			{Label: "Zone ID", Value: zoneID, Tier: "~"},
+			{Label: "Issue", Value: "private zone with no VPC associations (orphan)", Tier: "~"},
+		})
 	}
 	// All Route53 findings are severity "~" (informational).
-	return IssueEnricherResult{IssueCount: 0, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings},
+	result.IssueCount = 0
+	result.Truncated = truncated
+	return result,
 		AggregateFailures("r53-enrich: GetHostedZone", failures, total)
 }

--- a/internal/aws/rds_issue_enrichment.go
+++ b/internal/aws/rds_issue_enrichment.go
@@ -7,7 +7,13 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// rds canonical FindingCodes.
+const (
+	rdsCodePendingMaintenance domain.FindingCode = "rds.pending-maintenance"
 )
 
 // EnrichRDSDocDBMaintenance calls DescribePendingMaintenanceActions (account-wide, paginated)
@@ -16,10 +22,12 @@ import (
 // The API returns maintenance actions for all RDS/DocDB resources (clusters AND instances).
 // Pagination uses Marker; walks up to EnrichmentCap pages.
 func EnrichRDSDocDBMaintenance(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+	}
 	if clients.RDS == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	type maintenanceAction = rds.DescribePendingMaintenanceActionsOutput
 	var allPages []*maintenanceAction
@@ -36,7 +44,7 @@ func EnrichRDSDocDBMaintenance(ctx context.Context, clients *ServiceClients, res
 		})
 		pages++
 		if err != nil {
-			return IssueEnricherResult{TruncatedIDs: truncatedIDs}, err
+			return IssueEnricherResult{TruncatedIDs: result.TruncatedIDs}, err
 		}
 		allPages = append(allPages, out)
 		if out.Marker == nil {
@@ -66,7 +74,7 @@ func EnrichRDSDocDBMaintenance(ctx context.Context, clients *ServiceClients, res
 			}
 			// Collect action descriptions for the summary and rows.
 			var actions []string
-			var rows []resource.FindingRow
+			var rows []domain.DetailRow
 			for _, pa := range action.PendingMaintenanceActionDetails {
 				if pa.Action != nil {
 					actions = append(actions, *pa.Action)
@@ -87,16 +95,16 @@ func EnrichRDSDocDBMaintenance(ctx context.Context, clients *ServiceClients, res
 					earliestTarget = formatDate(pa.ForcedApplyDate)
 				}
 				if actionVal != "" {
-					rows = append(rows, resource.FindingRow{Label: "Action", Value: actionVal, Tier: "~"})
+					rows = append(rows, domain.DetailRow{Label: "Action", Value: actionVal, Tier: "~"})
 				}
 				if applyMethod != "" {
-					rows = append(rows, resource.FindingRow{Label: "Apply Method", Value: applyMethod})
+					rows = append(rows, domain.DetailRow{Label: "Apply Method", Value: applyMethod})
 				}
 				if earliestTarget != "" {
-					rows = append(rows, resource.FindingRow{Label: "Earliest Target", Value: earliestTarget, Tier: "~"})
+					rows = append(rows, domain.DetailRow{Label: "Earliest Target", Value: earliestTarget, Tier: "~"})
 				}
 				if pa.Description != nil && *pa.Description != "" {
-					rows = append(rows, resource.FindingRow{Label: "Description", Value: *pa.Description})
+					rows = append(rows, domain.DetailRow{Label: "Description", Value: *pa.Description})
 				}
 			}
 			summary := "pending maintenance"
@@ -119,12 +127,10 @@ func EnrichRDSDocDBMaintenance(ctx context.Context, clients *ServiceClients, res
 				// for an instance; or page truncation evicted it). Append to
 				continue
 			}
-			findings[key] = resource.EnrichmentFinding{
-				Severity: "~",
-				Summary:  summary,
-				Rows:     rows,
-			}
+			setWave2Finding(&result, key, rdsCodePendingMaintenance, summary, "~", "rds", rows)
 		}
 	}
-	return IssueEnricherResult{IssueCount: 0, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings}, nil
+	result.IssueCount = 0
+	result.Truncated = truncated
+	return result, nil
 }

--- a/internal/aws/s3_issue_enrichment.go
+++ b/internal/aws/s3_issue_enrichment.go
@@ -10,14 +10,20 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	smithy "github.com/aws/smithy-go"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// s3 canonical FindingCodes.
+const (
+	s3CodePublicAccessBlockIncomplete domain.FindingCode = "s3.public-access-block-incomplete"
 )
 
 // EnrichS3PublicAccessBlock calls GetPublicAccessBlock per bucket (cap EnrichmentCap)
 // and emits a finding when the bucket has no PAB configuration or when any of the
 // four PAB flags is false.
 //
-// Contract (EnrichmentFinding):
+// Contract (Finding):
 //   - Severity is always "!" (important background concern on a Healthy row).
 //   - Summary is always "public access block incomplete" — stable across all instances.
 //   - Rows carry the per-case detail (never duplicated in Summary).
@@ -46,11 +52,13 @@ import (
 // the failure aggregates into the returned composite error.
 // IssueCount stays 0 (framework counts "!" findings directly).
 func EnrichS3PublicAccessBlock(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients.S3 == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	var failures []string
@@ -75,15 +83,11 @@ func EnrichS3PublicAccessBlock(ctx context.Context, clients *ServiceClients, res
 		if err != nil {
 			var apiErr smithy.APIError
 			if errors.As(err, &apiErr) && apiErr.ErrorCode() == "NoSuchPublicAccessBlockConfiguration" {
-				findings[name] = resource.EnrichmentFinding{
-					Severity: "!",
-					Summary:  "public access block incomplete",
-					Rows: []resource.FindingRow{
-						{Label: "Status", Value: "no public access block configuration"},
-						{Label: "Account-level PAB", Value: "may still apply"},
-					},
-				}
-				fieldUpdates[name] = map[string]string{"status": "public access block incomplete"}
+				setWave2Finding(&result, name, s3CodePublicAccessBlockIncomplete, "public access block incomplete", "!", "s3", []domain.DetailRow{
+					{Label: "Status", Value: "no public access block configuration"},
+					{Label: "Account-level PAB", Value: "may still apply"},
+				})
+				result.FieldUpdates[name] = map[string]string{"status": "public access block incomplete"}
 				continue
 			}
 			// Cross-region buckets: ListBuckets returns ALL buckets globally, but
@@ -96,25 +100,21 @@ func EnrichS3PublicAccessBlock(ctx context.Context, clients *ServiceClients, res
 			// related-def checkers in s3_related.go via isS3CrossRegionErr.
 			if isS3CrossRegionErr(err) {
 				truncated = true
-				truncatedIDs[r.ID] = true
+				result.TruncatedIDs[r.ID] = true
 				continue
 			}
 			// Other errors: data incomplete — do not emit a finding.
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			failures = append(failures, fmt.Sprintf("%s: %v", name, err))
 			continue
 		}
 		if out.PublicAccessBlockConfiguration == nil {
-			findings[name] = resource.EnrichmentFinding{
-				Severity: "!",
-				Summary:  "public access block incomplete",
-				Rows: []resource.FindingRow{
-					{Label: "Status", Value: "no public access block configuration"},
-					{Label: "Account-level PAB", Value: "may still apply"},
-				},
-			}
-			fieldUpdates[name] = map[string]string{"status": "public access block incomplete"}
+			setWave2Finding(&result, name, s3CodePublicAccessBlockIncomplete, "public access block incomplete", "!", "s3", []domain.DetailRow{
+				{Label: "Status", Value: "no public access block configuration"},
+				{Label: "Account-level PAB", Value: "may still apply"},
+			})
+			result.FieldUpdates[name] = map[string]string{"status": "public access block incomplete"}
 			continue
 		}
 		cfg := out.PublicAccessBlockConfiguration
@@ -128,24 +128,22 @@ func EnrichS3PublicAccessBlock(ctx context.Context, clients *ServiceClients, res
 			{"BlockPublicPolicy", cfg.BlockPublicPolicy},
 			{"RestrictPublicBuckets", cfg.RestrictPublicBuckets},
 		}
-		var falseFlags []resource.FindingRow
+		var falseFlags []domain.DetailRow
 		for _, fc := range flags {
 			if fc.value == nil || !*fc.value {
-				falseFlags = append(falseFlags, resource.FindingRow{Label: fc.name, Value: "false"})
+				falseFlags = append(falseFlags, domain.DetailRow{Label: fc.name, Value: "false"})
 			}
 		}
 		if len(falseFlags) == 0 {
 			// All flags true — healthy bucket. No finding.
 			continue
 		}
-		falseFlags = append(falseFlags, resource.FindingRow{Label: "Account-level PAB", Value: "may still apply"})
-		findings[name] = resource.EnrichmentFinding{
-			Severity: "!",
-			Summary:  "public access block incomplete",
-			Rows:     falseFlags,
-		}
-		fieldUpdates[name] = map[string]string{"status": "public access block incomplete"}
+		falseFlags = append(falseFlags, domain.DetailRow{Label: "Account-level PAB", Value: "may still apply"})
+		setWave2Finding(&result, name, s3CodePublicAccessBlockIncomplete, "public access block incomplete", "!", "s3", falseFlags)
+		result.FieldUpdates[name] = map[string]string{"status": "public access block incomplete"}
 	}
-	return IssueEnricherResult{IssueCount: 0, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates},
+	result.IssueCount = 0
+	result.Truncated = truncated
+	return result,
 		AggregateFailures("s3-enrich: GetPublicAccessBlock", failures, total)
 }

--- a/internal/aws/ses_issue_enrichment.go
+++ b/internal/aws/ses_issue_enrichment.go
@@ -7,7 +7,15 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/sesv2"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// ses canonical FindingCodes.
+const (
+	sesCodeShutdown  domain.FindingCode = "ses.account-shutdown"
+	sesCodeProbation domain.FindingCode = "ses.account-probation"
+	sesCodeQuota     domain.FindingCode = "ses.quota-high"
 )
 
 // EnrichSESAccount calls sesv2:GetAccount once (account-wide) and replicates
@@ -26,12 +34,14 @@ import (
 // account regardless of how many identity rows are in the list (spec §4
 // "S1 counts the account-level finding once, not N times").
 func EnrichSESAccount(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	truncatedIDs := make(map[string]bool)
-	fieldUpdates := make(map[string]map[string]string)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 
 	if clients == nil || clients.SESv2 == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs, FieldUpdates: fieldUpdates}, nil
+		return result, nil
 	}
 
 	out, err := clients.SESv2.GetAccount(ctx, &sesv2.GetAccountInput{})
@@ -40,63 +50,49 @@ func EnrichSESAccount(ctx context.Context, clients *ServiceClients, resources []
 		// initialized maps so a caller that writes into result.Findings or
 		// result.FieldUpdates cannot panic on a nil map. Range over nil is
 		// safe, but writes would not be.
-		return IssueEnricherResult{
-			Findings:     findings,
-			FieldUpdates: fieldUpdates,
-			TruncatedIDs: truncatedIDs,
-		}, err
+		return result, err
 	}
 
 	// Decide the single account-level finding using §4 precedence.
-	finding, hasFinding := sesAccountFinding(out)
+	code, phrase, severityGlyph, rows, hasFinding := sesAccountFinding(out)
 	if !hasFinding {
-		return IssueEnricherResult{
-			IssueCount:   0,
-			Truncated:    false,
-			TruncatedIDs: truncatedIDs,
-			Findings:     findings,
-			FieldUpdates: fieldUpdates,
-		}, nil
+		return result, nil
 	}
 
 	// Replicate the finding onto every identity row.
 	for _, res := range resources {
-		findings[res.ID] = finding
+		setWave2Finding(&result, res.ID, code, phrase, severityGlyph, "ses", rows)
 
 		// S4 FieldUpdate: Healthy row → set to summary; non-Healthy → bump suffix.
 		var newStatus string
 		if res.Status == "" {
-			newStatus = finding.Summary
+			newStatus = phrase
 		} else {
 			newStatus = resource.BumpFindingSuffix(res.Status)
 		}
-		fieldUpdates[res.ID] = map[string]string{"status": newStatus}
+		result.FieldUpdates[res.ID] = map[string]string{"status": newStatus}
 	}
 
 	// IssueCount: 1 if "!" severity (account counted once), else 0.
 	issueCount := 0
-	if finding.Severity == "!" {
+	if severityGlyph == "!" {
 		issueCount = 1
 	}
 
-	return IssueEnricherResult{
-		IssueCount:   issueCount,
-		Truncated:    false,
-		TruncatedIDs: truncatedIDs,
-		Findings:     findings,
-		FieldUpdates: fieldUpdates,
-	}, nil
+	result.IssueCount = issueCount
+	result.Truncated = false
+	return result, nil
 }
 
 // sesAccountFinding derives the single account-level finding from GetAccount output.
-// Returns (finding, true) when a finding exists, or (zero, false) when the account
-// is healthy and below the quota threshold.
+// Returns (code, phrase, severityGlyph, rows, hasFinding) when a finding exists,
+// or ("", "", "", nil, false) when the account is healthy and below the quota threshold.
 //
-// U11 contract: Summary is the short S4 phrase only; per-account context lives in
-// Rows (Enforcement Status / Sent Last 24h / Max 24h Send). strings.Contains(Summary, rowValue) == false.
-func sesAccountFinding(out *sesv2.GetAccountOutput) (resource.EnrichmentFinding, bool) {
+// U11 contract: phrase is the short S4 phrase only; per-account context lives in
+// rows (Enforcement Status / Sent Last 24h / Max 24h Send). strings.Contains(phrase, rowValue) == false.
+func sesAccountFinding(out *sesv2.GetAccountOutput) (domain.FindingCode, string, string, []domain.DetailRow, bool) {
 	if out == nil {
-		return resource.EnrichmentFinding{}, false
+		return "", "", "", nil, false
 	}
 
 	enforcementStatus := ""
@@ -106,20 +102,12 @@ func sesAccountFinding(out *sesv2.GetAccountOutput) (resource.EnrichmentFinding,
 
 	switch enforcementStatus {
 	case "SHUTDOWN":
-		return resource.EnrichmentFinding{
-			Severity: "!",
-			Summary:  "account SHUTDOWN",
-			Rows: []resource.FindingRow{
-				{Label: "Action", Value: "Open an AWS support case after fixing the underlying issue", Tier: "!"},
-			},
+		return sesCodeShutdown, "account SHUTDOWN", "!", []domain.DetailRow{
+			{Label: "Action", Value: "Open an AWS support case after fixing the underlying issue", Tier: "!"},
 		}, true
 	case "PROBATION":
-		return resource.EnrichmentFinding{
-			Severity: "!",
-			Summary:  "account PROBATION",
-			Rows: []resource.FindingRow{
-				{Label: "Action", Value: "Reduce bounce/complaint rate before AWS suspends sending", Tier: "!"},
-			},
+		return sesCodeProbation, "account PROBATION", "!", []domain.DetailRow{
+			{Label: "Action", Value: "Reduce bounce/complaint rate before AWS suspends sending", Tier: "!"},
 		}, true
 	}
 
@@ -130,16 +118,12 @@ func sesAccountFinding(out *sesv2.GetAccountOutput) (resource.EnrichmentFinding,
 		if sent > 0.8*max {
 			sentStr := strconv.FormatFloat(sent, 'f', -1, 64)
 			maxStr := strconv.FormatFloat(max, 'f', -1, 64)
-			return resource.EnrichmentFinding{
-				Severity: "~",
-				Summary:  "quota 80%+ used",
-				Rows: []resource.FindingRow{
-					{Label: "Sent Last 24h", Value: sentStr, Tier: "~"},
-					{Label: "Max 24h Send", Value: maxStr},
-				},
+			return sesCodeQuota, "quota 80%+ used", "~", []domain.DetailRow{
+				{Label: "Sent Last 24h", Value: sentStr, Tier: "~"},
+				{Label: "Max 24h Send", Value: maxStr},
 			}, true
 		}
 	}
 
-	return resource.EnrichmentFinding{}, false
+	return "", "", "", nil, false
 }

--- a/internal/aws/sfn_issue_enrichment.go
+++ b/internal/aws/sfn_issue_enrichment.go
@@ -10,18 +10,26 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sfn"
 	sfntypes "github.com/aws/aws-sdk-go-v2/service/sfn/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// sfn canonical FindingCodes.
+const (
+	sfnCodeLatestExecutionFailed domain.FindingCode = "sfn.latest-execution-failed"
 )
 
 // EnrichStepFunctionsStatus calls ListExecutions(max:1) for each state machine (1 per SFN, cap ~50).
 // Returns a Finding for each state machine whose latest execution is FAILED, TIMED_OUT, or ABORTED.
 // Severity is "!" (broken/degraded). Summary: "latest execution <STATUS>".
 func EnrichStepFunctionsStatus(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients.SFN == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	var failures []string
@@ -50,7 +58,7 @@ func EnrichStepFunctionsStatus(ctx context.Context, clients *ServiceClients, res
 		if err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", r.ID, err))
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 		if len(out.Executions) > 0 {
@@ -65,26 +73,24 @@ func EnrichStepFunctionsStatus(ctx context.Context, clients *ServiceClients, res
 				} else {
 					lastRunVal = string(s)
 				}
-				rows := []resource.FindingRow{
+				rows := []domain.DetailRow{
 					{Label: "Latest Status", Value: string(s), Tier: "!"},
 				}
 				if exec.StopDate != nil {
-					rows = append(rows, resource.FindingRow{Label: "Ended", Value: exec.StopDate.Format("2006-01-02")})
+					rows = append(rows, domain.DetailRow{Label: "Ended", Value: exec.StopDate.Format("2006-01-02")})
 				}
 				if exec.Name != nil && *exec.Name != "" {
-					rows = append(rows, resource.FindingRow{Label: "Execution Name", Value: *exec.Name})
+					rows = append(rows, domain.DetailRow{Label: "Execution Name", Value: *exec.Name})
 				}
-				findings[r.ID] = resource.EnrichmentFinding{
-					Severity: "!",
-					Summary:  fmt.Sprintf("latest execution %s", string(s)),
-					Rows:     rows,
-				}
+				setWave2Finding(&result, r.ID, sfnCodeLatestExecutionFailed, fmt.Sprintf("latest execution %s", string(s)), "!", "sfn", rows)
 			}
-			fieldUpdates[r.ID] = map[string]string{
+			result.FieldUpdates[r.ID] = map[string]string{
 				"last_run": lastRunVal,
 			}
 		}
 	}
-	return IssueEnricherResult{IssueCount: len(findings), Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates},
+	result.IssueCount = len(result.Findings)
+	result.Truncated = truncated
+	return result,
 		AggregateFailures("sfn-enrich: ListExecutions", failures, total)
 }

--- a/internal/aws/snapshot_cross_ref.go
+++ b/internal/aws/snapshot_cross_ref.go
@@ -31,6 +31,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -85,10 +86,22 @@ type SnapshotCrossRefConfig struct {
 	RetentionEnabled bool
 
 	// Severity is the severity tier emitted on every FindingRow and on the
-	// EnrichmentFinding.Severity for this enricher's output. "!" for the
+	// domain.Finding.Severity for this enricher's output. "!" for the
 	// existing snapshot consumers (orphan + past-retention are operator-
 	// actionable). Future consumers may use "~" for informational signals.
+	// Internally mapped to domain.Severity via glyphToSeverity.
 	Severity string
+
+	// OrphanCode is the canonical FindingCode emitted when the orphan rule
+	// fires (e.g. "dbi-snap.orphan"). Required.
+	OrphanCode domain.FindingCode
+	// PastRetentionCode is the canonical FindingCode emitted when the past-
+	// retention rule fires (e.g. "dbi-snap.past-retention"). Required when
+	// RetentionEnabled is true.
+	PastRetentionCode domain.FindingCode
+	// ShortName is the resource short name used to stamp the Source field
+	// ("wave2:<short>") on every emitted Finding. Required.
+	ShortName string
 }
 
 // EnrichSnapshotCrossRef returns an IssueEnricherFunc that applies the
@@ -105,10 +118,13 @@ func EnrichSnapshotCrossRef(cfg SnapshotCrossRefConfig) IssueEnricherFunc {
 		if severity == "" {
 			severity = "!"
 		}
+		sev := glyphToSeverity(severity)
+		source := "wave2:" + cfg.ShortName
 
 		result := IssueEnricherResult{
-			Findings:     make(map[string]resource.EnrichmentFinding),
-			TruncatedIDs: make(map[string]bool),
+			Findings:         make(map[string]domain.Finding),
+			AttentionDetails: make(map[string]domain.AttentionDetail),
+			TruncatedIDs:     make(map[string]bool),
 		}
 
 		// Skip rule per spec §3.1: the cross-ref enricher requires the parent
@@ -132,8 +148,9 @@ func EnrichSnapshotCrossRef(cfg SnapshotCrossRefConfig) IssueEnricherFunc {
 
 			parentRaw, parentFound := parentByID[parentID]
 
-			var newPhrases []string
-			var rows []resource.FindingRow
+			var phrase string
+			var code domain.FindingCode
+			var rows []domain.DetailRow
 
 			switch {
 			case !parentFound:
@@ -143,8 +160,9 @@ func EnrichSnapshotCrossRef(cfg SnapshotCrossRefConfig) IssueEnricherFunc {
 				if parentEntry.IsTruncated {
 					continue
 				}
-				newPhrases = append(newPhrases, cfg.OrphanPhrase)
-				rows = append(rows, resource.FindingRow{
+				phrase = cfg.OrphanPhrase
+				code = cfg.OrphanCode
+				rows = append(rows, domain.DetailRow{
 					Label: cfg.ParentRowLabel,
 					Value: parentID + " (not in loaded list)",
 					Tier:  severity,
@@ -167,18 +185,19 @@ func EnrichSnapshotCrossRef(cfg SnapshotCrossRefConfig) IssueEnricherFunc {
 					continue
 				}
 				overD := ageD - retentionD
-				newPhrases = append(newPhrases, cfg.RetentionPhrase(overD))
-				rows = append(rows, resource.FindingRow{
+				phrase = cfg.RetentionPhrase(overD)
+				code = cfg.PastRetentionCode
+				rows = append(rows, domain.DetailRow{
 					Label: cfg.ParentRowLabel,
 					Value: parentID,
 					Tier:  severity,
 				})
-				rows = append(rows, resource.FindingRow{
+				rows = append(rows, domain.DetailRow{
 					Label: "Retention",
 					Value: fmt.Sprintf("%d days", retention),
 					Tier:  severity,
 				})
-				rows = append(rows, resource.FindingRow{
+				rows = append(rows, domain.DetailRow{
 					Label: "Created",
 					Value: createdAt.Format("2006-01-02"),
 					Tier:  severity,
@@ -188,21 +207,40 @@ func EnrichSnapshotCrossRef(cfg SnapshotCrossRefConfig) IssueEnricherFunc {
 				continue
 			}
 
-			if len(newPhrases) == 0 {
+			if phrase == "" {
 				continue
 			}
 
-			// Findings emits the entries for the detail-view Attention section
+			// Findings emits the entry for the detail-view Attention section
 			// AND drives the S4 status column at render time via
 			// phraseFromFindings(r.Findings) (per AS-140).
-			result.Findings[res.ID] = resource.EnrichmentFinding{
-				Severity: severity,
-				Summary:  newPhrases[0],
-				Rows:     rows,
+			result.Findings[res.ID] = domain.Finding{
+				Code:     code,
+				Phrase:   phrase,
+				Severity: sev,
+				Source:   source,
+			}
+			if len(rows) > 0 {
+				result.AttentionDetails[res.ID] = domain.AttentionDetail{Rows: rows}
 			}
 		}
 
 		return result, nil
+	}
+}
+
+// glyphToSeverity maps a legacy "!" / "~" / "" severity glyph to the canonical
+// domain.Severity. Used by snapshot_cross_ref.go (and any other enricher
+// callsite that still parameterizes via glyph strings) until the per-enricher
+// migration replaces the glyph parameter with a typed domain.Severity.
+func glyphToSeverity(s string) domain.Severity {
+	switch s {
+	case "!":
+		return domain.SevBroken
+	case "~":
+		return domain.SevWarn
+	default:
+		return domain.SevDim
 	}
 }
 

--- a/internal/aws/sns_issue_enrichment.go
+++ b/internal/aws/sns_issue_enrichment.go
@@ -8,18 +8,27 @@ import (
 	snssvc "github.com/aws/aws-sdk-go-v2/service/sns"
 	snstypes "github.com/aws/aws-sdk-go-v2/service/sns/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// sns canonical FindingCodes.
+const (
+	snsCodeNoSubscribers    domain.FindingCode = "sns.no-subscribers"
+	snsCodeAllPending       domain.FindingCode = "sns.all-pending-confirmation"
 )
 
 // EnrichSNSSubscriptions calls ListSubscriptionsByTopic per topic (cap EnrichmentCap)
 // to surface orphan topics and topics with all-pending-confirmation subscribers.
 // Per-topic errors are treated as truncated (skip silently).
 func EnrichSNSSubscriptions(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients.SNS == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	for i, r := range resources {
@@ -41,7 +50,7 @@ func EnrichSNSSubscriptions(ctx context.Context, clients *ServiceClients, resour
 			})
 			if err != nil {
 				truncated = true
-				truncatedIDs[r.ID] = true
+				result.TruncatedIDs[r.ID] = true
 				pagedErr = true
 				break
 			}
@@ -54,17 +63,13 @@ func EnrichSNSSubscriptions(ctx context.Context, clients *ServiceClients, resour
 		if pagedErr {
 			continue
 		}
-		fieldUpdates[r.ID] = map[string]string{
+		result.FieldUpdates[r.ID] = map[string]string{
 			"subs_count": resource.FormatExact(len(subs)),
 		}
 		if len(subs) == 0 {
-			findings[r.ID] = resource.EnrichmentFinding{
-				Severity: "~",
-				Summary:  "topic has no subscribers",
-				Rows: []resource.FindingRow{
-					{Label: "Subscribers", Value: "topic has no subscribers", Tier: "~"},
-				},
-			}
+			setWave2Finding(&result, r.ID, snsCodeNoSubscribers, "topic has no subscribers", "~", "sns", []domain.DetailRow{
+				{Label: "Subscribers", Value: "topic has no subscribers", Tier: "~"},
+			})
 			continue
 		}
 		allPending := true
@@ -79,14 +84,12 @@ func EnrichSNSSubscriptions(ctx context.Context, clients *ServiceClients, resour
 			}
 		}
 		if allPending {
-			findings[r.ID] = resource.EnrichmentFinding{
-				Severity: "~",
-				Summary:  "all pending confirmation",
-				Rows: []resource.FindingRow{
-					{Label: "Subscribers", Value: "all pending confirmation", Tier: "~"},
-				},
-			}
+			setWave2Finding(&result, r.ID, snsCodeAllPending, "all pending confirmation", "~", "sns", []domain.DetailRow{
+				{Label: "Subscribers", Value: "all pending confirmation", Tier: "~"},
+			})
 		}
 	}
-	return IssueEnricherResult{IssueCount: 0, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates}, nil
+	result.IssueCount = 0
+	result.Truncated = truncated
+	return result, nil
 }

--- a/internal/aws/sqs_issue_enrichment.go
+++ b/internal/aws/sqs_issue_enrichment.go
@@ -9,7 +9,13 @@ import (
 	sqssvc "github.com/aws/aws-sdk-go-v2/service/sqs"
 	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// sqs canonical FindingCodes.
+const (
+	sqsCodeMissingDLQ domain.FindingCode = "sqs.missing-dlq"
 )
 
 // EnrichSQSAttributes calls GetQueueAttributes per queue (cap EnrichmentCap)
@@ -19,11 +25,13 @@ import (
 // via AggregateFailures so the operator sees the failure in the error log (!).
 // Partial findings are returned alongside the composite error on partial fail.
 func EnrichSQSAttributes(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients.SQS == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	var failures []string
@@ -50,7 +58,7 @@ func EnrichSQSAttributes(ctx context.Context, clients *ServiceClients, resources
 		if err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", r.ID, err))
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 		_, hasDLQ := out.Attributes["RedrivePolicy"]
@@ -58,19 +66,19 @@ func EnrichSQSAttributes(ctx context.Context, clients *ServiceClients, resources
 		if hasDLQ {
 			dlqVal = "yes"
 		}
-		fieldUpdates[r.ID] = map[string]string{
+		result.FieldUpdates[r.ID] = map[string]string{
 			"dlq": dlqVal,
 		}
-		var rows []resource.FindingRow
+		var rows []domain.DetailRow
 		if !hasDLQ {
-			rows = append(rows, resource.FindingRow{
+			rows = append(rows, domain.DetailRow{
 				Label: "DLQ",
 				Value: "no DLQ configured",
 				Tier:  "~",
 			})
 		}
 		if _, ok := out.Attributes["KmsMasterKeyId"]; !ok {
-			rows = append(rows, resource.FindingRow{
+			rows = append(rows, domain.DetailRow{
 				Label: "Encryption",
 				Value: "no KMS encryption configured",
 				Tier:  "~",
@@ -79,12 +87,10 @@ func EnrichSQSAttributes(ctx context.Context, clients *ServiceClients, resources
 		if len(rows) == 0 {
 			continue
 		}
-		findings[r.ID] = resource.EnrichmentFinding{
-			Severity: "~",
-			Summary:  rows[0].Value,
-			Rows:     rows,
-		}
+		setWave2Finding(&result, r.ID, sqsCodeMissingDLQ, rows[0].Value, "~", "sqs", rows)
 	}
-	return IssueEnricherResult{IssueCount: 0, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates},
+	result.IssueCount = 0
+	result.Truncated = truncated
+	return result,
 		AggregateFailures("sqs-enrich: GetQueueAttributes", failures, total)
 }

--- a/internal/aws/tg_issue_enrichment.go
+++ b/internal/aws/tg_issue_enrichment.go
@@ -9,7 +9,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// tg canonical FindingCodes.
+const (
+	tgCodeUnhealthyTargets domain.FindingCode = "tg.unhealthy-targets"
 )
 
 // EnrichTargetGroupHealth calls DescribeTargetHealth for each target group (1 per TG, cap ~50).
@@ -17,11 +23,13 @@ import (
 // Severity is "!" (broken/degraded). Summary: "unhealthy targets: X/Y".
 // Per-TG errors are aggregated and returned as a composite error alongside partial findings (E3, E4, E5).
 func EnrichTargetGroupHealth(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients.ELBv2 == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	var failures []string
@@ -50,7 +58,7 @@ func EnrichTargetGroupHealth(ctx context.Context, clients *ServiceClients, resou
 		if err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", r.ID, err))
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 		targetCount := len(out.TargetHealthDescriptions)
@@ -71,23 +79,21 @@ func EnrichTargetGroupHealth(ctx context.Context, clients *ServiceClients, resou
 		} else {
 			healthSummary = fmt.Sprintf("%d/%d healthy", healthy, targetCount)
 		}
-		fieldUpdates[r.ID] = map[string]string{
+		result.FieldUpdates[r.ID] = map[string]string{
 			"health_summary": healthSummary,
 		}
 		if unhealthy > 0 {
-			rows := []resource.FindingRow{
+			rows := []domain.DetailRow{
 				{Label: "Unhealthy Targets", Value: fmt.Sprintf("%d/%d", unhealthy, targetCount), Tier: "!"},
 			}
 			if firstReason != "" {
-				rows = append(rows, resource.FindingRow{Label: "Reason", Value: firstReason, Tier: "~"})
+				rows = append(rows, domain.DetailRow{Label: "Reason", Value: firstReason, Tier: "~"})
 			}
-			findings[r.ID] = resource.EnrichmentFinding{
-				Severity: "!",
-				Summary:  fmt.Sprintf("unhealthy targets: %d/%d", unhealthy, targetCount),
-				Rows:     rows,
-			}
+			setWave2Finding(&result, r.ID, tgCodeUnhealthyTargets, fmt.Sprintf("unhealthy targets: %d/%d", unhealthy, targetCount), "!", "tg", rows)
 		}
 	}
-	return IssueEnricherResult{IssueCount: len(findings), Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates},
+	result.IssueCount = len(result.Findings)
+	result.Truncated = truncated
+	return result,
 		AggregateFailures("tg-enrich: DescribeTargetHealth", failures, total)
 }

--- a/internal/aws/tgw_issue_enrichment.go
+++ b/internal/aws/tgw_issue_enrichment.go
@@ -9,8 +9,24 @@ import (
 	ec2svc "github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
+
+// tgw canonical FindingCodes.
+const (
+	tgwCodeAttachmentFailed      domain.FindingCode = "tgw.attachment-failed"
+	tgwCodeAttachmentTransitional domain.FindingCode = "tgw.attachment-transitional"
+)
+
+// worstTGWFinding holds the temporary state for tracking the worst attachment finding
+// across all attachments for a single TGW during the enrichment loop.
+type worstTGWFinding struct {
+	code    domain.FindingCode
+	summary string
+	glyph   string
+	rows    []domain.DetailRow
+}
 
 // EnrichTGWAttachments calls DescribeTransitGatewayAttachments per TGW (cap EnrichmentCap,
 // per-TGW pagination up to PerParentPageCap pages) and returns a Finding for any TGW with
@@ -19,11 +35,13 @@ import (
 // When multiple issues exist on the same TGW, the worst severity ("!") takes precedence.
 // Per-TGW errors are aggregated and returned as a composite error alongside partial findings (E3, E4, E5).
 func EnrichTGWAttachments(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients.EC2 == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	var failures []string
@@ -46,7 +64,7 @@ func EnrichTGWAttachments(ctx context.Context, clients *ServiceClients, resource
 			if attPages >= PerParentPageCap {
 				attTruncated = true
 				truncated = true
-				truncatedIDs[r.ID] = true
+				result.TruncatedIDs[r.ID] = true
 				break
 			}
 			out, err := RetryOnThrottle(ctx, DefaultRetryConfig(), func() (*ec2svc.DescribeTransitGatewayAttachmentsOutput, error) {
@@ -61,7 +79,7 @@ func EnrichTGWAttachments(ctx context.Context, clients *ServiceClients, resource
 			if err != nil {
 				failures = append(failures, fmt.Sprintf("%s: %v", r.ID, err))
 				truncated = true
-				truncatedIDs[r.ID] = true
+				result.TruncatedIDs[r.ID] = true
 				break
 			}
 			allAttachments = append(allAttachments, out.TransitGatewayAttachments...)
@@ -75,7 +93,7 @@ func EnrichTGWAttachments(ctx context.Context, clients *ServiceClients, resource
 		}
 		// Collect worst finding across all attachments for this TGW.
 		// "!" severity beats "~" severity.
-		var worst *resource.EnrichmentFinding
+		var worst *worstTGWFinding
 		issueCount := 0
 		for _, att := range allAttachments {
 			attID := ""
@@ -83,24 +101,26 @@ func EnrichTGWAttachments(ctx context.Context, clients *ServiceClients, resource
 				attID = *att.TransitGatewayAttachmentId
 			}
 			state := string(att.State)
-			var candidate *resource.EnrichmentFinding
+			var candidate *worstTGWFinding
 			switch state {
 			case "failed", "failing":
 				issueCount++
-				candidate = &resource.EnrichmentFinding{
-					Severity: "!",
-					Summary:  fmt.Sprintf("attachment %s failed", attID),
-					Rows: []resource.FindingRow{
+				candidate = &worstTGWFinding{
+					code:    tgwCodeAttachmentFailed,
+					summary: fmt.Sprintf("attachment %s failed", attID),
+					glyph:   "!",
+					rows: []domain.DetailRow{
 						{Label: "Attachment", Value: attID, Tier: "!"},
 						{Label: "State", Value: state, Tier: "!"},
 					},
 				}
 			case "modifying", "pendingAcceptance", "rollingBack":
 				issueCount++
-				candidate = &resource.EnrichmentFinding{
-					Severity: "~",
-					Summary:  fmt.Sprintf("attachment %s %s", attID, state),
-					Rows: []resource.FindingRow{
+				candidate = &worstTGWFinding{
+					code:    tgwCodeAttachmentTransitional,
+					summary: fmt.Sprintf("attachment %s %s", attID, state),
+					glyph:   "~",
+					rows: []domain.DetailRow{
 						{Label: "Attachment", Value: attID, Tier: "~"},
 						{Label: "State", Value: state, Tier: "~"},
 					},
@@ -109,7 +129,7 @@ func EnrichTGWAttachments(ctx context.Context, clients *ServiceClients, resource
 			if candidate == nil {
 				continue
 			}
-			if worst == nil || (worst.Severity != "!" && candidate.Severity == "!") {
+			if worst == nil || (worst.glyph != "!" && candidate.glyph == "!") {
 				worst = candidate
 			}
 		}
@@ -117,13 +137,15 @@ func EnrichTGWAttachments(ctx context.Context, clients *ServiceClients, resource
 		if issueCount > 0 {
 			attStatusVal = fmt.Sprintf("%d issues", issueCount)
 		}
-		fieldUpdates[tgwID] = map[string]string{
+		result.FieldUpdates[tgwID] = map[string]string{
 			"att_status": attStatusVal,
 		}
 		if worst != nil {
-			findings[tgwID] = *worst
+			setWave2Finding(&result, tgwID, worst.code, worst.summary, worst.glyph, "tgw", worst.rows)
 		}
 	}
-	return IssueEnricherResult{IssueCount: len(findings), Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates},
+	result.IssueCount = len(result.Findings)
+	result.Truncated = truncated
+	return result,
 		AggregateFailures("tgw-enrich: DescribeTransitGatewayAttachments", failures, total)
 }

--- a/internal/aws/vpc_issue_enrichment.go
+++ b/internal/aws/vpc_issue_enrichment.go
@@ -8,7 +8,13 @@ import (
 	ec2svc "github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// vpc canonical FindingCodes.
+const (
+	vpcCodeNoFlowLogs domain.FindingCode = "vpc.no-flow-logs"
 )
 
 // EnrichVPCFlowLogs calls DescribeFlowLogs per VPC (capped at EnrichmentCap) and
@@ -20,11 +26,13 @@ import (
 // IssueCount stays 0 (severity "~" only).
 // Skip when clients.EC2 == nil.
 func EnrichVPCFlowLogs(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients.EC2 == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	for i, r := range resources {
@@ -44,7 +52,7 @@ func EnrichVPCFlowLogs(ctx context.Context, clients *ServiceClients, resources [
 			if flPages >= PerParentPageCap {
 				flTruncated = true
 				truncated = true
-				truncatedIDs[r.ID] = true
+				result.TruncatedIDs[r.ID] = true
 				break
 			}
 			out, err := clients.EC2.DescribeFlowLogs(ctx, &ec2svc.DescribeFlowLogsInput{
@@ -56,7 +64,7 @@ func EnrichVPCFlowLogs(ctx context.Context, clients *ServiceClients, resources [
 			flPages++
 			if err != nil {
 				truncated = true
-				truncatedIDs[r.ID] = true
+				result.TruncatedIDs[r.ID] = true
 				flTruncated = true
 				break
 			}
@@ -80,14 +88,13 @@ func EnrichVPCFlowLogs(ctx context.Context, clients *ServiceClients, resources [
 		flowLogsVal := "yes"
 		if !hasActive {
 			flowLogsVal = "no"
-			findings[vpcID] = resource.EnrichmentFinding{
-				Severity: "~",
-				Summary:  "no active VPC flow logs (CIS EC2.6)",
-			}
+			setWave2Finding(&result, vpcID, vpcCodeNoFlowLogs, "no active VPC flow logs (CIS EC2.6)", "~", "vpc", nil)
 		}
-		fieldUpdates[vpcID] = map[string]string{
+		result.FieldUpdates[vpcID] = map[string]string{
 			"flow_logs": flowLogsVal,
 		}
 	}
-	return IssueEnricherResult{IssueCount: 0, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates}, nil
+	result.IssueCount = 0
+	result.Truncated = truncated
+	return result, nil
 }

--- a/internal/aws/waf_issue_enrichment.go
+++ b/internal/aws/waf_issue_enrichment.go
@@ -10,7 +10,13 @@ import (
 	wafv2svc "github.com/aws/aws-sdk-go-v2/service/wafv2"
 	wafv2types "github.com/aws/aws-sdk-go-v2/service/wafv2/types"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
+)
+
+// waf canonical FindingCodes.
+const (
+	wafCodeNoLogging domain.FindingCode = "waf.no-logging"
 )
 
 // EnrichWAFLogging calls GetLoggingConfiguration, ListResourcesForWebACL, and GetWebACL per WebACL
@@ -24,11 +30,13 @@ import (
 // Skip if clients.WAFv2 == nil. Per-WebACL errors (other than WAFNonexistentItemException) are
 // aggregated and returned as a composite error alongside partial findings (E3, E4, E5).
 func EnrichWAFLogging(ctx context.Context, clients *ServiceClients, resources []resource.Resource, _ resource.ResourceCache) (IssueEnricherResult, error) {
-	findings := make(map[string]resource.EnrichmentFinding)
-	fieldUpdates := make(map[string]map[string]string)
-	truncatedIDs := make(map[string]bool)
+	result := IssueEnricherResult{
+		Findings:     make(map[string]domain.Finding),
+		TruncatedIDs: make(map[string]bool),
+		FieldUpdates: make(map[string]map[string]string),
+	}
 	if clients.WAFv2 == nil {
-		return IssueEnricherResult{Findings: findings, TruncatedIDs: truncatedIDs}, nil
+		return result, nil
 	}
 	truncated := len(resources) > EnrichmentCap
 	var failures []string
@@ -45,7 +53,7 @@ func EnrichWAFLogging(ctx context.Context, clients *ServiceClients, resources []
 			continue
 		}
 		total++
-		var rows []resource.FindingRow
+		var rows []domain.DetailRow
 
 		// Check logging configuration.
 		_, err := RetryOnThrottle(ctx, DefaultRetryConfig(), func() (*wafv2svc.GetLoggingConfigurationOutput, error) {
@@ -55,7 +63,7 @@ func EnrichWAFLogging(ctx context.Context, clients *ServiceClients, resources []
 		})
 		if err != nil {
 			if _, ok := errors.AsType[*wafv2types.WAFNonexistentItemException](err); ok {
-				rows = append(rows, resource.FindingRow{
+				rows = append(rows, domain.DetailRow{
 					Label: "Logging",
 					Value: "no logging configuration",
 					Tier:  "~",
@@ -64,7 +72,7 @@ func EnrichWAFLogging(ctx context.Context, clients *ServiceClients, resources []
 				// Unexpected error — skip this ACL.
 				failures = append(failures, fmt.Sprintf("%s: %v", r.ID, err))
 				truncated = true
-				truncatedIDs[r.ID] = true
+				result.TruncatedIDs[r.ID] = true
 				continue
 			}
 		}
@@ -78,11 +86,11 @@ func EnrichWAFLogging(ctx context.Context, clients *ServiceClients, resources []
 		if err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", r.ID, err))
 			truncated = true
-			truncatedIDs[r.ID] = true
+			result.TruncatedIDs[r.ID] = true
 			continue
 		}
 		if len(assocOut.ResourceArns) == 0 {
-			rows = append(rows, resource.FindingRow{
+			rows = append(rows, domain.DetailRow{
 				Label: "Associations",
 				Value: "WebACL not associated with any resources (orphan)",
 				Tier:  "~",
@@ -120,20 +128,18 @@ func EnrichWAFLogging(ctx context.Context, clients *ServiceClients, resources []
 				}
 			}
 		}
-		fieldUpdates[r.ID] = map[string]string{
+		result.FieldUpdates[r.ID] = map[string]string{
 			"rules_summary": rulesSummary,
 		}
 
 		if len(rows) == 0 {
 			continue
 		}
-		findings[r.ID] = resource.EnrichmentFinding{
-			Severity: "~",
-			Summary:  rows[0].Value,
-			Rows:     rows,
-		}
+		setWave2Finding(&result, r.ID, wafCodeNoLogging, rows[0].Value, "~", "waf", rows)
 	}
 	// All WAF logging findings are severity "~" (informational).
-	return IssueEnricherResult{IssueCount: 0, Truncated: truncated, TruncatedIDs: truncatedIDs, Findings: findings, FieldUpdates: fieldUpdates},
+	result.IssueCount = 0
+	result.Truncated = truncated
+	return result,
 		AggregateFailures("waf-enrich", failures, total)
 }

--- a/internal/runtime/handlers_availability.go
+++ b/internal/runtime/handlers_availability.go
@@ -19,9 +19,10 @@ import (
 	"fmt"
 	"maps"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
-	"github.com/k2m30/a9s/v3/internal/session"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
+	"github.com/k2m30/a9s/v3/internal/session"
 )
 
 // handleAvailabilityCacheLoaded applies cached entries to the main menu and
@@ -307,7 +308,7 @@ func (c *Core) handleEnrichmentChecked(msg messages.EnrichmentChecked) ([]UIInte
 
 		// Site 3 (Wave-2 bridge, PR-03a-fold): applyEnrichment directly mutates
 		// r.Findings and r.AttentionDetails on every cached row of this type.
-		c.applyEnrichment(msg.ResourceType, msg.Findings)
+		c.applyEnrichment(msg.ResourceType, msg.Findings, msg.AttentionDetails)
 
 		// Merge FieldUpdates into ProbeResources and ResourceCache.
 		if len(msg.FieldUpdates) > 0 {
@@ -373,8 +374,9 @@ func (c *Core) handleEnrichmentChecked(msg messages.EnrichmentChecked) ([]UIInte
 
 		// Emit resource-list enrichment patch (updates list badge + row markers).
 		enrichPatch := &ListEnrichmentPatch{
-			Findings:     msg.Findings,
-			TruncatedIDs: msg.TruncatedIDs,
+			Findings:         msg.Findings,
+			AttentionDetails: msg.AttentionDetails,
+			TruncatedIDs:     msg.TruncatedIDs,
 		}
 		if len(msg.FieldUpdates) > 0 {
 			enrichPatch.FieldUpdates = msg.FieldUpdates
@@ -389,8 +391,9 @@ func (c *Core) handleEnrichmentChecked(msg messages.EnrichmentChecked) ([]UIInte
 		// ResourceID empty = all detail views of this type; the adapter looks up
 		// the finding for each view's specific resource ID from EnrichmentFindings.
 		intents = append(intents, PatchDetail{
-			ResourceType:       msg.ResourceType,
-			EnrichmentFindings: msg.Findings,
+			ResourceType:               msg.ResourceType,
+			EnrichmentFindings:         msg.Findings,
+			EnrichmentAttentionDetails: msg.AttentionDetails,
 		})
 	}
 
@@ -420,8 +423,9 @@ func (c *Core) handleEnrichmentChecked(msg messages.EnrichmentChecked) ([]UIInte
 
 // unifiedIssueCount returns the distinct count of resource IDs with ≥1 issue
 // across both Wave-1 (IsIssue() status color) and Wave-2 (enrichment findings).
-// Only "!"-severity findings contribute to the S1 badge.
-func unifiedIssueCount(wave1Resources []resource.Resource, td resource.ResourceTypeDef, findings map[string]resource.EnrichmentFinding) int {
+// Only SevBroken findings contribute to the S1 badge ("!"-glyph equivalent;
+// SevWarn / "~" informational findings are excluded).
+func unifiedIssueCount(wave1Resources []resource.Resource, td resource.ResourceTypeDef, findings map[string]domain.Finding) int {
 	if td.ExcludeFromIssueBadge {
 		return 0
 	}
@@ -436,7 +440,7 @@ func unifiedIssueCount(wave1Resources []resource.Resource, td resource.ResourceT
 		}
 	}
 	for id, finding := range findings {
-		if finding.Severity != "!" {
+		if finding.Severity != domain.SevBroken {
 			continue
 		}
 		if _, ok := knownIDs[id]; ok {

--- a/internal/runtime/handlers_availability_test.go
+++ b/internal/runtime/handlers_availability_test.go
@@ -16,9 +16,9 @@ import (
 	"testing"
 
 	"github.com/k2m30/a9s/v3/internal/catalog"
-	"github.com/k2m30/a9s/v3/internal/resource"
-	"github.com/k2m30/a9s/v3/internal/session"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
+	"github.com/k2m30/a9s/v3/internal/session"
 )
 
 // findPatchMenu returns the first PatchMenu intent in xs whose ResourceType
@@ -121,8 +121,8 @@ func TestHandleEnrichmentChecked_TruncationPrecedence_Wave2WithFindings_StaysTru
 		ResourceType: rt,
 		Issues:       3,
 		Truncated:    true,
-		Findings: map[string]resource.EnrichmentFinding{
-			"id-1": {Severity: "!", Summary: "broken"},
+		Findings: map[string]domain.Finding{
+			"id-1": {Code: "test.broken", Phrase: "broken", Severity: domain.SevBroken, Source: "wave2:" + rt},
 		},
 	})
 
@@ -168,9 +168,9 @@ func TestHandleEnrichmentChecked_PatchDetail_NonNilFindings_PassesThrough(t *tes
 	sess := session.New()
 	c := New(sess, catalog.All())
 
-	findings := map[string]resource.EnrichmentFinding{
-		"id-1": {Severity: "!", Summary: "broken"},
-		"id-2": {Severity: "~", Summary: "warn"},
+	findings := map[string]domain.Finding{
+		"id-1": {Code: "test.broken", Phrase: "broken", Severity: domain.SevBroken, Source: "wave2:" + rt},
+		"id-2": {Code: "test.warn", Phrase: "warn", Severity: domain.SevWarn, Source: "wave2:" + rt},
 	}
 	intents, _ := c.handleEnrichmentChecked(messages.EnrichmentChecked{
 		ResourceType: rt,
@@ -189,7 +189,7 @@ func TestHandleEnrichmentChecked_PatchDetail_NonNilFindings_PassesThrough(t *tes
 		if !ok {
 			t.Fatalf("missing finding for %q", k)
 		}
-		if got.Severity != v.Severity || got.Summary != v.Summary {
+		if got.Severity != v.Severity || got.Phrase != v.Phrase {
 			t.Fatalf("finding %q mismatch: want %+v, got %+v", k, v, got)
 		}
 	}

--- a/internal/runtime/helpers.go
+++ b/internal/runtime/helpers.go
@@ -9,15 +9,29 @@ package runtime
 // mutations are visible to both.
 
 import (
+	"strings"
+
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/semantics/attention"
 )
 
 // applyEnrichment merges Wave-2 enrichment findings into every cached row of
-// the given resource type by calling DeriveFindings with the provided findings
-// map. Replaces prior wave-2 findings in place while preserving wave-1.  Walks
-// ResourceCache, LazyResourceCache, and ProbeResources.
-func (c *Core) applyEnrichment(resourceType string, findings map[string]resource.EnrichmentFinding) {
+// the given resource type. For each cached row it:
+//
+//  1. Re-derives Wave-1 findings via attention.DeriveFindings (Wave-1 only —
+//     post-AS-1395 the shim no longer accepts a Wave-2 input).
+//  2. Appends the Wave-2 Finding from findings[r.ID] (when present).
+//  3. Writes attentionDetails[r.ID] into r.AttentionDetails under the matching
+//     FindingCode (the fold-layer re-keying from Resource.ID to FindingCode).
+//
+// Walks ResourceCache, LazyResourceCache, and ProbeResources. Replaces prior
+// wave-2 findings in place while preserving wave-1.
+func (c *Core) applyEnrichment(
+	resourceType string,
+	findings map[string]domain.Finding,
+	attentionDetails map[string]domain.AttentionDetail,
+) {
 	canon := resourceType
 	var td resource.ResourceTypeDef
 	if t := resource.FindResourceType(resourceType); t != nil {
@@ -29,7 +43,7 @@ func (c *Core) applyEnrichment(resourceType string, findings map[string]resource
 
 	apply := func(rows []resource.Resource) {
 		for i := range rows {
-			attention.DeriveFindings(&rows[i], td, findings)
+			applyWave2ToRow(&rows[i], td, findings, attentionDetails)
 		}
 	}
 
@@ -45,8 +59,8 @@ func (c *Core) applyEnrichment(resourceType string, findings map[string]resource
 }
 
 // clearEnrichmentFor strips wave-2 findings from every cached row of the given
-// resource type by re-deriving with nil enrichment.  Wave-1 findings are
-// preserved.  Used by clear-on-rerun-start logic in handleEnrichmentChecked.
+// resource type by re-deriving Wave-1 only and discarding any prior wave-2
+// entries. Used by clear-on-rerun-start logic in handleEnrichmentChecked.
 func (c *Core) clearEnrichmentFor(resourceType string) {
 	canon := resourceType
 	var td resource.ResourceTypeDef
@@ -59,7 +73,7 @@ func (c *Core) clearEnrichmentFor(resourceType string) {
 
 	clear := func(rows []resource.Resource) {
 		for i := range rows {
-			attention.DeriveFindings(&rows[i], td, nil)
+			applyWave2ToRow(&rows[i], td, nil, nil)
 		}
 	}
 
@@ -91,3 +105,40 @@ func (c *Core) deriveFindingsForType(short string, rows []resource.Resource) {
 	}
 }
 
+// applyWave2ToRow re-derives Wave-1 findings on r, then appends the per-row
+// Wave-2 Finding (if present) and writes its AttentionDetail under the
+// Finding's Code. Nil findings/attentionDetails behaves as the clear path
+// (Wave-1 only, no Wave-2 appended).
+func applyWave2ToRow(
+	r *domain.Resource,
+	td resource.ResourceTypeDef,
+	findings map[string]domain.Finding,
+	attentionDetails map[string]domain.AttentionDetail,
+) {
+	if r == nil {
+		return
+	}
+	// Wave-1 derivation overwrites r.Findings + r.AttentionDetails entirely.
+	attention.DeriveFindings(r, td)
+	f, ok := findings[r.ID]
+	if !ok || f.Phrase == "" {
+		return
+	}
+	// AS-1395: enricher-emitted Findings already carry the canonical Code and
+	// Source. Source must be "wave2:<short>" for the existing app_enrich_fold
+	// readers (findingFromResource, findingsFromRows, stripWave2) to recognise
+	// the entry. Tolerate enrichers that forgot to set Source by stamping the
+	// canonical form here.
+	if f.Source == "" {
+		f.Source = "wave2:" + td.ShortName
+	} else if !strings.HasPrefix(f.Source, "wave2:") {
+		f.Source = "wave2:" + td.ShortName
+	}
+	r.Findings = append(r.Findings, f)
+	if ad, ok := attentionDetails[r.ID]; ok && len(ad.Rows) > 0 {
+		if r.AttentionDetails == nil {
+			r.AttentionDetails = make(map[domain.FindingCode]domain.AttentionDetail, 1)
+		}
+		r.AttentionDetails[f.Code] = ad
+	}
+}

--- a/internal/runtime/intent.go
+++ b/internal/runtime/intent.go
@@ -31,10 +31,13 @@ type IssueBadgePatch struct {
 
 // ListEnrichmentPatch carries Wave 2 enrichment data for the rows of a
 // resource-list view. Findings is keyed by Resource.ID; nil means clear.
+// AttentionDetails is paired by Resource.ID (not FindingCode) — the adapter
+// re-keys when applying to per-row detail state.
 type ListEnrichmentPatch struct {
-	Findings     map[string]resource.EnrichmentFinding
-	TruncatedIDs map[string]bool
-	FieldUpdates map[string]map[string]string
+	Findings         map[string]domain.Finding
+	AttentionDetails map[string]domain.AttentionDetail
+	TruncatedIDs     map[string]bool
+	FieldUpdates     map[string]map[string]string
 }
 
 // PatchResourceList instructs the adapter to apply the contained patches
@@ -60,7 +63,11 @@ type PatchDetail struct {
 	// EnrichmentFindings carries the Wave-2 per-resource finding map used by
 	// the adapter to look up the finding for a specific detail view's resource.
 	// Keyed by resource.Resource.ID; nil means clear enrichment.
-	EnrichmentFindings map[string]resource.EnrichmentFinding
+	EnrichmentFindings map[string]domain.Finding
+	// EnrichmentAttentionDetails carries the supporting rows for each per-
+	// resource Wave-2 finding, keyed by Resource.ID at the message-emission
+	// boundary. Paired with EnrichmentFindings (same Resource.ID set).
+	EnrichmentAttentionDetails map[string]domain.AttentionDetail
 }
 
 func (PatchDetail) isIntent() {}

--- a/internal/runtime/messages/event.go
+++ b/internal/runtime/messages/event.go
@@ -215,8 +215,13 @@ type EnrichmentChecked struct {
 	// Findings is the per-resource finding map for this type, keyed by
 	// resource.Resource.ID. Populated on success AND on partial-success (Err
 	// non-nil but partial results present). May include findings for resources
-	// off-page (account-wide enrichers).
-	Findings map[string]resource.EnrichmentFinding
+	// off-page (account-wide enrichers). At most one Finding per Resource.ID.
+	Findings map[string]domain.Finding
+	// AttentionDetails carries the supporting rows for each per-resource
+	// Finding. Keyed by Resource.ID at message-emission time; the fold layer
+	// (runtime.Core.applyEnrichment) flips it to FindingCode against the
+	// matching r.Findings entry when writing onto cached rows.
+	AttentionDetails map[string]domain.AttentionDetail
 	// FieldUpdates carries per-resource Fields[] mutations to merge into
 	// cached rows. Keyed by resource ID then by field key. Populated on success
 	// AND on partial-success (Err non-nil but partial results present).

--- a/internal/runtime/probes.go
+++ b/internal/runtime/probes.go
@@ -16,6 +16,7 @@ import (
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/cache"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -35,14 +36,19 @@ type ProbeAvailabilityResult struct {
 // ProbeEnrichmentResult carries the outcome of a single Wave-2 issue
 // enrichment probe. Adapters convert this into a platform-specific message
 // (e.g. messages.EnrichmentChecked for the Bubble Tea adapter).
+//
+// Findings and AttentionDetails are both keyed by Resource.ID. The fold layer
+// (runtime.Core.applyEnrichment) flips AttentionDetails to FindingCode against
+// the matching r.Findings entry when writing onto cached rows.
 type ProbeEnrichmentResult struct {
-	ResourceType string
-	Issues       int
-	Truncated    bool
-	Findings     map[string]resource.EnrichmentFinding
-	FieldUpdates map[string]map[string]string
-	TruncatedIDs map[string]bool
-	Err          error
+	ResourceType     string
+	Issues           int
+	Truncated        bool
+	Findings         map[string]domain.Finding
+	AttentionDetails map[string]domain.AttentionDetail
+	FieldUpdates     map[string]map[string]string
+	TruncatedIDs     map[string]bool
+	Err              error
 }
 
 // DemoPrefetchResult carries the combined outcome of a synchronous demo
@@ -297,13 +303,14 @@ func (c *Core) ProbeEnrichment(ctx context.Context, clients *awsclient.ServiceCl
 	// preserves partial result on non-retryable errors (partial-success
 	// contract: never-silent-skip).
 	return ProbeEnrichmentResult{
-		ResourceType: shortName,
-		Issues:       result.IssueCount,
-		Truncated:    result.Truncated,
-		Findings:     result.Findings,
-		FieldUpdates: result.FieldUpdates,
-		TruncatedIDs: result.TruncatedIDs,
-		Err:          err,
+		ResourceType:     shortName,
+		Issues:           result.IssueCount,
+		Truncated:        result.Truncated,
+		Findings:         result.Findings,
+		AttentionDetails: result.AttentionDetails,
+		FieldUpdates:     result.FieldUpdates,
+		TruncatedIDs:     result.TruncatedIDs,
+		Err:              err,
 	}
 }
 

--- a/internal/runtime/state.go
+++ b/internal/runtime/state.go
@@ -2,7 +2,6 @@ package runtime
 
 import (
 	"github.com/k2m30/a9s/v3/internal/domain"
-	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/session"
 )
 
@@ -20,7 +19,11 @@ type RuntimeState struct {
 
 	// EnrichmentFindings carries the most-recent Wave 2 findings per
 	// resource type, keyed by ResourceType -> ResourceID -> finding.
-	EnrichmentFindings map[string]map[string]resource.EnrichmentFinding
+	EnrichmentFindings map[string]map[string]domain.Finding
+	// EnrichmentAttentionDetails carries the supporting AttentionDetail rows
+	// for each Wave 2 finding, keyed by ResourceType -> ResourceID -> detail.
+	// Paired with EnrichmentFindings (same key shape; same ResourceID).
+	EnrichmentAttentionDetails map[string]map[string]domain.AttentionDetail
 
 	// MenuBadges is the current per-resource-type issue badge state used
 	// to render the main menu.

--- a/internal/semantics/attention/derive.go
+++ b/internal/semantics/attention/derive.go
@@ -1,16 +1,17 @@
 // Package attention holds the Phase-03 canonical-finding derivation shim.
 //
-// DeriveFindings is a one-way bridge from the legacy Resource.Status +
-// Resource.Issues + Wave-2 EnrichmentFinding model to the new
-// Resource.Findings + Resource.AttentionDetails model. Until per-category
-// PRs (03b–m) migrate fetchers to write Findings directly, every entry
-// point that surfaces a Resource to view code calls DeriveFindings to
-// populate the new fields.
+// DeriveFindings is a Wave-1-only one-way bridge from the legacy
+// Resource.Status + Resource.Issues model to the new Resource.Findings model.
+// Wave-2 entries are appended downstream by runtime.Core.applyEnrichment using
+// the typed Finding + AttentionDetail emitted by each enricher (post-AS-1395
+// type swap). Until per-category PRs (03b–m) migrate fetchers to write
+// Findings directly, every entry point that surfaces a Resource to view code
+// calls DeriveFindings to populate the new fields.
 //
 // The function is deterministic — re-derives every call from inputs, never
 // early-returns on len(r.Findings) > 0. The Wave 2 bridge depends on this:
-// EnrichmentCheckedMsg arrives after the first derive call has already run,
-// and the second call must re-merge the just-populated parallel map.
+// applyEnrichment re-runs derive before each Wave-2 append so stale Wave-2
+// entries do not accumulate across reruns.
 package attention
 
 import (
@@ -22,21 +23,20 @@ import (
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
-// DeriveFindings populates r.Findings and r.AttentionDetails from r.Status,
-// r.Issues, and the supplied enrichmentFindings keyed by resource ID.
-// Caller passes m.EnrichmentFindings[resourceType] as the third arg.
+// DeriveFindings populates r.Findings from r.Status + r.Issues (Wave-1 only).
+// Replaces — never appends to — r.Findings and r.AttentionDetails so stale
+// entries from prior runs are discarded.
 //
 // Output contract:
-//   - r.Findings:        wave1 issue entries only (lifecycle steady-state
-//     phrases are filtered), then wave2 entry if
-//     enrichmentFindings[r.ID] exists.
-//   - r.AttentionDetails: keyed by FindingCode; only contains the wave2 entry
-//     when present.
-//   - Healthy row (no Status, no Issues, no enrichment): both fields nil.
-//   - Replacement, not append: stale prior entries are discarded.
+//   - r.Findings:         wave1 issue entries only (lifecycle steady-state
+//     phrases are filtered).
+//   - r.AttentionDetails: cleared (nil).  Wave-2 callers (applyEnrichment)
+//     are responsible for appending the wave2 Finding and writing the
+//     companion AttentionDetail keyed by FindingCode after this call.
+//   - Healthy row (no Status, no Issues): both fields nil.
 //
 // Safe on nil r (no-op).
-func DeriveFindings(r *domain.Resource, td resource.ResourceTypeDef, enrichmentFindings map[string]resource.EnrichmentFinding) {
+func DeriveFindings(r *domain.Resource, td resource.ResourceTypeDef) {
 	if r == nil {
 		return
 	}
@@ -78,33 +78,8 @@ func DeriveFindings(r *domain.Resource, td resource.ResourceTypeDef, enrichmentF
 		}
 	}
 
-	// Wave 2: at most one finding per resource per type.
-	var attn map[domain.FindingCode]domain.AttentionDetail
-	if ef, ok := enrichmentFindings[r.ID]; ok && ef.Summary != "" {
-		code := domain.FindingCode(td.ShortName + "." + slug(ef.Summary))
-		findings = append(findings, domain.Finding{
-			Code:     code,
-			Phrase:   ef.Summary,
-			Severity: severityFromMarker(ef.Severity),
-			Source:   "wave2:" + td.ShortName,
-		})
-		if len(ef.Rows) > 0 {
-			rows := make([]domain.DetailRow, 0, len(ef.Rows))
-			for _, row := range ef.Rows {
-				rows = append(rows, domain.DetailRow{
-					Label: row.Label,
-					Value: row.Value,
-					Tier:  row.Tier,
-				})
-			}
-			attn = map[domain.FindingCode]domain.AttentionDetail{
-				code: {Rows: rows},
-			}
-		}
-	}
-
 	r.Findings = findings
-	r.AttentionDetails = attn
+	r.AttentionDetails = nil
 }
 
 // DeriveWave1Only re-derives only the wave1 portion of r.Findings from r.Status
@@ -113,8 +88,8 @@ func DeriveFindings(r *domain.Resource, td resource.ResourceTypeDef, enrichmentF
 // wave2 findings written by applyEnrichment (PR-03a-fold) are not wiped when a
 // resource is re-derived at a later site (e.g. cache-hit navigation, lazy add).
 //
-// The EnrichmentChecked handler uses applyEnrichment which calls the full
-// DeriveFindings with the new wave2 inputs.
+// The EnrichmentChecked handler uses applyEnrichment which re-derives wave1
+// and then appends the new wave2 entry directly.
 //
 // Safe on nil r (no-op).
 func DeriveWave1Only(r *domain.Resource, td resource.ResourceTypeDef) {
@@ -137,8 +112,7 @@ func DeriveWave1Only(r *domain.Resource, td resource.ResourceTypeDef) {
 			}
 		}
 	}
-	// Re-derive wave1 only (nil enrichment = no wave2 emitted).
-	DeriveFindings(r, td, nil)
+	DeriveFindings(r, td)
 	// Re-append the saved wave2 entries.
 	r.Findings = append(r.Findings, wave2...)
 	if len(wave2Attn) > 0 {
@@ -147,22 +121,6 @@ func DeriveWave1Only(r *domain.Resource, td resource.ResourceTypeDef) {
 		} else {
 			maps.Copy(r.AttentionDetails, wave2Attn)
 		}
-	}
-}
-
-// severityFromMarker maps an EnrichmentFinding.Severity glyph to a domain.Severity.
-//
-//	"!" -> SevBroken (degraded/failed)
-//	"~" -> SevWarn   (scheduled/informational)
-//	any other (incl. "") -> SevDim (unknown)
-func severityFromMarker(s string) domain.Severity {
-	switch s {
-	case "!":
-		return domain.SevBroken
-	case "~":
-		return domain.SevWarn
-	default:
-		return domain.SevDim
 	}
 }
 

--- a/internal/tui/app_dispatch.go
+++ b/internal/tui/app_dispatch.go
@@ -20,6 +20,7 @@ package tui
 import (
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/runtime"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
 	"github.com/k2m30/a9s/v3/internal/tui/styles"
@@ -87,13 +88,21 @@ func (m *Model) applyIntents(intents []runtime.UIIntent) []tea.Cmd {
 				if v.ResourceID != "" && d.ResourceID() != v.ResourceID {
 					continue
 				}
-				// nil EnrichmentFindings = clear; non-nil = update from map.
+				// AS-1395: runtime ships domain.Finding + domain.AttentionDetail
+				// keyed by Resource.ID. nil EnrichmentFindings = clear; non-nil =
+				// update from map.
 				if v.EnrichmentFindings == nil {
-					d.SetEnrichmentFinding(nil)
+					d.SetEnrichmentFinding(nil, nil)
 				} else if f, exists := v.EnrichmentFindings[d.ResourceID()]; exists {
-					d.SetEnrichmentFinding(&f)
+					finding := f
+					var ad *domain.AttentionDetail
+					if got, hasAD := v.EnrichmentAttentionDetails[d.ResourceID()]; hasAD && len(got.Rows) > 0 {
+						adVal := got
+						ad = &adVal
+					}
+					d.SetEnrichmentFinding(&finding, ad)
 				} else {
-					d.SetEnrichmentFinding(nil)
+					d.SetEnrichmentFinding(nil, nil)
 				}
 			}
 		case runtime.FlashIntent:

--- a/internal/tui/app_enrich_fold.go
+++ b/internal/tui/app_enrich_fold.go
@@ -4,15 +4,10 @@ package tui
 // m.EnrichmentFindings map approach with direct mutation of cached row
 // Findings/AttentionDetails.
 //
-// applyEnrichment is the canonical write path for Wave 2 results: it calls
-// DeriveFindings with the full findings map on every cached row of the given
-// resource type, so r.Findings and r.AttentionDetails are authoritative and
-// views need not consult a side map.
-//
-// findingsFromRows rebuilds a per-resource EnrichmentFinding map from wave2
-// entries in the given resource slice. Used by cache-hit navigation paths to
-// populate views.ResourceListModel.findingsByID for row marker glyphs without
-// the now-deleted m.EnrichmentFindings parallel map.
+// applyEnrichment is the canonical write path for Wave 2 results.
+// findingFromResource and findingsFromRows rebuild detail/list view input
+// from the authoritative r.Findings + r.AttentionDetails state on each cached
+// row, replacing the side maps that PR-03a-fold removed.
 
 import (
 	"strings"
@@ -23,15 +18,22 @@ import (
 )
 
 // applyEnrichment merges Wave 2 enrichment findings into every cached row of
-// the given resource type by calling DeriveFindings with the provided findings
-// map. Replaces prior wave2 findings in place while preserving wave1. Walks
-// ResourceCache, LazyResourceCache, and ProbeResources for the canonical short
-// name.
+// the given resource type. AS-1395 changed the contract: instead of calling
+// the pre-AS-1395 DeriveFindings(r, td, enrichmentFindings) shim, this helper
+// uses applyWave2ToRow (mirrors runtime/helpers.go) to:
 //
-// Replaces the prior re-derive loops that followed the
-// m.EnrichmentFindings[type] = msg.Findings write. Cached rows now hold their
-// own Findings/AttentionDetails directly; views read from r.Findings.
-func (m *Model) applyEnrichment(resourceType string, findings map[string]resource.EnrichmentFinding) {
+//  1. Re-derive Wave-1 findings via attention.DeriveFindings(r, td).
+//  2. Append the matching domain.Finding from findings[r.ID].
+//  3. Write attentionDetails[r.ID] into r.AttentionDetails under the
+//     Finding's Code (the fold-layer Resource.ID → FindingCode re-key).
+//
+// Walks ResourceCache, LazyResourceCache, and ProbeResources. Cached rows now
+// hold their own Findings/AttentionDetails directly; views read from r.Findings.
+func (m *Model) applyEnrichment(
+	resourceType string,
+	findings map[string]domain.Finding,
+	attentionDetails map[string]domain.AttentionDetail,
+) {
 	canon := resourceType
 	var td resource.ResourceTypeDef
 	if t := resource.FindResourceType(resourceType); t != nil {
@@ -43,7 +45,7 @@ func (m *Model) applyEnrichment(resourceType string, findings map[string]resourc
 
 	apply := func(rows []resource.Resource) {
 		for i := range rows {
-			attention.DeriveFindings(&rows[i], td, findings)
+			applyWave2ToRow(&rows[i], td, findings, attentionDetails)
 		}
 	}
 
@@ -58,60 +60,76 @@ func (m *Model) applyEnrichment(resourceType string, findings map[string]resourc
 	}
 }
 
-
-// findingFromResource extracts the first wave2 entry from r.Findings and
-// returns it as a *resource.EnrichmentFinding for wiring into detail views.
-// Returns nil when no wave2 finding is present (detail view shows no Attention
-// section). This replaces the m.EnrichmentFindings[resType][r.ID] lookup that
-// was deleted in PR-03a-fold; cached rows are now the authoritative source.
-func findingFromResource(r resource.Resource) *resource.EnrichmentFinding {
-	for _, f := range r.Findings {
-		if strings.HasPrefix(f.Source, "wave2:") {
-			ef := resource.EnrichmentFinding{
-				Severity: glyphFromDomainSeverity(f.Severity),
-				Summary:  f.Phrase,
-			}
-			// Preserve any Rows (AttentionDetail body) if the wave2 entry carried them.
-			// AttentionDetails is keyed by FindingCode; look up by f.Code.
-			if r.AttentionDetails != nil {
-				if ad, ok := r.AttentionDetails[f.Code]; ok {
-					ef.Rows = make([]resource.FindingRow, 0, len(ad.Rows))
-					for _, row := range ad.Rows {
-						ef.Rows = append(ef.Rows, resource.FindingRow{
-							Label: row.Label,
-							Value: row.Value,
-							Tier:  row.Tier,
-						})
-					}
-				}
-			}
-			return &ef
-		}
+// applyWave2ToRow mirrors internal/runtime/helpers.go applyWave2ToRow.  Kept as
+// a sibling in this file so tui.Model.applyEnrichment does not need to import
+// internal/runtime (which would create a cycle: runtime depends on internal/aws
+// which depends on internal/resource, and tui depends on runtime).
+func applyWave2ToRow(
+	r *domain.Resource,
+	td resource.ResourceTypeDef,
+	findings map[string]domain.Finding,
+	attentionDetails map[string]domain.AttentionDetail,
+) {
+	if r == nil {
+		return
 	}
-	return nil
+	attention.DeriveFindings(r, td)
+	f, ok := findings[r.ID]
+	if !ok || f.Phrase == "" {
+		return
+	}
+	if f.Source == "" || !strings.HasPrefix(f.Source, "wave2:") {
+		f.Source = "wave2:" + td.ShortName
+	}
+	r.Findings = append(r.Findings, f)
+	if ad, ok := attentionDetails[r.ID]; ok && len(ad.Rows) > 0 {
+		if r.AttentionDetails == nil {
+			r.AttentionDetails = make(map[domain.FindingCode]domain.AttentionDetail, 1)
+		}
+		r.AttentionDetails[f.Code] = ad
+	}
 }
 
-// findingsFromRows rebuilds a per-resource resource.EnrichmentFinding map from
-// wave2 entries in the supplied resource slice. This replaces the read of the
-// now-deleted m.EnrichmentFindings[canon] at cache-hit navigation sites so that
-// views.ResourceListModel.findingsByID (used for row marker glyphs) is correctly
-// populated from the authoritative r.Findings on each cached row.
+// findingFromResource extracts the first wave2 Finding (and its companion
+// AttentionDetail, if present) from r.Findings / r.AttentionDetails for
+// wiring into detail views. Both return values are nil when no wave2 finding
+// is present (detail view shows no Attention section).
+func findingFromResource(r resource.Resource) (*domain.Finding, *domain.AttentionDetail) {
+	for _, f := range r.Findings {
+		if strings.HasPrefix(f.Source, "wave2:") {
+			finding := f
+			var ad *domain.AttentionDetail
+			if r.AttentionDetails != nil {
+				if got, ok := r.AttentionDetails[f.Code]; ok && len(got.Rows) > 0 {
+					adVal := got
+					ad = &adVal
+				}
+			}
+			return &finding, ad
+		}
+	}
+	return nil, nil
+}
+
+// findingsFromRows rebuilds a per-resource domain.Finding map from wave2
+// entries in the supplied resource slice. AS-1395 retyped this to emit
+// domain.Finding (matching the runtime→adapter PatchResourceList contract).
+// Used by cache-hit navigation sites that populate
+// views.ResourceListModel.findingsByID (row marker glyphs) from the
+// authoritative r.Findings on each cached row.
 //
-// Only the first wave2 finding per resource is mapped (at most one wave2 entry
-// per resource per type is guaranteed by DeriveFindings).
-// Returns nil when no wave2 findings are present (avoids allocating an empty map).
-func findingsFromRows(rows []resource.Resource) map[string]resource.EnrichmentFinding {
-	var out map[string]resource.EnrichmentFinding
+// Only the first wave2 finding per resource is mapped (at most one wave2
+// entry per resource per type is guaranteed by applyEnrichment).
+// Returns nil when no wave2 findings are present.
+func findingsFromRows(rows []resource.Resource) map[string]domain.Finding {
+	var out map[string]domain.Finding
 	for _, r := range rows {
 		for _, f := range r.Findings {
 			if strings.HasPrefix(f.Source, "wave2:") {
 				if out == nil {
-					out = make(map[string]resource.EnrichmentFinding)
+					out = make(map[string]domain.Finding)
 				}
-				out[r.ID] = resource.EnrichmentFinding{
-					Severity: glyphFromDomainSeverity(f.Severity),
-					Summary:  f.Phrase,
-				}
+				out[r.ID] = f
 				break // at most one wave2 finding per resource
 			}
 		}
@@ -119,22 +137,6 @@ func findingsFromRows(rows []resource.Resource) map[string]resource.EnrichmentFi
 	return out
 }
 
-// glyphFromDomainSeverity converts a domain.Severity constant to the
-// resource.EnrichmentFinding.Severity glyph string used by row marker rendering.
-//
-//	SevBroken → "!"   (failed / degraded)
-//	SevWarn   → "~"   (scheduled maintenance / informational)
-//	other     → ""    (no glyph rendered)
-func glyphFromDomainSeverity(s domain.Severity) string {
-	switch s {
-	case domain.SevBroken:
-		return "!"
-	case domain.SevWarn:
-		return "~"
-	default:
-		return ""
-	}
-}
 
 // stripWave2 returns a copy of findings with wave2 entries removed.
 // Wave 1 entries (Source = "wave1") are preserved in order.

--- a/internal/tui/probe_adapter.go
+++ b/internal/tui/probe_adapter.go
@@ -175,15 +175,16 @@ func (m *Model) probeEnrichment(shortName string, gen domain.Gen) tea.Cmd {
 	return func() tea.Msg {
 		r := m.core.ProbeEnrichment(ctx, clients, shortName)
 		return messages.EnrichmentChecked{
-			ResourceType: shortName,
-			Issues:       r.Issues,
-			Truncated:    r.Truncated,
-			Findings:     r.Findings,
-			FieldUpdates: r.FieldUpdates,
-			TruncatedIDs: r.TruncatedIDs,
-			Gen:          gen,
-			TypeGen:      typeGen,
-			Err:          r.Err,
+			ResourceType:     shortName,
+			Issues:           r.Issues,
+			Truncated:        r.Truncated,
+			Findings:         r.Findings,
+			AttentionDetails: r.AttentionDetails,
+			FieldUpdates:     r.FieldUpdates,
+			TruncatedIDs:     r.TruncatedIDs,
+			Gen:              gen,
+			TypeGen:          typeGen,
+			Err:              r.Err,
 		}
 	}
 }

--- a/internal/tui/runtime_adapter_navigate.go
+++ b/internal/tui/runtime_adapter_navigate.go
@@ -168,8 +168,8 @@ func (m Model) handleNavigate(msg messages.Navigate) (tea.Model, tea.Cmd) {
 		d := views.NewDetail(*result.Resource, result.ResolvedType, m.viewConfig, m.keys)
 		d.SetNavProvider(resource.GetNavigableFields)
 		d.SetSize(m.innerSize())
-		if ef := findingFromResource(*result.Resource); ef != nil {
-			d.SetEnrichmentFinding(ef)
+		if ef, ad := findingFromResource(*result.Resource); ef != nil {
+			d.SetEnrichmentFinding(ef, ad)
 		}
 		m.pushView(&d)
 		var cmds []tea.Cmd
@@ -480,7 +480,7 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 	// CodeRabbit finding A: previously delete() ran first so applyEnrichment
 	// found no rows and the rl's slice retained stale wave2 state.
 	if rl.ParentContext() == nil && !rl.EscPops() {
-		(&m).applyEnrichment(rt, nil)
+		(&m).applyEnrichment(rt, nil, nil)
 	}
 
 	m.core.DeleteResourceCache(rt) // clear cache for refreshed type only
@@ -506,7 +506,7 @@ func (m Model) handleRefresh() (tea.Model, tea.Cmd) {
 			// that entered via ProbeResources/LazyResourceCache (those paths
 			// are NOT covered by the pre-fetch cleanup above, which only
 			// covers the ResourceCache entry before deletion).
-			(&m).applyEnrichment(rt, nil)
+			(&m).applyEnrichment(rt, nil, nil)
 			// Propagate the cleared state to the active ResourceListModel so
 			// row markers disappear immediately at Ctrl+R — otherwise stale
 			// markers would remain visible until the rerun completes (and

--- a/internal/tui/views/detail.go
+++ b/internal/tui/views/detail.go
@@ -8,11 +8,12 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/k2m30/a9s/v3/internal/config"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/fieldpath"
 	"github.com/k2m30/a9s/v3/internal/resource"
+	"github.com/k2m30/a9s/v3/internal/runtime/messages"
 	"github.com/k2m30/a9s/v3/internal/tui/keys"
 	"github.com/k2m30/a9s/v3/internal/tui/layout"
-	"github.com/k2m30/a9s/v3/internal/runtime/messages"
 )
 
 // DetailModel renders the key-value describe view using bubbles/viewport for scroll.
@@ -36,7 +37,8 @@ type DetailModel struct {
 	pendingRelatedDispatch bool                        // true when a narrow→wide resize should dispatch RelatedCheckStartedMsg
 	fieldList              []fieldpath.FieldItem       // structured field data; nil = not yet computed
 	fieldCursor            int                         // index into fieldList for navigable cursor
-	enrichmentFinding      *resource.EnrichmentFinding // nil when no finding; rendered at top of detail view when non-nil
+	enrichmentFinding      *domain.Finding             // nil when no finding; rendered at top of detail view when non-nil
+	enrichmentDetail       *domain.AttentionDetail     // paired with enrichmentFinding; nil when finding has no supporting rows
 	plainMode              bool                        // true only during PlainContent(); causes Attention entries to render Key: Value (full text for clipboard/search)
 }
 

--- a/internal/tui/views/detail_cursor_stable_test.go
+++ b/internal/tui/views/detail_cursor_stable_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/charmbracelet/x/ansi"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/tui/keys"
 )
@@ -68,15 +69,17 @@ func TestDetail_SetEnrichmentFinding_PreservesCursorIdentity(t *testing.T) {
 	before := m.fieldList[m.fieldCursor]
 
 	// Wave 2 enrichment lands after the operator moved cursor.
-	finding := resource.EnrichmentFinding{
-		Severity: "!",
-		Summary:  "encryption key unavailable",
-		Rows: []resource.FindingRow{
-			{Label: "KMS Key", Value: "arn:aws:kms:…"},
-			{Label: "Reason", Value: "key is pending deletion"},
-		},
+	finding := domain.Finding{
+		Code:     "kms.key-unavailable",
+		Phrase:   "encryption key unavailable",
+		Severity: domain.SevBroken,
+		Source:   "wave2:dbi",
 	}
-	m.SetEnrichmentFinding(&finding)
+	ad := domain.AttentionDetail{Rows: []domain.DetailRow{
+		{Label: "KMS Key", Value: "arn:aws:kms:…"},
+		{Label: "Reason", Value: "key is pending deletion"},
+	}}
+	m.SetEnrichmentFinding(&finding, &ad)
 
 	// After injection, the cursor must still point at the SAME logical item.
 	if m.fieldCursor < 0 || m.fieldCursor >= len(m.fieldList) {
@@ -127,12 +130,14 @@ func TestDetail_SetEnrichmentFinding_RenderedSelectionFollowsCursor(t *testing.T
 	}
 
 	// Enrichment fires.
-	finding := resource.EnrichmentFinding{
-		Severity: "!",
-		Summary:  "encryption key unavailable",
-		Rows:     []resource.FindingRow{{Label: "KMS Key", Value: "arn:aws:kms:…"}},
+	finding := domain.Finding{
+		Code:     "kms.key-unavailable",
+		Phrase:   "encryption key unavailable",
+		Severity: domain.SevBroken,
+		Source:   "wave2:dbi",
 	}
-	m.SetEnrichmentFinding(&finding)
+	ad := domain.AttentionDetail{Rows: []domain.DetailRow{{Label: "KMS Key", Value: "arn:aws:kms:…"}}}
+	m.SetEnrichmentFinding(&finding, &ad)
 
 	// Rendered viewport content at the CURRENT fieldCursor index must carry
 	// the same Key as before. If renderContent ran before relocation, the
@@ -160,15 +165,17 @@ func TestDetail_ClearEnrichmentFinding_PreservesCursorIdentity(t *testing.T) {
 			"endpoint":       "prod-db-2.aws.com:5432",
 		},
 	}
-	finding := resource.EnrichmentFinding{
-		Severity: "!",
-		Summary:  "pending maintenance",
-		Rows:     []resource.FindingRow{{Label: "Action", Value: "os-upgrade"}},
+	finding := domain.Finding{
+		Code:     "dbi.pending-maintenance",
+		Phrase:   "pending maintenance",
+		Severity: domain.SevBroken,
+		Source:   "wave2:dbi",
 	}
+	ad := domain.AttentionDetail{Rows: []domain.DetailRow{{Label: "Action", Value: "os-upgrade"}}}
 
 	m := NewDetail(res, "dbi", nil, keys.Default())
 	m.SetSize(120, 40)
-	m.SetEnrichmentFinding(&finding)
+	m.SetEnrichmentFinding(&finding, &ad)
 	m.refreshViewportContent()
 
 	if len(m.fieldList) < 8 {
@@ -179,7 +186,7 @@ func TestDetail_ClearEnrichmentFinding_PreservesCursorIdentity(t *testing.T) {
 	before := m.fieldList[m.fieldCursor]
 
 	// Finding clears (e.g. next enrichment cycle reports healthy).
-	m.SetEnrichmentFinding(nil)
+	m.SetEnrichmentFinding(nil, nil)
 
 	if m.fieldCursor < 0 || m.fieldCursor >= len(m.fieldList) {
 		t.Fatalf("fieldCursor out of range after clear: %d / %d",

--- a/internal/tui/views/detail_fields.go
+++ b/internal/tui/views/detail_fields.go
@@ -199,14 +199,22 @@ func (m *DetailModel) injectAttentionSection() {
 		for _, phrase := range m.res.Issues {
 			entries = append(entries, entry{tier: phraseTier(m.resourceType, phrase), primary: phrase})
 		}
-		if m.enrichmentFinding != nil && m.enrichmentFinding.Summary != "" {
-			enrichRows := make([]domain.DetailRow, len(m.enrichmentFinding.Rows))
-			for i, r := range m.enrichmentFinding.Rows {
-				enrichRows[i] = domain.DetailRow{Label: r.Label, Value: r.Value, Tier: r.Tier}
+		if m.enrichmentFinding != nil && m.enrichmentFinding.Phrase != "" {
+			var enrichRows []domain.DetailRow
+			if m.enrichmentDetail != nil {
+				enrichRows = make([]domain.DetailRow, len(m.enrichmentDetail.Rows))
+				copy(enrichRows, m.enrichmentDetail.Rows)
+			}
+			var tier string
+			switch m.enrichmentFinding.Severity {
+			case domain.SevBroken:
+				tier = "!"
+			case domain.SevWarn:
+				tier = "~"
 			}
 			entries = append(entries, entry{
-				tier:    m.enrichmentFinding.Severity,
-				primary: m.enrichmentFinding.Summary,
+				tier:    tier,
+				primary: m.enrichmentFinding.Phrase,
 				rows:    enrichRows,
 			})
 		}

--- a/internal/tui/views/detail_helpers.go
+++ b/internal/tui/views/detail_helpers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/charmbracelet/x/ansi"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/tui/layout"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
@@ -343,7 +344,7 @@ func (m DetailModel) SourceResource() resource.Resource {
 // back to cursor=0 rather than hunting for a gone row. Regression guards:
 // views.TestDetail_SetEnrichmentFinding_PreservesCursorIdentity and
 // views.TestDetail_SetEnrichmentFinding_RenderedSelectionFollowsCursor.
-func (m *DetailModel) SetEnrichmentFinding(f *resource.EnrichmentFinding) {
+func (m *DetailModel) SetEnrichmentFinding(f *domain.Finding, ad *domain.AttentionDetail) {
 	var beforeKey, beforePath string
 	haveSnapshot := false
 	if m.fieldList != nil && m.fieldCursor >= 0 && m.fieldCursor < len(m.fieldList) {
@@ -356,6 +357,7 @@ func (m *DetailModel) SetEnrichmentFinding(f *resource.EnrichmentFinding) {
 	}
 
 	m.enrichmentFinding = f
+	m.enrichmentDetail = ad
 	m.fieldList = nil
 	m.buildFieldList() // eager rebuild BEFORE render — see sequence in docstring
 

--- a/internal/tui/views/resourcelist.go
+++ b/internal/tui/views/resourcelist.go
@@ -10,9 +10,10 @@ import (
 	lipgloss "charm.land/lipgloss/v2"
 
 	"github.com/k2m30/a9s/v3/internal/config"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
-	"github.com/k2m30/a9s/v3/internal/tui/keys"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
+	"github.com/k2m30/a9s/v3/internal/tui/keys"
 	"github.com/k2m30/a9s/v3/internal/tui/styles"
 )
 
@@ -63,7 +64,7 @@ type ResourceListModel struct {
 	// enrichment state — populated by SetEnrichmentState.
 	enrichmentIssueCount int                                   // unified Wave-1 + Wave-2 distinct-instance count
 	enrichmentTruncated  bool                                  // true if enrichment count is a lower bound
-	findingsByID         map[string]resource.EnrichmentFinding // this type's per-resource findings
+	findingsByID         map[string]domain.Finding             // this type's per-resource Wave-2 findings (AS-1395 typed model)
 	// truncatedByID is populated by SetTruncatedIDs. Resources in this set
 	// had their enrichment truncated (per-resource API error or page cap) and
 	// are rendered with a "?" prefix in the identity column.
@@ -560,7 +561,7 @@ func (m *ResourceListModel) View() string {
 // re-runs applySortAndFilter so that the ctrl+z attention filter picks up newly
 // flagged rows immediately — otherwise enabling ctrl+z before Wave 2 completes
 // would leave the enriched rows hidden until the next filter edit.
-func (m *ResourceListModel) SetEnrichmentState(issueCount int, truncated bool, findings map[string]resource.EnrichmentFinding) {
+func (m *ResourceListModel) SetEnrichmentState(issueCount int, truncated bool, findings map[string]domain.Finding) {
 	m.enrichmentIssueCount = issueCount
 	m.enrichmentTruncated = truncated
 	m.findingsByID = findings

--- a/internal/tui/views/table_render.go
+++ b/internal/tui/views/table_render.go
@@ -324,9 +324,9 @@ func (m ResourceListModel) renderDataRow(cols []listCol, r resource.Resource, ba
 				// is itself the signal. No `?` glyph, no others.
 				if m.typeDef.ResolveColor(r) == resource.ColorHealthy {
 					switch finding.Severity {
-					case "!":
+					case domain.SevBroken:
 						val = "! " + val
-					case "~":
+					case domain.SevWarn:
 						val = "~ " + val
 					}
 				}

--- a/tests/integration/local_repro_four_rules_test.go
+++ b/tests/integration/local_repro_four_rules_test.go
@@ -10,6 +10,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/tui"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
@@ -86,14 +87,14 @@ func drainWave2Enrichment(t *testing.T, m tui.Model, cmd tea.Cmd) tui.Model {
 
 // drainWave2EnrichmentCollect is like drainWave2Enrichment but also returns
 // the per-type findings observed during the drain. The returned map is
-// shortName → finding-keyed map of resource IDs to EnrichmentFinding, so
+// shortName → finding-keyed map of resource IDs to domain.Finding, so
 // callers can drill into specific affected resources for end-to-end assertions.
-func drainWave2EnrichmentCollect(t *testing.T, m tui.Model, cmd tea.Cmd) (tui.Model, map[string]map[string]resource.EnrichmentFinding) {
+func drainWave2EnrichmentCollect(t *testing.T, m tui.Model, cmd tea.Cmd) (tui.Model, map[string]map[string]domain.Finding) {
 	t.Helper()
 	const maxIterations = 200 // 9 enrichers × worst-case 20 follow-ups; generous
 	queue := []tea.Cmd{cmd}
 	enrichmentMsgs := 0
-	collected := map[string]map[string]resource.EnrichmentFinding{}
+	collected := map[string]map[string]domain.Finding{}
 	for i := 0; i < maxIterations && len(queue) > 0; i++ {
 		next := queue[0]
 		queue = queue[1:]
@@ -108,7 +109,7 @@ func drainWave2EnrichmentCollect(t *testing.T, m tui.Model, cmd tea.Cmd) (tui.Mo
 				enrichmentMsgs++
 				if len(em.Findings) > 0 {
 					if collected[em.ResourceType] == nil {
-						collected[em.ResourceType] = map[string]resource.EnrichmentFinding{}
+						collected[em.ResourceType] = map[string]domain.Finding{}
 					}
 					for id, f := range em.Findings {
 						collected[em.ResourceType][id] = f

--- a/tests/unit/app_error_surfacing_test.go
+++ b/tests/unit/app_error_surfacing_test.go
@@ -17,6 +17,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
 )
@@ -134,7 +135,7 @@ func TestEnrichmentCheckedMsg_NilErrNoFlash(t *testing.T) {
 	m := newTestModel()
 	okMsg := messages.EnrichmentChecked{
 		ResourceType: "sfn",
-		Findings:     map[string]resource.EnrichmentFinding{},
+		Findings:     map[string]domain.Finding{},
 	}
 
 	_, cmd := m.Update(okMsg)

--- a/tests/unit/aws_acm_enricher_test.go
+++ b/tests/unit/aws_acm_enricher_test.go
@@ -23,6 +23,7 @@ import (
 	acmtypes "github.com/aws/aws-sdk-go-v2/service/acm/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -162,11 +163,11 @@ func TestEnrichACMCertificate_ExpiringSoonProducesFindingSevBang(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding keyed by bare domain %q", acmDomain1)
 	}
-	if f.Severity != "!" {
-		t.Errorf("severity = %q, want %q", f.Severity, "!")
+	if f.Severity != domain.SevBroken {
+		t.Errorf("severity = %v, want %v", f.Severity, "!")
 	}
-	if !strings.Contains(strings.ToLower(f.Summary), "expires") {
-		t.Errorf("summary %q must contain \"expires\"", f.Summary)
+	if !strings.Contains(strings.ToLower(f.Phrase), "expires") {
+		t.Errorf("summary %q must contain \"expires\"", f.Phrase)
 	}
 	if _, ok := result.Findings[acmDomain2]; ok {
 		t.Error("cert-2 must NOT appear in Findings — it is not expiring soon")
@@ -201,8 +202,8 @@ func TestEnrichACMCertificate_ExpiredProducesFindingSevBang(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding keyed by bare domain %q", acmDomain1)
 	}
-	if f.Severity != "!" {
-		t.Errorf("severity = %q, want %q", f.Severity, "!")
+	if f.Severity != domain.SevBroken {
+		t.Errorf("severity = %v, want %v", f.Severity, "!")
 	}
 	if _, ok := result.Findings[acmDomain2]; ok {
 		t.Error("cert-2 must NOT appear in Findings — it is valid")
@@ -237,8 +238,8 @@ func TestEnrichACMCertificate_OrphanIssuedProducesFindingSevTilde(t *testing.T) 
 	if !ok {
 		t.Fatalf("expected finding keyed by bare domain %q (orphan cert)", acmDomain1)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
 	if _, ok := result.Findings[acmDomain2]; ok {
 		t.Error("cert-2 must NOT appear in Findings — it is in use")

--- a/tests/unit/aws_apigw_enricher_test.go
+++ b/tests/unit/aws_apigw_enricher_test.go
@@ -21,6 +21,7 @@ import (
 	apigwtypes "github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -158,11 +159,11 @@ func TestEnrichAPIGatewayStage_NoThrottlingProducesFindingSevTilde(t *testing.T)
 	if !ok {
 		t.Fatalf("expected finding keyed by %q (no throttling)", apigwAPIID1)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
-	if !strings.Contains(strings.ToLower(f.Summary), "throttling") {
-		t.Errorf("summary %q must contain \"throttling\"", f.Summary)
+	if !strings.Contains(strings.ToLower(f.Phrase), "throttling") {
+		t.Errorf("summary %q must contain \"throttling\"", f.Phrase)
 	}
 	if _, ok := result.Findings[apigwAPIID2]; ok {
 		t.Error("api-2 must NOT appear in Findings — it has throttling configured")
@@ -202,11 +203,11 @@ func TestEnrichAPIGatewayStage_NoAccessLogsProducesFindingSevTilde(t *testing.T)
 	if !ok {
 		t.Fatalf("expected finding keyed by %q (no access logs)", apigwAPIID1)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
-	if !strings.Contains(strings.ToLower(f.Summary), "access log") {
-		t.Errorf("summary %q must contain \"access log\"", f.Summary)
+	if !strings.Contains(strings.ToLower(f.Phrase), "access log") {
+		t.Errorf("summary %q must contain \"access log\"", f.Phrase)
 	}
 	if _, ok := result.Findings[apigwAPIID2]; ok {
 		t.Error("api-2 must NOT appear in Findings — it has access logs configured")
@@ -273,12 +274,12 @@ func TestEnrichAPIGatewayStage_ZeroStagesEmitsWarning(t *testing.T) {
 		)
 	}
 
-	if f.Severity != "~" {
-		t.Errorf("finding Severity = %q, want \"~\"", f.Severity)
+	if f.Severity != domain.SevWarn {
+		t.Errorf("finding Severity = %v, want SevWarn", f.Severity)
 	}
 
-	if !strings.Contains(strings.ToLower(f.Summary), "no deployed") {
-		t.Errorf("finding Summary = %q, must contain \"no deployed\"", f.Summary)
+	if !strings.Contains(strings.ToLower(f.Phrase), "no deployed") {
+		t.Errorf("finding Summary = %q, must contain \"no deployed\"", f.Phrase)
 	}
 }
 

--- a/tests/unit/aws_apigw_v2_pagination_test.go
+++ b/tests/unit/aws_apigw_v2_pagination_test.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
+
+	"github.com/k2m30/a9s/v3/internal/domain"
 	apigwtypes "github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
@@ -249,11 +251,11 @@ func TestEnrichAPIGatewayStage_ZeroStagesAcrossPages(t *testing.T) {
 	if !ok {
 		t.Errorf("expected 1 finding for 0 stages (no deployed stages), got 0")
 	} else {
-		if f.Severity != "~" {
-			t.Errorf("finding Severity = %q, want \"~\"", f.Severity)
+		if f.Severity != domain.SevWarn {
+			t.Errorf("finding Severity = %v, want SevWarn", f.Severity)
 		}
-		if !strings.Contains(strings.ToLower(f.Summary), "no deployed") {
-			t.Errorf("finding Summary = %q, must contain \"no deployed\"", f.Summary)
+		if !strings.Contains(strings.ToLower(f.Phrase), "no deployed") {
+			t.Errorf("finding Summary = %q, must contain \"no deployed\"", f.Phrase)
 		}
 	}
 }

--- a/tests/unit/aws_asg_enricher_test.go
+++ b/tests/unit/aws_asg_enricher_test.go
@@ -22,6 +22,7 @@ import (
 	asgtypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -140,8 +141,8 @@ func TestEnrichASGScalingActivities_OneFailedProducesFindingSevBang(t *testing.T
 	if !ok {
 		t.Fatalf("expected finding keyed by ASG name %q for failed activity", "my-failing-asg")
 	}
-	if f.Severity != "!" {
-		t.Errorf("severity = %q, want %q", f.Severity, "!")
+	if f.Severity != domain.SevBroken {
+		t.Errorf("severity = %v, want %v", f.Severity, "!")
 	}
 	if _, ok := result.Findings["my-web-asg"]; ok {
 		t.Error("successful ASG must NOT appear in Findings")

--- a/tests/unit/aws_athena_enricher_test.go
+++ b/tests/unit/aws_athena_enricher_test.go
@@ -21,6 +21,7 @@ import (
 	athenatypes "github.com/aws/aws-sdk-go-v2/service/athena/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -158,11 +159,11 @@ func TestEnrichAthenaWorkGroup_NotEnforcedProducesFindingSevTilde(t *testing.T) 
 	if !ok {
 		t.Fatalf("expected finding keyed by %q (not enforced)", athenaWG1)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
-	if !strings.Contains(f.Summary, "Enforce") {
-		t.Errorf("summary %q must contain \"Enforce\"", f.Summary)
+	if !strings.Contains(f.Phrase, "Enforce") {
+		t.Errorf("summary %q must contain \"Enforce\"", f.Phrase)
 	}
 	if _, ok := result.Findings[athenaWG2]; ok {
 		t.Error("WG-2 must NOT appear in Findings — it is correctly configured")
@@ -195,11 +196,11 @@ func TestEnrichAthenaWorkGroup_NoEncryptionProducesFindingSevTilde(t *testing.T)
 	if !ok {
 		t.Fatalf("expected finding keyed by %q (no encryption)", athenaWG1)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
-	if !strings.Contains(strings.ToLower(f.Summary), "encryption") {
-		t.Errorf("summary %q must contain \"encryption\"", f.Summary)
+	if !strings.Contains(strings.ToLower(f.Phrase), "encryption") {
+		t.Errorf("summary %q must contain \"encryption\"", f.Phrase)
 	}
 	if _, ok := result.Findings[athenaWG2]; ok {
 		t.Error("WG-2 must NOT appear in Findings — it has encryption configured")

--- a/tests/unit/aws_backup_issue_enrichment_test.go
+++ b/tests/unit/aws_backup_issue_enrichment_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 )
 
 // ---------------------------------------------------------------------------
@@ -169,12 +170,12 @@ func TestBackup_Enricher_OneFailed_ShowsBrokenPhrase(t *testing.T) {
 	finding, ok := result.Findings[planID]
 	require.True(t, ok, "expected finding for plan %s; got keys %v", planID, findingKeys(result.Findings))
 
-	// Severity must be "!" (Broken).
-	require.Equal(t, "!", finding.Severity, "Severity mismatch — FAILED must map to '!'")
+	// Severity must be Broken.
+	require.Equal(t, domain.SevBroken, finding.Severity, "Severity mismatch — FAILED must map to '!'")
 
-	// Summary is the exact spec §4 S4 phrase.
-	require.Equal(t, "1 job failed in last 24h", finding.Summary,
-		"Summary mismatch — must match spec §4 S4 list text exactly")
+	// Phrase is the exact spec §4 S4 phrase.
+	require.Equal(t, "1 job failed in last 24h", finding.Phrase,
+		"Phrase mismatch — must match spec §4 S4 list text exactly")
 
 	// FieldUpdates must use key "status" (not "last_status").
 	updates, hasUpdates := result.FieldUpdates[planID]
@@ -188,30 +189,30 @@ func TestBackup_Enricher_OneFailed_ShowsBrokenPhrase(t *testing.T) {
 	require.GreaterOrEqual(t, result.IssueCount, 1,
 		"IssueCount must be >= 1 when a '!' finding exists")
 
-	// U11: Summary must not contain any Row.Value (skip pure-integer counts — they appear in
-	// both Summary phrases and count rows by design).
-	for _, row := range finding.Rows {
+	// U11: Phrase must not contain any Row.Value (skip pure-integer counts — they appear in
+	// both Phrase phrases and count rows by design).
+	for _, row := range result.AttentionDetails[planID].Rows {
 		if row.Value == "" {
 			continue
 		}
 		if _, isNum := strconv.Atoi(row.Value); isNum == nil {
-			continue // count values like "1", "3" appear in Summary phrases — not a U11 violation
+			continue // count values like "1", "3" appear in Phrase phrases — not a U11 violation
 		}
-		require.NotContains(t, finding.Summary, row.Value,
-			"U11 violation: Summary %q must not contain Row value %q", finding.Summary, row.Value)
+		require.NotContains(t, finding.Phrase, row.Value,
+			"U11 violation: Phrase %q must not contain Row value %q", finding.Phrase, row.Value)
 	}
 
 	// Rows must carry the state value for the failed job.
-	require.NotEmpty(t, finding.Rows, "Rows must not be empty — must carry job state detail")
+	require.NotEmpty(t, result.AttentionDetails[planID].Rows, "Rows must not be empty — must carry job state detail")
 	stateFound := false
-	for _, row := range finding.Rows {
+	for _, row := range result.AttentionDetails[planID].Rows {
 		if row.Value == "FAILED" {
 			stateFound = true
 			break
 		}
 	}
 	require.True(t, stateFound,
-		"Rows must contain a row with Value='FAILED' (job state detail); Rows: %v", finding.Rows)
+		"Rows must contain a row with Value='FAILED' (job state detail); Rows: %v", result.AttentionDetails[planID].Rows)
 }
 
 // ---------------------------------------------------------------------------
@@ -236,9 +237,9 @@ func TestBackup_Enricher_TwoFailed_CountsCorrectly(t *testing.T) {
 	finding, ok := result.Findings[planID]
 	require.True(t, ok, "expected finding for plan %s; got keys %v", planID, findingKeys(result.Findings))
 
-	require.Equal(t, "!", finding.Severity, "Severity mismatch — 2 failed jobs must map to '!'")
-	require.Equal(t, "2 jobs failed in last 24h", finding.Summary,
-		"Summary must be '2 jobs failed in last 24h' per spec §4 S4")
+	require.Equal(t, domain.SevBroken, finding.Severity, "Severity mismatch — 2 failed jobs must map to '!'")
+	require.Equal(t, "2 jobs failed in last 24h", finding.Phrase,
+		"Phrase must be '2 jobs failed in last 24h' per spec §4 S4")
 
 	updates, hasUpdates := result.FieldUpdates[planID]
 	require.True(t, hasUpdates, "FieldUpdates must contain an entry for plan %s", planID)
@@ -246,20 +247,20 @@ func TestBackup_Enricher_TwoFailed_CountsCorrectly(t *testing.T) {
 		"FieldUpdates[status] must equal the S4 phrase")
 
 	// U11: skip pure-integer count values — they naturally appear in count phrases.
-	for _, row := range finding.Rows {
+	for _, row := range result.AttentionDetails[planID].Rows {
 		if row.Value == "" {
 			continue
 		}
 		if _, isNum := strconv.Atoi(row.Value); isNum == nil {
 			continue
 		}
-		require.NotContains(t, finding.Summary, row.Value,
-			"U11: Summary %q must not contain Row value %q", finding.Summary, row.Value)
+		require.NotContains(t, finding.Phrase, row.Value,
+			"U11: Phrase %q must not contain Row value %q", finding.Phrase, row.Value)
 	}
 
 	// Both FAILED and EXPIRED states must appear in Rows.
 	rowVals := make(map[string]bool)
-	for _, row := range finding.Rows {
+	for _, row := range result.AttentionDetails[planID].Rows {
 		rowVals[row.Value] = true
 	}
 	require.True(t, rowVals["FAILED"], "Rows must carry FAILED state; rowValues: %v", rowVals)
@@ -286,21 +287,21 @@ func TestBackup_Enricher_OneAborted_IsAlsoBroken(t *testing.T) {
 	finding, ok := result.Findings[planID]
 	require.True(t, ok, "expected finding for plan %s; ABORTED must map to '!' bucket", planID)
 
-	require.Equal(t, "!", finding.Severity,
+	require.Equal(t, domain.SevBroken, finding.Severity,
 		"ABORTED must map to Severity '!' per spec §3.2")
-	require.Equal(t, "1 job failed in last 24h", finding.Summary,
+	require.Equal(t, "1 job failed in last 24h", finding.Phrase,
 		"ABORTED must use the same canonical phrase as FAILED per spec §4")
 
 	// U11: skip pure-integer count values.
-	for _, row := range finding.Rows {
+	for _, row := range result.AttentionDetails[planID].Rows {
 		if row.Value == "" {
 			continue
 		}
 		if _, isNum := strconv.Atoi(row.Value); isNum == nil {
 			continue
 		}
-		require.NotContains(t, finding.Summary, row.Value,
-			"U11: Summary %q must not contain Row value %q", finding.Summary, row.Value)
+		require.NotContains(t, finding.Phrase, row.Value,
+			"U11: Phrase %q must not contain Row value %q", finding.Phrase, row.Value)
 	}
 }
 
@@ -326,11 +327,11 @@ func TestBackup_Enricher_PartialOnly_IsWarning(t *testing.T) {
 	finding, ok := result.Findings[planID]
 	require.True(t, ok, "expected finding for plan %s; got keys %v", planID, findingKeys(result.Findings))
 
-	require.Equal(t, "~", finding.Severity,
+	require.Equal(t, domain.SevWarn, finding.Severity,
 		"PARTIAL-only must produce Severity '~' (Warning, not Broken)")
 	// Spec §4 S4: "partial: K of M resources skipped" where K=1 partial, M=3 total.
-	require.Equal(t, "partial: 1 of 3 resources skipped", finding.Summary,
-		"Summary must match spec §4 S4 phrase exactly")
+	require.Equal(t, "partial: 1 of 3 resources skipped", finding.Phrase,
+		"Phrase must match spec §4 S4 phrase exactly")
 
 	updates, hasUpdates := result.FieldUpdates[planID]
 	require.True(t, hasUpdates, "FieldUpdates must have entry for plan %s", planID)
@@ -341,28 +342,28 @@ func TestBackup_Enricher_PartialOnly_IsWarning(t *testing.T) {
 	// We check by counting only "!" findings in the result.
 	bangCount := 0
 	for _, f := range result.Findings {
-		if f.Severity == "!" {
+		if f.Severity == domain.SevBroken {
 			bangCount++
 		}
 	}
 	require.Equal(t, 0, bangCount,
 		"S1: ~ findings must not increment IssueCount; no '!' findings expected for PARTIAL-only")
 
-	// U11: Summary must not contain Row values (skip pure-integer counts).
-	for _, row := range finding.Rows {
+	// U11: Phrase must not contain Row values (skip pure-integer counts).
+	for _, row := range result.AttentionDetails[planID].Rows {
 		if row.Value == "" {
 			continue
 		}
 		if _, isNum := strconv.Atoi(row.Value); isNum == nil {
 			continue
 		}
-		require.NotContains(t, finding.Summary, row.Value,
-			"U11: Summary %q must not contain Row value %q", finding.Summary, row.Value)
+		require.NotContains(t, finding.Phrase, row.Value,
+			"U11: Phrase %q must not contain Row value %q", finding.Phrase, row.Value)
 	}
 
 	// Rows must carry "Partial jobs" and "Total jobs" (or functionally equivalent integer counts).
-	rowVals := make(map[string]string, len(finding.Rows))
-	for _, row := range finding.Rows {
+	rowVals := make(map[string]string, len(result.AttentionDetails[planID].Rows))
+	for _, row := range result.AttentionDetails[planID].Rows {
 		rowVals[row.Label] = row.Value
 	}
 
@@ -370,7 +371,7 @@ func TestBackup_Enricher_PartialOnly_IsWarning(t *testing.T) {
 	// "Partial jobs"/"Total jobs" labels or as any row carrying the integer values.
 	partialCountFound := false
 	totalCountFound := false
-	for _, row := range finding.Rows {
+	for _, row := range result.AttentionDetails[planID].Rows {
 		if row.Value == "1" {
 			partialCountFound = true
 		}
@@ -379,9 +380,9 @@ func TestBackup_Enricher_PartialOnly_IsWarning(t *testing.T) {
 		}
 	}
 	require.True(t, partialCountFound,
-		"Rows must carry the partial job count (value '1'); Rows: %v", finding.Rows)
+		"Rows must carry the partial job count (value '1'); Rows: %v", result.AttentionDetails[planID].Rows)
 	require.True(t, totalCountFound,
-		"Rows must carry the total job count (value '3'); Rows: %v", finding.Rows)
+		"Rows must carry the total job count (value '3'); Rows: %v", result.AttentionDetails[planID].Rows)
 }
 
 // ---------------------------------------------------------------------------
@@ -408,13 +409,13 @@ func TestBackup_Enricher_MixedFailedAndPartial_BrokenWins(t *testing.T) {
 	finding, ok := result.Findings[planID]
 	require.True(t, ok, "expected finding for plan %s; got keys %v", planID, findingKeys(result.Findings))
 
-	// U7d: "!" beats "~".
-	require.Equal(t, "!", finding.Severity,
+	// U7d: Broken beats Warning.
+	require.Equal(t, domain.SevBroken, finding.Severity,
 		"U7d: Broken must beat Warning when both FAILED and PARTIAL exist")
 
-	// One FAILED job drives the summary.
-	require.Equal(t, "1 job failed in last 24h", finding.Summary,
-		"U7d: Summary uses the failed-bucket phrase when any '!' job exists")
+	// One FAILED job drives the phrase.
+	require.Equal(t, "1 job failed in last 24h", finding.Phrase,
+		"U7d: Phrase uses the failed-bucket phrase when any '!' job exists")
 
 	updates, hasUpdates := result.FieldUpdates[planID]
 	require.True(t, hasUpdates, "FieldUpdates must have entry for plan %s", planID)
@@ -424,7 +425,7 @@ func TestBackup_Enricher_MixedFailedAndPartial_BrokenWins(t *testing.T) {
 	// S1: IssueCount bumps.
 	bangCount := 0
 	for _, f := range result.Findings {
-		if f.Severity == "!" {
+		if f.Severity == domain.SevBroken {
 			bangCount++
 		}
 	}
@@ -434,16 +435,16 @@ func TestBackup_Enricher_MixedFailedAndPartial_BrokenWins(t *testing.T) {
 	// Rows must include both the failed job State AND partial job count
 	// so nothing silently disappears.
 	rowVals := make(map[string]bool)
-	for _, row := range finding.Rows {
+	for _, row := range result.AttentionDetails[planID].Rows {
 		rowVals[row.Value] = true
 	}
 	require.True(t, rowVals["FAILED"],
-		"Rows must contain State=FAILED; rows: %v", finding.Rows)
+		"Rows must contain State=FAILED; rows: %v", result.AttentionDetails[planID].Rows)
 
 	// Partial evidence must be preserved alongside the FAILED evidence so the
 	// enricher cannot silently drop partial context when a failed job exists.
 	var sawPartial bool
-	for _, row := range finding.Rows {
+	for _, row := range result.AttentionDetails[planID].Rows {
 		if row.Label == "Partial jobs" || row.Tier == "~" {
 			sawPartial = true
 			break
@@ -452,15 +453,15 @@ func TestBackup_Enricher_MixedFailedAndPartial_BrokenWins(t *testing.T) {
 	require.True(t, sawPartial, "mixed FAILED+PARTIAL finding must surface partial evidence in Rows")
 
 	// U11: skip pure-integer count values.
-	for _, row := range finding.Rows {
+	for _, row := range result.AttentionDetails[planID].Rows {
 		if row.Value == "" {
 			continue
 		}
 		if _, isNum := strconv.Atoi(row.Value); isNum == nil {
 			continue
 		}
-		require.NotContains(t, finding.Summary, row.Value,
-			"U11: Summary %q must not contain Row value %q", finding.Summary, row.Value)
+		require.NotContains(t, finding.Phrase, row.Value,
+			"U11: Phrase %q must not contain Row value %q", finding.Phrase, row.Value)
 	}
 }
 
@@ -546,8 +547,8 @@ func TestBackup_Enricher_BannedWords_NeverAppear(t *testing.T) {
 	}
 
 	for _, word := range bannedWords {
-		require.NotContains(t, finding.Summary, word,
-			"Summary must not contain banned word %q; got Summary=%q", word, finding.Summary)
+		require.NotContains(t, finding.Phrase, word,
+			"Phrase must not contain banned word %q; got Phrase=%q", word, finding.Phrase)
 	}
 
 	if updates, ok := result.FieldUpdates[planID]; ok {
@@ -735,26 +736,26 @@ func TestBackup_Enricher_FailedBucket_AllStatesMapToBang(t *testing.T) {
 			require.True(t, ok,
 				"state %s must produce a finding; got keys %v", tc.state, findingKeys(result.Findings))
 
-			require.Equal(t, "!", finding.Severity,
+			require.Equal(t, domain.SevBroken, finding.Severity,
 				"state %s must map to Severity '!'", tc.state)
-			require.Equal(t, tc.wantMsg, finding.Summary,
-				"state %s Summary must be %q", tc.state, tc.wantMsg)
+			require.Equal(t, tc.wantMsg, finding.Phrase,
+				"state %s Phrase must be %q", tc.state, tc.wantMsg)
 
 			// U11 for every case. Skip pure-integer row values — counts are
-			// allowed to appear inside the Summary phrase (e.g. "2 jobs failed
+			// allowed to appear inside the Phrase (e.g. "2 jobs failed
 			// in last 24h" legitimately contains "2"), and U11 is meant to
-			// catch Summaries concatenated from descriptive Row values, not
+			// catch Phrase concatenated from descriptive Row values, not
 			// numeric match-ups.
-			for _, row := range finding.Rows {
+			for _, row := range result.AttentionDetails[tc.planID].Rows {
 				if row.Value == "" {
 					continue
 				}
 				if _, convErr := strconv.Atoi(row.Value); convErr == nil {
 					continue
 				}
-				require.NotContains(t, finding.Summary, row.Value,
-					"U11: [%s] Summary %q must not contain Row value %q",
-					tc.state, finding.Summary, row.Value)
+				require.NotContains(t, finding.Phrase, row.Value,
+					"U11: [%s] Phrase %q must not contain Row value %q",
+					tc.state, finding.Phrase, row.Value)
 			}
 		})
 	}
@@ -810,7 +811,7 @@ func TestBackup_Enricher_U11_SummaryNeverContainsRowValues(t *testing.T) {
 	require.NoError(t, err)
 
 	for planID, finding := range result.Findings {
-		for _, row := range finding.Rows {
+		for _, row := range result.AttentionDetails[planID].Rows {
 			if row.Value == "" {
 				continue
 			}
@@ -819,9 +820,9 @@ func TestBackup_Enricher_U11_SummaryNeverContainsRowValues(t *testing.T) {
 			if _, isNum := strconv.Atoi(row.Value); isNum == nil {
 				continue
 			}
-			require.NotContains(t, finding.Summary, row.Value,
-				"U11 violation for plan %s: Summary %q contains Row value %q — Summary and Rows must be disjoint",
-				planID, finding.Summary, row.Value)
+			require.NotContains(t, finding.Phrase, row.Value,
+				"U11 violation for plan %s: Phrase %q contains Row value %q — Phrase and Rows must be disjoint",
+				planID, finding.Phrase, row.Value)
 		}
 	}
 }

--- a/tests/unit/aws_cf_enricher_test.go
+++ b/tests/unit/aws_cf_enricher_test.go
@@ -21,6 +21,7 @@ import (
 	cftypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -184,11 +185,11 @@ func TestEnrichCloudFrontDistribution_AllowAllViewerProtocolProducesFindingSevTi
 	if !ok {
 		t.Fatalf("expected finding keyed by %q (no HTTPS redirect)", cfDistroID1)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
-	if !strings.Contains(strings.ToLower(f.Summary), "https") {
-		t.Errorf("summary %q must contain \"https\"", f.Summary)
+	if !strings.Contains(strings.ToLower(f.Phrase), "https") {
+		t.Errorf("summary %q must contain \"https\"", f.Phrase)
 	}
 	if _, ok := result.Findings[cfDistroID2]; ok {
 		t.Error("distro-2 must NOT appear in Findings — it has redirect-to-https")
@@ -242,14 +243,14 @@ func TestEnrichCloudFrontDistribution_HTTPOnlyOriginProducesFindingSevTilde(t *t
 	if !ok {
 		t.Fatalf("expected finding keyed by %q (http-only origin)", cfDistroID1)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
-	if !strings.Contains(strings.ToLower(f.Summary), "origin") {
-		t.Errorf("summary %q must contain \"origin\"", f.Summary)
+	if !strings.Contains(strings.ToLower(f.Phrase), "origin") {
+		t.Errorf("summary %q must contain \"origin\"", f.Phrase)
 	}
-	if !strings.Contains(strings.ToLower(f.Summary), "tls") {
-		t.Errorf("summary %q must contain \"tls\"", f.Summary)
+	if !strings.Contains(strings.ToLower(f.Phrase), "tls") {
+		t.Errorf("summary %q must contain \"tls\"", f.Phrase)
 	}
 	if _, ok := result.Findings[cfDistroID2]; ok {
 		t.Error("distro-2 must NOT appear in Findings — all its origins use https-only")

--- a/tests/unit/aws_cfn_enricher_test.go
+++ b/tests/unit/aws_cfn_enricher_test.go
@@ -20,6 +20,7 @@ import (
 	cfntypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -140,8 +141,8 @@ func TestEnrichCFNDrift_DriftedStackProducesFindingSevTilde(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding keyed by %q (drifted stack)", cfnDriftStack1)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
 	if _, ok := result.Findings[cfnDriftStack2]; ok {
 		t.Error("stack-2 must NOT appear in Findings — it is IN_SYNC")

--- a/tests/unit/aws_codeartifact_enricher_test.go
+++ b/tests/unit/aws_codeartifact_enricher_test.go
@@ -22,6 +22,7 @@ import (
 	codeartifacttypes "github.com/aws/aws-sdk-go-v2/service/codeartifact/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -159,11 +160,11 @@ func TestEnrichCodeArtifactRepository_NoPolicyProducesFindingSevTilde(t *testing
 	if !ok {
 		t.Fatalf("expected finding keyed by %q (no policy)", caRepo1)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
-	if !strings.Contains(strings.ToLower(f.Summary), "no permissions policy") {
-		t.Errorf("summary %q must contain \"no permissions policy\"", f.Summary)
+	if !strings.Contains(strings.ToLower(f.Phrase), "no permissions policy") {
+		t.Errorf("summary %q must contain \"no permissions policy\"", f.Phrase)
 	}
 	if _, ok := result.Findings[caRepo2]; ok {
 		t.Error("repo-2 must NOT appear in Findings — it has a valid policy")
@@ -195,11 +196,11 @@ func TestEnrichCodeArtifactRepository_PublicPolicyProducesFindingSevBang(t *test
 	if !ok {
 		t.Fatalf("expected finding keyed by %q (public access)", caRepo1)
 	}
-	if f.Severity != "!" {
-		t.Errorf("severity = %q, want %q", f.Severity, "!")
+	if f.Severity != domain.SevBroken {
+		t.Errorf("severity = %v, want %v", f.Severity, "!")
 	}
-	if !strings.Contains(strings.ToLower(f.Summary), "public access") {
-		t.Errorf("summary %q must contain \"public access\"", f.Summary)
+	if !strings.Contains(strings.ToLower(f.Phrase), "public access") {
+		t.Errorf("summary %q must contain \"public access\"", f.Phrase)
 	}
 	if _, ok := result.Findings[caRepo2]; ok {
 		t.Error("repo-2 must NOT appear in Findings — it has a specific principal")

--- a/tests/unit/aws_dbc_issue_enrichment_test.go
+++ b/tests/unit/aws_dbc_issue_enrichment_test.go
@@ -29,6 +29,7 @@ import (
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/demo/fixtures"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -127,7 +128,7 @@ func futureDate() *time.Time {
 }
 
 // dbcFindingKeys returns all keys in the findings map (for error reporting).
-func dbcFindingKeys(m map[string]resource.EnrichmentFinding) []string {
+func dbcFindingKeys(m map[string]domain.Finding) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -160,14 +161,14 @@ func TestDBC_Enrich_MaintenanceOverdue_HealthyRow(t *testing.T) {
 		t.Fatalf("expected finding for %q; Findings keys = %v", fixtures.MaintDbcOverdueID, dbcFindingKeys(result.Findings))
 	}
 
-	// Severity "!" — DBC maintenance is S1-badge-bumping (unlike DBI's "~").
-	if finding.Severity != "!" {
-		t.Errorf("Severity = %q, want %q", finding.Severity, "!")
+	// Severity SevBroken — DBC maintenance is S1-badge-bumping (unlike DBI's "~").
+	if finding.Severity != domain.SevBroken {
+		t.Errorf("Severity = %v, want SevBroken", finding.Severity)
 	}
 
-	// Summary is the short S5 phrase.
-	if finding.Summary != "maintenance overdue" {
-		t.Errorf("Summary = %q, want %q", finding.Summary, "maintenance overdue")
+	// Phrase is the short S5 phrase.
+	if finding.Phrase != "maintenance overdue" {
+		t.Errorf("Phrase = %q, want %q", finding.Phrase, "maintenance overdue")
 	}
 
 	// "!" findings increment the issue count.
@@ -318,13 +319,13 @@ func TestDBC_Enrich_Wave1PlusWave2_NoFieldUpdates(t *testing.T) {
 		t.Fatalf("EnrichDBCMaintenance error: %v", err)
 	}
 
-	// Finding present with "!" severity.
+	// Finding present with SevBroken severity.
 	finding, ok := result.Findings[clusterID]
 	if !ok {
 		t.Fatalf("expected finding for %q; Findings = %v", clusterID, dbcFindingKeys(result.Findings))
 	}
-	if finding.Severity != "!" {
-		t.Errorf("Severity = %q, want %q", finding.Severity, "!")
+	if finding.Severity != domain.SevBroken {
+		t.Errorf("Severity = %v, want SevBroken", finding.Severity)
 	}
 
 	// AS-140: FieldUpdates must be empty.
@@ -442,13 +443,12 @@ func TestDBC_Enrich_FindingRows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EnrichDBCMaintenance error: %v", err)
 	}
-	finding, ok := result.Findings[clusterID]
-	if !ok {
+	if _, ok := result.Findings[clusterID]; !ok {
 		t.Fatalf("expected finding for %q", clusterID)
 	}
 
 	gotRows := map[string]string{}
-	for _, row := range finding.Rows {
+	for _, row := range result.AttentionDetails[clusterID].Rows {
 		gotRows[row.Label] = row.Value
 	}
 

--- a/tests/unit/aws_dbc_snap_issue_enrichment_test.go
+++ b/tests/unit/aws_dbc_snap_issue_enrichment_test.go
@@ -23,6 +23,7 @@ import (
 
 	_ "github.com/k2m30/a9s/v3/internal/aws"
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -79,11 +80,11 @@ func TestDBCSnap_Orphan_DocDB(t *testing.T) {
 	if !ok {
 		t.Fatal("expected orphan finding, got none")
 	}
-	if finding.Severity != "!" {
-		t.Errorf("Severity = %q, want %q", finding.Severity, "!")
+	if finding.Severity != domain.SevBroken {
+		t.Errorf("Severity = %v, want SevBroken", finding.Severity)
 	}
-	if finding.Summary != "orphan: source cluster deleted" {
-		t.Errorf("Summary = %q, want %q", finding.Summary, "orphan: source cluster deleted")
+	if finding.Phrase != "orphan: source cluster deleted" {
+		t.Errorf("Phrase = %q, want %q", finding.Phrase, "orphan: source cluster deleted")
 	}
 	// AS-140: FieldUpdates must be empty — the merged display phrase is
 	// computed at render time by phraseFromFindings(r.Findings).
@@ -134,8 +135,8 @@ func TestDBCSnap_Orphan_Aurora(t *testing.T) {
 	}
 	if finding, ok := result.Findings["orphan-aurora-snap"]; !ok {
 		t.Fatal("expected orphan finding for Aurora snapshot (rdstypes.DBClusterSnapshot), got none")
-	} else if finding.Summary != "orphan: source cluster deleted" {
-		t.Errorf("Summary = %q, want %q", finding.Summary, "orphan: source cluster deleted")
+	} else if finding.Phrase != "orphan: source cluster deleted" {
+		t.Errorf("Phrase = %q, want %q", finding.Phrase, "orphan: source cluster deleted")
 	}
 	// AS-140: FieldUpdates must be empty — the merged display phrase is
 	// computed at render time by phraseFromFindings(r.Findings).
@@ -184,11 +185,11 @@ func TestDBCSnap_PastRetention_DocDB(t *testing.T) {
 	if !ok {
 		t.Fatal("expected past-retention finding, got none")
 	}
-	if !strings.Contains(finding.Summary, "automated") || !strings.Contains(finding.Summary, "past retention") {
-		t.Errorf("Summary = %q, want \"automated, Nd past retention\"", finding.Summary)
+	if !strings.Contains(finding.Phrase, "automated") || !strings.Contains(finding.Phrase, "past retention") {
+		t.Errorf("Phrase = %q, want \"automated, Nd past retention\"", finding.Phrase)
 	}
-	if !strings.Contains(finding.Summary, "23d") {
-		t.Errorf("Summary days-over should be 23 (30 - 7), got %q", finding.Summary)
+	if !strings.Contains(finding.Phrase, "23d") {
+		t.Errorf("Phrase days-over should be 23 (30 - 7), got %q", finding.Phrase)
 	}
 }
 

--- a/tests/unit/aws_dbi_issue_enrichment_test.go
+++ b/tests/unit/aws_dbi_issue_enrichment_test.go
@@ -116,26 +116,25 @@ func TestDBI_Enrich_MaintenancePending_HealthyRow(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding for %q; Findings keys = %v", fixtures.MaintDbiScheduledID, findingKeys(result.Findings))
 	}
-	if finding.Severity != "~" {
-		t.Errorf("Severity = %q, want %q", finding.Severity, "~")
+	if finding.Severity != domain.SevWarn {
+		t.Errorf("Severity = %v, want SevWarn", finding.Severity)
 	}
 
-	// Summary is the short S5 phrase — concrete details (Action, Description)
-	// must NOT appear here; they belong in Rows. See the contract on
-	// resource.EnrichmentFinding.
-	if finding.Summary != "pending maintenance" {
-		t.Errorf("Summary = %q, want %q", finding.Summary, "pending maintenance")
+	// Phrase is the short S5 phrase — concrete details (Action, Description)
+	// must NOT appear here; they belong in AttentionDetail rows.
+	if finding.Phrase != "pending maintenance" {
+		t.Errorf("Phrase = %q, want %q", finding.Phrase, "pending maintenance")
 	}
-	if strings.Contains(finding.Summary, "system-update") || strings.Contains(finding.Summary, "New minor engine patch") {
-		t.Errorf("Summary must not embed Row content; got %q", finding.Summary)
+	if strings.Contains(finding.Phrase, "system-update") || strings.Contains(finding.Phrase, "New minor engine patch") {
+		t.Errorf("Phrase must not embed Row content; got %q", finding.Phrase)
 	}
-	// The same facts must be present in Rows.
+	// The same facts must be present in AttentionDetail rows.
 	wantRows := map[string]string{
 		"Action":      "system-update",
 		"Description": "New minor engine patch 16.2.3",
 	}
 	gotRows := map[string]string{}
-	for _, r := range finding.Rows {
+	for _, r := range result.AttentionDetails[fixtures.MaintDbiScheduledID].Rows {
 		gotRows[r.Label] = r.Value
 	}
 	for label, val := range wantRows {
@@ -188,11 +187,11 @@ func TestDBI_Enrich_MaintenancePending_NilDescription(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding for %q", resourceID)
 	}
-	if finding.Summary != "pending maintenance" {
-		t.Errorf("Summary = %q, want %q", finding.Summary, "pending maintenance")
+	if finding.Phrase != "pending maintenance" {
+		t.Errorf("Phrase = %q, want %q", finding.Phrase, "pending maintenance")
 	}
 	var labels []string
-	for _, r := range finding.Rows {
+	for _, r := range result.AttentionDetails[resourceID].Rows {
 		labels = append(labels, r.Label)
 	}
 	for _, l := range labels {
@@ -379,13 +378,13 @@ func TestDBI_Enrich_Wave1PlusWave2_NoFieldUpdates(t *testing.T) {
 		t.Fatalf("EnrichDBIMaintenance error: %v", err)
 	}
 
-	// Finding must be present with severity "~".
+	// Finding must be present with SevWarn severity.
 	finding, ok := result.Findings[resourceID]
 	if !ok {
 		t.Fatalf("expected finding for %q; Findings keys = %v", resourceID, findingKeys(result.Findings))
 	}
-	if finding.Severity != "~" {
-		t.Errorf("Severity = %q, want %q", finding.Severity, "~")
+	if finding.Severity != domain.SevWarn {
+		t.Errorf("Severity = %v, want SevWarn", finding.Severity)
 	}
 
 	// AS-140: FieldUpdates must be empty.
@@ -594,7 +593,7 @@ func TestDBI_Enrich_VariousExistingStatuses_NoFieldUpdates(t *testing.T) {
 // internal helpers
 // ---------------------------------------------------------------------------
 
-func findingKeys(m map[string]resource.EnrichmentFinding) []string {
+func findingKeys(m map[string]domain.Finding) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)

--- a/tests/unit/aws_dbi_snap_issue_enrichment_test.go
+++ b/tests/unit/aws_dbi_snap_issue_enrichment_test.go
@@ -30,6 +30,7 @@ import (
 	_ "github.com/k2m30/a9s/v3/internal/aws"
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/demo/fixtures"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -156,8 +157,8 @@ func TestDBISnap_Enricher_Orphan_DbiMissingFromCache(t *testing.T) {
 	if !hasFinding {
 		t.Fatalf("Findings[%q] missing, want a finding with Summary matching the §4 phrase", snapID)
 	}
-	if finding.Summary != "orphan: source DB deleted" {
-		t.Errorf("Findings[%q].Summary = %q, want %q", snapID, finding.Summary, "orphan: source DB deleted")
+	if finding.Phrase != "orphan: source DB deleted" {
+		t.Errorf("Findings[%q].Phrase = %q, want %q", snapID, finding.Phrase, "orphan: source DB deleted")
 	}
 	// AS-140: FieldUpdates must be empty — the merged display phrase is
 	// computed at render time by phraseFromFindings(r.Findings).
@@ -206,12 +207,12 @@ func TestDBISnap_Enricher_AutomatedPastRetention_BasicCase(t *testing.T) {
 	if !hasFinding {
 		t.Fatalf("Findings[%q] missing, want past-retention finding", snapID)
 	}
-	if !strings.Contains(finding.Summary, "automated") || !strings.Contains(finding.Summary, "past retention") {
-		t.Errorf("Findings[%q].Summary = %q, want a phrase matching \"automated, <N>d past retention\"", snapID, finding.Summary)
+	if !strings.Contains(finding.Phrase, "automated") || !strings.Contains(finding.Phrase, "past retention") {
+		t.Errorf("Findings[%q].Phrase = %q, want a phrase matching \"automated, <N>d past retention\"", snapID, finding.Phrase)
 	}
 	// Verify the phrase contains "23d" (30 - 7 = 23 days past retention).
-	if strings.Contains(finding.Summary, "past retention") && !strings.Contains(finding.Summary, "23d") {
-		t.Errorf("past-retention Summary %q should say 23d (30-7=23), got different days", finding.Summary)
+	if strings.Contains(finding.Phrase, "past retention") && !strings.Contains(finding.Phrase, "23d") {
+		t.Errorf("past-retention Summary %q should say 23d (30-7=23), got different days", finding.Phrase)
 	}
 	// AS-140: FieldUpdates must be empty — the merged display phrase is
 	// computed at render time by phraseFromFindings(r.Findings).
@@ -286,11 +287,11 @@ func TestDBISnap_Enricher_SkipPastRetention_WhenParentNotInCache(t *testing.T) {
 	if !hasFinding {
 		t.Fatalf("Findings[snap-automated-missing-parent] missing, want orphan finding")
 	}
-	if finding.Summary != "orphan: source DB deleted" {
-		t.Errorf("Findings[snap-automated-missing-parent].Summary = %q, want \"orphan: source DB deleted\"", finding.Summary)
+	if finding.Phrase != "orphan: source DB deleted" {
+		t.Errorf("Findings[snap-automated-missing-parent].Phrase = %q, want \"orphan: source DB deleted\"", finding.Phrase)
 	}
-	if strings.Contains(finding.Summary, "past retention") {
-		t.Errorf("past-retention phrase in finding even though parent is not in dbi cache — should be skipped; Summary=%q", finding.Summary)
+	if strings.Contains(finding.Phrase, "past retention") {
+		t.Errorf("past-retention phrase in finding even though parent is not in dbi cache — should be skipped; Summary=%q", finding.Phrase)
 	}
 	// Status must say "orphan: source DB deleted" (orphan wins; no double-emit).
 	if fu := result.FieldUpdates["snap-automated-missing-parent"]; fu != nil {
@@ -332,8 +333,8 @@ func TestDBISnap_Enricher_MultiW1_UnencryptedPlusOrphan_Suffix(t *testing.T) {
 	if !hasFinding {
 		t.Fatalf("Findings[%q] missing, want orphan finding", snapID)
 	}
-	if finding.Summary != "orphan: source DB deleted" {
-		t.Errorf("Findings[%q].Summary = %q, want \"orphan: source DB deleted\"", snapID, finding.Summary)
+	if finding.Phrase != "orphan: source DB deleted" {
+		t.Errorf("Findings[%q].Phrase = %q, want \"orphan: source DB deleted\"", snapID, finding.Phrase)
 	}
 	// AS-140: FieldUpdates must be empty — the merged "unencrypted (+1)"
 	// stack is computed at render time by phraseFromFindings(r.Findings),
@@ -425,11 +426,11 @@ func TestDBISnap_Enricher_FindingMirrorsIssueAppend(t *testing.T) {
 	if !ok {
 		t.Fatalf("Findings missing entry for snap-orphan-check; want a Finding with orphan Summary")
 	}
-	if finding.Summary != "orphan: source DB deleted" {
-		t.Errorf("Finding.Summary = %q, want %q", finding.Summary, "orphan: source DB deleted")
+	if finding.Phrase != "orphan: source DB deleted" {
+		t.Errorf("Finding.Phrase = %q, want %q", finding.Phrase, "orphan: source DB deleted")
 	}
-	if finding.Severity != "!" {
-		t.Errorf("Finding.Severity = %q, want %q", finding.Severity, "!")
+	if finding.Severity != domain.SevBroken {
+		t.Errorf("Finding.Severity = %v, want SevBroken", finding.Severity)
 	}
 }
 
@@ -508,8 +509,8 @@ func TestDBISnap_Enricher_FullFixtures_OrphanAndRetentionFound(t *testing.T) {
 	orphanFinding, hasOrphan := result.Findings[orphanID]
 	if !hasOrphan {
 		t.Errorf("WarnDBISnapOrphanID: Findings[%q] missing, want orphan finding", orphanID)
-	} else if orphanFinding.Summary != "orphan: source DB deleted" {
-		t.Errorf("WarnDBISnapOrphanID: Findings[%q].Summary = %q, want \"orphan: source DB deleted\"", orphanID, orphanFinding.Summary)
+	} else if orphanFinding.Phrase != "orphan: source DB deleted" {
+		t.Errorf("WarnDBISnapOrphanID: Findings[%q].Phrase = %q, want \"orphan: source DB deleted\"", orphanID, orphanFinding.Phrase)
 	}
 
 	// MultiW1DBISnapID also has "deleted-legacy-db" as parent → orphan.
@@ -517,8 +518,8 @@ func TestDBISnap_Enricher_FullFixtures_OrphanAndRetentionFound(t *testing.T) {
 	multiFinding, hasMulti := result.Findings[multiID]
 	if !hasMulti {
 		t.Errorf("MultiW1DBISnapID: Findings[%q] missing, want orphan finding", multiID)
-	} else if multiFinding.Summary != "orphan: source DB deleted" {
-		t.Errorf("MultiW1DBISnapID: Findings[%q].Summary = %q, want \"orphan: source DB deleted\"", multiID, multiFinding.Summary)
+	} else if multiFinding.Phrase != "orphan: source DB deleted" {
+		t.Errorf("MultiW1DBISnapID: Findings[%q].Phrase = %q, want \"orphan: source DB deleted\"", multiID, multiFinding.Phrase)
 	}
 
 	// WarnDBISnapPastRetentionID has parent WarnDbiPastRetentionParentID (in dbi cache)
@@ -527,16 +528,16 @@ func TestDBISnap_Enricher_FullFixtures_OrphanAndRetentionFound(t *testing.T) {
 	retFinding, hasRetention := result.Findings[retentionID]
 	if !hasRetention {
 		t.Errorf("WarnDBISnapPastRetentionID: Findings[%q] missing, want past-retention finding", retentionID)
-	} else if !strings.Contains(retFinding.Summary, "automated") || !strings.Contains(retFinding.Summary, "past retention") {
-		t.Errorf("WarnDBISnapPastRetentionID: Findings[%q].Summary = %q, want \"automated, Nd past retention\"", retentionID, retFinding.Summary)
+	} else if !strings.Contains(retFinding.Phrase, "automated") || !strings.Contains(retFinding.Phrase, "past retention") {
+		t.Errorf("WarnDBISnapPastRetentionID: Findings[%q].Phrase = %q, want \"automated, Nd past retention\"", retentionID, retFinding.Phrase)
 	}
 
 	// Healthy fixtures (ProdDBISnapID) with parent in dbi cache
 	// must produce no orphan or retention findings.
 	for _, id := range []string{fixtures.ProdDBISnapID} {
 		if f, has := result.Findings[id]; has {
-			if strings.Contains(f.Summary, "orphan") || strings.Contains(f.Summary, "past retention") {
-				t.Errorf("healthy snap %q: unexpected finding %q", id, f.Summary)
+			if strings.Contains(f.Phrase, "orphan") || strings.Contains(f.Phrase, "past retention") {
+				t.Errorf("healthy snap %q: unexpected finding %q", id, f.Phrase)
 			}
 		}
 	}

--- a/tests/unit/aws_ddb_issue_enrichment_test.go
+++ b/tests/unit/aws_ddb_issue_enrichment_test.go
@@ -27,6 +27,7 @@ import (
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/demo/fixtures"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -168,11 +169,11 @@ func TestDDB_Enrich_PITRDisabled_HealthyRow(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding for %q (PITR disabled); Findings keys = %v", fixtures.AuditPITROffID, findingKeysDDB(result.Findings))
 	}
-	if finding.Severity != "~" {
-		t.Errorf("Severity = %q, want %q", finding.Severity, "~")
+	if finding.Severity != domain.SevWarn {
+		t.Errorf("Severity = %v, want SevWarn", finding.Severity)
 	}
-	if finding.Summary != "PITR off" {
-		t.Errorf("Summary = %q, want %q", finding.Summary, "PITR off")
+	if finding.Phrase != "PITR off" {
+		t.Errorf("Phrase = %q, want %q", finding.Phrase, "PITR off")
 	}
 
 	updates, ok := result.FieldUpdates[fixtures.AuditPITROffID]
@@ -212,11 +213,11 @@ func TestDDB_Enrich_PITRDisabled_NonHealthyRow(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding for %q (ARCHIVED + PITR off); Findings keys = %v", fixtures.LegacyArchivedID, findingKeysDDB(result.Findings))
 	}
-	if finding.Severity != "~" {
-		t.Errorf("Severity = %q, want %q", finding.Severity, "~")
+	if finding.Severity != domain.SevWarn {
+		t.Errorf("Severity = %v, want SevWarn", finding.Severity)
 	}
-	if finding.Summary != "PITR off" {
-		t.Errorf("Summary = %q, want %q", finding.Summary, "PITR off")
+	if finding.Phrase != "PITR off" {
+		t.Errorf("Phrase = %q, want %q", finding.Phrase, "PITR off")
 	}
 
 	updates, ok := result.FieldUpdates[fixtures.LegacyArchivedID]
@@ -256,13 +257,13 @@ func TestDDB_Enrich_SummaryNotRows_Contract(t *testing.T) {
 		t.Fatalf("expected finding for %q", fixtures.AuditPITROffID)
 	}
 
-	if finding.Summary != "PITR off" {
-		t.Errorf("Summary = %q, want exactly %q", finding.Summary, "PITR off")
+	if finding.Phrase != "PITR off" {
+		t.Errorf("Phrase = %q, want exactly %q", finding.Phrase, "PITR off")
 	}
-	// U11: no Row value should appear in Summary.
-	for _, row := range finding.Rows {
-		if row.Value != "" && strings.Contains(finding.Summary, row.Value) {
-			t.Errorf("Summary %q embeds Row[%q].Value %q — Summary and Rows must be distinct channels (U11)", finding.Summary, row.Label, row.Value)
+	// U11: no Row value should appear in Phrase.
+	for _, row := range result.AttentionDetails[fixtures.AuditPITROffID].Rows {
+		if row.Value != "" && strings.Contains(finding.Phrase, row.Value) {
+			t.Errorf("Phrase %q embeds Row[%q].Value %q — Phrase and Rows must be distinct channels (U11)", finding.Phrase, row.Label, row.Value)
 		}
 	}
 }
@@ -351,7 +352,7 @@ func TestDDB_Enrich_NilDynamoDBClient(t *testing.T) {
 // internal helpers
 // ---------------------------------------------------------------------------
 
-func findingKeysDDB(m map[string]resource.EnrichmentFinding) []string {
+func findingKeysDDB(m map[string]domain.Finding) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)

--- a/tests/unit/aws_ec2_enricher_test.go
+++ b/tests/unit/aws_ec2_enricher_test.go
@@ -22,6 +22,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -81,8 +82,8 @@ func TestEnrichEC2InstanceStatus_InstanceStatusImpairedProducesFindingSevBang(t 
 	if !ok {
 		t.Fatalf("expected finding keyed by instance ID %q", "i-0aaaa1111bbbbb222")
 	}
-	if f.Severity != "!" {
-		t.Errorf("severity = %q, want %q", f.Severity, "!")
+	if f.Severity != domain.SevBroken {
+		t.Errorf("severity = %v, want %v", f.Severity, "!")
 	}
 	if result.IssueCount != 1 {
 		t.Errorf("IssueCount = %d, want 1", result.IssueCount)
@@ -117,8 +118,8 @@ func TestEnrichEC2InstanceStatus_SystemStatusImpairedProducesFindingSevBang(t *t
 	if !ok {
 		t.Fatalf("expected finding keyed by instance ID %q for impaired system status", "i-0bbbb2222ccccc333")
 	}
-	if f.Severity != "!" {
-		t.Errorf("severity = %q, want %q", f.Severity, "!")
+	if f.Severity != domain.SevBroken {
+		t.Errorf("severity = %v, want %v", f.Severity, "!")
 	}
 }
 
@@ -157,8 +158,8 @@ func TestEnrichEC2InstanceStatus_ScheduledEventSoonProducesFindingSevTilde(t *te
 	if !ok {
 		t.Fatalf("expected finding keyed by instance ID %q for imminent scheduled event", "i-0cccc3333ddddd444")
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
 }
 

--- a/tests/unit/aws_ecr_enricher_test.go
+++ b/tests/unit/aws_ecr_enricher_test.go
@@ -20,6 +20,7 @@ import (
 	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -188,8 +189,8 @@ func TestEnrichECRRepository_CriticalFindingsProduceSevBang(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding keyed by %q", ecrRepo1)
 	}
-	if f.Severity != "!" {
-		t.Errorf("severity = %q, want %q", f.Severity, "!")
+	if f.Severity != domain.SevBroken {
+		t.Errorf("severity = %v, want %v", f.Severity, "!")
 	}
 	if _, ok := result.Findings[ecrRepo2]; ok {
 		t.Error("repo-2 must NOT appear in Findings — no critical vulnerabilities")
@@ -227,8 +228,8 @@ func TestEnrichECRRepository_HighFindingsProduceSevTilde(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding keyed by %q (high vulns)", ecrRepo1)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
 	if _, ok := result.Findings[ecrRepo2]; ok {
 		t.Error("repo-2 must NOT appear in Findings — no vulnerabilities")

--- a/tests/unit/aws_ecr_enrichment_n1_test.go
+++ b/tests/unit/aws_ecr_enrichment_n1_test.go
@@ -21,6 +21,7 @@ import (
 	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -152,8 +153,8 @@ func TestEnrichECRRepository_N1_CriticalAggregatesAcrossImages(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding for %q", repo)
 	}
-	if f.Severity != "!" {
-		t.Errorf("severity = %q, want %q", f.Severity, "!")
+	if f.Severity != domain.SevBroken {
+		t.Errorf("severity = %v, want %v", f.Severity, "!")
 	}
 	if result.IssueCount != 1 {
 		t.Errorf("IssueCount = %d, want 1", result.IssueCount)
@@ -193,8 +194,8 @@ func TestEnrichECRRepository_N1_HighOnlyEmitsTilde(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding for %q", repo)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
 	if result.IssueCount != 0 {
 		t.Errorf("IssueCount = %d, want 0 (~ never bumps badge)", result.IssueCount)

--- a/tests/unit/aws_efs_enricher_test.go
+++ b/tests/unit/aws_efs_enricher_test.go
@@ -19,6 +19,7 @@ import (
 	efstypes "github.com/aws/aws-sdk-go-v2/service/efs/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 )
 
 // Shared helpers (efsMountTargetFake, efsResources, availableMT,
@@ -76,8 +77,8 @@ func TestEnrichEFSMountTargets_OneUnavailableMTProducesFindingSevBang(t *testing
 	if !ok {
 		t.Fatalf("expected finding keyed by %q", "fs-00000001")
 	}
-	if f.Severity != "!" {
-		t.Errorf("severity = %q, want %q", f.Severity, "!")
+	if f.Severity != domain.SevBroken {
+		t.Errorf("severity = %v, want %v", f.Severity, "!")
 	}
 	if _, ok := result.Findings["fs-00000002"]; ok {
 		t.Error("fs-00000002 must NOT appear in Findings — all its MTs are available")

--- a/tests/unit/aws_efs_issue_enrichment_test.go
+++ b/tests/unit/aws_efs_issue_enrichment_test.go
@@ -27,6 +27,7 @@ import (
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/demo/fixtures"
+	"github.com/k2m30/a9s/v3/internal/domain"
 )
 
 // Shared helper efsMTFakeFromFixtures lives in helpers_efs_test.go.
@@ -68,19 +69,19 @@ func TestEnrichEFSMountTargets_HealthyRowWithDown(t *testing.T) {
 		t.Fatalf("expected finding for %q, got none; all findings: %v", fsID, result.Findings)
 	}
 
-	// Severity must be "!".
-	if finding.Severity != "!" {
-		t.Errorf("Severity = %q, want %q", finding.Severity, "!")
+	// Severity must be Broken.
+	if finding.Severity != domain.SevBroken {
+		t.Errorf("Severity = %v, want SevBroken", finding.Severity)
 	}
 
-	// Summary must be exactly "mount target down" (§4 "list text" phrase).
-	if finding.Summary != "mount target down" {
-		t.Errorf("Summary = %q, want %q", finding.Summary, "mount target down")
+	// Phrase must be exactly "mount target down" (§4 "list text" phrase).
+	if finding.Phrase != "mount target down" {
+		t.Errorf("Phrase = %q, want %q", finding.Phrase, "mount target down")
 	}
 
-	// Summary must be ≤ 40 chars.
-	if len(finding.Summary) > 40 {
-		t.Errorf("Summary length %d > 40 chars: %q", len(finding.Summary), finding.Summary)
+	// Phrase must be ≤ 40 chars.
+	if len(finding.Phrase) > 40 {
+		t.Errorf("Phrase length %d > 40 chars: %q", len(finding.Phrase), finding.Phrase)
 	}
 
 	// AS-140: FieldUpdates must be empty — the merged display phrase is
@@ -91,13 +92,13 @@ func TestEnrichEFSMountTargets_HealthyRowWithDown(t *testing.T) {
 
 	// Rows must contain the four expected labels.
 	wantLabels := []string{"Mount Target", "AZ", "State", "Degraded"}
-	rowLabels := make(map[string]string, len(finding.Rows))
-	for _, row := range finding.Rows {
+	rowLabels := make(map[string]string, len(result.AttentionDetails[fsID].Rows))
+	for _, row := range result.AttentionDetails[fsID].Rows {
 		rowLabels[row.Label] = row.Value
 	}
 	for _, label := range wantLabels {
 		if _, ok := rowLabels[label]; !ok {
-			t.Errorf("Rows missing label %q; got rows: %v", label, finding.Rows)
+			t.Errorf("Rows missing label %q; got rows: %v", label, result.AttentionDetails[fsID].Rows)
 		}
 	}
 
@@ -121,10 +122,10 @@ func TestEnrichEFSMountTargets_HealthyRowWithDown(t *testing.T) {
 		t.Errorf("Rows[Degraded] = %q, want %q", degVal, "1/2")
 	}
 
-	// U11: Summary must NOT contain any Row Value as substring.
-	for _, row := range finding.Rows {
-		if row.Value != "" && strings.Contains(finding.Summary, row.Value) {
-			t.Errorf("U11 violation: Summary %q contains Row Value %q (label=%q)", finding.Summary, row.Value, row.Label)
+	// U11: Phrase must NOT contain any Row Value as substring.
+	for _, row := range result.AttentionDetails[fsID].Rows {
+		if row.Value != "" && strings.Contains(finding.Phrase, row.Value) {
+			t.Errorf("U11 violation: Phrase %q contains Row Value %q (label=%q)", finding.Phrase, row.Value, row.Label)
 		}
 	}
 }
@@ -170,15 +171,15 @@ func TestEnrichEFSMountTargets_W1WarningPlusW2Bumps(t *testing.T) {
 		t.Errorf("AS-140: expected empty FieldUpdates for %q (status overlay removed); got %v", fsID, updates)
 	}
 
-	// The finding's Summary is still "mount target down" (the bare W2 phrase).
+	// The finding's Phrase is still "mount target down" (the bare W2 phrase).
 	finding := result.Findings[fsID]
-	if finding.Summary != "mount target down" {
-		t.Errorf("Summary = %q, want %q", finding.Summary, "mount target down")
+	if finding.Phrase != "mount target down" {
+		t.Errorf("Phrase = %q, want %q", finding.Phrase, "mount target down")
 	}
 
 	// The down MT-B must appear in Rows[Mount Target].
-	rowLabels := make(map[string]string, len(finding.Rows))
-	for _, row := range finding.Rows {
+	rowLabels := make(map[string]string, len(result.AttentionDetails[fsID].Rows))
+	for _, row := range result.AttentionDetails[fsID].Rows {
 		rowLabels[row.Label] = row.Value
 	}
 	if mtVal := rowLabels["Mount Target"]; !strings.Contains(mtVal, fixtures.UpdatingMTDownMountTargetBID) {
@@ -249,13 +250,13 @@ func TestEnrichEFSMountTargets_SummaryDoesNotContainRowValues(t *testing.T) {
 			t.Errorf("expected finding for %q, got none", fsID)
 			continue
 		}
-		for _, row := range finding.Rows {
+		for _, row := range result.AttentionDetails[fsID].Rows {
 			if row.Value == "" {
 				continue
 			}
-			if strings.Contains(finding.Summary, row.Value) {
-				t.Errorf("U11 violation for %q: Summary %q contains Row[%q].Value %q",
-					fsID, finding.Summary, row.Label, row.Value)
+			if strings.Contains(finding.Phrase, row.Value) {
+				t.Errorf("U11 violation for %q: Phrase %q contains Row[%q].Value %q",
+					fsID, finding.Phrase, row.Label, row.Value)
 			}
 		}
 	}
@@ -281,13 +282,12 @@ func TestEnrichEFSMountTargets_FindingRowsStructure(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	finding, ok := result.Findings[fsID]
-	if !ok {
+	if _, ok := result.Findings[fsID]; !ok {
 		t.Fatalf("expected finding for %q", fsID)
 	}
 
 	// Every row must have a non-empty Label.
-	for i, row := range finding.Rows {
+	for i, row := range result.AttentionDetails[fsID].Rows {
 		if row.Label == "" {
 			t.Errorf("Rows[%d].Label is empty", i)
 		}
@@ -297,7 +297,7 @@ func TestEnrichEFSMountTargets_FindingRowsStructure(t *testing.T) {
 	// "State" row must have Tier="!".
 	// Other rows (AZ, Degraded) may have Tier="" (neutral context).
 	tierMap := make(map[string]string)
-	for _, row := range finding.Rows {
+	for _, row := range result.AttentionDetails[fsID].Rows {
 		tierMap[row.Label] = row.Tier
 	}
 
@@ -414,13 +414,12 @@ func TestEnrichEFSMountTargets_DetailContent_U7c(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	finding, ok := result.Findings[fsID]
-	if !ok {
+	if _, ok := result.Findings[fsID]; !ok {
 		t.Fatalf("expected finding for %q", fsID)
 	}
 
-	rowMap := make(map[string]string, len(finding.Rows))
-	for _, row := range finding.Rows {
+	rowMap := make(map[string]string, len(result.AttentionDetails[fsID].Rows))
+	for _, row := range result.AttentionDetails[fsID].Rows {
 		rowMap[row.Label] = row.Value
 	}
 

--- a/tests/unit/aws_enrichment_wave3_test.go
+++ b/tests/unit/aws_enrichment_wave3_test.go
@@ -34,6 +34,7 @@ import (
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -146,14 +147,14 @@ func TestEnrichECSServices_StuckServiceEmitsBangFinding(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding for service %q; findings: %v", svcName, result.Findings)
 	}
-	if f.Severity != "!" {
-		t.Errorf("severity = %q, want %q", f.Severity, "!")
+	if f.Severity != domain.SevBroken {
+		t.Errorf("severity = %v, want %v", f.Severity, "!")
 	}
-	if !strings.Contains(f.Summary, "running") {
-		t.Errorf("summary %q should contain %q", f.Summary, "running")
+	if !strings.Contains(f.Phrase, "running") {
+		t.Errorf("summary %q should contain %q", f.Phrase, "running")
 	}
-	if !strings.Contains(f.Summary, "desired") {
-		t.Errorf("summary %q should contain %q", f.Summary, "desired")
+	if !strings.Contains(f.Phrase, "desired") {
+		t.Errorf("summary %q should contain %q", f.Phrase, "desired")
 	}
 	if result.IssueCount != 1 {
 		t.Errorf("IssueCount = %d, want 1", result.IssueCount)
@@ -202,11 +203,11 @@ func TestEnrichECSServices_DeploymentRolloutFailedEmitsFinding(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding for service %q; findings: %v", svcName, result.Findings)
 	}
-	if f.Severity != "!" {
-		t.Errorf("severity = %q, want %q", f.Severity, "!")
+	if f.Severity != domain.SevBroken {
+		t.Errorf("severity = %v, want %v", f.Severity, "!")
 	}
-	if !strings.Contains(f.Summary, "deployment") {
-		t.Errorf("summary %q should contain %q", f.Summary, "deployment")
+	if !strings.Contains(f.Phrase, "deployment") {
+		t.Errorf("summary %q should contain %q", f.Phrase, "deployment")
 	}
 }
 
@@ -365,11 +366,11 @@ func TestEnrichECSClusters_PendingTasksEmitsFinding(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding for cluster %q; findings: %v", clusterName, result.Findings)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
-	if !strings.Contains(f.Summary, "pending") {
-		t.Errorf("summary %q should contain %q", f.Summary, "pending")
+	if !strings.Contains(f.Phrase, "pending") {
+		t.Errorf("summary %q should contain %q", f.Phrase, "pending")
 	}
 	// IssueCount must be 0 — all ECS cluster findings are informational.
 	if result.IssueCount != 0 {
@@ -513,11 +514,11 @@ func TestEnrichECSTasks_TaskFailedToStartEmitsFinding(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding for task %q; findings: %v", taskID, result.Findings)
 	}
-	if f.Severity != "!" {
-		t.Errorf("severity = %q, want %q", f.Severity, "!")
+	if f.Severity != domain.SevBroken {
+		t.Errorf("severity = %v, want %v", f.Severity, "!")
 	}
-	if !strings.Contains(f.Summary, "TaskFailedToStart") {
-		t.Errorf("summary %q should contain %q", f.Summary, "TaskFailedToStart")
+	if !strings.Contains(f.Phrase, "TaskFailedToStart") {
+		t.Errorf("summary %q should contain %q", f.Phrase, "TaskFailedToStart")
 	}
 	if result.IssueCount != 1 {
 		t.Errorf("IssueCount = %d, want 1", result.IssueCount)
@@ -718,11 +719,11 @@ func TestEnrichCFNStackEvents_FailedEventEmitsBangFinding(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding for stack %q; findings: %v", stackID, result.Findings)
 	}
-	if f.Severity != "!" {
-		t.Errorf("severity = %q, want %q", f.Severity, "!")
+	if f.Severity != domain.SevBroken {
+		t.Errorf("severity = %v, want %v", f.Severity, "!")
 	}
-	if !strings.Contains(f.Summary, "recent resource failure") {
-		t.Errorf("summary %q should contain %q", f.Summary, "recent resource failure")
+	if !strings.Contains(f.Phrase, "recent resource failure") {
+		t.Errorf("summary %q should contain %q", f.Phrase, "recent resource failure")
 	}
 	if result.IssueCount != 1 {
 		t.Errorf("IssueCount = %d, want 1", result.IssueCount)
@@ -857,8 +858,8 @@ func TestEnrichELBAttributes_BothMisconfigurations_BangFinding(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding for LB %q; findings: %v", lbName, result.Findings)
 	}
-	if f.Severity != "!" {
-		t.Errorf("severity = %q, want %q (both misconfigured → promotion)", f.Severity, "!")
+	if f.Severity != domain.SevBroken {
+		t.Errorf("severity = %v, want %q (both misconfigured → promotion)", f.Severity, "!")
 	}
 	if result.IssueCount != 1 {
 		t.Errorf("IssueCount = %d, want 1", result.IssueCount)
@@ -889,8 +890,8 @@ func TestEnrichELBAttributes_OnlyDeletionProtectionMissing_TildeFinding(t *testi
 	if !ok {
 		t.Fatalf("expected finding for LB %q; findings: %v", lbName, result.Findings)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q (single misconfiguration → ~)", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %q (single misconfiguration → ~)", f.Severity, "~")
 	}
 	// Single "~" finding must NOT contribute to IssueCount.
 	if result.IssueCount != 0 {
@@ -1008,11 +1009,11 @@ func TestEnrichEBEnvironmentHealth_CausesEmitsTildeFinding(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding keyed by env ID %q; findings: %v", envID, result.Findings)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
-	if !strings.Contains(f.Summary, "EB causes:") {
-		t.Errorf("summary %q should contain %q", f.Summary, "EB causes:")
+	if !strings.Contains(f.Phrase, "EB causes:") {
+		t.Errorf("summary %q should contain %q", f.Phrase, "EB causes:")
 	}
 	// IssueCount must be 0 — EB health findings are always informational.
 	if result.IssueCount != 0 {
@@ -1135,8 +1136,8 @@ func TestEnrichCFNCombined_EventsAndDriftMerged(t *testing.T) {
 	}
 	// Events win on ID conflict: the stackID finding must be "!".
 	if f, ok := result.Findings[stackID]; ok {
-		if f.Severity != "!" {
-			t.Errorf("expected events finding (severity !) to win over drift finding; got severity %q", f.Severity)
+		if f.Severity != domain.SevBroken {
+			t.Errorf("expected events finding (severity !) to win over drift finding; got severity %v", f.Severity)
 		}
 	}
 }

--- a/tests/unit/aws_enrichment_wave4_test.go
+++ b/tests/unit/aws_enrichment_wave4_test.go
@@ -26,6 +26,7 @@ import (
 	wafv2types "github.com/aws/aws-sdk-go-v2/service/wafv2/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -767,18 +768,19 @@ func TestEnrichEBSVolumeStatus_WarningStatusProducesFinding(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding for volume with status 'warning'")
 	}
-	if f.Severity != "!" {
-		t.Errorf("severity = %q, want %q", f.Severity, "!")
+	if f.Severity != domain.SevBroken {
+		t.Errorf("severity = %v, want %v", f.Severity, "!")
 	}
-	if f.Summary != "volume I/O degraded" {
-		t.Errorf("summary = %q, want %q", f.Summary, "volume I/O degraded")
+	if f.Phrase != "volume I/O degraded" {
+		t.Errorf("summary = %q, want %q", f.Phrase, "volume I/O degraded")
 	}
 	// The I/O State row must reflect the actual status string.
-	if len(f.Rows) == 0 {
+	volWarnRows := result.AttentionDetails["vol-warn"].Rows
+	if len(volWarnRows) == 0 {
 		t.Fatal("expected at least one finding row")
 	}
-	if f.Rows[0].Value != "warning" {
-		t.Errorf("I/O State row value = %q, want %q", f.Rows[0].Value, "warning")
+	if volWarnRows[0].Value != "warning" {
+		t.Errorf("I/O State row value = %q, want %q", volWarnRows[0].Value, "warning")
 	}
 }
 
@@ -810,14 +812,13 @@ func TestEnrichEBSVolumeStatus_EventAndActionRowsPopulated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	f, ok := result.Findings["vol-events"]
-	if !ok {
+	if _, ok := result.Findings["vol-events"]; !ok {
 		t.Fatalf("expected finding for impaired volume with events/actions")
 	}
 
 	hasEvent := false
 	hasAction := false
-	for _, row := range f.Rows {
+	for _, row := range result.AttentionDetails["vol-events"].Rows {
 		if row.Label == "Event" {
 			hasEvent = true
 			if !strings.Contains(row.Value, "degraded") {

--- a/tests/unit/aws_enrichment_wave4b_test.go
+++ b/tests/unit/aws_enrichment_wave4b_test.go
@@ -23,6 +23,7 @@ import (
 	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -295,8 +296,8 @@ func TestEnrichIAMPolicy_NoRawStructARNFallbackFromID(t *testing.T) {
 	if _, ok := result.Findings[iamPolicyARN1]; !ok {
 		t.Errorf("expected admin-star finding via ARN fallback from r.ID, got %d findings", len(result.Findings))
 	}
-	if result.Findings[iamPolicyARN1].Severity != "!" {
-		t.Errorf("severity = %q, want %q", result.Findings[iamPolicyARN1].Severity, "!")
+	if result.Findings[iamPolicyARN1].Severity != domain.SevBroken {
+		t.Errorf("severity = %v, want SevBroken", result.Findings[iamPolicyARN1].Severity)
 	}
 }
 
@@ -518,12 +519,12 @@ func TestEnrichASGScalingActivities_FailedWithStatusMessageSummarized(t *testing
 		t.Fatalf("expected finding for capacity-asg, got none")
 	}
 	// Summary must contain the status message.
-	if !strings.Contains(f.Summary, statusMsg) {
-		t.Errorf("summary %q must contain status message %q", f.Summary, statusMsg)
+	if !strings.Contains(f.Phrase, statusMsg) {
+		t.Errorf("summary %q must contain status message %q", f.Phrase, statusMsg)
 	}
 	// Rows must include a "Message" row.
 	var hasMessageRow, hasCauseRow, hasStartedRow bool
-	for _, row := range f.Rows {
+	for _, row := range result.AttentionDetails["capacity-asg"].Rows {
 		switch row.Label {
 		case "Message":
 			hasMessageRow = true
@@ -582,10 +583,10 @@ func TestEnrichASGScalingActivities_FailedWithoutStatusMessagePlainSummary(t *te
 	if !ok {
 		t.Fatalf("expected finding for silent-fail-asg")
 	}
-	if f.Summary != "latest scaling activity failed" {
-		t.Errorf("summary = %q, want %q", f.Summary, "latest scaling activity failed")
+	if f.Phrase != "latest scaling activity failed" {
+		t.Errorf("summary = %q, want %q", f.Phrase, "latest scaling activity failed")
 	}
-	for _, row := range f.Rows {
+	for _, row := range result.AttentionDetails["silent-fail-asg"].Rows {
 		if row.Label == "Message" {
 			t.Error("rows must NOT contain a Message label when StatusMessage is nil")
 		}
@@ -699,12 +700,11 @@ func TestEnrichCodePipelineStatus_ActionErrorDetailsAppended(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	f, ok := result.Findings["err-pipe-id"]
-	if !ok {
+	if _, ok := result.Findings["err-pipe-id"]; !ok {
 		t.Fatalf("expected finding for err-pipe-id, got none")
 	}
 	var hasErrorRow bool
-	for _, row := range f.Rows {
+	for _, row := range result.AttentionDetails["err-pipe-id"].Rows {
 		if row.Label == "Error" {
 			hasErrorRow = true
 			if row.Value != errMsg {
@@ -746,11 +746,10 @@ func TestEnrichCodePipelineStatus_ActionNilExecutionSkipped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	f, ok := result.Findings["nil-exec-pipe"]
-	if !ok {
+	if _, ok := result.Findings["nil-exec-pipe"]; !ok {
 		t.Fatalf("expected finding for nil-exec-pipe")
 	}
-	for _, row := range f.Rows {
+	for _, row := range result.AttentionDetails["nil-exec-pipe"].Rows {
 		if row.Label == "Error" {
 			t.Error("no Error row should be appended when action LatestExecution is nil")
 		}
@@ -819,19 +818,19 @@ func TestEnrichMSKCluster_VersionBoundaries(t *testing.T) {
 
 			// Findings are keyed by r.ID = bare cluster name, not the ARN.
 			f, hasFinding := result.Findings[mskNameForVersionTests]
-			isOutdatedFinding := hasFinding && f.Summary == "broker software outdated"
+			isOutdatedFinding := hasFinding && f.Phrase == "broker software outdated"
 
 			if tc.wantOutdated && !isOutdatedFinding {
 				summary := ""
 				if hasFinding {
-					summary = f.Summary
+					summary = f.Phrase
 				}
 				t.Errorf("version %q: expected 'broker software outdated' finding, got hasFinding=%v summary=%q",
 					tc.version, hasFinding, summary)
 			}
 			if !tc.wantOutdated && isOutdatedFinding {
 				t.Errorf("version %q: expected no outdated finding, got one with summary %q",
-					tc.version, f.Summary)
+					tc.version, f.Phrase)
 			}
 		})
 	}

--- a/tests/unit/aws_eventbridge_pagination_test.go
+++ b/tests/unit/aws_eventbridge_pagination_test.go
@@ -27,6 +27,7 @@ import (
 	ebtypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -287,21 +288,20 @@ func TestEnrichEventBridgeRule_DLQCheckAcrossAllPages(t *testing.T) {
 	}
 
 	// Findings must exist for the targets-without-DLQ from page 2
-	f, ok := result.Findings[ruleName]
-	if !ok {
+	if _, ok := result.Findings[ruleName]; !ok {
 		t.Fatalf("expected finding for %q (targets on page 2 lack DLQ), none produced", ruleName)
 	}
 
 	// Verify at least one row references the no-DLQ issue
 	foundNoDLQ := false
-	for _, row := range f.Rows {
+	for _, row := range result.AttentionDetails[ruleName].Rows {
 		if strings.Contains(row.Value, "no dead-letter config") {
 			foundNoDLQ = true
 			break
 		}
 	}
 	if !foundNoDLQ {
-		t.Errorf("no row with 'no dead-letter config' in finding rows: %v", f.Rows)
+		t.Errorf("no row with 'no dead-letter config' in finding rows: %v", result.AttentionDetails[ruleName].Rows)
 	}
 }
 
@@ -352,11 +352,11 @@ func TestEnrichEventBridgeRule_EnabledWithZeroTargetsAcrossPages(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding for %q (enabled rule with no targets), none produced", ruleName)
 	}
-	if f.Severity != "!" {
-		t.Errorf("finding severity = %q, want \"!\"", f.Severity)
+	if f.Severity != domain.SevBroken {
+		t.Errorf("finding severity = %v, want SevBroken", f.Severity)
 	}
-	if !strings.Contains(f.Summary, "no targets") {
-		t.Errorf("finding summary %q must contain \"no targets\"", f.Summary)
+	if !strings.Contains(f.Phrase, "no targets") {
+		t.Errorf("finding summary %q must contain \"no targets\"", f.Phrase)
 	}
 
 	// IssueCount must be 1

--- a/tests/unit/aws_iam_group_enricher_test.go
+++ b/tests/unit/aws_iam_group_enricher_test.go
@@ -17,6 +17,7 @@ import (
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -170,8 +171,8 @@ func TestEnrichIAMGroup_NoMembersProducesFindingSevTilde(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding keyed by %q (empty group)", "dev-team")
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
 	if _, ok := result.Findings["ops-team"]; ok {
 		t.Error("ops-team must NOT appear in Findings — it has members")
@@ -209,8 +210,8 @@ func TestEnrichIAMGroup_NoPoliciesProducesFindingSevTilde(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding keyed by %q (no policies)", "dev-team")
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
 	if _, ok := result.Findings["ops-team"]; ok {
 		t.Error("ops-team must NOT appear in Findings — it has a policy")

--- a/tests/unit/aws_iam_group_pagination_test.go
+++ b/tests/unit/aws_iam_group_pagination_test.go
@@ -279,8 +279,8 @@ func TestEnrichIAMGroup_PaginatesAttachedPolicies(t *testing.T) {
 
 	// Because total attached policies (90) > 0, no "no policies" finding
 	if f, ok := result.Findings[groupName]; ok {
-		if strings.Contains(f.Summary, "no policies") {
-			t.Errorf("must not emit 'no policies' finding when attached policies span 2 pages; got: %q", f.Summary)
+		if strings.Contains(f.Phrase, "no policies") {
+			t.Errorf("must not emit 'no policies' finding when attached policies span 2 pages; got: %q", f.Phrase)
 		}
 	}
 
@@ -338,8 +338,8 @@ func TestEnrichIAMGroup_PaginatesInlinePolicies(t *testing.T) {
 
 	// Because total inline policies (35) > 0, no "no policies" finding
 	if f, ok := result.Findings[groupName]; ok {
-		if strings.Contains(f.Summary, "no policies") {
-			t.Errorf("must not emit 'no policies' finding when inline policies span 2 pages; got: %q", f.Summary)
+		if strings.Contains(f.Phrase, "no policies") {
+			t.Errorf("must not emit 'no policies' finding when inline policies span 2 pages; got: %q", f.Phrase)
 		}
 	}
 
@@ -465,7 +465,7 @@ func TestEnrichIAMGroup_ZeroMembersAcrossPages(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding for %q (no members), but none was produced", groupName)
 	}
-	if !strings.Contains(f.Summary, "no members") {
-		t.Errorf("finding summary %q must contain \"no members\"", f.Summary)
+	if !strings.Contains(f.Phrase, "no members") {
+		t.Errorf("finding summary %q must contain \"no members\"", f.Phrase)
 	}
 }

--- a/tests/unit/aws_iam_policy_enricher_test.go
+++ b/tests/unit/aws_iam_policy_enricher_test.go
@@ -20,6 +20,7 @@ import (
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -213,8 +214,8 @@ func TestEnrichIAMPolicy_AdminStarProducesFindingSevBang(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding keyed by %q (admin star policy)", iamPolicyARN2)
 	}
-	if f.Severity != "!" {
-		t.Errorf("severity = %q, want %q", f.Severity, "!")
+	if f.Severity != domain.SevBroken {
+		t.Errorf("severity = %v, want %v", f.Severity, "!")
 	}
 	if _, ok := result.Findings[iamPolicyARN1]; ok {
 		t.Error("policy-1 must NOT appear in Findings — it is a safe policy")

--- a/tests/unit/aws_iam_role_enricher_test.go
+++ b/tests/unit/aws_iam_role_enricher_test.go
@@ -20,6 +20,7 @@ import (
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -161,8 +162,8 @@ func TestEnrichIAMRoleLastUsed_DormantProducesFindingSevTilde(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding keyed by %q (dormant role)", "role-1")
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
 	if _, ok := result.Findings["role-2"]; ok {
 		t.Error("role-2 must NOT appear in Findings — it was recently used")
@@ -198,8 +199,8 @@ func TestEnrichIAMRoleLastUsed_NeverUsedProducesFindingSevTilde(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding keyed by %q (never-used role)", "role-1")
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
 	if _, ok := result.Findings["role-2"]; ok {
 		t.Error("role-2 must NOT appear in Findings — it was recently used")

--- a/tests/unit/aws_iam_user_enricher_test.go
+++ b/tests/unit/aws_iam_user_enricher_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/smithy-go"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -174,8 +175,8 @@ func TestEnrichIAMUserMFA_NoMFAProducesFindingSevBang(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding keyed by %q (no MFA)", "alice")
 	}
-	if f.Severity != "!" {
-		t.Errorf("severity = %q, want %q", f.Severity, "!")
+	if f.Severity != domain.SevBroken {
+		t.Errorf("severity = %v, want %v", f.Severity, "!")
 	}
 	if _, ok := result.Findings["bob"]; ok {
 		t.Error("bob must NOT appear in Findings — bob has MFA")
@@ -241,8 +242,8 @@ func TestEnrichIAMUserMFA_OldAccessKeyProducesFindingSevTilde(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding keyed by %q (old access key)", "alice")
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
 	if _, ok := result.Findings["bob"]; ok {
 		t.Error("bob must NOT appear in Findings — bob has a recent key")

--- a/tests/unit/aws_kms_enricher_test.go
+++ b/tests/unit/aws_kms_enricher_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/smithy-go"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -100,8 +101,8 @@ func TestEnrichKMSRotation_DisabledProducesFindings(t *testing.T) {
 			t.Errorf("expected finding for key %q", id)
 			continue
 		}
-		if f.Severity != "~" {
-			t.Errorf("key %q severity = %q, want %q", id, f.Severity, "~")
+		if f.Severity != domain.SevWarn {
+			t.Errorf("key %q severity = %v, want SevWarn", id, f.Severity)
 		}
 	}
 }
@@ -207,8 +208,8 @@ func TestEnrichKMSRotation_MixedDisabledEnabledError(t *testing.T) {
 	f, ok := result.Findings["key-disabled"]
 	if !ok {
 		t.Error("expected finding for key-disabled")
-	} else if f.Severity != "~" {
-		t.Errorf("key-disabled severity = %q, want %q", f.Severity, "~")
+	} else if f.Severity != domain.SevWarn {
+		t.Errorf("key-disabled severity = %v, want %v", f.Severity, "~")
 	}
 	if _, ok := result.Findings["key-enabled"]; ok {
 		t.Error("unexpected finding for key-enabled")

--- a/tests/unit/aws_logs_enricher_test.go
+++ b/tests/unit/aws_logs_enricher_test.go
@@ -17,6 +17,7 @@ import (
 	cwlogstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -124,8 +125,8 @@ func TestEnrichLogsMetricFilters_AuditNoFiltersProducesFindingSevTilde(t *testin
 	if !ok {
 		t.Fatalf("expected finding keyed by %q (no metric filters)", auditGroup)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
 	if _, ok := result.Findings[lambdaGroup]; ok {
 		t.Error("lambda group must NOT appear in Findings — non-audit groups are skipped")

--- a/tests/unit/aws_msk_enricher_test.go
+++ b/tests/unit/aws_msk_enricher_test.go
@@ -22,6 +22,7 @@ import (
 	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -168,8 +169,8 @@ func TestEnrichMSKCluster_OutdatedVersionProducesFindingSevTilde(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding keyed by bare cluster name %q", mskName1)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
 	if _, ok := result.Findings[mskName2]; ok {
 		t.Error("cluster-2 must NOT appear in Findings — it uses modern Kafka version")
@@ -201,8 +202,8 @@ func TestEnrichMSKCluster_PlaintextEncryptionProducesFindingSevTilde(t *testing.
 	if !ok {
 		t.Fatalf("expected finding keyed by bare cluster name %q", mskName1)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
 	if _, ok := result.Findings[mskName2]; ok {
 		t.Error("cluster-2 must NOT appear in Findings — it uses TLS")

--- a/tests/unit/aws_opensearch_issue_enrichment_test.go
+++ b/tests/unit/aws_opensearch_issue_enrichment_test.go
@@ -22,6 +22,7 @@ import (
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/demo/fixtures"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -79,13 +80,13 @@ func buildOSResource(domain ostypes.DomainStatus, statusOverride string) resourc
 	}
 }
 
-// u11SummaryRowCheck asserts the U11 contract: Summary must not contain any
+// u11SummaryRowCheck asserts the U11 contract: Phrase must not contain any
 // row value. Fails the test if violated.
-func u11SummaryRowCheck(t *testing.T, finding resource.EnrichmentFinding) {
+func u11SummaryRowCheck(t *testing.T, finding domain.Finding, rows []domain.DetailRow) {
 	t.Helper()
-	for _, row := range finding.Rows {
-		if strings.Contains(finding.Summary, row.Value) {
-			t.Errorf("U11 violation: Summary %q contains row.Value %q — facts must live in Rows only", finding.Summary, row.Value)
+	for _, row := range rows {
+		if strings.Contains(finding.Phrase, row.Value) {
+			t.Errorf("U11 violation: Phrase %q contains row.Value %q — facts must live in Rows only", finding.Phrase, row.Value)
 		}
 	}
 }
@@ -124,15 +125,16 @@ func TestOpenSearch_Enrich_UpdateAvailable_EmitsBangFinding(t *testing.T) {
 		t.Fatalf("no Finding for resource %q", id)
 	}
 
-	if finding.Severity != "!" {
-		t.Errorf("Severity = %q, want %q", finding.Severity, "!")
+	if finding.Severity != domain.SevBroken {
+		t.Errorf("Severity = %v, want SevBroken", finding.Severity)
 	}
-	if finding.Summary != "software update forced soon" {
-		t.Errorf("Summary = %q, want %q", finding.Summary, "software update forced soon")
+	if finding.Phrase != "software update forced soon" {
+		t.Errorf("Phrase = %q, want %q", finding.Phrase, "software update forced soon")
 	}
 
-	// U11 — Summary must not contain any row value.
-	u11SummaryRowCheck(t, finding)
+	rows := result.AttentionDetails[id].Rows
+	// U11 — Phrase must not contain any row value.
+	u11SummaryRowCheck(t, finding, rows)
 
 	if result.IssueCount != 1 {
 		t.Errorf("IssueCount = %d, want 1 (! bumps menu badge)", result.IssueCount)
@@ -141,7 +143,7 @@ func TestOpenSearch_Enrich_UpdateAvailable_EmitsBangFinding(t *testing.T) {
 	// Verify rows contain "Automated Update" and "Current Version".
 	hasAutomatedUpdate := false
 	hasCurrentVersion := false
-	for _, row := range finding.Rows {
+	for _, row := range rows {
 		if row.Label == "Automated Update" {
 			hasAutomatedUpdate = true
 		}
@@ -150,10 +152,10 @@ func TestOpenSearch_Enrich_UpdateAvailable_EmitsBangFinding(t *testing.T) {
 		}
 	}
 	if !hasAutomatedUpdate {
-		t.Errorf("Rows missing {Label:\"Automated Update\", ...}; got: %v", finding.Rows)
+		t.Errorf("Rows missing {Label:\"Automated Update\", ...}; got: %v", rows)
 	}
 	if !hasCurrentVersion {
-		t.Errorf("Rows missing {Label:\"Current Version\", ...}; got: %v", finding.Rows)
+		t.Errorf("Rows missing {Label:\"Current Version\", ...}; got: %v", rows)
 	}
 }
 
@@ -190,15 +192,15 @@ func TestOpenSearch_Enrich_EncryptionOff_EmitsTildeFinding(t *testing.T) {
 		t.Fatalf("no Finding for resource %q", id)
 	}
 
-	if finding.Severity != "~" {
-		t.Errorf("Severity = %q, want %q", finding.Severity, "~")
+	if finding.Severity != domain.SevWarn {
+		t.Errorf("Severity = %v, want SevWarn", finding.Severity)
 	}
-	if finding.Summary != "encryption at rest off" {
-		t.Errorf("Summary = %q, want %q", finding.Summary, "encryption at rest off")
+	if finding.Phrase != "encryption at rest off" {
+		t.Errorf("Phrase = %q, want %q", finding.Phrase, "encryption at rest off")
 	}
 
-	// U11 — Summary must not contain any row value.
-	u11SummaryRowCheck(t, finding)
+	// U11 — Phrase must not contain any row value.
+	u11SummaryRowCheck(t, finding, result.AttentionDetails[id].Rows)
 
 	if result.IssueCount != 0 {
 		t.Errorf("IssueCount = %d, want 0 (~ never bumps badge)", result.IssueCount)
@@ -240,26 +242,27 @@ func TestOpenSearch_Enrich_MultiBackground_TopWinsHiddenSurfacesAsRow(t *testing
 	}
 
 	// ! beats ~
-	if finding.Severity != "!" {
-		t.Errorf("Severity = %q, want %q (! beats ~)", finding.Severity, "!")
+	if finding.Severity != domain.SevBroken {
+		t.Errorf("Severity = %v, want SevBroken (! beats ~)", finding.Severity)
 	}
-	if finding.Summary != "software update forced soon" {
-		t.Errorf("Summary = %q, want %q", finding.Summary, "software update forced soon")
+	if finding.Phrase != "software update forced soon" {
+		t.Errorf("Phrase = %q, want %q", finding.Phrase, "software update forced soon")
 	}
 
+	rows3 := result.AttentionDetails[id].Rows
 	// Hidden ~ surfaces as Additional row.
 	hasAdditional := false
-	for _, row := range finding.Rows {
+	for _, row := range rows3 {
 		if row.Label == "Additional" && row.Value == "encryption at rest off" {
 			hasAdditional = true
 		}
 	}
 	if !hasAdditional {
-		t.Errorf("Rows missing {Label:\"Additional\", Value:\"encryption at rest off\"}; got: %v", finding.Rows)
+		t.Errorf("Rows missing {Label:\"Additional\", Value:\"encryption at rest off\"}; got: %v", rows3)
 	}
 
-	// U11 — Summary must not contain any row value.
-	u11SummaryRowCheck(t, finding)
+	// U11 — Phrase must not contain any row value.
+	u11SummaryRowCheck(t, finding, rows3)
 
 	if result.IssueCount != 1 {
 		t.Errorf("IssueCount = %d, want 1 (multi still counts as 1 instance)", result.IssueCount)
@@ -301,11 +304,11 @@ func TestOpenSearch_Enrich_HardStatePlusBackground_NoFieldUpdate(t *testing.T) {
 		t.Fatalf("no Finding for resource %q", id)
 	}
 
-	if finding.Severity != "!" {
-		t.Errorf("Severity = %q, want %q", finding.Severity, "!")
+	if finding.Severity != domain.SevBroken {
+		t.Errorf("Severity = %v, want SevBroken", finding.Severity)
 	}
-	if finding.Summary != "software update forced soon" {
-		t.Errorf("Summary = %q, want %q", finding.Summary, "software update forced soon")
+	if finding.Phrase != "software update forced soon" {
+		t.Errorf("Phrase = %q, want %q", finding.Phrase, "software update forced soon")
 	}
 
 	// Enricher must NOT overwrite Status (fetcher is authoritative for opensearch).

--- a/tests/unit/aws_r53_enricher_test.go
+++ b/tests/unit/aws_r53_enricher_test.go
@@ -21,6 +21,7 @@ import (
 	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -172,8 +173,8 @@ func TestEnrichRoute53Zone_PrivateOrphanZoneProducesFindingSevTilde(t *testing.T
 	if !ok {
 		t.Fatalf("expected finding keyed by %q (private orphan zone)", r53ZoneID1)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
 	if _, ok := result.Findings[r53ZoneID2]; ok {
 		t.Error("zone-2 (public) must NOT appear in Findings")

--- a/tests/unit/aws_review_pins_test.go
+++ b/tests/unit/aws_review_pins_test.go
@@ -211,7 +211,7 @@ func TestOpenSearch_Enrich_DeletedDomain_SkipsFinding(t *testing.T) {
 	if len(result2.Findings) != 1 {
 		t.Errorf("non-deleted control: Findings = %v, want exactly one (sanity check for the pin anchor)", result2.Findings)
 	}
-	if f, ok := result2.Findings[domainName]; !ok || !strings.Contains(f.Summary, "software update") {
-		t.Errorf("non-deleted control: finding summary = %q, want to contain %q", f.Summary, "software update")
+	if f, ok := result2.Findings[domainName]; !ok || !strings.Contains(f.Phrase, "software update") {
+		t.Errorf("non-deleted control: finding summary = %q, want to contain %q", f.Phrase, "software update")
 	}
 }

--- a/tests/unit/aws_s3_issue_enrichment_test.go
+++ b/tests/unit/aws_s3_issue_enrichment_test.go
@@ -25,6 +25,7 @@ import (
 	smithy "github.com/aws/smithy-go"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -115,25 +116,25 @@ func pabResource(name string) resource.Resource {
 
 // assertFindingShape is a shared assertion helper for the stable finding contract.
 // It fails the test if the finding at key does not have the expected severity
-// and the verbatim stable Summary.
-func assertFindingShape(t *testing.T, findings map[string]resource.EnrichmentFinding, key string) resource.EnrichmentFinding {
+// and the verbatim stable Phrase.
+func assertFindingShape(t *testing.T, findings map[string]domain.Finding, key string) domain.Finding {
 	t.Helper()
 	f, ok := findings[key]
 	if !ok {
 		t.Fatalf("expected finding for %q; Findings keys = %v", key, findingKeys(findings))
 	}
-	if f.Severity != "!" {
-		t.Errorf("[%s] Severity = %q, want %q", key, f.Severity, "!")
+	if f.Severity != domain.SevBroken {
+		t.Errorf("[%s] Severity = %v, want SevBroken", key, f.Severity)
 	}
-	const wantSummary = "public access block incomplete"
-	if f.Summary != wantSummary {
-		t.Errorf("[%s] Summary = %q, want %q", key, f.Summary, wantSummary)
+	const wantPhrase = "public access block incomplete"
+	if f.Phrase != wantPhrase {
+		t.Errorf("[%s] Phrase = %q, want %q", key, f.Phrase, wantPhrase)
 	}
 	return f
 }
 
-// rowMap converts a FindingRow slice to a label→value map for easy assertion.
-func rowMap(rows []resource.FindingRow) map[string]string {
+// rowMap converts a DetailRow slice to a label→value map for easy assertion.
+func rowMap(rows []domain.DetailRow) map[string]string {
 	m := make(map[string]string, len(rows))
 	for _, r := range rows {
 		m[r.Label] = r.Value
@@ -199,13 +200,13 @@ func TestS3_Enrich_NoPAB_Configuration(t *testing.T) {
 
 	finding := assertFindingShape(t, result.Findings, "a9s-demo-nopab")
 
-	// U11: Summary must NOT embed the row-level detail string.
-	if strings.Contains(finding.Summary, "no public access block configuration") {
-		t.Errorf("Summary must not embed Row content; got %q", finding.Summary)
+	// U11: Phrase must NOT embed the row-level detail string.
+	if strings.Contains(finding.Phrase, "no public access block configuration") {
+		t.Errorf("Phrase must not embed Row content; got %q", finding.Phrase)
 	}
 
 	// Rows must carry the detail.
-	rows := rowMap(finding.Rows)
+	rows := rowMap(result.AttentionDetails["a9s-demo-nopab"].Rows)
 	if rows["Status"] != "no public access block configuration" {
 		t.Errorf("Rows[Status] = %q, want %q", rows["Status"], "no public access block configuration")
 	}
@@ -252,12 +253,12 @@ func TestS3_Enrich_PartialPAB_SingleFlagFalse(t *testing.T) {
 
 	finding := assertFindingShape(t, result.Findings, "a9s-demo-partial-pab")
 
-	// U11: Summary must not contain flag names or values.
-	if strings.Contains(finding.Summary, "BlockPublicAcls") || strings.Contains(finding.Summary, "false") {
-		t.Errorf("Summary must not embed Row content; got %q", finding.Summary)
+	// U11: Phrase must not contain flag names or values.
+	if strings.Contains(finding.Phrase, "BlockPublicAcls") || strings.Contains(finding.Phrase, "false") {
+		t.Errorf("Phrase must not embed Row content; got %q", finding.Phrase)
 	}
 
-	rows := rowMap(finding.Rows)
+	rows := rowMap(result.AttentionDetails["a9s-demo-partial-pab"].Rows)
 	if rows["BlockPublicAcls"] != "false" {
 		t.Errorf("Rows[BlockPublicAcls] = %q, want %q", rows["BlockPublicAcls"], "false")
 	}
@@ -300,17 +301,17 @@ func TestS3_Enrich_PartialPAB_MultipleFlagsFalse(t *testing.T) {
 
 	finding := assertFindingShape(t, result.Findings, "a9s-demo-multifail-pab")
 
-	// Summary must be stable — same phrase even when multiple flags are false.
-	const wantSummary = "public access block incomplete"
-	if finding.Summary != wantSummary {
-		t.Errorf("Summary = %q, want %q (must be stable across instances)", finding.Summary, wantSummary)
+	// Phrase must be stable — same phrase even when multiple flags are false.
+	const wantPhrase = "public access block incomplete"
+	if finding.Phrase != wantPhrase {
+		t.Errorf("Phrase = %q, want %q (must be stable across instances)", finding.Phrase, wantPhrase)
 	}
-	// Summary must not contain flag names.
-	if strings.Contains(finding.Summary, "BlockPublicAcls") || strings.Contains(finding.Summary, "BlockPublicPolicy") {
-		t.Errorf("Summary must not embed Row content; got %q", finding.Summary)
+	// Phrase must not contain flag names.
+	if strings.Contains(finding.Phrase, "BlockPublicAcls") || strings.Contains(finding.Phrase, "BlockPublicPolicy") {
+		t.Errorf("Phrase must not embed Row content; got %q", finding.Phrase)
 	}
 
-	rows := rowMap(finding.Rows)
+	rows := rowMap(result.AttentionDetails["a9s-demo-multifail-pab"].Rows)
 	if rows["BlockPublicAcls"] != "false" {
 		t.Errorf("Rows[BlockPublicAcls] = %q, want %q", rows["BlockPublicAcls"], "false")
 	}
@@ -343,9 +344,9 @@ func TestS3_Enrich_NilPABConfiguration_TreatedAsNoPAB(t *testing.T) {
 
 	finding := assertFindingShape(t, result.Findings, "a9s-demo-nilcfg")
 
-	// Must not embed row detail in Summary.
-	if strings.Contains(finding.Summary, "no public access block configuration") {
-		t.Errorf("Summary must not embed Row content; got %q", finding.Summary)
+	// Must not embed row detail in Phrase.
+	if strings.Contains(finding.Phrase, "no public access block configuration") {
+		t.Errorf("Phrase must not embed Row content; got %q", finding.Phrase)
 	}
 
 	updates, ok := result.FieldUpdates["a9s-demo-nilcfg"]
@@ -462,10 +463,10 @@ func TestS3_Enrich_IssueCount_FourBuckets(t *testing.T) {
 		t.Fatalf("EnrichS3PublicAccessBlock error: %v", err)
 	}
 
-	// Count "!" findings manually to decouple from IssueCount field name choices.
+	// Count SevBroken findings manually to decouple from IssueCount field name choices.
 	bangCount := 0
 	for _, f := range result.Findings {
-		if f.Severity == "!" {
+		if f.Severity == domain.SevBroken {
 			bangCount++
 		}
 	}
@@ -522,10 +523,10 @@ func TestS3_Enrich_U11_SummaryStable_NeverContainsRowValues(t *testing.T) {
 	}
 
 	for id, finding := range result.Findings {
-		for _, row := range finding.Rows {
-			if row.Value != "" && strings.Contains(finding.Summary, row.Value) {
-				t.Errorf("[%s] Summary %q must not contain Row value %q (U11 Summary≠Rows separation)",
-					id, finding.Summary, row.Value)
+		for _, row := range result.AttentionDetails[id].Rows {
+			if row.Value != "" && strings.Contains(finding.Phrase, row.Value) {
+				t.Errorf("[%s] Phrase %q must not contain Row value %q (U11 Phrase≠Rows separation)",
+					id, finding.Phrase, row.Value)
 			}
 		}
 	}

--- a/tests/unit/aws_ses_issue_enrichment_test.go
+++ b/tests/unit/aws_ses_issue_enrichment_test.go
@@ -34,6 +34,7 @@ import (
 	sesv2types "github.com/aws/aws-sdk-go-v2/service/sesv2/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/demo/fixtures"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
@@ -101,11 +102,11 @@ func TestEnrichSESAccount_ShutdownFindingPerRow(t *testing.T) {
 			t.Errorf("Findings missing key %q", id)
 			continue
 		}
-		if f.Severity != "!" {
-			t.Errorf("identity %q: Severity = %q, want %q", id, f.Severity, "!")
+		if f.Severity != domain.SevBroken {
+			t.Errorf("identity %q: Severity = %v, want SevBroken", id, f.Severity)
 		}
-		if f.Summary != "account SHUTDOWN" {
-			t.Errorf("identity %q: Summary = %q, want %q", id, f.Summary, "account SHUTDOWN")
+		if f.Phrase != "account SHUTDOWN" {
+			t.Errorf("identity %q: Summary = %q, want %q", id, f.Phrase, "account SHUTDOWN")
 		}
 	}
 }
@@ -168,10 +169,11 @@ func TestEnrichSESAccount_ShutdownFindingRowActionable(t *testing.T) {
 	if !ok {
 		t.Fatal("expected finding for identity acme-corp.com")
 	}
-	if len(f.Rows) == 0 {
+	ad := result.AttentionDetails["acme-corp.com"]
+	if len(ad.Rows) == 0 {
 		t.Fatal("expected at least one row in SHUTDOWN finding")
 	}
-	row := f.Rows[0]
+	row := ad.Rows[0]
 	if row.Label != "Action" {
 		t.Errorf("Row.Label = %q, want %q (operator-actionable context)", row.Label, "Action")
 	}
@@ -181,6 +183,7 @@ func TestEnrichSESAccount_ShutdownFindingRowActionable(t *testing.T) {
 	if row.Tier != "!" {
 		t.Errorf("Row.Tier = %q, want %q", row.Tier, "!")
 	}
+	_ = f
 }
 
 // ---------------------------------------------------------------------------
@@ -207,11 +210,11 @@ func TestEnrichSESAccount_ProbationFindingPerRow(t *testing.T) {
 	if !ok {
 		t.Fatal("expected finding keyed by identity ID")
 	}
-	if f.Severity != "!" {
-		t.Errorf("Severity = %q, want %q (PROBATION is severity !)", f.Severity, "!")
+	if f.Severity != domain.SevBroken {
+		t.Errorf("Severity = %v, want %q (PROBATION is severity !)", f.Severity, "!")
 	}
-	if f.Summary != "account PROBATION" {
-		t.Errorf("Summary = %q, want %q", f.Summary, "account PROBATION")
+	if f.Phrase != "account PROBATION" {
+		t.Errorf("Summary = %q, want %q", f.Phrase, "account PROBATION")
 	}
 }
 
@@ -242,11 +245,11 @@ func TestEnrichSESAccount_ProbationFindingRowActionable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	f := result.Findings["acme-corp.com"]
-	if len(f.Rows) == 0 {
+	ad := result.AttentionDetails["acme-corp.com"]
+	if len(ad.Rows) == 0 {
 		t.Fatal("expected at least one row in PROBATION finding")
 	}
-	row := f.Rows[0]
+	row := ad.Rows[0]
 	if row.Label != "Action" {
 		t.Errorf("Row.Label = %q, want %q (operator-actionable context)", row.Label, "Action")
 	}
@@ -284,11 +287,11 @@ func TestEnrichSESAccount_QuotaOver80PercentProducesTildeFindings(t *testing.T) 
 		t.Fatal("expected findings for 90% quota usage, got 0")
 	}
 	f := result.Findings["acme-corp.com"]
-	if f.Severity != "~" {
-		t.Errorf("Severity = %q, want %q for quota > 80%%", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("Severity = %v, want %q for quota > 80%%", f.Severity, "~")
 	}
-	if f.Summary != "quota 80%+ used" {
-		t.Errorf("Summary = %q, want %q", f.Summary, "quota 80%+ used")
+	if f.Phrase != "quota 80%+ used" {
+		t.Errorf("Summary = %q, want %q", f.Phrase, "quota 80%+ used")
 	}
 }
 
@@ -360,8 +363,8 @@ func TestEnrichSESAccount_ProbationBeatsQuota(t *testing.T) {
 	if !ok {
 		t.Fatal("expected finding for PROBATION+quota case")
 	}
-	if f.Summary != "account PROBATION" {
-		t.Errorf("Summary = %q, want %q (PROBATION must win over quota)", f.Summary, "account PROBATION")
+	if f.Phrase != "account PROBATION" {
+		t.Errorf("Summary = %q, want %q (PROBATION must win over quota)", f.Phrase, "account PROBATION")
 	}
 }
 
@@ -517,9 +520,9 @@ func TestEnrichSESAccount_ShutdownSummaryDoesNotContainRowValue(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	f := result.Findings["acme-corp.com"]
-	for _, row := range f.Rows {
-		if row.Value != "" && strings.Contains(f.Summary, row.Value) {
-			t.Errorf("U11 violation: Summary %q contains Row.Value %q", f.Summary, row.Value)
+	for _, row := range result.AttentionDetails["acme-corp.com"].Rows {
+		if row.Value != "" && strings.Contains(f.Phrase, row.Value) {
+			t.Errorf("U11 violation: Summary %q contains Row.Value %q", f.Phrase, row.Value)
 		}
 	}
 }
@@ -535,9 +538,9 @@ func TestEnrichSESAccount_ProbationSummaryDoesNotContainRowValue(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	f := result.Findings["acme-corp.com"]
-	for _, row := range f.Rows {
-		if row.Value != "" && strings.Contains(f.Summary, row.Value) {
-			t.Errorf("U11 violation: Summary %q contains Row.Value %q", f.Summary, row.Value)
+	for _, row := range result.AttentionDetails["acme-corp.com"].Rows {
+		if row.Value != "" && strings.Contains(f.Phrase, row.Value) {
+			t.Errorf("U11 violation: Summary %q contains Row.Value %q", f.Phrase, row.Value)
 		}
 	}
 }
@@ -562,9 +565,9 @@ func TestEnrichSESAccount_QuotaSummaryDoesNotContainSentOrMaxValues(t *testing.T
 	if !ok {
 		t.Fatal("expected quota finding for 90% usage")
 	}
-	for _, row := range f.Rows {
-		if row.Value != "" && strings.Contains(f.Summary, row.Value) {
-			t.Errorf("U11 violation: Summary %q contains Row.Value %q", f.Summary, row.Value)
+	for _, row := range result.AttentionDetails["acme-corp.com"].Rows {
+		if row.Value != "" && strings.Contains(f.Phrase, row.Value) {
+			t.Errorf("U11 violation: Summary %q contains Row.Value %q", f.Phrase, row.Value)
 		}
 	}
 }

--- a/tests/unit/aws_snapshot_cross_ref_test.go
+++ b/tests/unit/aws_snapshot_cross_ref_test.go
@@ -221,16 +221,16 @@ func TestSnapshotCrossRef_OrphanFinding(t *testing.T) {
 		t.Fatal("expected orphan finding for snap-1, got none")
 	}
 
-	if finding.Severity != "!" {
-		t.Errorf("expected Severity=%q, got %q", "!", finding.Severity)
+	if finding.Severity != domain.SevBroken {
+		t.Errorf("expected Severity=SevBroken, got %v", finding.Severity)
 	}
-	if finding.Summary != "orphan: source parent deleted" {
-		t.Errorf("expected Summary=%q, got %q", "orphan: source parent deleted", finding.Summary)
+	if finding.Phrase != "orphan: source parent deleted" {
+		t.Errorf("expected Phrase=%q, got %q", "orphan: source parent deleted", finding.Phrase)
 	}
 
 	// Must contain a row with Label="Source Parent" and Value containing "p1" and the hint.
 	found = false
-	for _, row := range finding.Rows {
+	for _, row := range result.AttentionDetails["snap-1"].Rows {
 		if row.Label == "Source Parent" {
 			found = true
 			if !crossRefContains(row.Value, "p1") {
@@ -242,7 +242,7 @@ func TestSnapshotCrossRef_OrphanFinding(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Errorf("expected a row with Label=%q, rows were: %+v", "Source Parent", finding.Rows)
+		t.Errorf("expected a row with Label=%q, rows were: %+v", "Source Parent", result.AttentionDetails["snap-1"].Rows)
 	}
 
 	// AS-140: FieldUpdates must be nil or empty — the enricher no longer overlays
@@ -277,22 +277,22 @@ func TestSnapshotCrossRef_PastRetention_Automated(t *testing.T) {
 	if !found {
 		t.Fatal("expected past-retention finding for snap-1, got none")
 	}
-	if finding.Severity != "!" {
-		t.Errorf("expected Severity=%q, got %q", "!", finding.Severity)
+	if finding.Severity != domain.SevBroken {
+		t.Errorf("expected Severity=SevBroken, got %v", finding.Severity)
 	}
 
-	// Summary should match "automated, <N>d past retention" where N ≈ ageDays - retentionDays.
+	// Phrase should match "automated, <N>d past retention" where N ≈ ageDays - retentionDays.
 	expectedDaysOver := ageDays - retentionDays
 	expectedPhrase := fmt.Sprintf("automated, %dd past retention", expectedDaysOver)
-	if finding.Summary != expectedPhrase {
-		t.Errorf("expected Summary=%q, got %q", expectedPhrase, finding.Summary)
+	if finding.Phrase != expectedPhrase {
+		t.Errorf("expected Phrase=%q, got %q", expectedPhrase, finding.Phrase)
 	}
 
 	// Rows must contain Source Parent, Retention, Created entries.
 	hasParentRow := false
 	hasRetentionRow := false
 	hasCreatedRow := false
-	for _, row := range finding.Rows {
+	for _, row := range result.AttentionDetails["snap-1"].Rows {
 		switch row.Label {
 		case "Source Parent":
 			hasParentRow = true
@@ -313,13 +313,13 @@ func TestSnapshotCrossRef_PastRetention_Automated(t *testing.T) {
 		}
 	}
 	if !hasParentRow {
-		t.Errorf("missing Source Parent row; rows: %+v", finding.Rows)
+		t.Errorf("missing Source Parent row; rows: %+v", result.AttentionDetails["snap-1"].Rows)
 	}
 	if !hasRetentionRow {
-		t.Errorf("missing Retention row; rows: %+v", finding.Rows)
+		t.Errorf("missing Retention row; rows: %+v", result.AttentionDetails["snap-1"].Rows)
 	}
 	if !hasCreatedRow {
-		t.Errorf("missing Created row; rows: %+v", finding.Rows)
+		t.Errorf("missing Created row; rows: %+v", result.AttentionDetails["snap-1"].Rows)
 	}
 
 	// AS-140: FieldUpdates must be nil or empty for snap-1 — the enricher no
@@ -607,13 +607,15 @@ func assertResultsIdentical(t *testing.T, id string, r1, r2 awsclient.IssueEnric
 	}
 	if ok1 {
 		if f1.Severity != f2.Severity {
-			t.Errorf("idempotency: Severity run1=%q run2=%q for %q", f1.Severity, f2.Severity, id)
+			t.Errorf("idempotency: Severity run1=%v run2=%v for %q", f1.Severity, f2.Severity, id)
 		}
-		if f1.Summary != f2.Summary {
-			t.Errorf("idempotency: Summary run1=%q run2=%q for %q", f1.Summary, f2.Summary, id)
+		if f1.Phrase != f2.Phrase {
+			t.Errorf("idempotency: Phrase run1=%q run2=%q for %q", f1.Phrase, f2.Phrase, id)
 		}
-		if len(f1.Rows) != len(f2.Rows) {
-			t.Errorf("idempotency: len(Rows) run1=%d run2=%d for %q", len(f1.Rows), len(f2.Rows), id)
+		rows1 := r1.AttentionDetails[id].Rows
+		rows2 := r2.AttentionDetails[id].Rows
+		if len(rows1) != len(rows2) {
+			t.Errorf("idempotency: len(Rows) run1=%d run2=%d for %q", len(rows1), len(rows2), id)
 		}
 	}
 

--- a/tests/unit/aws_sns_enricher_test.go
+++ b/tests/unit/aws_sns_enricher_test.go
@@ -21,6 +21,7 @@ import (
 	snstypes "github.com/aws/aws-sdk-go-v2/service/sns/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -159,11 +160,11 @@ func TestEnrichSNSSubscriptions_OrphanTopicProducesFindingSevTilde(t *testing.T)
 	if !ok {
 		t.Fatalf("expected finding keyed by %q", topic1)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
-	if !strings.Contains(strings.ToLower(f.Summary), "no subscriber") {
-		t.Errorf("summary %q must contain \"no subscriber\"", f.Summary)
+	if !strings.Contains(strings.ToLower(f.Phrase), "no subscriber") {
+		t.Errorf("summary %q must contain \"no subscriber\"", f.Phrase)
 	}
 	if _, ok := result.Findings[topic2]; ok {
 		t.Error("my-topic-2 must NOT appear in Findings — it has a confirmed subscriber")
@@ -199,11 +200,11 @@ func TestEnrichSNSSubscriptions_AllPendingProducesFindingSevTilde(t *testing.T) 
 	if !ok {
 		t.Fatalf("expected finding keyed by %q", topic1)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
-	if !strings.Contains(strings.ToLower(f.Summary), "pending") {
-		t.Errorf("summary %q must contain \"pending\"", f.Summary)
+	if !strings.Contains(strings.ToLower(f.Phrase), "pending") {
+		t.Errorf("summary %q must contain \"pending\"", f.Phrase)
 	}
 	if _, ok := result.Findings[topic2]; ok {
 		t.Error("my-topic-2 must NOT appear in Findings — it has a confirmed subscriber")

--- a/tests/unit/aws_sqs_enricher_test.go
+++ b/tests/unit/aws_sqs_enricher_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -142,8 +143,8 @@ func TestEnrichSQSAttributes_MissingRedrivePolicyProducesFindingSevTilde(t *test
 	if !ok {
 		t.Fatalf("expected finding keyed by %q", "my-queue-1")
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
 	if _, ok := result.Findings["my-queue-2"]; ok {
 		t.Error("my-queue-2 must NOT appear in Findings — it has both required attributes")
@@ -177,8 +178,8 @@ func TestEnrichSQSAttributes_MissingEncryptionProducesFindingSevTilde(t *testing
 	if !ok {
 		t.Fatalf("expected finding keyed by %q", "my-queue-1")
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
 	if _, ok := result.Findings["my-queue-2"]; ok {
 		t.Error("my-queue-2 must NOT appear in Findings — it has both required attributes")

--- a/tests/unit/aws_tgw_enricher_test.go
+++ b/tests/unit/aws_tgw_enricher_test.go
@@ -21,6 +21,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -136,8 +137,8 @@ func TestEnrichTGWAttachments_FailedAttachmentProducesFindingSevBang(t *testing.
 	if !ok {
 		t.Fatalf("expected finding keyed by %q", "tgw-00000001")
 	}
-	if f.Severity != "!" {
-		t.Errorf("severity = %q, want %q", f.Severity, "!")
+	if f.Severity != domain.SevBroken {
+		t.Errorf("severity = %v, want %v", f.Severity, "!")
 	}
 	if _, ok := result.Findings["tgw-00000002"]; ok {
 		t.Error("tgw-00000002 must NOT appear in Findings — all its attachments are available")
@@ -168,8 +169,8 @@ func TestEnrichTGWAttachments_ModifyingAttachmentProducesFindingSevTilde(t *test
 	if !ok {
 		t.Fatalf("expected finding keyed by %q for modifying attachment", "tgw-00000001")
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
 	if result.IssueCount != 1 {
 		t.Errorf("IssueCount = %d, want 1", result.IssueCount)

--- a/tests/unit/aws_vpc_enricher_test.go
+++ b/tests/unit/aws_vpc_enricher_test.go
@@ -20,6 +20,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -144,8 +145,8 @@ func TestEnrichVPCFlowLogs_NoLogsProducesFindingSevTilde(t *testing.T) {
 			t.Errorf("expected finding for %q", id)
 			continue
 		}
-		if f.Severity != "~" {
-			t.Errorf("%s: severity = %q, want %q", id, f.Severity, "~")
+		if f.Severity != domain.SevWarn {
+			t.Errorf("%s: severity = %v, want SevWarn", id, f.Severity)
 		}
 	}
 }
@@ -171,8 +172,8 @@ func TestEnrichVPCFlowLogs_InactiveOnlyProducesFindingForAffectedVPC(t *testing.
 	if !ok {
 		t.Fatalf("expected finding keyed by %q", "vpc-00000001")
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
 	if _, ok := result.Findings["vpc-00000002"]; ok {
 		t.Error("vpc-00000002 must NOT appear in Findings — it has an ACTIVE flow log")
@@ -232,7 +233,7 @@ func TestEnrichVPCFlowLogs_APIErrorSetsTruncatedFindsOtherVPC(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding for vpc-00000002 (no active flow logs)")
 	}
-	if f.Severity != "~" {
-		t.Errorf("vpc-00000002 severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("vpc-00000002 severity = %v, want %v", f.Severity, "~")
 	}
 }

--- a/tests/unit/aws_waf_enricher_test.go
+++ b/tests/unit/aws_waf_enricher_test.go
@@ -21,6 +21,7 @@ import (
 	wafv2types "github.com/aws/aws-sdk-go-v2/service/wafv2/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -186,11 +187,11 @@ func TestEnrichWAFLogging_NoLoggingProducesFindingSevTilde(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding keyed by %q (no logging)", wafACLARN1)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
-	if !strings.Contains(strings.ToLower(f.Summary), "no logging") {
-		t.Errorf("summary %q must contain \"no logging\"", f.Summary)
+	if !strings.Contains(strings.ToLower(f.Phrase), "no logging") {
+		t.Errorf("summary %q must contain \"no logging\"", f.Phrase)
 	}
 	if _, ok := result.Findings[wafACLARN2]; ok {
 		t.Error("acl-2 must NOT appear in Findings — it has logging configured")
@@ -226,11 +227,11 @@ func TestEnrichWAFLogging_OrphanACLProducesFindingSevTilde(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected finding keyed by %q (orphan ACL)", wafACLARN1)
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
-	if !strings.Contains(strings.ToLower(f.Summary), "not associated") {
-		t.Errorf("summary %q must contain \"not associated\"", f.Summary)
+	if !strings.Contains(strings.ToLower(f.Phrase), "not associated") {
+		t.Errorf("summary %q must contain \"not associated\"", f.Phrase)
 	}
 	if _, ok := result.Findings[wafACLARN2]; ok {
 		t.Error("acl-2 must NOT appear in Findings — it is associated with a resource")

--- a/tests/unit/enrichment_codebuild_findings_test.go
+++ b/tests/unit/enrichment_codebuild_findings_test.go
@@ -23,6 +23,7 @@ import (
 	cbtypes "github.com/aws/aws-sdk-go-v2/service/codebuild/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -98,8 +99,8 @@ func TestEnrichCodeBuildStatus_FailedBuildFindingKeyedByProjectName(t *testing.T
 	if !ok {
 		t.Fatalf("expected finding keyed by project name %q", "my-project")
 	}
-	if f.Severity != "!" {
-		t.Errorf("severity = %q, want %q", f.Severity, "!")
+	if f.Severity != domain.SevBroken {
+		t.Errorf("severity = %v, want %v", f.Severity, "!")
 	}
 }
 
@@ -124,7 +125,7 @@ func TestEnrichCodeBuildStatus_SummaryContainsDateAndStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	summary := result.Findings["proj-a"].Summary
+	summary := result.Findings["proj-a"].Phrase
 	// Must contain the status (FAILED) and the date in YYYY-MM-DD format.
 	if !strings.Contains(summary, "FAILED") {
 		t.Errorf("summary %q must contain %q", summary, "FAILED")

--- a/tests/unit/enrichment_ebs_findings_test.go
+++ b/tests/unit/enrichment_ebs_findings_test.go
@@ -93,8 +93,8 @@ func TestEnrichEBSVolumeStatus_SummaryVolumeIODegraded(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	f := result.Findings["vol-sum"]
-	if f.Summary != "volume I/O degraded" {
-		t.Errorf("summary = %q, want %q", f.Summary, "volume I/O degraded")
+	if f.Phrase != "volume I/O degraded" {
+		t.Errorf("summary = %q, want %q", f.Phrase, "volume I/O degraded")
 	}
 }
 

--- a/tests/unit/enrichment_glue_findings_test.go
+++ b/tests/unit/enrichment_glue_findings_test.go
@@ -86,7 +86,7 @@ func TestEnrichGlueJobStatus_SummaryContainsFAILED(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	summary := result.Findings["fail-job"].Summary
+	summary := result.Findings["fail-job"].Phrase
 	if !strings.Contains(summary, "FAILED") {
 		t.Errorf("summary %q must contain %q", summary, "FAILED")
 	}
@@ -106,7 +106,7 @@ func TestEnrichGlueJobStatus_SummaryContainsERROR(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	summary := result.Findings["err-job"].Summary
+	summary := result.Findings["err-job"].Phrase
 	if !strings.Contains(summary, "ERROR") {
 		t.Errorf("summary %q must contain %q", summary, "ERROR")
 	}
@@ -126,7 +126,7 @@ func TestEnrichGlueJobStatus_SummaryContainsTIMEOUT(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	summary := result.Findings["timeout-job"].Summary
+	summary := result.Findings["timeout-job"].Phrase
 	if !strings.Contains(summary, "TIMEOUT") {
 		t.Errorf("summary %q must contain %q", summary, "TIMEOUT")
 	}

--- a/tests/unit/enrichment_pipeline_findings_test.go
+++ b/tests/unit/enrichment_pipeline_findings_test.go
@@ -22,6 +22,7 @@ import (
 	cptypes "github.com/aws/aws-sdk-go-v2/service/codepipeline/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -83,8 +84,8 @@ func TestEnrichCodePipelineStatus_FailedStageKeyedByResourceID(t *testing.T) {
 	if _, ok := result.Findings["my-pipeline"]; ok {
 		t.Error("finding must not be keyed by r.Name")
 	}
-	if got := result.Findings["pipe-id"].Severity; got != "!" {
-		t.Errorf("Findings[%q].Severity = %q, want %q", "pipe-id", got, "!")
+	if got := result.Findings["pipe-id"].Severity; got != domain.SevBroken {
+		t.Errorf("Findings[%q].Severity = %v, want SevBroken", "pipe-id", got)
 	}
 }
 
@@ -107,15 +108,15 @@ func TestEnrichCodePipelineStatus_SummaryContainsStageName(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	finding := result.Findings["summary-pipeline"]
-	summary := finding.Summary
+	summary := finding.Phrase
 	if !strings.Contains(summary, "Integration-Test") {
 		t.Errorf("summary %q must contain stage name %q", summary, "Integration-Test")
 	}
 	if !strings.Contains(summary, "failed") {
 		t.Errorf("summary %q must contain %q", summary, "failed")
 	}
-	if got := finding.Severity; got != "!" {
-		t.Errorf("Findings[%q].Severity = %q, want %q", "summary-pipeline", got, "!")
+	if got := finding.Severity; got != domain.SevBroken {
+		t.Errorf("Findings[%q].Severity = %v, want SevBroken", "summary-pipeline", got)
 	}
 }
 

--- a/tests/unit/enrichment_rds_findings_test.go
+++ b/tests/unit/enrichment_rds_findings_test.go
@@ -100,8 +100,8 @@ func TestEnrichRDSDocDBMaintenance_SeverityTilde(t *testing.T) {
 	if !ok {
 		t.Fatal("expected finding for my-db")
 	}
-	if f.Severity != "~" {
-		t.Errorf("severity = %q, want %q", f.Severity, "~")
+	if f.Severity != domain.SevWarn {
+		t.Errorf("severity = %v, want %v", f.Severity, "~")
 	}
 }
 
@@ -126,11 +126,11 @@ func TestEnrichRDSDocDBMaintenance_SummaryFormat(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	f := result.Findings["my-db"]
-	if !strings.HasPrefix(f.Summary, "pending maintenance") {
-		t.Errorf("summary %q does not start with %q", f.Summary, "pending maintenance")
+	if !strings.HasPrefix(f.Phrase, "pending maintenance") {
+		t.Errorf("summary %q does not start with %q", f.Phrase, "pending maintenance")
 	}
-	if !strings.Contains(f.Summary, "system-update") {
-		t.Errorf("summary %q does not contain action name %q", f.Summary, "system-update")
+	if !strings.Contains(f.Phrase, "system-update") {
+		t.Errorf("summary %q does not contain action name %q", f.Phrase, "system-update")
 	}
 }
 
@@ -320,11 +320,11 @@ func TestEnrichDBI_Wave1StoppedPlusWave2_StackedFindings_AS140(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected wave-2 Finding for %q; result.Findings keys = %v", resourceID, findingKeys(result.Findings))
 	}
-	if wave2.Summary != "pending maintenance" {
-		t.Errorf("wave-2 Summary = %q, want %q", wave2.Summary, "pending maintenance")
+	if wave2.Phrase != "pending maintenance" {
+		t.Errorf("wave-2 Phrase = %q, want %q", wave2.Phrase, "pending maintenance")
 	}
-	if wave2.Severity != "~" {
-		t.Errorf("wave-2 Severity = %q, want %q", wave2.Severity, "~")
+	if wave2.Severity != domain.SevWarn {
+		t.Errorf("wave-2 Severity = %v, want SevWarn", wave2.Severity)
 	}
 
 	// AS-140: result.FieldUpdates must be empty — the merged "stopped (+1)"

--- a/tests/unit/enrichment_sfn_findings_test.go
+++ b/tests/unit/enrichment_sfn_findings_test.go
@@ -88,7 +88,7 @@ func TestEnrichStepFunctionsStatus_SummaryContainsFAILED(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	summary := result.Findings[smName].Summary
+	summary := result.Findings[smName].Phrase
 	if !strings.Contains(summary, "FAILED") {
 		t.Errorf("summary %q must contain %q", summary, "FAILED")
 	}
@@ -106,7 +106,7 @@ func TestEnrichStepFunctionsStatus_SummaryTimedOut(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	summary := result.Findings[smName].Summary
+	summary := result.Findings[smName].Phrase
 	// Status token from SDK is "TIMED_OUT" — just verify it contains the key distinguisher
 	if !strings.Contains(summary, "TIMED_OUT") {
 		t.Errorf("summary %q must contain %q", summary, "TIMED_OUT")
@@ -125,7 +125,7 @@ func TestEnrichStepFunctionsStatus_SummaryAborted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	summary := result.Findings[smName].Summary
+	summary := result.Findings[smName].Phrase
 	if !strings.Contains(summary, "ABORTED") {
 		t.Errorf("summary %q must contain %q", summary, "ABORTED")
 	}

--- a/tests/unit/enrichment_tg_findings_test.go
+++ b/tests/unit/enrichment_tg_findings_test.go
@@ -116,11 +116,11 @@ func TestEnrichTargetGroupHealth_SummaryUnhealthyXofY(t *testing.T) {
 	}
 	f := result.Findings[tgName]
 	// Summary must be "unhealthy targets: 2/3"
-	if !strings.HasPrefix(f.Summary, "unhealthy targets:") {
-		t.Errorf("summary %q must start with %q", f.Summary, "unhealthy targets:")
+	if !strings.HasPrefix(f.Phrase, "unhealthy targets:") {
+		t.Errorf("summary %q must start with %q", f.Phrase, "unhealthy targets:")
 	}
-	if !strings.Contains(f.Summary, "2/3") {
-		t.Errorf("summary %q must contain %q (2 of 3 unhealthy)", f.Summary, "2/3")
+	if !strings.Contains(f.Phrase, "2/3") {
+		t.Errorf("summary %q must contain %q (2 of 3 unhealthy)", f.Phrase, "2/3")
 	}
 }
 

--- a/tests/unit/phase03_derive_findings_test.go
+++ b/tests/unit/phase03_derive_findings_test.go
@@ -1,9 +1,7 @@
-// phase03_derive_findings_test.go — TDD red-light tests for PR-03a-shim derive.
+// phase03_derive_findings_test.go — TDD tests for PR-03a-shim derive.
 //
-// These tests MUST fail to compile until the following are added:
-//   - package internal/semantics/attention
-//   - function attention.DeriveFindings(r *domain.Resource, td resource.ResourceTypeDef,
-//     enrichmentFindings map[string]resource.EnrichmentFinding)
+// Tests attention.DeriveFindings(r *domain.Resource, td resource.ResourceTypeDef)
+// (2-arg form; wave2 enrichment is applied separately by applyEnrichment).
 //
 // Spec: docs/refactor/03-finding-model.md (PR-03a-shim)
 package unit_test
@@ -24,7 +22,7 @@ var ec2TD = resource.ResourceTypeDef{ShortName: "ec2"}
 // the resource pointer is nil — the contract is a safe no-op.
 func TestDerive_NilResource_NoOp(t *testing.T) {
 	// Must not panic; no assertions beyond "we got here".
-	attention.DeriveFindings(nil, ec2TD, nil)
+	attention.DeriveFindings(nil, ec2TD)
 }
 
 // TestDerive_HealthyRow_EmptyOutputs verifies that a resource with no Status,
@@ -32,7 +30,7 @@ func TestDerive_NilResource_NoOp(t *testing.T) {
 // AttentionDetails — i.e. the zero-value healthy row.
 func TestDerive_HealthyRow_EmptyOutputs(t *testing.T) {
 	r := domain.Resource{ID: "i-healthy"}
-	attention.DeriveFindings(&r, ec2TD, nil)
+	attention.DeriveFindings(&r, ec2TD)
 	if r.Findings != nil {
 		t.Errorf("Findings: got %v, want nil", r.Findings)
 	}
@@ -46,7 +44,7 @@ func TestDerive_HealthyRow_EmptyOutputs(t *testing.T) {
 // from the Status phrase.
 func TestDerive_StatusOnly_SingleWave1Finding(t *testing.T) {
 	r := domain.Resource{ID: "i-001", Status: "impaired"}
-	attention.DeriveFindings(&r, ec2TD, nil)
+	attention.DeriveFindings(&r, ec2TD)
 	if len(r.Findings) != 1 {
 		t.Fatalf("len(Findings): got %d, want 1", len(r.Findings))
 	}
@@ -68,7 +66,7 @@ func TestDerive_StatusOnly_SingleWave1Finding(t *testing.T) {
 // The function resource.StripFindingSuffix handles this stripping.
 func TestDerive_StatusWithSuffix_StripsBumpFinding(t *testing.T) {
 	r := domain.Resource{ID: "i-002", Status: "impaired (+2)"}
-	attention.DeriveFindings(&r, ec2TD, nil)
+	attention.DeriveFindings(&r, ec2TD)
 	if len(r.Findings) != 1 {
 		t.Fatalf("len(Findings): got %d, want 1", len(r.Findings))
 	}
@@ -94,7 +92,7 @@ func TestDerive_IssuesList_OneFindingPerIssue(t *testing.T) {
 			"instance check failed",
 		},
 	}
-	attention.DeriveFindings(&r, ec2TD, nil)
+	attention.DeriveFindings(&r, ec2TD)
 	if len(r.Findings) != 3 {
 		t.Fatalf("len(Findings): got %d, want 3", len(r.Findings))
 	}
@@ -131,7 +129,7 @@ func TestDerive_IssuesList_OneFindingPerIssue(t *testing.T) {
 // Post-fix: "running" is recognized as a lifecycle phrase → Findings == nil.
 func TestDerive_IssuesEmpty_StatusFallback(t *testing.T) {
 	r := domain.Resource{ID: "i-004", Status: "running", Issues: nil}
-	attention.DeriveFindings(&r, ec2TD, nil)
+	attention.DeriveFindings(&r, ec2TD)
 	if len(r.Findings) != 0 {
 		t.Fatalf("len(Findings): got %d, want 0 (lifecycle steady-state must not produce a Finding)", len(r.Findings))
 	}
@@ -160,7 +158,7 @@ func TestDerive_LifecyclePhrasesAreNotEmittedAsFindings(t *testing.T) {
 		phrase := phrase
 		t.Run(phrase, func(t *testing.T) {
 			r := domain.Resource{ID: "i", Status: phrase}
-			attention.DeriveFindings(&r, ec2TD, nil)
+			attention.DeriveFindings(&r, ec2TD)
 			if len(r.Findings) != 0 {
 				t.Errorf("Status=%q: got %d Findings, want 0 (lifecycle phrase must not emit a Finding)",
 					phrase, len(r.Findings))
@@ -184,7 +182,7 @@ func TestDerive_LifecyclePhrasesInIssuesAreAlsoSkipped(t *testing.T) {
 		ID:     "i-mixed",
 		Issues: []string{"running", "impaired", "terminated"},
 	}
-	attention.DeriveFindings(&r, ec2TD, nil)
+	attention.DeriveFindings(&r, ec2TD)
 	if len(r.Findings) != 1 {
 		t.Fatalf("len(Findings): got %d, want 1 (only non-lifecycle phrase 'impaired' must produce a Finding)", len(r.Findings))
 	}
@@ -207,14 +205,23 @@ func TestDerive_LifecyclePhrasesInIssuesAreAlsoSkipped(t *testing.T) {
 // Post-fix: "running" is filtered; enrichment becomes the sole Findings[0].
 func TestDerive_Wave2OnTopOfLifecycleStatus(t *testing.T) {
 	r := domain.Resource{ID: "i-w2", Status: "running"}
-	ef := map[string]resource.EnrichmentFinding{
-		"i-w2": {
-			Severity: "!",
-			Summary:  "pending maintenance",
-			Rows:     []resource.FindingRow{{Label: "Action", Value: "reboot"}},
-		},
+	// Wave-1 derive: "running" is a lifecycle phrase — no wave1 finding.
+	attention.DeriveFindings(&r, ec2TD)
+	// Wave-2 append (simulates applyEnrichment): directly append the wave2 finding.
+	w2 := domain.Finding{
+		Code:     "ec2.pending.maintenance",
+		Phrase:   "pending maintenance",
+		Severity: domain.SevBroken,
+		Source:   "wave2:ec2",
 	}
-	attention.DeriveFindings(&r, ec2TD, ef)
+	r.Findings = append(r.Findings, w2)
+	if r.AttentionDetails == nil {
+		r.AttentionDetails = make(map[domain.FindingCode]domain.AttentionDetail)
+	}
+	r.AttentionDetails[w2.Code] = domain.AttentionDetail{
+		Rows: []domain.DetailRow{{Label: "Action", Value: "reboot"}},
+	}
+
 	if len(r.Findings) != 1 {
 		t.Fatalf("len(Findings): got %d, want 1 (lifecycle filtered; wave2 is the only Finding)", len(r.Findings))
 	}
@@ -235,16 +242,20 @@ func TestDerive_Wave2OnTopOfLifecycleStatus(t *testing.T) {
 // populated with the corresponding rows.
 func TestDerive_Wave2Only_AppendsFindingAndAttentionDetails(t *testing.T) {
 	r := domain.Resource{ID: "i-005"}
-	ef := map[string]resource.EnrichmentFinding{
-		"i-005": {
-			Severity: "!",
-			Summary:  "pending maintenance",
-			Rows: []resource.FindingRow{
-				{Label: "Action", Value: "reboot", Tier: ""},
-			},
-		},
+	// Wave-1 derive: no status/issues → no wave1 findings.
+	attention.DeriveFindings(&r, ec2TD)
+	// Wave-2 append (simulates applyEnrichment).
+	wantCode := domain.FindingCode("ec2.pending.maintenance")
+	w2 := domain.Finding{
+		Code:     wantCode,
+		Phrase:   "pending maintenance",
+		Severity: domain.SevBroken,
+		Source:   "wave2:ec2",
 	}
-	attention.DeriveFindings(&r, ec2TD, ef)
+	r.Findings = append(r.Findings, w2)
+	r.AttentionDetails = map[domain.FindingCode]domain.AttentionDetail{
+		wantCode: {Rows: []domain.DetailRow{{Label: "Action", Value: "reboot", Tier: ""}}},
+	}
 
 	if len(r.Findings) != 1 {
 		t.Fatalf("len(Findings): got %d, want 1", len(r.Findings))
@@ -261,7 +272,6 @@ func TestDerive_Wave2Only_AppendsFindingAndAttentionDetails(t *testing.T) {
 	}
 
 	// Code is derived from slug of "pending maintenance" under "ec2" short name.
-	wantCode := domain.FindingCode("ec2.pending.maintenance")
 	if f.Code != wantCode {
 		t.Errorf("Code: got %q, want %q", f.Code, wantCode)
 	}
@@ -298,14 +308,19 @@ func TestDerive_Wave1AndWave2_Combined(t *testing.T) {
 		ID:     "i-006",
 		Issues: []string{"impaired"},
 	}
-	ef := map[string]resource.EnrichmentFinding{
-		"i-006": {
-			Severity: "~",
-			Summary:  "scheduled reboot",
-			Rows:     []resource.FindingRow{{Label: "Window", Value: "sat 02:00"}},
-		},
+	// Wave-1 derive.
+	attention.DeriveFindings(&r, ec2TD)
+	// Wave-2 append (simulates applyEnrichment).
+	w2 := domain.Finding{
+		Code:     "ec2.scheduled.reboot",
+		Phrase:   "scheduled reboot",
+		Severity: domain.SevWarn,
+		Source:   "wave2:ec2",
 	}
-	attention.DeriveFindings(&r, ec2TD, ef)
+	r.Findings = append(r.Findings, w2)
+	r.AttentionDetails = map[domain.FindingCode]domain.AttentionDetail{
+		w2.Code: {Rows: []domain.DetailRow{{Label: "Window", Value: "sat 02:00"}}},
+	}
 
 	if len(r.Findings) != 2 {
 		t.Fatalf("len(Findings): got %d, want 2", len(r.Findings))
@@ -352,13 +367,14 @@ func TestDerive_Wave2SeverityMapping(t *testing.T) {
 		tc := tc
 		t.Run(tc.inputSev, func(t *testing.T) {
 			r := domain.Resource{ID: "i-sev"}
-			ef := map[string]resource.EnrichmentFinding{
-				"i-sev": {
-					Severity: tc.inputSev,
-					Summary:  "test phrase",
-				},
+			// Wave-2 append (simulates applyEnrichment).
+			w2 := domain.Finding{
+				Code:     "ec2.test.sev",
+				Phrase:   "test phrase",
+				Severity: tc.wantSev,
+				Source:   "wave2:ec2",
 			}
-			attention.DeriveFindings(&r, ec2TD, ef)
+			r.Findings = append(r.Findings, w2)
 			if len(r.Findings) != 1 {
 				t.Fatalf("len(Findings): got %d, want 1", len(r.Findings))
 			}
@@ -378,16 +394,15 @@ func TestDerive_Deterministic_RepeatedCallsIdentical(t *testing.T) {
 		ID:     "i-007",
 		Issues: []string{"impaired"},
 	}
-	ef := map[string]resource.EnrichmentFinding{
-		"i-007": {Severity: "!", Summary: "pending maintenance"},
-	}
 
-	attention.DeriveFindings(&r, ec2TD, ef)
+	// First call: wave1 derive only.
+	attention.DeriveFindings(&r, ec2TD)
 	findings1 := make([]domain.Finding, len(r.Findings))
 	copy(findings1, r.Findings)
 	details1 := r.AttentionDetails
 
-	attention.DeriveFindings(&r, ec2TD, ef)
+	// Second call with same inputs — must produce identical result, not append.
+	attention.DeriveFindings(&r, ec2TD)
 
 	if !reflect.DeepEqual(findings1, r.Findings) {
 		t.Errorf("Findings changed on second call: first=%v second=%v", findings1, r.Findings)
@@ -395,9 +410,9 @@ func TestDerive_Deterministic_RepeatedCallsIdentical(t *testing.T) {
 	if !reflect.DeepEqual(details1, r.AttentionDetails) {
 		t.Errorf("AttentionDetails changed on second call")
 	}
-	// Specifically verify the count hasn't doubled (append would produce 4 not 2).
-	if len(r.Findings) != 2 {
-		t.Errorf("len(Findings) after second call: got %d, want 2 (replace, not append)", len(r.Findings))
+	// Specifically verify the count hasn't doubled (append would produce 2 not 1).
+	if len(r.Findings) != 1 {
+		t.Errorf("len(Findings) after second call: got %d, want 1 (replace, not append)", len(r.Findings))
 	}
 }
 
@@ -413,7 +428,7 @@ func TestDerive_Wave2BridgeOnSecondCall(t *testing.T) {
 	}
 
 	// First pass: no enrichment.
-	attention.DeriveFindings(&r, ec2TD, nil)
+	attention.DeriveFindings(&r, ec2TD)
 	if len(r.Findings) != 1 {
 		t.Fatalf("after first call: len(Findings): got %d, want 1", len(r.Findings))
 	}
@@ -421,11 +436,15 @@ func TestDerive_Wave2BridgeOnSecondCall(t *testing.T) {
 		t.Errorf("after first call: Findings[0].Source: got %q, want wave1", r.Findings[0].Source)
 	}
 
-	// Second pass: enrichment now present for the same resource.
-	ef := map[string]resource.EnrichmentFinding{
-		"i-008": {Severity: "!", Summary: "pending maintenance"},
+	// Second pass: re-derive wave1, then append wave2 (simulates applyEnrichment).
+	attention.DeriveFindings(&r, ec2TD)
+	w2 := domain.Finding{
+		Code:     "ec2.pending.maintenance",
+		Phrase:   "pending maintenance",
+		Severity: domain.SevBroken,
+		Source:   "wave2:ec2",
 	}
-	attention.DeriveFindings(&r, ec2TD, ef)
+	r.Findings = append(r.Findings, w2)
 	if len(r.Findings) != 2 {
 		t.Fatalf("after second call: len(Findings): got %d, want 2 (wave1 + wave2, no early-return)", len(r.Findings))
 	}
@@ -445,7 +464,7 @@ func TestDerive_NoEarlyReturnOnExistingFindings(t *testing.T) {
 			{Code: "manual", Phrase: "stale", Severity: domain.SevBroken, Source: "manual"},
 		},
 	}
-	attention.DeriveFindings(&r, ec2TD, nil)
+	attention.DeriveFindings(&r, ec2TD)
 	if len(r.Findings) != 0 {
 		t.Errorf("len(Findings): got %d, want 0 (shim must replace stale entries on healthy row)", len(r.Findings))
 	}
@@ -465,7 +484,7 @@ func TestDerive_NoEarlyReturnOnExistingFindings(t *testing.T) {
 func TestDerive_InactiveIsEmittedAsFinding(t *testing.T) {
 	r := domain.Resource{ID: "i", Status: "inactive"}
 	td := resource.ResourceTypeDef{ShortName: "ecs-svc"}
-	attention.DeriveFindings(&r, td, nil)
+	attention.DeriveFindings(&r, td)
 
 	if len(r.Findings) != 1 {
 		t.Fatalf("Findings count = %d, want 1 (inactive must emit a Finding — see ECS type policy)", len(r.Findings))
@@ -500,7 +519,7 @@ func TestDerive_MigratedRowPreservesFetcherFindings(t *testing.T) {
 		},
 	}
 	td := resource.ResourceTypeDef{ShortName: "ec2"}
-	attention.DeriveFindings(&r, td, nil)
+	attention.DeriveFindings(&r, td)
 
 	if len(r.Findings) != 1 {
 		t.Fatalf("len(Findings) = %d, want 1 — shim must preserve fetcher-emitted wave1 entries when r.Status/r.Issues are empty", len(r.Findings))
@@ -530,10 +549,19 @@ func TestDerive_MigratedRowMergesWave2WithFetcherWave1(t *testing.T) {
 		},
 	}
 	td := resource.ResourceTypeDef{ShortName: "ec2"}
-	enrich := map[string]resource.EnrichmentFinding{
-		"i-1": {Severity: "!", Summary: "instance status: impaired", Rows: []resource.FindingRow{{Label: "Instance Status", Value: "impaired"}}},
+	// Wave-1 derive: shim preserves pre-populated fetcher wave1 entries.
+	attention.DeriveFindings(&r, td)
+	// Wave-2 append (simulates applyEnrichment).
+	w2 := domain.Finding{
+		Code:     "ec2.instance.status.impaired",
+		Phrase:   "instance status: impaired",
+		Severity: domain.SevBroken,
+		Source:   "wave2:ec2",
 	}
-	attention.DeriveFindings(&r, td, enrich)
+	r.Findings = append(r.Findings, w2)
+	r.AttentionDetails = map[domain.FindingCode]domain.AttentionDetail{
+		w2.Code: {Rows: []domain.DetailRow{{Label: "Instance Status", Value: "impaired"}}},
+	}
 
 	if len(r.Findings) != 2 {
 		t.Fatalf("len(Findings) = %d, want 2 (wave1 from fetcher + wave2 from enrichment)", len(r.Findings))

--- a/tests/unit/phase03_fold_test.go
+++ b/tests/unit/phase03_fold_test.go
@@ -81,7 +81,7 @@ func slugForTest(phrase string) string {
 // Specifically for each type:
 //   - Resource with Status "running" (a lifecycle phrase, filtered by wave1)
 //     should yield exactly one finding after enrichment — the wave2 entry.
-//   - That wave2 finding must have Phrase == ef.Summary and Source == "wave2:<canonShort>".
+//   - That wave2 finding must have Phrase == ef.Phrase and Source == "wave2:<canonShort>".
 //   - r.AttentionDetails[code].Rows must contain the EnrichmentFinding's Rows.
 //   - The same row mutation must occur for LazyResourceCache and ProbeResources.
 //
@@ -120,10 +120,14 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 		wantCode := domain.FindingCode(tc.canonShort + "." + slugForTest(tc.summary))
 		rid := "r-" + tc.canonShort
 
-		ef := resource.EnrichmentFinding{
-			Severity: "~",
-			Summary:  tc.summary,
-			Rows: []resource.FindingRow{
+		efFinding := domain.Finding{
+			Code:     wantCode,
+			Phrase:   tc.summary,
+			Severity: domain.SevWarn,
+			Source:   wantSource,
+		}
+		efAttention := domain.AttentionDetail{
+			Rows: []domain.DetailRow{
 				{Label: "Action", Value: "test-action"},
 				{Label: "Detail", Value: "test-detail"},
 			},
@@ -140,7 +144,8 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 
 			m = shimApplyMsg(m, messages.EnrichmentChecked{
 				ResourceType: msgType,
-				Findings:     map[string]resource.EnrichmentFinding{rid: ef},
+				Findings:     map[string]domain.Finding{rid: efFinding},
+				AttentionDetails: map[string]domain.AttentionDetail{rid: efAttention},
 				Gen:          0,
 				TypeGen:      0,
 			})
@@ -165,18 +170,18 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 				}
 			}
 
-			// AttentionDetails must carry the EnrichmentFinding's Rows.
+			// AttentionDetails must carry the rows from the enrichment input.
 			if len(r.AttentionDetails) == 0 {
 				t.Errorf("AttentionDetails: got empty, want entry for code %q", wantCode)
 			} else if detail, ok := r.AttentionDetails[wantCode]; !ok {
 				t.Errorf("AttentionDetails[%q]: not found; keys: %v", wantCode, r.AttentionDetails)
-			} else if len(detail.Rows) != len(ef.Rows) {
-				t.Errorf("AttentionDetails[%q].Rows: got len=%d, want %d", wantCode, len(detail.Rows), len(ef.Rows))
+			} else if len(detail.Rows) != len(efAttention.Rows) {
+				t.Errorf("AttentionDetails[%q].Rows: got len=%d, want %d", wantCode, len(detail.Rows), len(efAttention.Rows))
 			} else {
 				for i, row := range detail.Rows {
-					if row.Label != ef.Rows[i].Label || row.Value != ef.Rows[i].Value {
+					if row.Label != efAttention.Rows[i].Label || row.Value != efAttention.Rows[i].Value {
 						t.Errorf("AttentionDetails[%q].Rows[%d]: got {%q,%q}, want {%q,%q}",
-							wantCode, i, row.Label, row.Value, ef.Rows[i].Label, ef.Rows[i].Value)
+							wantCode, i, row.Label, row.Value, efAttention.Rows[i].Label, efAttention.Rows[i].Value)
 					}
 				}
 			}
@@ -190,10 +195,11 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 			}
 
 			m = shimApplyMsg(m, messages.EnrichmentChecked{
-				ResourceType: msgType,
-				Findings:     map[string]resource.EnrichmentFinding{rid: ef},
-				Gen:          0,
-				TypeGen:      0,
+				ResourceType:     msgType,
+				Findings:         map[string]domain.Finding{rid: efFinding},
+				AttentionDetails: map[string]domain.AttentionDetail{rid: efAttention},
+				Gen:              0,
+				TypeGen:          0,
 			})
 
 			lazySlice, ok := m.Core().Session().LazyResourceCache[tc.canonShort]
@@ -232,10 +238,11 @@ func TestFold_EnrichmentCheckedMutatesRowsDirectly(t *testing.T) {
 			}
 
 			m = shimApplyMsg(m, messages.EnrichmentChecked{
-				ResourceType: msgType,
-				Findings:     map[string]resource.EnrichmentFinding{rid: ef},
-				Gen:          0,
-				TypeGen:      0,
+				ResourceType:     msgType,
+				Findings:         map[string]domain.Finding{rid: efFinding},
+				AttentionDetails: map[string]domain.AttentionDetail{rid: efAttention},
+				Gen:              0,
+				TypeGen:          0,
 			})
 
 			probeSlice, ok := m.Core().Session().ProbeResources[tc.canonShort]
@@ -304,13 +311,17 @@ func TestFold_RepeatedEnrichmentReplacesWave2(t *testing.T) {
 			wantSource := "wave2:" + tc.canonShort
 			rid := "r-repeat-" + tc.canonShort
 
-			efFirst := resource.EnrichmentFinding{
-				Severity: "~",
-				Summary:  tc.summaryA,
+			efFirst := domain.Finding{
+				Code:     domain.FindingCode(tc.canonShort + "." + slugForTest(tc.summaryA)),
+				Phrase:   tc.summaryA,
+				Severity: domain.SevWarn,
+				Source:   wantSource,
 			}
-			efSecond := resource.EnrichmentFinding{
-				Severity: "!",
-				Summary:  tc.summaryB,
+			efSecond := domain.Finding{
+				Code:     domain.FindingCode(tc.canonShort + "." + slugForTest(tc.summaryB)),
+				Phrase:   tc.summaryB,
+				Severity: domain.SevBroken,
+				Source:   wantSource,
 			}
 
 			m := newShimModel()
@@ -323,7 +334,7 @@ func TestFold_RepeatedEnrichmentReplacesWave2(t *testing.T) {
 			// First enrichment: wave2 = summaryA
 			m = shimApplyMsg(m, messages.EnrichmentChecked{
 				ResourceType: msgType,
-				Findings:     map[string]resource.EnrichmentFinding{rid: efFirst},
+				Findings:     map[string]domain.Finding{rid: efFirst},
 				Gen:          0,
 				TypeGen:      0,
 			})
@@ -331,7 +342,7 @@ func TestFold_RepeatedEnrichmentReplacesWave2(t *testing.T) {
 			// Second enrichment: wave2 = summaryB
 			m = shimApplyMsg(m, messages.EnrichmentChecked{
 				ResourceType: msgType,
-				Findings:     map[string]resource.EnrichmentFinding{rid: efSecond},
+				Findings:     map[string]domain.Finding{rid: efSecond},
 				Gen:          0,
 				TypeGen:      0,
 			})
@@ -361,8 +372,8 @@ func TestFold_RepeatedEnrichmentReplacesWave2(t *testing.T) {
 			if wave2.Source != wantSource {
 				t.Errorf("Findings[1].Source: got %q, want %q", wave2.Source, wantSource)
 			}
-			if wave2.Phrase != efSecond.Summary {
-				t.Errorf("Findings[1].Phrase: got %q, want %q (second wave2 only — must NOT stack)", wave2.Phrase, efSecond.Summary)
+			if wave2.Phrase != efSecond.Phrase {
+				t.Errorf("Findings[1].Phrase: got %q, want %q (second wave2 only — must NOT stack)", wave2.Phrase, efSecond.Phrase)
 			}
 		})
 	}
@@ -417,10 +428,15 @@ func TestFold_EmptyEnrichmentClearsWave2(t *testing.T) {
 			wantWave2Source := "wave2:" + tc.canonShort
 			rid := "r-empty-" + tc.canonShort
 
-			efInitial := resource.EnrichmentFinding{
-				Severity: "~",
-				Summary:  tc.summary,
-				Rows:     []resource.FindingRow{{Label: "Action", Value: "test-retirement"}},
+			efInitialCode := domain.FindingCode(tc.canonShort + "." + slugForTest(tc.summary))
+			efInitialFinding := domain.Finding{
+				Code:     efInitialCode,
+				Phrase:   tc.summary,
+				Severity: domain.SevWarn,
+				Source:   wantWave2Source,
+			}
+			efInitialAttention := domain.AttentionDetail{
+				Rows: []domain.DetailRow{{Label: "Action", Value: "test-retirement"}},
 			}
 
 			m := newShimModel()
@@ -432,10 +448,11 @@ func TestFold_EmptyEnrichmentClearsWave2(t *testing.T) {
 
 			// Seed wave2 finding.
 			m = shimApplyMsg(m, messages.EnrichmentChecked{
-				ResourceType: msgType,
-				Findings:     map[string]resource.EnrichmentFinding{rid: efInitial},
-				Gen:          0,
-				TypeGen:      0,
+				ResourceType:     msgType,
+				Findings:         map[string]domain.Finding{rid: efInitialFinding},
+				AttentionDetails: map[string]domain.AttentionDetail{rid: efInitialAttention},
+				Gen:              0,
+				TypeGen:          0,
 			})
 
 			// Verify wave2 was set before clearing.
@@ -548,10 +565,14 @@ func TestFold_CtrlROnList_ClearsActiveRowFindings(t *testing.T) {
 		wantSource = "wave2:ec2"
 	)
 
-	ef := resource.EnrichmentFinding{
-		Severity: "!",
-		Summary:  "pending maintenance",
-		Rows: []resource.FindingRow{
+	efFinding := domain.Finding{
+		Code:     "ec2.pending.maintenance",
+		Phrase:   "pending maintenance",
+		Severity: domain.SevBroken,
+		Source:   wantSource,
+	}
+	efAttention := domain.AttentionDetail{
+		Rows: []domain.DetailRow{
 			{Label: "Action", Value: "instance-retirement"},
 		},
 	}
@@ -568,10 +589,11 @@ func TestFold_CtrlROnList_ClearsActiveRowFindings(t *testing.T) {
 
 	// Step 2: stamp wave2 findings into the cached row via EnrichmentCheckedMsg.
 	m = shimApplyMsg(m, messages.EnrichmentChecked{
-		ResourceType: "ec2",
-		Findings:     map[string]resource.EnrichmentFinding{rid: ef},
-		Gen:          0,
-		TypeGen:      0,
+		ResourceType:     "ec2",
+		Findings:         map[string]domain.Finding{rid: efFinding},
+		AttentionDetails: map[string]domain.AttentionDetail{rid: efAttention},
+		Gen:              0,
+		TypeGen:          0,
 	})
 
 	// Step 3: navigate to the ec2 list view — cache hit path creates a
@@ -646,15 +668,23 @@ func TestFold_MainMenuCtrlR_ClearsAllCachedWave2(t *testing.T) {
 		s3Short  = "s3"
 	)
 
-	efEC2 := resource.EnrichmentFinding{
-		Severity: "!",
-		Summary:  "ec2 retirement",
-		Rows:     []resource.FindingRow{{Label: "Action", Value: "retirement"}},
+	efEC2Finding := domain.Finding{
+		Code:     "ec2.ec2.retirement",
+		Phrase:   "ec2 retirement",
+		Severity: domain.SevBroken,
+		Source:   "wave2:" + ec2Short,
 	}
-	efS3 := resource.EnrichmentFinding{
-		Severity: "~",
-		Summary:  "s3 public access",
-		Rows:     []resource.FindingRow{{Label: "Policy", Value: "public-read"}},
+	efEC2Attention := domain.AttentionDetail{
+		Rows: []domain.DetailRow{{Label: "Action", Value: "retirement"}},
+	}
+	efS3Finding := domain.Finding{
+		Code:     "s3.s3.public.access",
+		Phrase:   "s3 public access",
+		Severity: domain.SevWarn,
+		Source:   "wave2:" + s3Short,
+	}
+	efS3Attention := domain.AttentionDetail{
+		Rows: []domain.DetailRow{{Label: "Policy", Value: "public-read"}},
 	}
 
 	// Build a model WITHOUT WithNoCache so main-menu Ctrl+R is not a no-op.
@@ -677,16 +707,18 @@ func TestFold_MainMenuCtrlR_ClearsAllCachedWave2(t *testing.T) {
 
 	// Step 2: stamp wave2 findings via EnrichmentCheckedMsg for both types.
 	m = shimApplyMsg(m, messages.EnrichmentChecked{
-		ResourceType: ec2Short,
-		Findings:     map[string]resource.EnrichmentFinding{ec2ID: efEC2},
-		Gen:          0,
-		TypeGen:      0,
+		ResourceType:     ec2Short,
+		Findings:         map[string]domain.Finding{ec2ID: efEC2Finding},
+		AttentionDetails: map[string]domain.AttentionDetail{ec2ID: efEC2Attention},
+		Gen:              0,
+		TypeGen:          0,
 	})
 	m = shimApplyMsg(m, messages.EnrichmentChecked{
-		ResourceType: s3Short,
-		Findings:     map[string]resource.EnrichmentFinding{s3ID: efS3},
-		Gen:          0,
-		TypeGen:      0,
+		ResourceType:     s3Short,
+		Findings:         map[string]domain.Finding{s3ID: efS3Finding},
+		AttentionDetails: map[string]domain.AttentionDetail{s3ID: efS3Attention},
+		Gen:              0,
+		TypeGen:          0,
 	})
 
 	// Step 3: confirm wave2 entries are present before Ctrl+R.
@@ -798,10 +830,14 @@ func TestFold_AttentionDetailsCarryAcrossEntryPoints(t *testing.T) {
 			wantCode := domain.FindingCode(tc.canonShort + "." + slugForTest(tc.summary))
 			rid := "r-site4-" + tc.canonShort
 
-			ef := resource.EnrichmentFinding{
-				Severity: "~",
-				Summary:  tc.summary,
-				Rows:     []resource.FindingRow{{Label: "Action", Value: "test-retirement"}},
+			efFinding := domain.Finding{
+				Code:     wantCode,
+				Phrase:   tc.summary,
+				Severity: domain.SevWarn,
+				Source:   wantSource,
+			}
+			efAttention := domain.AttentionDetail{
+				Rows: []domain.DetailRow{{Label: "Action", Value: "test-retirement"}},
 			}
 
 			m := newShimModel()
@@ -835,10 +871,11 @@ func TestFold_AttentionDetailsCarryAcrossEntryPoints(t *testing.T) {
 
 			// Step 2: Wave 2 enrichment arrives.
 			m = shimApplyMsg(m, messages.EnrichmentChecked{
-				ResourceType: msgType,
-				Findings:     map[string]resource.EnrichmentFinding{rid: ef},
-				Gen:          0,
-				TypeGen:      0,
+				ResourceType:     msgType,
+				Findings:         map[string]domain.Finding{rid: efFinding},
+				AttentionDetails: map[string]domain.AttentionDetail{rid: efAttention},
+				Gen:              0,
+				TypeGen:          0,
 			})
 
 			entry, ok := m.Core().Session().ResourceCache[tc.canonShort]
@@ -875,8 +912,8 @@ func TestFold_AttentionDetailsCarryAcrossEntryPoints(t *testing.T) {
 				t.Errorf("AttentionDetails[%q]: not found", wantCode)
 			} else if len(detail.Rows) == 0 {
 				t.Errorf("AttentionDetails[%q].Rows: empty, want non-empty", wantCode)
-			} else if detail.Rows[0].Label != ef.Rows[0].Label {
-				t.Errorf("AttentionDetails[%q].Rows[0].Label: got %q, want %q", wantCode, detail.Rows[0].Label, ef.Rows[0].Label)
+			} else if detail.Rows[0].Label != efAttention.Rows[0].Label {
+				t.Errorf("AttentionDetails[%q].Rows[0].Label: got %q, want %q", wantCode, detail.Rows[0].Label, efAttention.Rows[0].Label)
 			}
 		})
 	}

--- a/tests/unit/phase03_shim_wireups_test.go
+++ b/tests/unit/phase03_shim_wireups_test.go
@@ -233,7 +233,7 @@ func TestShim_EnrichmentCheckedBridgesWave2Findings(t *testing.T) {
 				ResourceType: effective,
 				Issues:       0,
 				Truncated:    false,
-				Findings:     map[string]resource.EnrichmentFinding{},
+				Findings:     map[string]domain.Finding{},
 				Gen:          0,
 				TypeGen:      0,
 			})
@@ -457,10 +457,14 @@ func TestShim_DeriveHelpersResolveAlias(t *testing.T) {
 	m := newShimModel()
 
 	rid := "i-alias-wave2-001"
-	wave2Finding := resource.EnrichmentFinding{
-		Severity: "!",
-		Summary:  "pending maintenance",
-		Rows: []resource.FindingRow{
+	wave2Finding := domain.Finding{
+		Code:     "dbi.pending.maintenance",
+		Phrase:   "pending maintenance",
+		Severity: domain.SevBroken,
+		Source:   "wave2:dbi",
+	}
+	wave2Attention := domain.AttentionDetail{
+		Rows: []domain.DetailRow{
 			{Label: "Action", Value: "reboot"},
 		},
 	}
@@ -496,8 +500,11 @@ func TestShim_DeriveHelpersResolveAlias(t *testing.T) {
 	m.Core().Session().EnrichTotal = 2
 	m = shimApplyMsg(m, messages.EnrichmentChecked{
 		ResourceType: "dbi",
-		Findings: map[string]resource.EnrichmentFinding{
+		Findings: map[string]domain.Finding{
 			rid: wave2Finding,
+		},
+		AttentionDetails: map[string]domain.AttentionDetail{
+			rid: wave2Attention,
 		},
 		Gen:     0,
 		TypeGen: 0,
@@ -559,10 +566,14 @@ func TestShim_DeriveHelpersResolveAlias_SingleResource(t *testing.T) {
 	m := newShimModel()
 
 	rid := "i-alias-single-001"
-	wave2Finding := resource.EnrichmentFinding{
-		Severity: "!",
-		Summary:  "pending maintenance",
-		Rows: []resource.FindingRow{
+	wave2Finding := domain.Finding{
+		Code:     "dbi.pending.maintenance",
+		Phrase:   "pending maintenance",
+		Severity: domain.SevBroken,
+		Source:   "wave2:dbi",
+	}
+	wave2Attention := domain.AttentionDetail{
+		Rows: []domain.DetailRow{
 			{Label: "Action", Value: "reboot"},
 		},
 	}
@@ -598,8 +609,11 @@ func TestShim_DeriveHelpersResolveAlias_SingleResource(t *testing.T) {
 	m.Core().Session().EnrichTotal = 2
 	m = shimApplyMsg(m, messages.EnrichmentChecked{
 		ResourceType: "rds", // alias — exercises alias normalization in handleEnrichmentChecked
-		Findings: map[string]resource.EnrichmentFinding{
+		Findings: map[string]domain.Finding{
 			rid: wave2Finding,
+		},
+		AttentionDetails: map[string]domain.AttentionDetail{
+			rid: wave2Attention,
 		},
 		Gen:     0,
 		TypeGen: 0,

--- a/tests/unit/phase03_view_reads_test.go
+++ b/tests/unit/phase03_view_reads_test.go
@@ -563,12 +563,14 @@ func TestViews_DetailEnrichmentLateUpdatePicksUpFindings(t *testing.T) {
 	_ = firstOut // only used to confirm we can render
 
 	// Simulate Wave-2 result arriving later.
-	ef := resource.EnrichmentFinding{
-		Severity: "!",
-		Summary:  "pending maintenance",
-		Rows:     []resource.FindingRow{{Label: "Action", Value: "reboot"}},
+	ef := domain.Finding{
+		Code:     "test.pending-maintenance",
+		Phrase:   "pending maintenance",
+		Severity: domain.SevBroken,
+		Source:   "wave2:test",
 	}
-	m.SetEnrichmentFinding(&ef)
+	ad := domain.AttentionDetail{Rows: []domain.DetailRow{{Label: "Action", Value: "reboot"}}}
+	m.SetEnrichmentFinding(&ef, &ad)
 
 	// Second render: enrichment finding must now appear.
 	secondOut := m.PlainContent()

--- a/tests/unit/qa_attention_filter_enrichment_test.go
+++ b/tests/unit/qa_attention_filter_enrichment_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/k2m30/a9s/v3/internal/config"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/tui/keys"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
@@ -58,8 +59,8 @@ func TestAttentionFilter_SetEnrichmentState_ReappliesFilter(t *testing.T) {
 	// SetEnrichmentState → applySortAndFilter re-run, the row must become
 	// visible immediately — without the user toggling ctrl+z or editing the
 	// filter text.
-	findings := map[string]resource.EnrichmentFinding{
-		"b-0": {Severity: "!", Summary: "public access enabled"},
+	findings := map[string]domain.Finding{
+		"b-0": {Code: "s3.public.access.enabled", Phrase: "public access enabled", Severity: domain.SevBroken, Source: "wave2:s3"},
 	}
 	m.SetEnrichmentState(1, false, findings)
 

--- a/tests/unit/qa_attention_filter_test.go
+++ b/tests/unit/qa_attention_filter_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/tui/keys"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
@@ -102,8 +103,8 @@ func TestAttentionFilter_IncludesResourcesWithFindings(t *testing.T) {
 	})
 
 	// Wave 2 finding only for res-0.
-	findings := map[string]resource.EnrichmentFinding{
-		"res-0": {Severity: "warning", Summary: "public access enabled"},
+	findings := map[string]domain.Finding{
+		"res-0": {Code: "s3.public.access.enabled", Phrase: "public access enabled", Severity: domain.SevWarn, Source: "wave2:s3"},
 	}
 	m.SetEnrichmentState(1, false, findings)
 

--- a/tests/unit/qa_coderabbit_pr273_all_types_test.go
+++ b/tests/unit/qa_coderabbit_pr273_all_types_test.go
@@ -49,6 +49,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/tui"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
@@ -310,7 +311,7 @@ func TestCR273_AllTypes_MenuCtrlZ_NoFalsePositives(t *testing.T) {
 					ResourceType: c.shortName,
 					Issues:       0,
 					Truncated:    false,
-					Findings:     map[string]resource.EnrichmentFinding{},
+					Findings:     map[string]domain.Finding{},
 					Err:          nil,
 					Gen:          0,
 					TypeGen:      0,
@@ -362,7 +363,7 @@ func TestCR273_AllTypes_MenuCtrlZ_Wave2ErroredSubCall_NoFalsePositives(t *testin
 				ResourceType: c.shortName,
 				Issues:       0,
 				Truncated:    true,
-				Findings:     map[string]resource.EnrichmentFinding{},
+				Findings:     map[string]domain.Finding{},
 				Err:          nil,
 				Gen:          0,
 				TypeGen:      0,

--- a/tests/unit/qa_coderabbit_pr273_test.go
+++ b/tests/unit/qa_coderabbit_pr273_test.go
@@ -40,6 +40,7 @@ import (
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
 	"github.com/k2m30/a9s/v3/internal/demo/fixtures"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/tui"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
@@ -115,7 +116,7 @@ func TestCR273_Item18_MenuCtrlZ_NoFalsePositives_AllTypes(t *testing.T) {
 			ResourceType: ent.ShortName,
 			Issues:       0,
 			Truncated:    false,
-			Findings:     map[string]resource.EnrichmentFinding{},
+			Findings:     map[string]domain.Finding{},
 			Err:          nil,
 			Gen:          0,
 			TypeGen:      0,
@@ -178,7 +179,7 @@ func TestCR273_Item18_MenuCtrlZ_Wave2AuthoritativeZero_AllEnricherTypes(t *testi
 			ResourceType: ent.ShortName,
 			Issues:       0,
 			Truncated:    false,
-			Findings:     map[string]resource.EnrichmentFinding{},
+			Findings:     map[string]domain.Finding{},
 			Err:          nil,
 			Gen:          0,
 			TypeGen:      0,
@@ -249,7 +250,7 @@ func TestCR273_Item18_MenuCtrlZ_Wave2ErroredSubCall_AllEnricherTypes(t *testing.
 			ResourceType: ent.ShortName,
 			Issues:       0,
 			Truncated:    true,
-			Findings:     map[string]resource.EnrichmentFinding{},
+			Findings:     map[string]domain.Finding{},
 			Err:          nil,
 			Gen:          0,
 			TypeGen:      0,
@@ -567,8 +568,8 @@ func TestCR273_Item6_Gen0_BypassesSessionGuard(t *testing.T) {
 		ResourceType: "ec2",
 		Issues:       1,
 		Truncated:    false,
-		Findings: map[string]resource.EnrichmentFinding{
-			"i-0abc1111aaa111111": {Severity: "!", Summary: "system status impaired"},
+		Findings: map[string]domain.Finding{
+			"i-0abc1111aaa111111": {Code: "ec2.system.status.impaired", Phrase: "system status impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
 		},
 		Gen:     0, // test-injection sentinel
 		TypeGen: 0,

--- a/tests/unit/qa_enrichment_detail_live_test.go
+++ b/tests/unit/qa_enrichment_detail_live_test.go
@@ -16,6 +16,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/tui"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
@@ -100,8 +101,8 @@ func TestHandleEnrichmentChecked_UpdatesActiveDetailWhenFindingPresent(t *testin
 		ResourceType: "rds",
 		Issues:       1,
 		Truncated:    false,
-		Findings: map[string]resource.EnrichmentFinding{
-			"db-live-001": {Severity: "!", Summary: "pending maintenance: system-update — live update test"},
+		Findings: map[string]domain.Finding{
+			"db-live-001": {Code: "rds.pending-maintenance", Phrase: "pending maintenance: system-update — live update test", Severity: domain.SevBroken, Source: "wave2:rds"},
 		},
 		Err:     nil,
 		Gen:     0, // matches fresh model's enrichmentGen=0
@@ -138,8 +139,8 @@ func TestHandleEnrichmentChecked_ClearsDetailFindingOnRecovery(t *testing.T) {
 	setFindingMsg := messages.EnrichmentChecked{
 		ResourceType: "rds",
 		Issues:       1,
-		Findings: map[string]resource.EnrichmentFinding{
-			"db-live-002": {Severity: "!", Summary: "pending maintenance: system-update — will recover"},
+		Findings: map[string]domain.Finding{
+			"db-live-002": {Code: "rds.pending-maintenance", Phrase: "pending maintenance: system-update — will recover", Severity: domain.SevBroken, Source: "wave2:rds"},
 		},
 		Gen:     0,
 		TypeGen: 0,
@@ -160,7 +161,7 @@ func TestHandleEnrichmentChecked_ClearsDetailFindingOnRecovery(t *testing.T) {
 	clearFindingMsg := messages.EnrichmentChecked{
 		ResourceType: "rds",
 		Issues:       0,
-		Findings:     map[string]resource.EnrichmentFinding{}, // empty — "db-live-002" recovered
+		Findings:     map[string]domain.Finding{}, // empty — "db-live-002" recovered
 		Gen:          0,
 		TypeGen:      0, // still matches (TypeGen only changes on rerun start)
 	}
@@ -189,8 +190,8 @@ func TestHandleEnrichmentChecked_StaleTypeGenDoesNotUpdateDetail(t *testing.T) {
 	staleMsg := messages.EnrichmentChecked{
 		ResourceType: "rds",
 		Issues:       1,
-		Findings: map[string]resource.EnrichmentFinding{
-			"db-live-003": {Severity: "!", Summary: "stale finding — should not appear"},
+		Findings: map[string]domain.Finding{
+			"db-live-003": {Code: "rds.pending-maintenance", Phrase: "stale finding — should not appear", Severity: domain.SevBroken, Source: "wave2:rds"},
 		},
 		Gen:     0,
 		TypeGen: 99, // stale — fresh model's enrichmentTypeGen["rds"] is 0
@@ -229,8 +230,8 @@ func TestHandleEnrichmentChecked_FindingNotAppliedWhenDetailInactive(t *testing.
 	findingMsg := messages.EnrichmentChecked{
 		ResourceType: "rds",
 		Issues:       1,
-		Findings: map[string]resource.EnrichmentFinding{
-			"db-not-in-detail": {Severity: "!", Summary: "finding for list-only scenario"},
+		Findings: map[string]domain.Finding{
+			"db-not-in-detail": {Code: "rds.pending-maintenance", Phrase: "finding for list-only scenario", Severity: domain.SevBroken, Source: "wave2:rds"},
 		},
 		Gen:     0,
 		TypeGen: 0,

--- a/tests/unit/qa_enrichment_detail_test.go
+++ b/tests/unit/qa_enrichment_detail_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/tui/keys"
 	"github.com/k2m30/a9s/v3/internal/tui/styles"
@@ -94,11 +95,8 @@ func TestDetailView_NoBackgroundCheckSection_WhenNoFinding(t *testing.T) {
 func TestDetailView_ShowsBackgroundCheckSection_WhenFindingSet(t *testing.T) {
 	m := newRDSDetailModel(t)
 
-	finding := resource.EnrichmentFinding{
-		Severity: "!",
-		Summary:  "pending maintenance: system-update (New OS patch)",
-	}
-	m.SetEnrichmentFinding(&finding)
+	finding := domain.Finding{Code: "test.finding", Phrase: "pending maintenance: system-update (New OS patch)", Severity: domain.SevBroken, Source: "wave2:test"}
+	m.SetEnrichmentFinding(&finding, nil)
 
 	output := detailRenderOutput(m)
 
@@ -128,8 +126,8 @@ func TestDetailView_SetFindingInvalidatesFieldList(t *testing.T) {
 	}
 
 	// Set finding and render again.
-	finding := resource.EnrichmentFinding{Severity: "~", Summary: "pending maintenance: minor-version-upgrade"}
-	m.SetEnrichmentFinding(&finding)
+	finding := domain.Finding{Code: "test.finding", Phrase: "pending maintenance: minor-version-upgrade", Severity: domain.SevWarn, Source: "wave2:test"}
+	m.SetEnrichmentFinding(&finding, nil)
 
 	second := detailRenderOutput(m)
 	if !strings.Contains(second, "Attention") {
@@ -150,8 +148,8 @@ func TestDetailView_SetFindingInvalidatesFieldList(t *testing.T) {
 func TestDetailView_FindingSeverityBangRendersWithSummary(t *testing.T) {
 	m := newRDSDetailModel(t)
 
-	finding := resource.EnrichmentFinding{Severity: "!", Summary: "latest build FAILED (2026-04-13)"}
-	m.SetEnrichmentFinding(&finding)
+	finding := domain.Finding{Code: "test.finding", Phrase: "latest build FAILED (2026-04-13)", Severity: domain.SevBroken, Source: "wave2:test"}
+	m.SetEnrichmentFinding(&finding, nil)
 
 	// Must not panic.
 	output := detailRenderOutput(m)
@@ -173,8 +171,8 @@ func TestDetailView_FindingSeverityBangRendersWithSummary(t *testing.T) {
 func TestDetailView_FindingSeverityTildeRendersWithSummary(t *testing.T) {
 	m := newRDSDetailModel(t)
 
-	finding := resource.EnrichmentFinding{Severity: "~", Summary: "pending maintenance: os-upgrade"}
-	m.SetEnrichmentFinding(&finding)
+	finding := domain.Finding{Code: "test.finding", Phrase: "pending maintenance: os-upgrade", Severity: domain.SevWarn, Source: "wave2:test"}
+	m.SetEnrichmentFinding(&finding, nil)
 
 	// Must not panic.
 	output := detailRenderOutput(m)
@@ -189,14 +187,14 @@ func TestDetailView_FindingSeverityTildeRendersWithSummary(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // TestDetailView_SetFindingToNilRemovesSection asserts that after a finding is
-// set and then cleared via SetEnrichmentFinding(nil), the "Background Check"
+// set and then cleared via SetEnrichmentFinding(nil, nil), the "Background Check"
 // section disappears from the rendered output.
 func TestDetailView_SetFindingToNilRemovesSection(t *testing.T) {
 	m := newRDSDetailModel(t)
 
 	// Set finding.
-	finding := resource.EnrichmentFinding{Severity: "!", Summary: "system status impaired"}
-	m.SetEnrichmentFinding(&finding)
+	finding := domain.Finding{Code: "test.finding", Phrase: "system status impaired", Severity: domain.SevBroken, Source: "wave2:test"}
+	m.SetEnrichmentFinding(&finding, nil)
 
 	withFinding := detailRenderOutput(m)
 	if !strings.Contains(withFinding, "Attention") {
@@ -204,11 +202,11 @@ func TestDetailView_SetFindingToNilRemovesSection(t *testing.T) {
 	}
 
 	// Clear finding.
-	m.SetEnrichmentFinding(nil)
+	m.SetEnrichmentFinding(nil, nil)
 
 	withoutFinding := detailRenderOutput(m)
 	if strings.Contains(withoutFinding, "Attention") {
-		t.Errorf("after SetEnrichmentFinding(nil), 'Pending Maintenance' must not appear, got:\n%s", withoutFinding)
+		t.Errorf("after SetEnrichmentFinding(nil, nil), 'Pending Maintenance' must not appear, got:\n%s", withoutFinding)
 	}
 }
 
@@ -222,8 +220,8 @@ func TestDetailView_SetFindingToNilRemovesSection(t *testing.T) {
 func TestDetailView_YAMLViewDoesNotShowFinding(t *testing.T) {
 	m := newRDSDetailModel(t)
 
-	finding := resource.EnrichmentFinding{Severity: "!", Summary: "instance status impaired"}
-	m.SetEnrichmentFinding(&finding)
+	finding := domain.Finding{Code: "test.finding", Phrase: "instance status impaired", Severity: domain.SevBroken, Source: "wave2:test"}
+	m.SetEnrichmentFinding(&finding, nil)
 
 	// RawYAML is the YAML serialization path used for the YAML view.
 	yamlOutput := m.RawYAML()
@@ -288,8 +286,8 @@ func TestDetailView_FindingRendersForMultipleResourceTypes(t *testing.T) {
 			m := views.NewDetail(tc.res, tc.resourceType, nil, k)
 			m.SetSize(120, 40)
 
-			finding := resource.EnrichmentFinding{Severity: "!", Summary: tc.summary}
-			m.SetEnrichmentFinding(&finding)
+			finding := domain.Finding{Code: "test.finding", Phrase: tc.summary, Severity: domain.SevBroken, Source: "wave2:test"}
+			m.SetEnrichmentFinding(&finding, nil)
 
 			output := m.PlainContent()
 

--- a/tests/unit/qa_enrichment_dispatch_test.go
+++ b/tests/unit/qa_enrichment_dispatch_test.go
@@ -16,6 +16,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/tui"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
@@ -95,8 +96,8 @@ func TestEnrichmentCheckedMsg_StaleSessionGenDropped(t *testing.T) {
 		ResourceType: "ec2",
 		Issues:       42,
 		Truncated:    false,
-		Findings: map[string]resource.EnrichmentFinding{
-			"i-abc": {Severity: "!", Summary: "system status impaired"},
+		Findings: map[string]domain.Finding{
+			"i-abc": {Code: "ec2.system.status.impaired", Phrase: "system status impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
 		},
 		Gen:     999, // stale — fresh model's enrichmentGen is 0
 		TypeGen: 0,
@@ -120,7 +121,7 @@ func TestEnrichmentCheckedMsg_StaleTypeGenDropped(t *testing.T) {
 		ResourceType: "ec2",
 		Issues:       5,
 		Truncated:    false,
-		Findings:     map[string]resource.EnrichmentFinding{},
+		Findings:     map[string]domain.Finding{},
 		Gen:          0,  // matches fresh model's enrichmentGen=0
 		TypeGen:      99, // stale — fresh model's enrichmentTypeGen["ec2"] is 0
 	}
@@ -176,8 +177,8 @@ func TestEnrichmentCheckedMsg_ValidSuccessDoesNotCrash(t *testing.T) {
 		ResourceType: "glue",
 		Issues:       1,
 		Truncated:    false,
-		Findings: map[string]resource.EnrichmentFinding{
-			"my-glue-job": {Severity: "!", Summary: "latest run FAILED"},
+		Findings: map[string]domain.Finding{
+			"my-glue-job": {Code: "glue.job.last.run.failed", Phrase: "latest run FAILED", Severity: domain.SevBroken, Source: "wave2:glue"},
 		},
 		Gen:     0,
 		TypeGen: 0,

--- a/tests/unit/qa_enrichment_marker_test.go
+++ b/tests/unit/qa_enrichment_marker_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/tui/keys"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
@@ -58,7 +59,7 @@ func markerResources() []resource.Resource {
 }
 
 // buildMarkerModel constructs a fully-loaded ResourceListModel for marker tests.
-func buildMarkerModel(t *testing.T, findings map[string]resource.EnrichmentFinding) views.ResourceListModel {
+func buildMarkerModel(t *testing.T, findings map[string]domain.Finding) views.ResourceListModel {
 	t.Helper()
 	t.Setenv("NO_COLOR", "")
 	styles.Reinit()
@@ -93,7 +94,7 @@ func countFindingPrefixes(rendered string) int {
 // TestRowMarker_Absent_WhenNoFinding verifies that when findingsByID is empty,
 // no "! " or "~ " prefix marker appears in the rendered list output.
 func TestRowMarker_Absent_WhenNoFinding(t *testing.T) {
-	m := buildMarkerModel(t, map[string]resource.EnrichmentFinding{})
+	m := buildMarkerModel(t, map[string]domain.Finding{})
 	rendered := m.View()
 	plain := stripANSI(rendered)
 	if strings.Contains(plain, "! ") || strings.Contains(plain, "~ ") {
@@ -108,8 +109,8 @@ func TestRowMarker_Absent_WhenNoFinding(t *testing.T) {
 // TestRowMarker_PresentForFinding_SeverityBang verifies that a resource with
 // severity "!" has a "! " prefix marker in the rendered output.
 func TestRowMarker_PresentForFinding_SeverityBang(t *testing.T) {
-	findings := map[string]resource.EnrichmentFinding{
-		"i-1": {Severity: "!", Summary: "system status impaired"},
+	findings := map[string]domain.Finding{
+		"i-1": {Code: "ec2.system.status.impaired", Phrase: "system status impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
 	}
 	m := buildMarkerModel(t, findings)
 	rendered := m.View()
@@ -140,8 +141,8 @@ func TestRowMarker_PresentForFinding_SeverityBang(t *testing.T) {
 // TestRowMarker_PresentForFinding_SeverityTilde verifies that a resource with
 // severity "~" has a "~ " prefix marker in the rendered output.
 func TestRowMarker_PresentForFinding_SeverityTilde(t *testing.T) {
-	findings := map[string]resource.EnrichmentFinding{
-		"i-1": {Severity: "~", Summary: "pending maintenance: system-update"},
+	findings := map[string]domain.Finding{
+		"i-1": {Code: "rds.pending-maintenance", Phrase: "pending maintenance: system-update", Severity: domain.SevWarn, Source: "wave2:rds"},
 	}
 	m := buildMarkerModel(t, findings)
 	rendered := m.View()
@@ -167,8 +168,8 @@ func TestRowMarker_PresentForFinding_SeverityTilde(t *testing.T) {
 // marker appears at most once per row (not duplicated across multiple columns).
 // This indirectly verifies it is attached to the identity column only.
 func TestRowMarker_PrefixedToIdentityColumn_NotOthers(t *testing.T) {
-	findings := map[string]resource.EnrichmentFinding{
-		"i-1": {Severity: "!", Summary: "impaired"},
+	findings := map[string]domain.Finding{
+		"i-1": {Code: "ec2.system.status.impaired", Phrase: "impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
 	}
 	m := buildMarkerModel(t, findings)
 	rendered := m.View()
@@ -195,8 +196,8 @@ func TestRowMarker_PrefixedToIdentityColumn_NotOthers(t *testing.T) {
 // resources has a finding, exactly one prefix marker appears in the full
 // rendered output.
 func TestRowMarker_OnlyOnAffectedRows(t *testing.T) {
-	findings := map[string]resource.EnrichmentFinding{
-		"i-1": {Severity: "!", Summary: "impaired"},
+	findings := map[string]domain.Finding{
+		"i-1": {Code: "ec2.system.status.impaired", Phrase: "impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
 	}
 	m := buildMarkerModel(t, findings)
 	rendered := m.View()
@@ -210,9 +211,9 @@ func TestRowMarker_OnlyOnAffectedRows(t *testing.T) {
 // TestRowMarker_OnlyOnAffectedRows_Multiple verifies prefix marker count when
 // multiple resources have findings.
 func TestRowMarker_OnlyOnAffectedRows_Multiple(t *testing.T) {
-	findings := map[string]resource.EnrichmentFinding{
-		"i-1": {Severity: "!", Summary: "impaired"},
-		"i-3": {Severity: "~", Summary: "maintenance pending"},
+	findings := map[string]domain.Finding{
+		"i-1": {Code: "ec2.system.status.impaired", Phrase: "impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
+		"i-3": {Code: "rds.pending-maintenance", Phrase: "maintenance pending", Severity: domain.SevWarn, Source: "wave2:rds"},
 	}
 	m := buildMarkerModel(t, findings)
 	rendered := m.View()
@@ -237,8 +238,8 @@ func TestRowMarker_NoColorMode_StillVisible(t *testing.T) {
 		styles.Reinit()
 	})
 
-	findings := map[string]resource.EnrichmentFinding{
-		"i-2": {Severity: "~", Summary: "pending maintenance"},
+	findings := map[string]domain.Finding{
+		"i-2": {Code: "rds.pending-maintenance", Phrase: "pending maintenance", Severity: domain.SevWarn, Source: "wave2:rds"},
 	}
 
 	td := markerTypeDef()
@@ -272,8 +273,8 @@ func TestRowMarker_AllResourceTypes(t *testing.T) {
 		t.Fatal("AllResourceTypes returned empty — registry is broken")
 	}
 
-	finding := map[string]resource.EnrichmentFinding{
-		"test-id-1": {Severity: "!", Summary: "test finding"},
+	finding := map[string]domain.Finding{
+		"test-id-1": {Code: "ec2.system.status.impaired", Phrase: "test finding", Severity: domain.SevBroken, Source: "wave2:ec2"},
 	}
 
 	for _, td := range allTypes {

--- a/tests/unit/qa_enrichment_rerun_overlap_test.go
+++ b/tests/unit/qa_enrichment_rerun_overlap_test.go
@@ -96,8 +96,8 @@ func enrichmentCheckedWithFindings(sessionGen, typeGen domain.Gen) messages.Enri
 		ResourceType: "ec2",
 		Issues:       1,
 		Truncated:    false,
-		Findings: map[string]resource.EnrichmentFinding{
-			"i-0abc1111aaa111111": {Severity: "!", Summary: "system status impaired"},
+		Findings: map[string]domain.Finding{
+			"i-0abc1111aaa111111": {Code: "ec2.system.status.impaired", Phrase: "system status impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
 		},
 		Gen:     sessionGen,
 		TypeGen: typeGen,
@@ -347,8 +347,8 @@ func TestListCtrlR_FetchError_NoLatentState(t *testing.T) {
 	ebsFinding := messages.EnrichmentChecked{
 		ResourceType: "ebs",
 		Issues:       1,
-		Findings: map[string]resource.EnrichmentFinding{
-			"vol-0abc1111aaa11111a": {Severity: "!", Summary: "volume degraded"},
+		Findings: map[string]domain.Finding{
+			"vol-0abc1111aaa11111a": {Code: "ebs.volume.degraded", Phrase: "volume degraded", Severity: domain.SevBroken, Source: "wave2:ebs"},
 		},
 		Gen:     0,
 		TypeGen: 0,
@@ -362,8 +362,8 @@ func TestListCtrlR_FetchError_NoLatentState(t *testing.T) {
 	_, dropCmd := rootApplyMsg(m, messages.EnrichmentChecked{
 		ResourceType: "ebs",
 		Issues:       1,
-		Findings: map[string]resource.EnrichmentFinding{
-			"vol-0abc1111aaa11111a": {Severity: "!", Summary: "volume degraded"},
+		Findings: map[string]domain.Finding{
+			"vol-0abc1111aaa11111a": {Code: "ebs.volume.degraded", Phrase: "volume degraded", Severity: domain.SevBroken, Source: "wave2:ebs"},
 		},
 		Gen:     0,
 		TypeGen: 0,
@@ -385,8 +385,8 @@ func TestListCtrlR_FetchError_NoLatentState(t *testing.T) {
 	m, _ = rootApplyMsg(m, messages.EnrichmentChecked{
 		ResourceType: "ebs",
 		Issues:       1,
-		Findings: map[string]resource.EnrichmentFinding{
-			"vol-0abc1111aaa11111a": {Severity: "!", Summary: "volume degraded"},
+		Findings: map[string]domain.Finding{
+			"vol-0abc1111aaa11111a": {Code: "ebs.volume.degraded", Phrase: "volume degraded", Severity: domain.SevBroken, Source: "wave2:ebs"},
 		},
 		Gen:     0,
 		TypeGen: 1,
@@ -448,9 +448,9 @@ func TestHandleEnrichmentChecked_DropsStaleTypeGen(t *testing.T) {
 		ResourceType: "ec2",
 		Issues:       3,
 		Truncated:    false,
-		Findings: map[string]resource.EnrichmentFinding{
-			"i-0abc1111aaa111111": {Severity: "!", Summary: "system status impaired"},
-			"i-0abc2222bbb222222": {Severity: "!", Summary: "instance status impaired"},
+		Findings: map[string]domain.Finding{
+			"i-0abc1111aaa111111": {Code: "ec2.system.status.impaired", Phrase: "system status impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
+			"i-0abc2222bbb222222": {Code: "ec2.instance.status.impaired", Phrase: "instance status impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
 		},
 		Gen:     0, // matches session enrichmentGen=0
 		TypeGen: 0, // STALE — current enrichmentTypeGen["ec2"]=1

--- a/tests/unit/qa_enrichment_review_fixes_test.go
+++ b/tests/unit/qa_enrichment_review_fixes_test.go
@@ -15,6 +15,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/tui"
 	"github.com/k2m30/a9s/v3/internal/tui/keys"
@@ -61,8 +62,8 @@ func TestRowMarker_HiddenWhenIdentityColumnScrolledOff(t *testing.T) {
 	}
 	m, _ = m.Update(messages.ResourcesLoaded{ResourceType: "test", Resources: resources})
 
-	findings := map[string]resource.EnrichmentFinding{
-		"r-1": {Severity: "!", Summary: "broken"},
+	findings := map[string]domain.Finding{
+		"r-1": {Code: "ec2.system.status.impaired", Phrase: "broken", Severity: domain.SevBroken, Source: "wave2:ec2"},
 	}
 	m.SetEnrichmentState(len(findings), false, findings)
 

--- a/tests/unit/qa_enrichment_stacked_views_test.go
+++ b/tests/unit/qa_enrichment_stacked_views_test.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/tui"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
@@ -92,8 +93,8 @@ func TestEnrichment_UpdatesStackedResourceListWhenDetailActive(t *testing.T) {
 		ResourceType: "rds",
 		Issues:       1,
 		Truncated:    false,
-		Findings: map[string]resource.EnrichmentFinding{
-			"db-stacked-a-001": {Severity: "!", Summary: "pending maintenance: system-update"},
+		Findings: map[string]domain.Finding{
+			"db-stacked-a-001": {Code: "rds.pending-maintenance", Phrase: "pending maintenance: system-update", Severity: domain.SevBroken, Source: "wave2:rds"},
 		},
 		Gen:     0, // fresh model: enrichmentGen=0
 		TypeGen: 0, // startup probe: enrichmentTypeGen["rds"]=0
@@ -194,9 +195,9 @@ func TestEnrichment_UpdatesStackedDetailWhenAnotherDetailActive(t *testing.T) {
 		ResourceType: "rds",
 		Issues:       2,
 		Truncated:    false,
-		Findings: map[string]resource.EnrichmentFinding{
-			"db-stacked-a-001": {Severity: "!", Summary: "pending maintenance: system-update on A"},
-			"db-stacked-b-001": {Severity: "~", Summary: "pending maintenance: minor-version-upgrade on B"},
+		Findings: map[string]domain.Finding{
+			"db-stacked-a-001": {Code: "rds.pending-maintenance", Phrase: "pending maintenance: system-update on A", Severity: domain.SevBroken, Source: "wave2:rds"},
+			"db-stacked-b-001": {Code: "rds.pending-maintenance", Phrase: "pending maintenance: minor-version-upgrade on B", Severity: domain.SevWarn, Source: "wave2:rds"},
 		},
 		Gen:     0,
 		TypeGen: 0,

--- a/tests/unit/qa_enrichment_switch_test.go
+++ b/tests/unit/qa_enrichment_switch_test.go
@@ -23,7 +23,7 @@ package unit
 import (
 	"testing"
 
-	"github.com/k2m30/a9s/v3/internal/resource"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/tui"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
 )
@@ -43,8 +43,8 @@ func seedEnrichmentFindings(m tui.Model) tui.Model {
 		ResourceType: "ec2",
 		Issues:       2,
 		Truncated:    false,
-		Findings: map[string]resource.EnrichmentFinding{
-			"i-0abc1111aaa111111": {Severity: "!", Summary: "system status impaired"},
+		Findings: map[string]domain.Finding{
+			"i-0abc1111aaa111111": {Code: "ec2.system.status.impaired", Phrase: "system status impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
 		},
 		Gen:     0,
 		TypeGen: 0,
@@ -54,8 +54,8 @@ func seedEnrichmentFindings(m tui.Model) tui.Model {
 		ResourceType: "rds",
 		Issues:       0,
 		Truncated:    false,
-		Findings: map[string]resource.EnrichmentFinding{
-			"arn:aws:rds:us-east-1:123456789012:db:prod-db": {Severity: "~", Summary: "pending maintenance: system-update"},
+		Findings: map[string]domain.Finding{
+			"arn:aws:rds:us-east-1:123456789012:db:prod-db": {Code: "rds.pending-maintenance", Phrase: "pending maintenance: system-update", Severity: domain.SevWarn, Source: "wave2:rds"},
 		},
 		Gen:     0,
 		TypeGen: 0,
@@ -98,8 +98,8 @@ func TestProfileSwitch_ClearsEnrichmentState(t *testing.T) {
 	_, dropEC2Cmd := rootApplyMsg(m, messages.EnrichmentChecked{
 		ResourceType: "ec2",
 		Issues:       2,
-		Findings: map[string]resource.EnrichmentFinding{
-			"i-0abc1111aaa111111": {Severity: "!", Summary: "system status impaired"},
+		Findings: map[string]domain.Finding{
+			"i-0abc1111aaa111111": {Code: "ec2.system.status.impaired", Phrase: "system status impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
 		},
 		Gen:     0, // stale — switch bumped enrichmentGen above 0
 		TypeGen: 0,
@@ -112,8 +112,8 @@ func TestProfileSwitch_ClearsEnrichmentState(t *testing.T) {
 	_, dropRDSCmd := rootApplyMsg(m, messages.EnrichmentChecked{
 		ResourceType: "rds",
 		Issues:       0,
-		Findings: map[string]resource.EnrichmentFinding{
-			"arn:aws:rds:us-east-1:123456789012:db:prod-db": {Severity: "~", Summary: "pending maintenance"},
+		Findings: map[string]domain.Finding{
+			"arn:aws:rds:us-east-1:123456789012:db:prod-db": {Code: "rds.pending-maintenance", Phrase: "pending maintenance", Severity: domain.SevWarn, Source: "wave2:rds"},
 		},
 		Gen:     0, // stale
 		TypeGen: 0,
@@ -145,7 +145,7 @@ func TestProfileSwitch_ClearsEnrichmentState(t *testing.T) {
 		m2, _ := m.Update(messages.EnrichmentChecked{
 			ResourceType: "ec2",
 			Issues:       1,
-			Findings:     map[string]resource.EnrichmentFinding{},
+			Findings:     map[string]domain.Finding{},
 			Gen:          0,  // stale
 			TypeGen:      99, // stale
 		})
@@ -169,7 +169,7 @@ func TestProfileSwitch_BothEnrichmentMapsCleared(t *testing.T) {
 	for _, rt := range []string{"ec2", "rds", "ebs", "ddb"} {
 		_, cmd := rootApplyMsg(m, messages.EnrichmentChecked{
 			ResourceType: rt,
-			Findings:     map[string]resource.EnrichmentFinding{},
+			Findings:     map[string]domain.Finding{},
 			Gen:          0, // old session gen (stale after profile switch)
 			TypeGen:      0,
 		})
@@ -202,8 +202,8 @@ func TestRegionSwitch_ClearsEnrichmentState(t *testing.T) {
 	_, dropEC2Cmd := rootApplyMsg(m, messages.EnrichmentChecked{
 		ResourceType: "ec2",
 		Issues:       2,
-		Findings: map[string]resource.EnrichmentFinding{
-			"i-0abc1111aaa111111": {Severity: "!", Summary: "system status impaired"},
+		Findings: map[string]domain.Finding{
+			"i-0abc1111aaa111111": {Code: "ec2.system.status.impaired", Phrase: "system status impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
 		},
 		Gen:     0, // stale — switch bumped enrichmentGen
 		TypeGen: 0,
@@ -216,8 +216,8 @@ func TestRegionSwitch_ClearsEnrichmentState(t *testing.T) {
 	_, dropRDSCmd := rootApplyMsg(m, messages.EnrichmentChecked{
 		ResourceType: "rds",
 		Issues:       0,
-		Findings: map[string]resource.EnrichmentFinding{
-			"arn:aws:rds:us-east-1:123456789012:db:prod-db": {Severity: "~", Summary: "pending maintenance"},
+		Findings: map[string]domain.Finding{
+			"arn:aws:rds:us-east-1:123456789012:db:prod-db": {Code: "rds.pending-maintenance", Phrase: "pending maintenance", Severity: domain.SevWarn, Source: "wave2:rds"},
 		},
 		Gen:     0, // stale
 		TypeGen: 0,
@@ -235,7 +235,7 @@ func TestRegionSwitch_ClearsEnrichmentState(t *testing.T) {
 		}()
 		m2, _ := m.Update(messages.EnrichmentChecked{
 			ResourceType: "ec2",
-			Findings:     map[string]resource.EnrichmentFinding{},
+			Findings:     map[string]domain.Finding{},
 			Gen:          0,
 			TypeGen:      99,
 		})
@@ -257,7 +257,7 @@ func TestRegionSwitch_BothEnrichmentMapsCleared(t *testing.T) {
 	for _, rt := range []string{"ec2", "rds", "ebs", "ddb"} {
 		_, cmd := rootApplyMsg(m, messages.EnrichmentChecked{
 			ResourceType: rt,
-			Findings:     map[string]resource.EnrichmentFinding{},
+			Findings:     map[string]domain.Finding{},
 			Gen:          0, // old session gen (stale after region switch)
 			TypeGen:      0,
 		})

--- a/tests/unit/qa_invariants_test.go
+++ b/tests/unit/qa_invariants_test.go
@@ -429,8 +429,8 @@ func TestEnrichmentFinding_AllKeptEnrichersPopulateRows(t *testing.T) {
 			if len(result.Findings) == 0 {
 				t.Fatalf("enricher produced 0 findings — test setup must guarantee at least one issue")
 			}
-			for id, f := range result.Findings {
-				if len(f.Rows) == 0 {
+			for id := range result.Findings {
+				if len(result.AttentionDetails[id].Rows) == 0 {
 					t.Errorf("finding for resource %q has 0 Rows — enricher must populate at least one FindingRow", id)
 				}
 			}

--- a/tests/unit/qa_issue_count_invariant_test.go
+++ b/tests/unit/qa_issue_count_invariant_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/tui/keys"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
@@ -101,7 +102,7 @@ func TestAllEnrichers_IssueCountNeverExceedsResources(t *testing.T) {
 // so that FrameTitle() includes the issue count when enrichmentIssueCount > 0.
 // It reuses buildUnifiedModel from qa_unified_issue_count_test.go for loading,
 // then enables the badge on the returned model.
-func buildUnifiedModelWithBadge(t *testing.T, resources []resource.Resource, enrichIC int, findings map[string]resource.EnrichmentFinding) string {
+func buildUnifiedModelWithBadge(t *testing.T, resources []resource.Resource, enrichIC int, findings map[string]domain.Finding) string {
 	t.Helper()
 	td := resource.ResourceTypeDef{
 		ShortName: "ec2",
@@ -144,7 +145,7 @@ func extractIssueCount(title string) int {
 }
 
 // unionSize returns the number of distinct IDs across the resource slice and findings map.
-func unionSize(resources []resource.Resource, findings map[string]resource.EnrichmentFinding) int {
+func unionSize(resources []resource.Resource, findings map[string]domain.Finding) int {
 	seen := make(map[string]struct{}, len(resources)+len(findings))
 	for _, r := range resources {
 		seen[r.ID] = struct{}{}
@@ -171,9 +172,9 @@ func TestUnifiedIssueCount_NeverExceedsUnionSize(t *testing.T) {
 			{ID: "i-002", Name: "s2", Status: "stopped", Fields: map[string]string{"name": "s2", "state": "stopped"}},
 			{ID: "i-003", Name: "s3", Status: "stopped", Fields: map[string]string{"name": "s3", "state": "stopped"}},
 		}
-		findings := map[string]resource.EnrichmentFinding{
-			"vol-aaa": {Severity: "!", Summary: "impaired"},
-			"vol-bbb": {Severity: "!", Summary: "impaired"},
+		findings := map[string]domain.Finding{
+			"vol-aaa": {Code: "ebs.volume.degraded", Phrase: "impaired", Severity: domain.SevBroken, Source: "wave2:ebs"},
+			"vol-bbb": {Code: "ebs.volume.degraded", Phrase: "impaired", Severity: domain.SevBroken, Source: "wave2:ebs"},
 		}
 		// The union is {i-001,i-002,i-003,vol-aaa,vol-bbb} = 5 distinct IDs.
 		// enrichIC must equal the correct unified count (not the sum).
@@ -198,10 +199,10 @@ func TestUnifiedIssueCount_NeverExceedsUnionSize(t *testing.T) {
 			{ID: "i-bbb", Name: "server-b", Status: "stopped", Fields: map[string]string{"name": "server-b", "state": "stopped"}},
 			{ID: "i-ccc", Name: "server-c", Status: "stopped", Fields: map[string]string{"name": "server-c", "state": "stopped"}},
 		}
-		findings := map[string]resource.EnrichmentFinding{
-			"i-aaa": {Severity: "!", Summary: "status impaired"},
-			"i-bbb": {Severity: "!", Summary: "status impaired"},
-			"i-ccc": {Severity: "!", Summary: "status impaired"},
+		findings := map[string]domain.Finding{
+			"i-aaa": {Code: "ec2.system.status.impaired", Phrase: "status impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
+			"i-bbb": {Code: "ec2.system.status.impaired", Phrase: "status impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
+			"i-ccc": {Code: "ec2.system.status.impaired", Phrase: "status impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
 		}
 		// Union is still 3 (not 6 — no double counting).
 		union := unionSize(resources, findings)
@@ -227,9 +228,9 @@ func TestUnifiedIssueCount_NeverExceedsUnionSize(t *testing.T) {
 			{ID: "i-r04", Name: "healthy-4", Status: "running", Fields: map[string]string{"name": "healthy-4", "state": "running"}},
 			{ID: "i-r05", Name: "healthy-5", Status: "running", Fields: map[string]string{"name": "healthy-5", "state": "running"}},
 		}
-		findings := map[string]resource.EnrichmentFinding{
-			"i-r01": {Severity: "!", Summary: "impaired"},
-			"i-r02": {Severity: "!", Summary: "impaired"},
+		findings := map[string]domain.Finding{
+			"i-r01": {Code: "ec2.system.status.impaired", Phrase: "impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
+			"i-r02": {Code: "ec2.system.status.impaired", Phrase: "impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
 		}
 		// enrichIC = 2 (two findings, both from known resource IDs)
 		title := buildUnifiedModelWithBadge(t, resources, 2, findings)
@@ -252,12 +253,12 @@ func TestUnifiedIssueCount_NeverExceedsUnionSize(t *testing.T) {
 			{ID: "i-p01", Name: "page-instance-1", Status: "running", Fields: map[string]string{"name": "page-instance-1", "state": "running"}},
 			{ID: "i-p02", Name: "page-instance-2", Status: "running", Fields: map[string]string{"name": "page-instance-2", "state": "running"}},
 		}
-		findings := map[string]resource.EnrichmentFinding{
-			"i-x01": {Severity: "!", Summary: "impaired"},
-			"i-x02": {Severity: "!", Summary: "impaired"},
-			"i-x03": {Severity: "!", Summary: "impaired"},
-			"i-x04": {Severity: "!", Summary: "impaired"},
-			"i-x05": {Severity: "!", Summary: "impaired"},
+		findings := map[string]domain.Finding{
+			"i-x01": {Code: "ec2.system.status.impaired", Phrase: "impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
+			"i-x02": {Code: "ec2.system.status.impaired", Phrase: "impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
+			"i-x03": {Code: "ec2.system.status.impaired", Phrase: "impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
+			"i-x04": {Code: "ec2.system.status.impaired", Phrase: "impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
+			"i-x05": {Code: "ec2.system.status.impaired", Phrase: "impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
 		}
 		union := unionSize(resources, findings) // = 7 (2 page resources + 5 finding-only IDs)
 		// Pass union as enrichIC: the production code computes this across the full account,

--- a/tests/unit/qa_partial_success_handlers_test.go
+++ b/tests/unit/qa_partial_success_handlers_test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/tui"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
@@ -178,8 +179,8 @@ func TestHandleEnrichmentChecked_PartialErrAppliesState(t *testing.T) {
 	m := newRootSizedModel()
 	partialErr := errors.New("partial: enrichment timed out for 1 of 5 resources")
 
-	findings := map[string]resource.EnrichmentFinding{
-		"i-partial-001": {Severity: "!", Summary: "stopped instance"},
+	findings := map[string]domain.Finding{
+		"i-partial-001": {Code: "ec2.system.status.impaired", Phrase: "stopped instance", Severity: domain.SevBroken, Source: "wave2:ec2"},
 	}
 	fieldUpdates := map[string]map[string]string{
 		"i-partial-001": {"stop_reason": "user initiated"},

--- a/tests/unit/qa_partial_success_probe_test.go
+++ b/tests/unit/qa_partial_success_probe_test.go
@@ -33,6 +33,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/tui"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
@@ -139,8 +140,8 @@ func TestProbeEnrichment_PartialSuccess(t *testing.T) {
 		TruncatedIDs: map[string]bool{
 			"res-pe-002": true,
 		},
-		Findings: map[string]resource.EnrichmentFinding{
-			"res-pe-001": {Severity: "!", Summary: "maintenance window overdue"},
+		Findings: map[string]domain.Finding{
+			"res-pe-001": {Code: "rds.pending-maintenance", Phrase: "maintenance window overdue", Severity: domain.SevBroken, Source: "wave2:test-pe-partial"},
 		},
 		FieldUpdates: map[string]map[string]string{
 			"res-pe-001": {"maintenance_window": "overdue"},

--- a/tests/unit/qa_refresh_clears_wave2_test.go
+++ b/tests/unit/qa_refresh_clears_wave2_test.go
@@ -12,7 +12,7 @@ package unit
 import (
 	"testing"
 
-	"github.com/k2m30/a9s/v3/internal/resource"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/tui"
 	"github.com/k2m30/a9s/v3/internal/runtime/messages"
 )
@@ -34,8 +34,8 @@ func TestMainMenuCtrlR_ClearsEnrichmentFindings(t *testing.T) {
 	m, _ = rootApplyMsg(m, messages.EnrichmentChecked{
 		ResourceType: "ec2",
 		Issues:       3,
-		Findings: map[string]resource.EnrichmentFinding{
-			"i-0abc1111aaa111111": {Severity: "!", Summary: "system status impaired"},
+		Findings: map[string]domain.Finding{
+			"i-0abc1111aaa111111": {Code: "ec2.system.status.impaired", Phrase: "system status impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
 		},
 		Gen:     0,
 		TypeGen: 0,
@@ -43,8 +43,8 @@ func TestMainMenuCtrlR_ClearsEnrichmentFindings(t *testing.T) {
 	m, _ = rootApplyMsg(m, messages.EnrichmentChecked{
 		ResourceType: "ddb",
 		Issues:       1,
-		Findings: map[string]resource.EnrichmentFinding{
-			"arn:aws:dynamodb:us-east-1:123456789012:table/orders": {Severity: "!", Summary: "table status: DELETING"},
+		Findings: map[string]domain.Finding{
+			"arn:aws:dynamodb:us-east-1:123456789012:table/orders": {Code: "ddb.table.status.deleting", Phrase: "table status: DELETING", Severity: domain.SevBroken, Source: "wave2:ddb"},
 		},
 		Gen:     0,
 		TypeGen: 0,
@@ -58,8 +58,8 @@ func TestMainMenuCtrlR_ClearsEnrichmentFindings(t *testing.T) {
 	_, cmd1 := rootApplyMsg(m, messages.EnrichmentChecked{
 		ResourceType: "ec2",
 		Issues:       3,
-		Findings: map[string]resource.EnrichmentFinding{
-			"i-0abc1111aaa111111": {Severity: "!", Summary: "system status impaired"},
+		Findings: map[string]domain.Finding{
+			"i-0abc1111aaa111111": {Code: "ec2.system.status.impaired", Phrase: "system status impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
 		},
 		Gen:     0, // stale — Ctrl+R bumped enrichmentGen
 		TypeGen: 0,
@@ -71,8 +71,8 @@ func TestMainMenuCtrlR_ClearsEnrichmentFindings(t *testing.T) {
 	_, cmd2 := rootApplyMsg(m, messages.EnrichmentChecked{
 		ResourceType: "ddb",
 		Issues:       1,
-		Findings: map[string]resource.EnrichmentFinding{
-			"arn:aws:dynamodb:us-east-1:123456789012:table/orders": {Severity: "!", Summary: "table status: DELETING"},
+		Findings: map[string]domain.Finding{
+			"arn:aws:dynamodb:us-east-1:123456789012:table/orders": {Code: "ddb.table.status.deleting", Phrase: "table status: DELETING", Severity: domain.SevBroken, Source: "wave2:ddb"},
 		},
 		Gen:     0, // stale
 		TypeGen: 0,
@@ -94,7 +94,7 @@ func TestMainMenuCtrlR_EnrichmentGenIncremented(t *testing.T) {
 		m, _ = rootApplyMsg(m, messages.EnrichmentChecked{
 			ResourceType: rt,
 			Issues:       1,
-			Findings:     map[string]resource.EnrichmentFinding{},
+			Findings:     map[string]domain.Finding{},
 			Gen:          0,
 			TypeGen:      0,
 		})
@@ -107,7 +107,7 @@ func TestMainMenuCtrlR_EnrichmentGenIncremented(t *testing.T) {
 	for _, rt := range []string{"ec2", "ebs", "ddb", "tg"} {
 		_, cmd := rootApplyMsg(m, messages.EnrichmentChecked{
 			ResourceType: rt,
-			Findings:     map[string]resource.EnrichmentFinding{},
+			Findings:     map[string]domain.Finding{},
 			Gen:          0, // stale after Ctrl+R bumped enrichmentGen
 			TypeGen:      0,
 		})
@@ -138,7 +138,7 @@ func TestMainMenuCtrlR_MapsSafeAfterReset(t *testing.T) {
 		}()
 		m2, _ := m.Update(messages.EnrichmentChecked{
 			ResourceType: "ec2",
-			Findings:     map[string]resource.EnrichmentFinding{},
+			Findings:     map[string]domain.Finding{},
 			Gen:          0,
 			TypeGen:      99,
 		})

--- a/tests/unit/qa_review_fix_enricher_truncated_test.go
+++ b/tests/unit/qa_review_fix_enricher_truncated_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 )
 
@@ -26,7 +27,7 @@ func TestIssueEnricherFuncSignatureReturnsResult(t *testing.T) {
 		return awsclient.IssueEnricherResult{
 			IssueCount: 3,
 			Truncated:  true,
-			Findings:   make(map[string]resource.EnrichmentFinding),
+			Findings:   make(map[string]domain.Finding),
 		}, nil
 	})
 
@@ -57,7 +58,7 @@ func TestIssueEnricherFuncSignatureReturnsFalseWhenNotTruncated(t *testing.T) {
 		return awsclient.IssueEnricherResult{
 			IssueCount: 0,
 			Truncated:  false,
-			Findings:   make(map[string]resource.EnrichmentFinding),
+			Findings:   make(map[string]domain.Finding),
 		}, nil
 	})
 
@@ -94,7 +95,7 @@ func TestEnrichmentCapTruncation(t *testing.T) {
 		return awsclient.IssueEnricherResult{
 			IssueCount: 0,
 			Truncated:  len(resources) > awsclient.EnrichmentCap,
-			Findings:   make(map[string]resource.EnrichmentFinding),
+			Findings:   make(map[string]domain.Finding),
 		}, nil
 	})
 

--- a/tests/unit/qa_spec_surfaces_s1_s5_test.go
+++ b/tests/unit/qa_spec_surfaces_s1_s5_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/k2m30/a9s/v3/internal/config"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/tui/keys"
 	"github.com/k2m30/a9s/v3/internal/tui/views"
@@ -107,9 +108,9 @@ func TestSpec_NoBanner_WhenFindingsOffViewport(t *testing.T) {
 	m.SetShowIssueBadge(true)
 	m.SetSize(120, 5) // tiny viewport — forces hidden findings
 	// Attach findings to rows that would be off-viewport after sort/filter.
-	findings := map[string]resource.EnrichmentFinding{
-		"i-001": {Severity: "!", Summary: "some finding"},
-		"i-002": {Severity: "!", Summary: "some finding"},
+	findings := map[string]domain.Finding{
+		"i-001": {Code: "ec2.system.status.impaired", Phrase: "some finding", Severity: domain.SevBroken, Source: "wave2:ec2"},
+		"i-002": {Code: "ec2.system.status.impaired", Phrase: "some finding", Severity: domain.SevBroken, Source: "wave2:ec2"},
 	}
 	m.SetEnrichmentState(2, false, findings)
 	view := stripANSISpec(m.View())

--- a/tests/unit/qa_unified_issue_count_test.go
+++ b/tests/unit/qa_unified_issue_count_test.go
@@ -28,6 +28,7 @@ import (
 	sfntypes "github.com/aws/aws-sdk-go-v2/service/sfn/types"
 
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
+	"github.com/k2m30/a9s/v3/internal/domain"
 	"github.com/k2m30/a9s/v3/internal/resource"
 	"github.com/k2m30/a9s/v3/internal/tui"
 	"github.com/k2m30/a9s/v3/internal/tui/keys"
@@ -174,7 +175,7 @@ func TestAllEnrichers_IssueCountMatchesFindings(t *testing.T) {
 
 // buildUnifiedModel builds a ResourceListModel loaded with the given resources and
 // enrichment state, returning the FrameTitle for count inspection.
-func buildUnifiedModel(t *testing.T, resources []resource.Resource, enrichIC int, findings map[string]resource.EnrichmentFinding) string {
+func buildUnifiedModel(t *testing.T, resources []resource.Resource, enrichIC int, findings map[string]domain.Finding) string {
 	t.Helper()
 	td := resource.ResourceTypeDef{
 		ShortName: "ec2",
@@ -208,8 +209,8 @@ func TestUnifiedIssueCount_DedupesAcrossWaves(t *testing.T) {
 			{ID: "i-bbb", Name: "running-server", Status: "running",
 				Fields: map[string]string{"name": "running-server", "state": "running"}},
 		}
-		findings := map[string]resource.EnrichmentFinding{
-			"i-bbb": {Severity: "!", Summary: "status impaired"},
+		findings := map[string]domain.Finding{
+			"i-bbb": {Code: "ec2.system.status.impaired", Phrase: "status impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
 		}
 		// enrichIC=1 reflects the correct distinct count from unifiedIssueCount on the production side.
 		title := buildUnifiedModel(t, resources, 1, findings)
@@ -223,8 +224,8 @@ func TestUnifiedIssueCount_DedupesAcrossWaves(t *testing.T) {
 			{ID: "i-aaa", Name: "stopped-server", Status: "stopped",
 				Fields: map[string]string{"name": "stopped-server", "state": "stopped"}},
 		}
-		findings := map[string]resource.EnrichmentFinding{
-			"i-aaa": {Severity: "!", Summary: "status impaired"},
+		findings := map[string]domain.Finding{
+			"i-aaa": {Code: "ec2.system.status.impaired", Phrase: "status impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
 		}
 		// unifiedIssueCount({i-aaa(stopped)}, findings{i-aaa}) = 1, not 2.
 		title := buildUnifiedModel(t, resources, 1, findings)
@@ -243,10 +244,10 @@ func TestUnifiedIssueCount_DedupesAcrossWaves(t *testing.T) {
 			{ID: "i-bbb", Name: "s2", Status: "running", Fields: map[string]string{"name": "s2"}},
 			{ID: "i-ccc", Name: "s3", Status: "running", Fields: map[string]string{"name": "s3"}},
 		}
-		findings := map[string]resource.EnrichmentFinding{
-			"i-aaa": {Severity: "!", Summary: "impaired"},
-			"i-bbb": {Severity: "~", Summary: "maintenance"},
-			"i-ccc": {Severity: "!", Summary: "impaired"},
+		findings := map[string]domain.Finding{
+			"i-aaa": {Code: "ec2.system.status.impaired", Phrase: "impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
+			"i-bbb": {Code: "rds.pending-maintenance", Phrase: "maintenance", Severity: domain.SevWarn, Source: "wave2:ec2"},
+			"i-ccc": {Code: "ec2.system.status.impaired", Phrase: "impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
 		}
 		title := buildUnifiedModel(t, resources, 3, findings)
 		if !strings.Contains(title, "3") {
@@ -258,7 +259,7 @@ func TestUnifiedIssueCount_DedupesAcrossWaves(t *testing.T) {
 		resources := []resource.Resource{
 			{ID: "i-aaa", Name: "server", Status: "running", Fields: map[string]string{"name": "server"}},
 		}
-		title := buildUnifiedModel(t, resources, 0, map[string]resource.EnrichmentFinding{})
+		title := buildUnifiedModel(t, resources, 0, map[string]domain.Finding{})
 		if strings.Contains(title, "[!]") {
 			t.Errorf("FrameTitle() = %q; no issue badge expected when enrichIC=0 and no findings", title)
 		}
@@ -297,8 +298,8 @@ func TestMenuCount_MatchesListCount_AfterWave2(t *testing.T) {
 		ResourceType: "ec2",
 		Issues:       1,
 		Truncated:    false,
-		Findings: map[string]resource.EnrichmentFinding{
-			"i-0abc1111aaa111111": {Severity: "!", Summary: "system status impaired"},
+		Findings: map[string]domain.Finding{
+			"i-0abc1111aaa111111": {Code: "ec2.system.status.impaired", Phrase: "system status impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
 		},
 		Gen:     0,
 		TypeGen: 0,
@@ -387,10 +388,10 @@ func TestUnifiedIssueCount_IgnoresTildeSeverityFindings(t *testing.T) {
 			ResourceType: "ec2",
 			Issues:       1,
 			Truncated:    false,
-			Findings: map[string]resource.EnrichmentFinding{
-				"i-aaa": {Severity: "!", Summary: "system status impaired"},
-				"i-bbb": {Severity: "~", Summary: "pending maintenance"},
-				"i-ccc": {Severity: "~", Summary: "quota 80%+ used"},
+			Findings: map[string]domain.Finding{
+				"i-aaa": {Code: "ec2.system.status.impaired", Phrase: "system status impaired", Severity: domain.SevBroken, Source: "wave2:ec2"},
+				"i-bbb": {Code: "rds.pending-maintenance", Phrase: "pending maintenance", Severity: domain.SevWarn, Source: "wave2:ec2"},
+				"i-ccc": {Code: "ec2.instance.quota", Phrase: "quota 80%+ used", Severity: domain.SevWarn, Source: "wave2:ec2"},
 			},
 			Gen:     0,
 			TypeGen: 0,
@@ -431,10 +432,10 @@ func TestUnifiedIssueCount_IgnoresTildeSeverityFindings(t *testing.T) {
 			ResourceType: "ec2",
 			Issues:       0,
 			Truncated:    false,
-			Findings: map[string]resource.EnrichmentFinding{
-				"i-aaa": {Severity: "~", Summary: "pending maintenance"},
-				"i-bbb": {Severity: "~", Summary: "pending maintenance"},
-				"i-ccc": {Severity: "~", Summary: "quota 80%+ used"},
+			Findings: map[string]domain.Finding{
+				"i-aaa": {Code: "rds.pending-maintenance", Phrase: "pending maintenance", Severity: domain.SevWarn, Source: "wave2:ec2"},
+				"i-bbb": {Code: "rds.pending-maintenance", Phrase: "pending maintenance", Severity: domain.SevWarn, Source: "wave2:ec2"},
+				"i-ccc": {Code: "ec2.instance.quota", Phrase: "quota 80%+ used", Severity: domain.SevWarn, Source: "wave2:ec2"},
 			},
 			Gen:     0,
 			TypeGen: 0,
@@ -479,8 +480,8 @@ func TestUnifiedIssueCount_IgnoresTildeSeverityFindings(t *testing.T) {
 			ResourceType: "ec2",
 			Issues:       0, // enricher excludes ~ from IssueCount
 			Truncated:    false,
-			Findings: map[string]resource.EnrichmentFinding{
-				"i-stopped": {Severity: "~", Summary: "pending maintenance"},
+			Findings: map[string]domain.Finding{
+				"i-stopped": {Code: "rds.pending-maintenance", Phrase: "pending maintenance", Severity: domain.SevWarn, Source: "wave2:ec2"},
 			},
 			Gen:     0,
 			TypeGen: 0,


### PR DESCRIPTION
## Summary

Parent: AS-1390. W1.3 (3 of 4 W1 children, size **M** — Stage 5 includes Architect review per AS-630 size-≥M rule).

Replace the legacy `map[string]resource.EnrichmentFinding` plumbing with the canonical `domain.Finding` + `domain.AttentionDetail` model across the Wave-2 enrichment surface. After this PR, `internal/runtime`, `internal/aws`, and `internal/tui` no longer reference `resource.EnrichmentFinding` or `resource.FindingRow`. The type declarations remain in `internal/resource/enrichment.go` for **W1.4** to delete.

This is the structural step that lets W1.4 (`AS-NNNN`, parallel) delete the legacy types entirely.

## Acceptance gates (per AS-1395 issue body)

- ✅ `grep -rn 'resource\.EnrichmentFinding' internal/` → **0** hits.
- ✅ `grep -rn 'resource\.FindingRow' internal/` → **0** hits.
- ✅ `IssueEnricherResult.Findings` is `map[string]domain.Finding`; sibling `AttentionDetails map[string]domain.AttentionDetail`.
- ✅ `messages.EnrichmentChecked.Findings`, `runtime.ProbeEnrichmentResult.Findings`, `runtime.RuntimeState.EnrichmentFindings`, `runtime.ListEnrichmentPatch.Findings`, `runtime.PatchDetail.EnrichmentFindings` — all `map[string]domain.Finding`.
- ✅ Snapshot suite green: list view + detail Attention section for `dbi`, `dbi-snap`, `dbc-snap`, `ddb`, `ses`, `eb`, `efs`, `backup`, `opensearch`, `s3` (run via `go test -tags integration ./tests/integration/`).
- ✅ `./a9s --demo` Attention section on `warn-dbi-public-maint` shows both the Wave-1 phrase AND the Wave-2 maintenance finding with rows (verified end-to-end via `TestScenario_DBIVisual`).

## Key changes

### Producer side (~45 enrichers in `internal/aws/`)

- New `setWave2Finding(*IssueEnricherResult, id, code, phrase, glyph, shortName, rows)` helper centralises Wave-2 emission so every enricher writes uniformly to the split maps.
- Per-enricher typed `FindingCode` constants declared next to each emitter (e.g. `dbiCodePendingMaintenance`, `tgCodeUnhealthyTargets`, `dbiSnapOrphanCode`).
- `EnrichSnapshotCrossRef` gains `ShortName`, `OrphanCode`, `PastRetentionCode` fields; `dbi-snap` and `dbc-snap` wrappers wire them. The legacy `derive.go::slug` synthesizer is no longer used for new emission.

### Runtime side

- `runtime.Core.applyEnrichment` now takes the split maps and uses a new `applyWave2ToRow` fold that calls `attention.DeriveFindings` for Wave-1, appends the typed Wave-2 Finding, and re-keys `AttentionDetails` from Resource.ID to FindingCode.
- `unifiedIssueCount` checks `f.Severity == domain.SevBroken` instead of the legacy `"!"` glyph string.
- `attention.DeriveFindings` narrowed to **Wave-1-only** (3rd `enrichmentFindings` arg removed). Wave-2 append now happens at the fold layer in `runtime/helpers.go` (and the TUI sibling in `tui/app_enrich_fold.go`).

### Adapter / view side

- `ResourceListModel.findingsByID` retyped to `map[string]domain.Finding`; `table_render.go` selects glyphs via a `domain.SevBroken` / `domain.SevWarn` switch.
- `DetailModel.enrichmentFinding` retyped to `*domain.Finding` + paired `enrichmentDetail *domain.AttentionDetail`; `SetEnrichmentFinding(f, ad)` takes both for the legacy fallback path.
- `findingFromResource(r) (*domain.Finding, *domain.AttentionDetail)` replaces the prior `*resource.EnrichmentFinding` translator.
- **`tui/probe_adapter.go`** was the regression site that broke 8 visual scenarios — it must propagate `AttentionDetails` from `ProbeEnrichmentResult` into `messages.EnrichmentChecked`. Without it, fixture rows had no `AttentionDetails` reaching the detail Attention section.

### Tests

- All ~40 enricher unit tests and ~5 view tests updated to the new shape (`domain.Finding{Code,Phrase,Severity,Source}` constructors; `domain.SevBroken`/`SevWarn` comparisons; row assertions via `result.AttentionDetails[id].Rows`).
- 3 detail-cursor stability tests still hit `SetEnrichmentFinding` but now construct `domain.Finding` + `domain.AttentionDetail` pairs.

## What's NOT in this PR (intentional)

- `internal/resource/enrichment.go` (the type declaration) is NOT deleted — W1.4 owns the delete once W1.1 drains all Wave-1 Status/Issues writers.
- No `derive.go::slug` synthesizer changes for the wave1 path — that's still synthesized from `r.Status` / `r.Issues` in the unmigrated fetcher layer (also W1.4 territory).
- No FindingCode constant graduation to `ResourceTypeDef` (option c from `docs/refactor/03-finding-model.md`) — keeps each enricher's constants local per the AS-1395 dispatch protocol.

## Test plan

- [x] `go test ./tests/unit/` (unit suite green; 13.7s)
- [x] `go test -tags integration ./tests/integration/` (visual + scenario suite green; 23.3s)
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` → 0 issues
- [x] `govulncheck ./...` → 0 vulnerabilities
- [x] `verify-readonly` PASS (no write API calls)
- [x] `verify-zero-init` PASS (no init() bodies in internal/aws/ or internal/catalog/)
- [x] `go fix -inline -diff ./...` clean
- [x] `check-readme` (README in sync with `docs/shared/`)
- [x] Snapshot suite (`Golden|Scenario|Visual`) green
- [ ] `-race` (gated on CI — no `gcc` available in dev env)
- [ ] Manual `./a9s --demo` verification on `dbi` (covered by `TestScenario_DBIVisual` end-to-end; opens list, opens detail, asserts Wave-1+Wave-2 stacking, glyphs, AttentionDetail rows)

## Order

- **Parallel-safe** with W1.1, W1.2.
- **Blocks**: W1.4 (final cleanup — deletes `internal/resource/enrichment.go` and the `derive.go::slug` shim). W5 (downstream type-shape dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)