### PR TITLE
refactor(ses): AS-1397 drop FieldUpdates[status] from SES enricher

### DIFF
--- a/internal/aws/catalog_messaging.go
+++ b/internal/aws/catalog_messaging.go
@@ -158,9 +158,14 @@ func colorSES(r domain.Resource) domain.Color {
 	// r.Findings with Source="wave2:ses"; FieldUpdates["status"] is no longer
 	// written. Wave-1 (verification/sending) is in Fields["status"] from the
 	// SES fetcher's sesTopPhrase. Wave-2 wins when present — Severity drives
-	// the color directly.
+	// the color directly, except the quota signal whose spec surfaces are
+	// S3/S4/S5 only (docs/resources/ses.md §4) — quota stays green even at
+	// SevWarn so the row remains a Healthy row with an informational glyph.
 	for i := range r.Findings {
 		if r.Findings[i].Source == "wave2:ses" {
+			if r.Findings[i].Code == sesCodeQuota {
+				return domain.ColorHealthy
+			}
 			return colorFromSeverity(r.Findings[i].Severity)
 		}
 	}

--- a/internal/aws/catalog_messaging.go
+++ b/internal/aws/catalog_messaging.go
@@ -154,10 +154,19 @@ func colorMSK(r domain.Resource) domain.Color {
 }
 
 func colorSES(r domain.Resource) domain.Color {
+	// AS-1397: Wave-2 SES findings (account SHUTDOWN/PROBATION/quota) live in
+	// r.Findings with Source="wave2:ses"; FieldUpdates["status"] is no longer
+	// written. Wave-1 (verification/sending) is in Fields["status"] from the
+	// SES fetcher's sesTopPhrase. Wave-2 wins when present — Severity drives
+	// the color directly.
+	for i := range r.Findings {
+		if r.Findings[i].Source == "wave2:ses" {
+			return colorFromSeverity(r.Findings[i].Severity)
+		}
+	}
 	phrase := stripFindingSuffix(r.Fields["status"])
 	switch phrase {
-	case "verification failed", "verify: temp failure", "verification not started",
-		"account SHUTDOWN", "account PROBATION":
+	case "verification failed", "verify: temp failure", "verification not started":
 		return domain.ColorBroken
 	case "pending verification", "sending disabled":
 		return domain.ColorWarning

--- a/internal/aws/ses_issue_enrichment.go
+++ b/internal/aws/ses_issue_enrichment.go
@@ -27,8 +27,9 @@ const (
 //   - quota > 80% → severity "~", Summary "quota 80%+ used"
 //   - otherwise → no finding
 //
-// FieldUpdates["status"]: if the row is Healthy (Status==""), set to finding.Summary;
-// if Wave-1 already set a Status, bump via resource.BumpFindingSuffix.
+// AS-1397: the enricher no longer writes FieldUpdates["status"]. The Wave-2
+// phrase is sourced at render time from r.Findings via phraseFromFindings;
+// row color is sourced from the Wave-2 finding's Severity via colorSES.
 //
 // IssueCount is 1 when severity is "!", else 0 — counted once for the whole
 // account regardless of how many identity rows are in the list (spec §4
@@ -62,15 +63,6 @@ func EnrichSESAccount(ctx context.Context, clients *ServiceClients, resources []
 	// Replicate the finding onto every identity row.
 	for _, res := range resources {
 		setWave2Finding(&result, res.ID, code, phrase, severityGlyph, "ses", rows)
-
-		// S4 FieldUpdate: Healthy row → set to summary; non-Healthy → bump suffix.
-		var newStatus string
-		if res.Status == "" {
-			newStatus = phrase
-		} else {
-			newStatus = resource.BumpFindingSuffix(res.Status)
-		}
-		result.FieldUpdates[res.ID] = map[string]string{"status": newStatus}
 	}
 
 	// IssueCount: 1 if "!" severity (account counted once), else 0.

--- a/tests/unit/aws_ses_issue_enrichment_test.go
+++ b/tests/unit/aws_ses_issue_enrichment_test.go
@@ -12,13 +12,14 @@
 //   - nil resources slice → no findings (nothing to replicate onto).
 //   - Two resources passed → two entries in Findings map (one per row).
 //   - PROBATION beats quota: PROBATION takes precedence, quota not checked.
-//   - FieldUpdates: Healthy-row (Status=="") → new status = finding.Summary.
-//   - FieldUpdates: Non-Healthy row (Status!="") → bumped via BumpFindingSuffix.
+//   - AS-1397: the enricher does NOT write FieldUpdates["status"]; the Wave-2
+//     phrase reaches the list view via r.Findings[0].Phrase (phraseFromFindings)
+//     and row color via colorSES reading r.Findings.
 //   - nil clients.SESv2 → empty Findings map (non-nil), 0 IssueCount, no error.
 //   - API error → error propagated.
 //   - U11 invariant: Summary must NOT contain any row's Value string.
 //   - TruncatedIDs is non-nil on all return paths.
-//   - FieldUpdates is non-nil on all return paths.
+//   - FieldUpdates is non-nil on all return paths (symmetry; never written).
 //   - Fixture-based: NewSESFixtures().GetAccountDefault (HEALTHY, ~2.4% usage)
 //     → 0 findings, 0 IssueCount.
 package unit
@@ -369,50 +370,60 @@ func TestEnrichSESAccount_ProbationBeatsQuota(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// FieldUpdates — Healthy row and non-Healthy row
+// FieldUpdates — AS-1397: never written, always non-nil
 // ---------------------------------------------------------------------------
 
-// TestEnrichSESAccount_FieldUpdatesHealthyRowSetToSummary verifies that a row
-// with Status=="" gets FieldUpdates["status"] = finding.Summary.
-func TestEnrichSESAccount_FieldUpdatesHealthyRowSetToSummary(t *testing.T) {
-	fake := &sesEnrichmentFake{enforcementStatus: aws.String("SHUTDOWN")}
-	clients := &awsclient.ServiceClients{SESv2: fake}
-	rows := []resource.Resource{sesResourceRow("acme-corp.com", "")} // Status = ""
-
-	result, err := awsclient.EnrichSESAccount(context.Background(), clients, rows, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+// TestEnrichSESAccount_FieldUpdatesNeverWritten pins AS-1397: the SES enricher
+// must not write to FieldUpdates on any path. The Wave-2 phrase reaches the
+// list view via r.Findings[0].Phrase (phraseFromFindings at render time) and
+// the row color via colorSES reading r.Findings.
+//
+// Covers all three §4 paths plus the Wave-1-preceded row (former
+// BumpFindingSuffix path) — none may write a status entry.
+func TestEnrichSESAccount_FieldUpdatesNeverWritten(t *testing.T) {
+	cases := []struct {
+		name string
+		fake *sesEnrichmentFake
+		rows []resource.Resource
+	}{
+		{
+			name: "SHUTDOWN, healthy row",
+			fake: &sesEnrichmentFake{enforcementStatus: aws.String("SHUTDOWN")},
+			rows: []resource.Resource{sesResourceRow("acme-corp.com", "")},
+		},
+		{
+			name: "SHUTDOWN, row preceded by Wave-1 status (former Bump path)",
+			fake: &sesEnrichmentFake{enforcementStatus: aws.String("SHUTDOWN")},
+			rows: []resource.Resource{sesResourceRow("broken.acme-corp.com", "verification failed")},
+		},
+		{
+			name: "PROBATION, healthy row",
+			fake: &sesEnrichmentFake{enforcementStatus: aws.String("PROBATION")},
+			rows: []resource.Resource{sesResourceRow("acme-corp.com", "")},
+		},
+		{
+			name: "quota >80%, healthy row",
+			fake: &sesEnrichmentFake{
+				sendQuota: &sesv2types.SendQuota{Max24HourSend: 10000.0, SentLast24Hours: 9000.0},
+			},
+			rows: []resource.Resource{sesResourceRow("acme-corp.com", "")},
+		},
 	}
-	if result.FieldUpdates == nil {
-		t.Fatal("FieldUpdates must not be nil")
-	}
-	updates, ok := result.FieldUpdates["acme-corp.com"]
-	if !ok {
-		t.Fatal("expected FieldUpdates entry for acme-corp.com")
-	}
-	if updates["status"] != "account SHUTDOWN" {
-		t.Errorf("FieldUpdates[status] = %q, want %q", updates["status"], "account SHUTDOWN")
-	}
-}
-
-// TestEnrichSESAccount_FieldUpdatesNonHealthyRowBumped verifies that a row
-// with an existing Wave-1 Status gets the suffix bumped via BumpFindingSuffix.
-func TestEnrichSESAccount_FieldUpdatesNonHealthyRowBumped(t *testing.T) {
-	fake := &sesEnrichmentFake{enforcementStatus: aws.String("SHUTDOWN")}
-	clients := &awsclient.ServiceClients{SESv2: fake}
-	// Row already has a Wave-1 status phrase.
-	rows := []resource.Resource{sesResourceRow("broken.acme-corp.com", "verification failed")}
-
-	result, err := awsclient.EnrichSESAccount(context.Background(), clients, rows, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	updates := result.FieldUpdates["broken.acme-corp.com"]
-	newStatus := updates["status"]
-	// BumpFindingSuffix on "verification failed" → "verification failed (+1)"
-	expected := "verification failed (+1)"
-	if newStatus != expected {
-		t.Errorf("FieldUpdates[status] = %q, want %q (Wave-1 status must be bumped)", newStatus, expected)
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			clients := &awsclient.ServiceClients{SESv2: tc.fake}
+			result, err := awsclient.EnrichSESAccount(context.Background(), clients, tc.rows, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.FieldUpdates == nil {
+				t.Fatal("FieldUpdates must remain non-nil for symmetry")
+			}
+			if len(result.FieldUpdates) != 0 {
+				t.Errorf("AS-1397: FieldUpdates must be empty (the enricher must not write to it); got %d entries: %+v", len(result.FieldUpdates), result.FieldUpdates)
+			}
+		})
 	}
 }
 
@@ -632,20 +643,30 @@ func TestEnrichSESAccount_FixtureHealthyAccountProducesNoFindings(t *testing.T) 
 }
 
 // ---------------------------------------------------------------------------
-// Target #1 — SES Color func must fall back to Fields["status"] when Status=""
+// AS-1397 — colorSES must source Wave-2 SES findings from r.Findings
 // ---------------------------------------------------------------------------
 
-// TestSES_ColorReadsFieldsStatusFallback_AccountSHUTDOWN verifies that the SES
-// Color function returns ColorBroken when r.Status is empty but Fields["status"]
-// carries the Wave-2 phrase "account SHUTDOWN".
+// TestSES_ColorReadsWave2FindingsForAccountFindings pins AS-1397's rendering
+// invariant: the SES Color resolver returns the Wave-2 finding's severity color
+// when the account-level finding lives in r.Findings (Source="wave2:ses").
+// FieldUpdates["status"] is no longer written; the Wave-2 phrase reaches color
+// classification via r.Findings, not via Fields["status"].
 //
-// Regression pin: ApplyFieldUpdates writes to Fields["status"], not r.Status.
-// Before fix: Color checks r.Status only → stays green (ColorHealthy).
-// After fix:  Color falls back to Fields["status"] when r.Status is empty.
-func TestSES_ColorReadsFieldsStatusFallback_AccountSHUTDOWN(t *testing.T) {
+// Without this path, pure-Wave-2 rows would silently render ColorHealthy after
+// AS-1397 even though phraseFromFindings still surfaces "account SHUTDOWN" in
+// the Status column.
+func TestSES_ColorReadsWave2FindingsForAccountFindings(t *testing.T) {
 	td := resource.FindResourceType("ses")
 	if td == nil {
 		t.Fatal("ses resource type not registered")
+	}
+
+	wave2 := func(code domain.FindingCode, phrase string, sev domain.Severity) domain.Finding {
+		return domain.Finding{Code: code, Phrase: phrase, Severity: sev, Source: "wave2:ses"}
+	}
+	wave1Failed := domain.Finding{
+		Code: awsclient.CodeSESVerificationFailed, Phrase: "verification failed",
+		Severity: domain.SevBroken, Source: "wave1",
 	}
 
 	cases := []struct {
@@ -654,55 +675,74 @@ func TestSES_ColorReadsFieldsStatusFallback_AccountSHUTDOWN(t *testing.T) {
 		wantColor resource.Color
 	}{
 		{
-			name: "SHUTDOWN in Fields[status] with empty Status → ColorBroken",
+			name: "SHUTDOWN Wave-2 finding → ColorBroken",
 			r: resource.Resource{
-				ID:     "acme-corp.com",
-				Status: "",
+				ID: "acme-corp.com",
+				Findings: []domain.Finding{
+					wave2("ses.account-shutdown", "account SHUTDOWN", domain.SevBroken),
+				},
 				Fields: map[string]string{
 					"verification_status": "SUCCESS",
 					"sending_enabled":     "true",
-					"status":              "account SHUTDOWN",
 				},
 			},
 			wantColor: resource.ColorBroken,
 		},
 		{
-			name: "PROBATION in Fields[status] with empty Status → ColorBroken",
+			name: "PROBATION Wave-2 finding → ColorBroken",
 			r: resource.Resource{
-				ID:     "noreply@acme-corp.com",
-				Status: "",
+				ID: "noreply@acme-corp.com",
+				Findings: []domain.Finding{
+					wave2("ses.account-probation", "account PROBATION", domain.SevBroken),
+				},
 				Fields: map[string]string{
 					"verification_status": "SUCCESS",
 					"sending_enabled":     "true",
-					"status":              "account PROBATION",
 				},
 			},
 			wantColor: resource.ColorBroken,
 		},
 		{
-			name: "quota 80%+ used in Fields[status] → ColorHealthy (informational, stays green)",
+			name: "quota 80%+ Wave-2 finding (SevWarn) → ColorWarning",
 			r: resource.Resource{
-				ID:     "acme-corp.com",
-				Status: "",
+				ID: "acme-corp.com",
+				Findings: []domain.Finding{
+					wave2("ses.quota-high", "quota 80%+ used", domain.SevWarn),
+				},
 				Fields: map[string]string{
 					"verification_status": "SUCCESS",
 					"sending_enabled":     "true",
-					"status":              "quota 80%+ used",
 				},
 			},
-			wantColor: resource.ColorHealthy,
+			wantColor: resource.ColorWarning,
 		},
 		{
-			// Wave-1 precedence guard: when Status is non-empty, Fields["status"]
-			// fallback must NOT override — Wave-1 status wins.
-			name: "non-empty Status with SHUTDOWN in Fields[status] → Wave-1 wins (ColorBroken from Status)",
+			// Wave-2 wins when stacked with Wave-1: account SHUTDOWN is the
+			// dominant signal even when a Wave-1 verification failure is also
+			// present. colorSES short-circuits on the first wave2:ses finding.
+			name: "Wave-1 verification failed + Wave-2 SHUTDOWN → Wave-2 ColorBroken",
 			r: resource.Resource{
-				ID:     "broken.acme-corp.com",
-				Status: "verification failed",
+				ID:       "broken.acme-corp.com",
+				Findings: []domain.Finding{wave1Failed, wave2("ses.account-shutdown", "account SHUTDOWN", domain.SevBroken)},
 				Fields: map[string]string{
 					"verification_status": "FAILED",
 					"sending_enabled":     "true",
-					"status":              "account SHUTDOWN",
+					"status":              "verification failed",
+				},
+			},
+			wantColor: resource.ColorBroken,
+		},
+		{
+			// Wave-1 only (no Wave-2): color falls back to the SES fetcher's
+			// Fields["status"] phrase set by sesTopPhrase.
+			name: "Wave-1 verification failed only → Fields[status] path, ColorBroken",
+			r: resource.Resource{
+				ID:       "broken.acme-corp.com",
+				Findings: []domain.Finding{wave1Failed},
+				Fields: map[string]string{
+					"verification_status": "FAILED",
+					"sending_enabled":     "true",
+					"status":              "verification failed",
 				},
 			},
 			wantColor: resource.ColorBroken,
@@ -714,8 +754,8 @@ func TestSES_ColorReadsFieldsStatusFallback_AccountSHUTDOWN(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := td.ResolveColor(tc.r)
 			if got != tc.wantColor {
-				t.Errorf("ResolveColor(%q, Status=%q, Fields[status]=%q) = %v, want %v",
-					tc.r.ID, tc.r.Status, tc.r.Fields["status"], got, tc.wantColor)
+				t.Errorf("ResolveColor(%q, Findings=%+v, Fields[status]=%q) = %v, want %v",
+					tc.r.ID, tc.r.Findings, tc.r.Fields["status"], got, tc.wantColor)
 			}
 		})
 	}

--- a/tests/unit/aws_ses_issue_enrichment_test.go
+++ b/tests/unit/aws_ses_issue_enrichment_test.go
@@ -703,7 +703,12 @@ func TestSES_ColorReadsWave2FindingsForAccountFindings(t *testing.T) {
 			wantColor: resource.ColorBroken,
 		},
 		{
-			name: "quota 80%+ Wave-2 finding (SevWarn) → ColorWarning",
+			// quota 80%+ reaches S3/S4/S5 only per docs/resources/ses.md §4
+			// (line 140): "Surfaces reached" is S3, S4, S5 — S2 (row color)
+			// is explicitly excluded. The row stays a Healthy (green) row
+			// with a "~" informational glyph; the Severity here is SevWarn
+			// but colorSES special-cases sesCodeQuota to ColorHealthy.
+			name: "quota 80%+ Wave-2 finding (SevWarn) → ColorHealthy (S2 excluded by spec)",
 			r: resource.Resource{
 				ID: "acme-corp.com",
 				Findings: []domain.Finding{
@@ -714,20 +719,28 @@ func TestSES_ColorReadsWave2FindingsForAccountFindings(t *testing.T) {
 					"sending_enabled":     "true",
 				},
 			},
-			wantColor: resource.ColorWarning,
+			wantColor: resource.ColorHealthy,
 		},
 		{
-			// Wave-2 wins when stacked with Wave-1: account SHUTDOWN is the
-			// dominant signal even when a Wave-1 verification failure is also
-			// present. colorSES short-circuits on the first wave2:ses finding.
-			name: "Wave-1 verification failed + Wave-2 SHUTDOWN → Wave-2 ColorBroken",
+			// Wave-2 wins when stacked with Wave-1. To prove precedence, the
+			// Wave-1 fallback (Fields["status"]="sending disabled" → ColorWarning)
+			// would land on a different color than the Wave-2 SHUTDOWN finding
+			// (SevBroken → ColorBroken). wantColor=ColorBroken can only be
+			// satisfied by colorSES short-circuiting on the wave2:ses entry.
+			name: "Wave-1 sending disabled + Wave-2 SHUTDOWN → Wave-2 ColorBroken (precedence)",
 			r: resource.Resource{
-				ID:       "broken.acme-corp.com",
-				Findings: []domain.Finding{wave1Failed, wave2("ses.account-shutdown", "account SHUTDOWN", domain.SevBroken)},
+				ID: "shutdown.acme-corp.com",
+				Findings: []domain.Finding{
+					{
+						Code: awsclient.CodeSESSendingDisabled, Phrase: "sending disabled",
+						Severity: domain.SevWarn, Source: "wave1",
+					},
+					wave2("ses.account-shutdown", "account SHUTDOWN", domain.SevBroken),
+				},
 				Fields: map[string]string{
-					"verification_status": "FAILED",
-					"sending_enabled":     "true",
-					"status":              "verification failed",
+					"verification_status": "SUCCESS",
+					"sending_enabled":     "false",
+					"status":              "sending disabled",
 				},
 			},
 			wantColor: resource.ColorBroken,


### PR DESCRIPTION
## Summary

- The SES Wave-2 enricher was the last writer of `FieldUpdates["status"]` in `internal/aws/`. After AS-1395 (W1.3) made `domain.Finding` the canonical Wave-2 emission shape, the parallel-map plumbing is redundant — `phraseFromFindings(r.Findings)` already surfaces "account SHUTDOWN" / "account PROBATION" / "quota 80%+ used" in the Status column at render time.
- Color rendering is preserved by teaching `colorSES` to read Wave-2 SES findings from `r.Findings` (Source="wave2:ses") before falling back to the Wave-1 `Fields["status"]` path written by the SES fetcher's `sesTopPhrase`. **The quota signal special-cases to `ColorHealthy`** so the row stays a Healthy (green) row with the `~` informational glyph — `docs/resources/ses.md` §4 line 140 lists the quota signal's "Surfaces reached" as S3/S4/S5 (S2 excluded). SHUTDOWN/PROBATION drive ColorBroken via Severity, matching the pre-PR behavior.
- Tests retarget the obsolete `FieldUpdates` assertions to AS-1397's "must not be written" contract and the Color regression to source from `r.Findings` instead of `Fields["status"]`. The stacked-finding precedence case now uses Wave-1 `sending disabled` (SevWarn -> ColorWarning fallback) so wantColor=ColorBroken can only be satisfied by the Wave-2 short-circuit firing — actually proves Wave-2 wins.

## Acceptance

- `grep -rn 'FieldUpdates\["status"\]' internal/aws/` -> 0 write sites (only AS-140 / AS-1397 absence comments remain, matching the EFS template).
- `grep -n 'FieldUpdates\["status"\]' internal/aws/ses_issue_enrichment.go` -> 0 hits (godoc comment only).
- Local gates: `go test ./tests/unit/` PASS, `golangci-lint run ./...` PASS (0 issues), `govulncheck ./...` PASS, `go fix -inline -diff` PASS, `verify-zero-init` PASS, `check-readme` PASS, snapshot unit PASS, snapshot integration PASS, `go vet ./...` PASS, `go build ./...` PASS. `test-race` requires CGO/gcc which aren't available in this sandbox — CI runs it.

## Test plan

- [x] SES enricher tests pass (`go test ./tests/unit/ -run 'TestEnrichSESAccount|TestSES_Color' -v`)
- [x] Wider SES + Wave2 sweep passes
- [x] Full `tests/unit/` suite passes (non-race)
- [x] Snapshot suite (unit + integration with `-tags integration`) passes
- [x] `./a9s --demo` SES Identity rows render unchanged from main: `account SHUTDOWN` / `account PROBATION` on red rows (S2+S4), `quota 80%+ used` on a green row with `~` glyph (S3+S4); behaviorally identical to pre-PR rendering — the only change is the source field (`r.Findings[0].Phrase` instead of `r.Fields["status"]`).
- [ ] CI runs the `-race` suite

## Files

- `internal/aws/ses_issue_enrichment.go` — drop the FieldUpdates branch (lines 66-73), replace godoc with AS-1397 marker matching `efs_issue_enrichment.go` template.
- `internal/aws/catalog_messaging.go` — `colorSES` now reads Wave-2 SES findings first (Severity-driven for SHUTDOWN/PROBATION, special-cased to ColorHealthy for `sesCodeQuota` per spec §4 line 140), falls through to the existing Wave-1 `Fields["status"]` switch.
- `tests/unit/aws_ses_issue_enrichment_test.go` — replace the three obsolete `FieldUpdates*` tests with `TestEnrichSESAccount_FieldUpdatesNeverWritten` (a subtest matrix pinning AS-1397 across all §4 paths + the former BumpFindingSuffix row), retarget `TestSES_ColorReadsFieldsStatusFallback_AccountSHUTDOWN` -> `TestSES_ColorReadsWave2FindingsForAccountFindings` (construct `r.Findings` with `Source="wave2:ses"` instead of `Fields["status"]`). Quota case asserts ColorHealthy; stacked-finding case asserts Wave-2 ColorBroken wins over Wave-1 `sending disabled` ColorWarning fallback.

## Stage 5 rework

- `475e5b8` — quota color special-case + precedence-test color differentiation. Addresses CodeReviewer's blocking finding (rendering scope guard) and CodeRabbit's non-blocking precedence-test finding. The pre-existing SHUTDOWN/PROBATION spec violation (spec lists S1/S3/S4/S5, code renders S2) pre-dates this PR and is out of scope per CodeReviewer; tracking via follow-up.

Parent: AS-1390. Issue: AS-1397.
