### PR TITLE
AS-1428 W1.4b.1: sweep inert Status: "" literals from 11 fetchers

### DIFF
--- a/internal/aws/apigw.go
+++ b/internal/aws/apigw.go
@@ -40,9 +40,8 @@ func FetchAPIGatewaysPageMerged(ctx context.Context, c *ServiceClients, continua
 				name := aws.ToString(item.Name)
 				description := aws.ToString(item.Description)
 				r := resource.Resource{
-					ID:     apiID,
-					Name:   name,
-					Status: "",
+					ID:   apiID,
+					Name: name,
 					Fields: map[string]string{
 						"api_id":      apiID,
 						"name":        name,
@@ -133,9 +132,8 @@ func FetchAPIGatewaysPage(ctx context.Context, api APIGatewayV2GetApisAPI, conti
 		}
 
 		r := resource.Resource{
-			ID:     apiID,
-			Name:   name,
-			Status: "",
+			ID:   apiID,
+			Name: name,
 			Fields: map[string]string{
 				"api_id":      apiID,
 				"name":        name,

--- a/internal/aws/elb_listener_rules.go
+++ b/internal/aws/elb_listener_rules.go
@@ -108,9 +108,8 @@ func convertRule(rule elbtypes.Rule) resource.Resource {
 	}
 
 	return resource.Resource{
-		ID:     ruleArn,
-		Name:   priority,
-		Status: "",
+		ID:   ruleArn,
+		Name: priority,
 		Fields: map[string]string{
 			"priority":           priority,
 			"conditions_summary": conditionsSummary,

--- a/internal/aws/elb_listeners.go
+++ b/internal/aws/elb_listeners.go
@@ -113,9 +113,8 @@ func convertListener(listener elbtypes.Listener) resource.Resource {
 	}
 
 	return resource.Resource{
-		ID:     arn,
-		Name:   port,
-		Status: "",
+		ID:   arn,
+		Name: port,
 		Fields: map[string]string{
 			"port":                  port,
 			"protocol":              protocol,

--- a/internal/aws/iam_group_members.go
+++ b/internal/aws/iam_group_members.go
@@ -61,9 +61,8 @@ func FetchIAMGroupMembers(
 		}
 
 		resources = append(resources, resource.Resource{
-			ID:     userName,
-			Name:   userName,
-			Status: "",
+			ID:   userName,
+			Name: userName,
 			Fields: map[string]string{ //nolint:gosec // "password_last_used" is a display field key, not a credential
 				"user_name":          userName,
 				"user_id":            userID,

--- a/internal/aws/log_streams.go
+++ b/internal/aws/log_streams.go
@@ -77,9 +77,8 @@ func convertLogStream(s cwlogstypes.LogStream) resource.Resource {
 	}
 
 	return resource.Resource{
-		ID:     name,
-		Name:   name,
-		Status: "",
+		ID:   name,
+		Name: name,
 		Fields: map[string]string{
 			"stream_name": name,
 			"last_event":  lastEvent,

--- a/internal/aws/sg.go
+++ b/internal/aws/sg.go
@@ -201,9 +201,8 @@ func FetchSecurityGroupsPage(ctx context.Context, api EC2DescribeSecurityGroupsA
 		dangerousCount, wideOpen, riskSummary := computeSGRiskFields(sg.IpPermissions)
 
 		r := resource.Resource{
-			ID:     groupID,
-			Name:   groupName,
-			Status: "", // SGs have no status field
+			ID:   groupID,
+			Name: groupName,
 			Fields: map[string]string{
 				"group_id":             groupID,
 				"group_name":           groupName,

--- a/internal/aws/sns_sub.go
+++ b/internal/aws/sns_sub.go
@@ -71,9 +71,8 @@ func FetchSNSSubscriptionsPage(ctx context.Context, api SNSListSubscriptionsAPI,
 		}
 
 		r := resource.Resource{
-			ID:     subscriptionArn,
-			Name:   topicName,
-			Status: "",
+			ID:   subscriptionArn,
+			Name: topicName,
 			Fields: map[string]string{
 				"topic_arn":        topicArn,
 				"protocol":         protocol,

--- a/internal/aws/sns_sub_by_topic.go
+++ b/internal/aws/sns_sub_by_topic.go
@@ -91,9 +91,8 @@ func convertSNSSubscription(sub snstypes.Subscription) resource.Resource {
 	}
 
 	return resource.Resource{
-		ID:     id,
-		Name:   endpoint,
-		Status: "",
+		ID:   id,
+		Name: endpoint,
 		Fields: map[string]string{
 			"protocol":            protocol,
 			"endpoint":            endpoint,

--- a/internal/aws/tg.go
+++ b/internal/aws/tg.go
@@ -76,9 +76,8 @@ func FetchTargetGroupsPage(ctx context.Context, api ELBv2DescribeTargetGroupsAPI
 		}
 
 		r := resource.Resource{
-			ID:     tgName,
-			Name:   tgName,
-			Status: "",
+			ID:   tgName,
+			Name: tgName,
 			Fields: map[string]string{
 				"target_group_name": tgName,
 				"target_group_arn":  tgArn,

--- a/internal/aws/trail.go
+++ b/internal/aws/trail.go
@@ -79,9 +79,8 @@ func FetchCloudTrailTrails(ctx context.Context, api CloudTrailDescribeTrailsAPI)
 		}
 
 		r := resource.Resource{
-			ID:     trailName,
-			Name:   trailName,
-			Status: "",
+			ID:   trailName,
+			Name: trailName,
 			Fields: map[string]string{
 				"trail_name":                  trailName,
 				"trail_arn":                   trailARN,

--- a/internal/aws/waf.go
+++ b/internal/aws/waf.go
@@ -74,9 +74,8 @@ func FetchWAFWebACLsPage(ctx context.Context, api WAFv2ListWebACLsAPI, continuat
 		}
 
 		r := resource.Resource{
-			ID:     id,
-			Name:   name,
-			Status: "",
+			ID:   id,
+			Name: name,
 			Fields: map[string]string{
 				"name":        name,
 				"id":          id,


### PR DESCRIPTION
## Summary

- Drops the 12 zero-signal `Status: ""` initializer writes preserved by W1.4a (AS-1426/PR #421) across 11 fetchers. apigw has 2 writes (REST + non-REST branches); the other 10 fetchers have 1 each.
- All reads of `Resource.Status` for these resources go through `colorFallback("")` → `ColorDim`, which is identical to having no `Status` field at all. Zero behavioral change.
- Removes the `// SGs have no status field` comment on `sg.go:206` (it lived on the same line as the deleted field; per dispatch, "the trailing comment on the same line" is also dropped).

## Scope (unchanged by this PR)

- The 11 real-value `Status:` writes (acm, asg_activities, cb_build_logs, ecr_images, lambda_invocations, pipeline_stages, sfn_executions, sfn_execution_history, tg_health, s3 folder/file, catalog_compute AMI stub) are intentionally **untouched** — those migrate to `Fields["status"]` in **W1.4b.2** (sibling issue, blocked by this PR per AS-1432 parent).
- `Resource.Status` field stays on the struct for b.2 / b.3.
- Readers (`internal/catalog/color_helpers.go`, `internal/catalog/types.go`) untouched.
- All `tests/unit/*_test.go` untouched — b.3 fixture sweep.

## Verification gates (local)

| Gate | Status |
| --- | --- |
| `rg '^\s*Status:\s*""' internal/aws/` (production) | 0 hits ✅ |
| `rg '^\s*Status:\s*[a-zA-Z\"]' internal/aws/` real-value writes | unchanged ✅ |
| `go build ./...` | clean ✅ |
| `go test ./tests/unit/ -count=1` | ok (13.7s) ✅ |
| `go test -tags integration ./internal/aws/... -count=1` | ok ✅ |
| `golangci-lint run --timeout=5m ./...` | 0 issues ✅ |
| `govulncheck ./...` | 0 vulns ✅ |
| `verify-readonly` (Makefile logic) | PASS ✅ |
| `verify-zero-init` (Makefile logic) | PASS ✅ |
| `check-readme` | PASS ✅ |
| `snapshot` (Golden + Scenario unit + integration) | ok ✅ |
| `test-race` | **skipped** — no gcc/cgo in sandbox; CI will run |
| `mdlint` | **skipped** — no markdownlint-cli2 in sandbox; CI will run. Zero docs touched. |
| `./a9s --demo` smoke | binary boots through all fetcher init paths without panic (TTY open expected to fail in sandbox) |

## Files changed

11 files, +24 / −36, deletions only:

1. `internal/aws/apigw.go` — 2 deletions
2. `internal/aws/elb_listener_rules.go`
3. `internal/aws/elb_listeners.go`
4. `internal/aws/iam_group_members.go`
5. `internal/aws/log_streams.go`
6. `internal/aws/sg.go` (also drops the trailing `// SGs have no status field` comment)
7. `internal/aws/sns_sub.go`
8. `internal/aws/sns_sub_by_topic.go`
9. `internal/aws/tg.go`
10. `internal/aws/trail.go`
11. `internal/aws/waf.go`

## Stage 5

Per dispatch: CodeReviewer + CodexReviewer + CTO final. Architect not required (size XS).

## Parent / blocks

- Parent: AS-1428 (W1.4b umbrella)
- This issue: AS-1432
- Blocks: AS-1428 W1.4b.2 sibling (do not start b.2 until this merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)