### PR TITLE
AS-1428 W1.4b.2: migrate Status: real-value writes to Fields["status"] + reader updates

### DIFF
--- a/internal/aws/acm.go
+++ b/internal/aws/acm.go
@@ -86,9 +86,8 @@ func FetchACMCertificatesPage(ctx context.Context, api ACMListCertificatesAPI, c
 		}
 
 		r := resource.Resource{
-			ID:     domainName,
-			Name:   domainName,
-			Status: status,
+			ID:   domainName,
+			Name: domainName,
 			Fields: map[string]string{
 				"domain_name":     domainName,
 				"certificate_arn": certARN,

--- a/internal/aws/asg_activities.go
+++ b/internal/aws/asg_activities.go
@@ -92,11 +92,11 @@ func convertAsgActivity(activity asgtypes.Activity) resource.Resource {
 	}
 
 	return resource.Resource{
-		ID:     id,
-		Name:   name,
-		Status: statusCode,
+		ID:   id,
+		Name: name,
 		Fields: map[string]string{
 			"start_time":  startTime,
+			"status":      statusCode,
 			"status_code": statusCode,
 			"description": description,
 			"cause":       cause,

--- a/internal/aws/catalog_compute.go
+++ b/internal/aws/catalog_compute.go
@@ -50,9 +50,6 @@ func colorEC2(r domain.Resource) domain.Color {
 		return domain.ColorWarning
 	}
 	state := r.Fields["state"]
-	if state == "" {
-		state = r.Status
-	}
 	switch state {
 	case "running", "":
 		return domain.ColorHealthy
@@ -140,9 +137,6 @@ func colorLambda(r domain.Resource) domain.Color {
 		return c
 	}
 	state := r.Fields["state"]
-	if state == "" {
-		state = r.Status
-	}
 	switch state {
 	case "Failed":
 		return domain.ColorBroken
@@ -900,9 +894,8 @@ var computeTypes = []catalog.ResourceTypeDef{ //nolint:gochecknoglobals // stati
 		},
 		StubCreator: func(id string) domain.Resource {
 			return domain.Resource{
-				ID:     id,
-				Name:   id,
-				Status: "-",
+				ID:   id,
+				Name: id,
 				Fields: map[string]string{
 					"image_id": id,
 					"ImageId":  id,

--- a/internal/aws/cb_build_logs.go
+++ b/internal/aws/cb_build_logs.go
@@ -62,11 +62,11 @@ func FetchCBBuildLogs(
 		status := classifyBuildLogStatus(message)
 
 		r := resource.Resource{
-			ID:     id,
-			Name:   name,
-			Status: status,
+			ID:   id,
+			Name: name,
 			Fields: map[string]string{
 				"timestamp":      ts,
+				"status":         status,
 				"message":        message,
 				"ingestion_time": ingestionTime,
 				"event_id":       id,

--- a/internal/aws/ecr_images.go
+++ b/internal/aws/ecr_images.go
@@ -149,10 +149,10 @@ func convertECRImage(img ecrtypes.ImageDetail, repositoryURI, repositoryName str
 	status := computeImageStatus(img)
 
 	return resource.Resource{
-		ID:     digest,
-		Name:   name,
-		Status: status,
+		ID:   digest,
+		Name: name,
 		Fields: map[string]string{
+			"status":          status,
 			"image_tags":      imageTags,
 			"digest_short":    digestShort,
 			"pushed_at":       pushedAt,

--- a/internal/aws/lambda_invocations.go
+++ b/internal/aws/lambda_invocations.go
@@ -177,9 +177,8 @@ func convertReportEvent(event cwlogstypes.FilteredLogEvent) (resource.Resource, 
 	memoryUsed := memoryUsedMB + "/" + memorySizeMB + " MB"
 
 	return resource.Resource{
-		ID:     requestID,
-		Name:   name,
-		Status: status,
+		ID:   requestID,
+		Name: name,
 		Fields: map[string]string{
 			"request_id":             requestID,
 			"timestamp":              ts,

--- a/internal/aws/pipeline_stages.go
+++ b/internal/aws/pipeline_stages.go
@@ -145,10 +145,10 @@ func convertPipelineStageAction(stageName, stageStatus string, action cptypes.Ac
 	status := pipelineActionStatus(actionStatus)
 
 	return resource.Resource{
-		ID:     id,
-		Name:   actionName,
-		Status: status,
+		ID:   id,
+		Name: actionName,
 		Fields: map[string]string{
+			"status":               status,
 			"stage_name":           displayStageName,
 			"stage_status":         displayStageStatus,
 			"action_name":          actionName,

--- a/internal/aws/s3.go
+++ b/internal/aws/s3.go
@@ -179,15 +179,11 @@ func FetchS3Objects(ctx context.Context, api S3ListObjectsV2API, bucket, prefix 
 			folderKey = *cp.Prefix
 		}
 
-		// AS-1393: Fields["kind"] is the new structural folder/file marker the
-		// production DrillCondition reads; Status is a transitional mirror until
-		// the next W1 sibling lane drops it. Do not delete the Status write here
-		// without flipping every synthetic ChildViewDef in tests/unit/ that
-		// still asserts r.Status == "folder".
+		// Fields["kind"] is the structural folder/file marker the production
+		// DrillCondition reads.
 		r := resource.Resource{
-			ID:     folderKey,
-			Name:   folderKey,
-			Status: "folder",
+			ID:   folderKey,
+			Name: folderKey,
 			Fields: map[string]string{
 				"key":           folderKey,
 				"size":          "",
@@ -220,9 +216,8 @@ func FetchS3Objects(ctx context.Context, api S3ListObjectsV2API, bucket, prefix 
 		storageClass := string(obj.StorageClass)
 
 		r := resource.Resource{
-			ID:     objKey,
-			Name:   objKey,
-			Status: "file",
+			ID:   objKey,
+			Name: objKey,
 			Fields: map[string]string{
 				"key":           objKey,
 				"size":          size,

--- a/internal/aws/sfn_execution_history.go
+++ b/internal/aws/sfn_execution_history.go
@@ -81,10 +81,10 @@ func ConvertHistoryEvent(event sfntypes.HistoryEvent, lastStateName *string) res
 	stateName := resolveStateName(event, lastStateName)
 
 	return resource.Resource{
-		ID:     fmt.Sprintf("%d", event.Id),
-		Name:   HumanizeEventType(eventType),
-		Status: ClassifyEventStatus(eventType),
+		ID:   fmt.Sprintf("%d", event.Id),
+		Name: HumanizeEventType(eventType),
 		Fields: map[string]string{
+			"status":            ClassifyEventStatus(eventType),
 			"timestamp":         timestamp,
 			"event_type":        eventType,
 			"event_type_short":  HumanizeEventType(eventType),

--- a/internal/aws/sfn_executions.go
+++ b/internal/aws/sfn_executions.go
@@ -130,9 +130,8 @@ func convertSFNExecution(item sfntypes.ExecutionListItem) resource.Resource {
 	}
 
 	return resource.Resource{
-		ID:     name,
-		Name:   name,
-		Status: status,
+		ID:   name,
+		Name: name,
 		Fields: map[string]string{
 			"execution_arn":             executionArn,
 			"name":                      name,

--- a/internal/aws/tg_health.go
+++ b/internal/aws/tg_health.go
@@ -68,13 +68,13 @@ func convertTargetHealth(thd elbv2types.TargetHealthDescription) resource.Resour
 	}
 
 	return resource.Resource{
-		ID:     targetID,
-		Name:   targetID,
-		Status: health,
+		ID:   targetID,
+		Name: targetID,
 		Fields: map[string]string{
 			"target_id":   targetID,
 			"port":        port,
 			"az":          az,
+			"status":      health,
 			"health":      health,
 			"reason":      reason,
 			"description": description,

--- a/internal/catalog/types.go
+++ b/internal/catalog/types.go
@@ -132,11 +132,12 @@ type ResourceTypeDef struct {
 }
 
 // ResolveColor classifies r using d.Color, defaulting to a generic
-// status-based color when d.Color is nil. All registered types have non-nil
-// Color (invariant #7); the fallback exists only for ad-hoc test doubles.
+// status-based color when d.Color is nil, reading Fields["status"]. All
+// registered types have non-nil Color (invariant #7); the fallback exists
+// only for ad-hoc test doubles.
 func (d ResourceTypeDef) ResolveColor(r domain.Resource) domain.Color {
 	if d.Color == nil {
-		return colorFallback(r.Status)
+		return colorFallback(r.Fields["status"])
 	}
 	return d.Color(r)
 }

--- a/internal/semantics/ctevent/projector.go
+++ b/internal/semantics/ctevent/projector.go
@@ -315,13 +315,9 @@ func convertRow(r Row) domain.Item {
 }
 
 // ctEventStatus returns the ct-events status tier from a Resource.
-// After PR-03h the fetcher stores it in Fields["status"]; r.Status is the
-// legacy fallback for hand-constructed test resources.
+// The fetcher stores it in Fields["status"].
 func ctEventStatus(r domain.Resource) string {
-	if s := r.Fields["status"]; s != "" {
-		return s
-	}
-	return r.Status
+	return r.Fields["status"]
 }
 
 // tierToSeverity maps the ctevent tier string to a domain.Severity value.

--- a/internal/semantics/projection/generic.go
+++ b/internal/semantics/projection/generic.go
@@ -171,22 +171,19 @@ func buildItems(r domain.Resource, cfg *config.ViewsConfig, navProvider func(str
 		fields = FieldAliasProvider(shortName, fields)
 	}
 
-	// Synthesise minimal Fields from ID/Name/Status when the resource is a
-	// bare stub (no Fields, no RawStruct).
-	if len(fields) == 0 && r.RawStruct == nil && (r.ID != "" || r.Name != "" || r.Status != "") {
+	// Synthesise minimal Fields from ID/Name when the resource is a bare
+	// stub (no Fields, no RawStruct).
+	if len(fields) == 0 && r.RawStruct == nil && (r.ID != "" || r.Name != "") {
 		var fieldKeys []string
 		if shortName != "" && FieldKeysProvider != nil {
 			fieldKeys = FieldKeysProvider(shortName)
 		}
-		synth := make(map[string]string, 3)
+		synth := make(map[string]string, 2)
 		if r.ID != "" && len(fieldKeys) > 0 {
 			synth[fieldKeys[0]] = r.ID
 		}
 		if r.Name != "" && len(fieldKeys) > 1 {
 			synth[fieldKeys[1]] = r.Name
-		}
-		if r.Status != "" && len(fieldKeys) > 2 {
-			synth[fieldKeys[2]] = r.Status
 		}
 		if len(synth) > 0 {
 			fields = synth

--- a/internal/tui/views/detail_fields.go
+++ b/internal/tui/views/detail_fields.go
@@ -342,9 +342,9 @@ func capTierToRowBucket(tier string, rowBucket resource.Color) string {
 // owns its broken-vocabulary — dbi knows about "storage-full", ec2 about
 // "stopped", etc. — so this dispatcher stays universal.
 //
-// The phrase is injected as both r.Status and r.Fields["status"] because
-// some Color funcs read one, some read the other. Trailing "(+N)" suffix is
-// stripped inside the Color funcs themselves (via resource.StripFindingSuffix).
+// The phrase is injected as r.Fields["status"] because each per-type Color
+// func reads it from there. Trailing "(+N)" suffix is stripped inside the
+// Color funcs themselves (via resource.StripFindingSuffix).
 //
 // Unknown resource types default to "~" (warning) — safe for info-only
 // rendering without false-positive "!" coloring.
@@ -354,7 +354,6 @@ func phraseTier(resourceType, phrase string) string {
 		return "~"
 	}
 	probe := resource.Resource{
-		Status: phrase,
 		Fields: map[string]string{"status": phrase},
 	}
 	if td.ResolveColor(probe) == resource.ColorBroken {

--- a/tests/unit/aws_acm_test.go
+++ b/tests/unit/aws_acm_test.go
@@ -77,8 +77,8 @@ func TestFetchACMCertificates_ParsesMultipleCertificates(t *testing.T) {
 	if r0.Name != "api.example.com" {
 		t.Errorf("resource[0].Name: expected %q, got %q", "api.example.com", r0.Name)
 	}
-	if r0.Status != "ISSUED" {
-		t.Errorf("resource[0].Status: expected %q, got %q", "ISSUED", r0.Status)
+	if r0.Fields["status"] != "ISSUED" {
+		t.Errorf("resource[0].Fields[\"status\"]: expected %q, got %q", "ISSUED", r0.Fields["status"])
 	}
 	if r0.Fields["domain_name"] != "api.example.com" {
 		t.Errorf("resource[0].Fields[\"domain_name\"]: expected %q, got %q", "api.example.com", r0.Fields["domain_name"])
@@ -101,8 +101,8 @@ func TestFetchACMCertificates_ParsesMultipleCertificates(t *testing.T) {
 	if r1.ID != "staging.example.com" {
 		t.Errorf("resource[1].ID: expected %q, got %q", "staging.example.com", r1.ID)
 	}
-	if r1.Status != "PENDING_VALIDATION" {
-		t.Errorf("resource[1].Status: expected %q, got %q", "PENDING_VALIDATION", r1.Status)
+	if r1.Fields["status"] != "PENDING_VALIDATION" {
+		t.Errorf("resource[1].Fields[\"status\"]: expected %q, got %q", "PENDING_VALIDATION", r1.Fields["status"])
 	}
 	if r1.Fields["type"] != "IMPORTED" {
 		t.Errorf("resource[1].Fields[\"type\"]: expected %q, got %q", "IMPORTED", r1.Fields["type"])

--- a/tests/unit/aws_asg_activities_test.go
+++ b/tests/unit/aws_asg_activities_test.go
@@ -83,8 +83,8 @@ func TestFetchAsgActivities_Basic(t *testing.T) {
 	})
 
 	t.Run("Status_is_string_StatusCode", func(t *testing.T) {
-		if r.Status != "Successful" {
-			t.Errorf("Status: expected %q, got %q", "Successful", r.Status)
+		if r.Fields["status"] != "Successful" {
+			t.Errorf("Fields[\"status\"]: expected %q, got %q", "Successful", r.Fields["status"])
 		}
 	})
 
@@ -530,8 +530,8 @@ func TestFetchAsgActivities_Pagination(t *testing.T) {
 
 	t.Run("page1_all_have_status", func(t *testing.T) {
 		for i, r := range result1.Resources {
-			if r.Status == "" {
-				t.Errorf("page 1: resources[%d].Status should not be empty", i)
+			if r.Fields["status"] == "" {
+				t.Errorf("page 1: resources[%d].Fields[\"status\"] should not be empty", i)
 			}
 		}
 	})

--- a/tests/unit/aws_cb_build_logs_test.go
+++ b/tests/unit/aws_cb_build_logs_test.go
@@ -77,15 +77,15 @@ func TestFetchCBBuildLogs_Basic(t *testing.T) {
 
 	t.Run("first_event_Status_in_progress", func(t *testing.T) {
 		// "Running command" maps to IN_PROGRESS
-		if resources[0].Status != "IN_PROGRESS" {
-			t.Errorf("Status: expected %q, got %q", "IN_PROGRESS", resources[0].Status)
+		if resources[0].Fields["status"] != "IN_PROGRESS" {
+			t.Errorf("Fields[\"status\"]: expected %q, got %q", "IN_PROGRESS", resources[0].Fields["status"])
 		}
 	})
 
 	t.Run("second_event_Status_succeeded", func(t *testing.T) {
 		// "Phase complete" and "SUCCEEDED" maps to SUCCEEDED
-		if resources[1].Status != "SUCCEEDED" {
-			t.Errorf("Status: expected %q, got %q", "SUCCEEDED", resources[1].Status)
+		if resources[1].Fields["status"] != "SUCCEEDED" {
+			t.Errorf("Fields[\"status\"]: expected %q, got %q", "SUCCEEDED", resources[1].Fields["status"])
 		}
 	})
 
@@ -310,9 +310,9 @@ func TestFetchCBBuildLogs_StatusClassification(t *testing.T) {
 			if len(resources) != 1 {
 				t.Fatalf("expected 1 resource, got %d", len(resources))
 			}
-			if resources[0].Status != tc.wantStatus {
-				t.Errorf("Status for %q: expected %q, got %q",
-					tc.message, tc.wantStatus, resources[0].Status)
+			if resources[0].Fields["status"] != tc.wantStatus {
+				t.Errorf("Fields[\"status\"] for %q: expected %q, got %q",
+					tc.message, tc.wantStatus, resources[0].Fields["status"])
 			}
 		})
 	}

--- a/tests/unit/aws_ecr_images_test.go
+++ b/tests/unit/aws_ecr_images_test.go
@@ -352,8 +352,8 @@ func TestFetchECRImages_UntaggedImage(t *testing.T) {
 	})
 
 	t.Run("status_terminated", func(t *testing.T) {
-		if r.Status != "terminated" {
-			t.Errorf("Status: expected %q for untagged image, got %q", "terminated", r.Status)
+		if r.Fields["status"] != "terminated" {
+			t.Errorf("Fields[\"status\"]: expected %q for untagged image, got %q", "terminated", r.Fields["status"])
 		}
 	})
 }
@@ -891,8 +891,8 @@ func TestFetchECRImages_StatusMapping(t *testing.T) {
 				t.Fatalf("expected 1 resource, got %d", len(result.Resources))
 			}
 
-			if result.Resources[0].Status != tc.expectedStatus {
-				t.Errorf("Status: expected %q, got %q", tc.expectedStatus, result.Resources[0].Status)
+			if result.Resources[0].Fields["status"] != tc.expectedStatus {
+				t.Errorf("Fields[\"status\"]: expected %q, got %q", tc.expectedStatus, result.Resources[0].Fields["status"])
 			}
 		})
 	}

--- a/tests/unit/aws_lambda_invocations_test.go
+++ b/tests/unit/aws_lambda_invocations_test.go
@@ -68,8 +68,8 @@ func TestFetchLambdaInvocations_Basic(t *testing.T) {
 	})
 
 	t.Run("invocation_0_Status_OK", func(t *testing.T) {
-		if resources[0].Status != "OK" {
-			t.Errorf("Status: expected %q, got %q", "OK", resources[0].Status)
+		if resources[0].Fields["status"] != "OK" {
+			t.Errorf("Fields[\"status\"]: expected %q, got %q", "OK", resources[0].Fields["status"])
 		}
 	})
 
@@ -209,8 +209,8 @@ func TestFetchLambdaInvocations_ErrorStatus(t *testing.T) {
 	}
 
 	// A simple REPORT without error markers should be "OK"
-	if resources[0].Status != "OK" {
-		t.Errorf("Status: expected %q for normal REPORT, got %q", "OK", resources[0].Status)
+	if resources[0].Fields["status"] != "OK" {
+		t.Errorf("Fields[\"status\"]: expected %q for normal REPORT, got %q", "OK", resources[0].Fields["status"])
 	}
 }
 

--- a/tests/unit/aws_pipeline_stages_test.go
+++ b/tests/unit/aws_pipeline_stages_test.go
@@ -518,9 +518,9 @@ func TestFetchPipelineStages_StatusMapping(t *testing.T) {
 			if len(resources) != 1 {
 				t.Fatalf("expected 1 resource, got %d", len(resources))
 			}
-			if resources[0].Status != tc.wantStatus {
-				t.Errorf("Status for action %q: expected %q, got %q",
-					tc.actionStatus, tc.wantStatus, resources[0].Status)
+			if resources[0].Fields["status"] != tc.wantStatus {
+				t.Errorf("Fields[\"status\"] for action %q: expected %q, got %q",
+					tc.actionStatus, tc.wantStatus, resources[0].Fields["status"])
 			}
 		})
 	}

--- a/tests/unit/aws_sfn_execution_history_test.go
+++ b/tests/unit/aws_sfn_execution_history_test.go
@@ -98,22 +98,22 @@ func TestFetchSFNExecutionHistory_Basic(t *testing.T) {
 
 	t.Run("first_event_Status_active", func(t *testing.T) {
 		// ExecutionStarted maps to "active"
-		if resources[0].Status != "active" {
-			t.Errorf("Status: expected %q, got %q", "active", resources[0].Status)
+		if resources[0].Fields["status"] != "active" {
+			t.Errorf("Fields[\"status\"]: expected %q, got %q", "active", resources[0].Fields["status"])
 		}
 	})
 
 	t.Run("second_event_Status_pending", func(t *testing.T) {
 		// TaskScheduled maps to "pending"
-		if resources[1].Status != "pending" {
-			t.Errorf("Status: expected %q, got %q", "pending", resources[1].Status)
+		if resources[1].Fields["status"] != "pending" {
+			t.Errorf("Fields[\"status\"]: expected %q, got %q", "pending", resources[1].Fields["status"])
 		}
 	})
 
 	t.Run("third_event_Status_succeeded", func(t *testing.T) {
 		// TaskSucceeded maps to "succeeded"
-		if resources[2].Status != "succeeded" {
-			t.Errorf("Status: expected %q, got %q", "succeeded", resources[2].Status)
+		if resources[2].Fields["status"] != "succeeded" {
+			t.Errorf("Fields[\"status\"]: expected %q, got %q", "succeeded", resources[2].Fields["status"])
 		}
 	})
 

--- a/tests/unit/aws_sfn_executions_test.go
+++ b/tests/unit/aws_sfn_executions_test.go
@@ -83,8 +83,8 @@ func TestFetchSFNExecutions_Basic(t *testing.T) {
 	})
 
 	t.Run("Status_is_uppercase", func(t *testing.T) {
-		if r.Status != "SUCCEEDED" {
-			t.Errorf("Status: expected %q, got %q", "SUCCEEDED", r.Status)
+		if r.Fields["status"] != "SUCCEEDED" {
+			t.Errorf("Fields[\"status\"]: expected %q, got %q", "SUCCEEDED", r.Fields["status"])
 		}
 	})
 
@@ -348,8 +348,8 @@ func TestFetchSFNExecutions_NilFields(t *testing.T) {
 
 	t.Run("status_populated", func(t *testing.T) {
 		r := result.Resources[0]
-		if r.Status != "RUNNING" {
-			t.Errorf("Status: expected %q, got %q", "RUNNING", r.Status)
+		if r.Fields["status"] != "RUNNING" {
+			t.Errorf("Fields[\"status\"]: expected %q, got %q", "RUNNING", r.Fields["status"])
 		}
 	})
 }
@@ -450,8 +450,8 @@ func TestFetchSFNExecutions_Pagination(t *testing.T) {
 
 	t.Run("page1_all_have_status", func(t *testing.T) {
 		for i, r := range result1.Resources {
-			if r.Status == "" {
-				t.Errorf("page 1: resources[%d].Status should not be empty", i)
+			if r.Fields["status"] == "" {
+				t.Errorf("page 1: resources[%d].Fields[\"status\"] should not be empty", i)
 			}
 		}
 	})
@@ -761,9 +761,6 @@ func TestFetchSFNExecutions_StatusPreserved(t *testing.T) {
 				t.Fatalf("expected 1 resource, got %d", len(result.Resources))
 			}
 
-			if result.Resources[0].Status != tc.expected {
-				t.Errorf("Status: expected %q, got %q", tc.expected, result.Resources[0].Status)
-			}
 			if result.Resources[0].Fields["status"] != tc.expected {
 				t.Errorf("Fields[status]: expected %q, got %q", tc.expected, result.Resources[0].Fields["status"])
 			}

--- a/tests/unit/aws_tg_health_test.go
+++ b/tests/unit/aws_tg_health_test.go
@@ -106,8 +106,8 @@ func TestFetchTargetHealth_Basic(t *testing.T) {
 	})
 
 	t.Run("target_0_Status", func(t *testing.T) {
-		if resources[0].Status != "healthy" {
-			t.Errorf("Status: expected %q, got %q", "healthy", resources[0].Status)
+		if resources[0].Fields["status"] != "healthy" {
+			t.Errorf("Fields[\"status\"]: expected %q, got %q", "healthy", resources[0].Fields["status"])
 		}
 	})
 
@@ -149,8 +149,8 @@ func TestFetchTargetHealth_Basic(t *testing.T) {
 
 	t.Run("target_2_unhealthy", func(t *testing.T) {
 		r := resources[2]
-		if r.Status != "unhealthy" {
-			t.Errorf("Status: expected %q, got %q", "unhealthy", r.Status)
+		if r.Fields["status"] != "unhealthy" {
+			t.Errorf("Fields[\"status\"]: expected %q, got %q", "unhealthy", r.Fields["status"])
 		}
 		if r.Fields["reason"] != "Target.FailedHealthChecks" {
 			t.Errorf("Fields[reason]: expected %q, got %q", "Target.FailedHealthChecks", r.Fields["reason"])
@@ -162,8 +162,8 @@ func TestFetchTargetHealth_Basic(t *testing.T) {
 
 	t.Run("target_3_draining", func(t *testing.T) {
 		r := resources[3]
-		if r.Status != "draining" {
-			t.Errorf("Status: expected %q, got %q", "draining", r.Status)
+		if r.Fields["status"] != "draining" {
+			t.Errorf("Fields[\"status\"]: expected %q, got %q", "draining", r.Fields["status"])
 		}
 		if r.Fields["reason"] != "Target.DeregistrationInProgress" {
 			t.Errorf("Fields[reason]: expected %q, got %q", "Target.DeregistrationInProgress", r.Fields["reason"])
@@ -279,8 +279,8 @@ func TestFetchTargetHealth_AllStates(t *testing.T) {
 
 	for i, s := range states {
 		t.Run(s.expected, func(t *testing.T) {
-			if resources[i].Status != s.expected {
-				t.Errorf("Status: expected %q, got %q", s.expected, resources[i].Status)
+			if resources[i].Fields["status"] != s.expected {
+				t.Errorf("Fields[\"status\"]: expected %q, got %q", s.expected, resources[i].Fields["status"])
 			}
 			if resources[i].Fields["health"] != s.expected {
 				t.Errorf("Fields[health]: expected %q, got %q", s.expected, resources[i].Fields["health"])
@@ -362,8 +362,8 @@ func TestFetchTargetHealth_IPTargets(t *testing.T) {
 		if r.ID != "10.0.2.103" {
 			t.Errorf("ID: expected %q, got %q", "10.0.2.103", r.ID)
 		}
-		if r.Status != "unhealthy" {
-			t.Errorf("Status: expected %q, got %q", "unhealthy", r.Status)
+		if r.Fields["status"] != "unhealthy" {
+			t.Errorf("Fields[\"status\"]: expected %q, got %q", "unhealthy", r.Fields["status"])
 		}
 		if r.Fields["reason"] != "Target.Timeout" {
 			t.Errorf("Fields[reason]: expected %q, got %q", "Target.Timeout", r.Fields["reason"])

--- a/tests/unit/ctevent_projector_test.go
+++ b/tests/unit/ctevent_projector_test.go
@@ -360,8 +360,7 @@ func TestCTEventProjectorTierMapping(t *testing.T) {
 
 			projRes := domain.Resource{
 				ID:        "test-event-id",
-				Status:    tc.tier,
-				Fields:    map[string]string{},
+				Fields:    map[string]string{"status": tc.tier},
 				RawStruct: event,
 			}
 

--- a/tests/unit/qa_coverage_gaps_test.go
+++ b/tests/unit/qa_coverage_gaps_test.go
@@ -80,7 +80,10 @@ func TestEnrichProgressIndicator_CombinesWithCtrlZ(t *testing.T) {
 func gapResources(statuses ...string) []resource.Resource {
 	res := make([]resource.Resource, len(statuses))
 	for i, s := range statuses {
-		res[i] = resource.Resource{ID: fmt.Sprintf("gap-%d", i), Status: s}
+		res[i] = resource.Resource{
+			ID:     fmt.Sprintf("gap-%d", i),
+			Fields: map[string]string{"status": s},
+		}
 	}
 	return res
 }

--- a/tests/unit/qa_frame_title_issues_test.go
+++ b/tests/unit/qa_frame_title_issues_test.go
@@ -23,15 +23,17 @@ import (
 	"github.com/k2m30/a9s/v3/internal/tui/views"
 )
 
-// makeResourcesWithStatuses creates a slice of resources with the given statuses.
-// Each resource gets a synthetic ID to avoid collisions.
+// makeResourcesWithStatuses creates a slice of resources with the given
+// statuses. Each resource gets a synthetic ID to avoid collisions. The status
+// is stored under Fields["status"] which the colorFallback reads when the
+// ResourceTypeDef has no per-type Color func (as in these title tests).
 func makeResourcesWithStatuses(statuses ...string) []resource.Resource {
 	res := make([]resource.Resource, len(statuses))
 	for i, s := range statuses {
 		res[i] = resource.Resource{
 			ID:     fmt.Sprintf("i-%04d", i),
 			Name:   fmt.Sprintf("resource-%d", i),
-			Status: s,
+			Fields: map[string]string{"status": s},
 		}
 	}
 	return res
@@ -137,7 +139,7 @@ func TestFrameTitleTextFilterActive(t *testing.T) {
 	for i := range resources {
 		resources[i] = resource.Resource{
 			ID:     fmt.Sprintf("i-%04d", i),
-			Status: "stopped", // all are issues, but filter badge should not appear
+			Fields: map[string]string{"status": "stopped"}, // all are issues, but filter badge should not appear
 		}
 		if i < 7 {
 			resources[i].Name = fmt.Sprintf("web-%d", i)
@@ -190,13 +192,13 @@ func TestFrameTitleCtrlZAndTextFilter(t *testing.T) {
 		switch {
 		case i < 10:
 			resources[i].Name = fmt.Sprintf("web-%d", i)
-			resources[i].Status = "running"
+			resources[i].Fields = map[string]string{"status": "running"}
 		case i < 20:
 			resources[i].Name = fmt.Sprintf("app-%d", i)
-			resources[i].Status = "running"
+			resources[i].Fields = map[string]string{"status": "running"}
 		default:
-			resources[i].Name = fmt.Sprintf("web-%d", i) // matches text filter
-			resources[i].Status = "terminated"           // dim — filtered by ctrl+z
+			resources[i].Name = fmt.Sprintf("web-%d", i)                    // matches text filter
+			resources[i].Fields = map[string]string{"status": "terminated"} // dim — filtered by ctrl+z
 		}
 	}
 	// With text="web-" and attentionOnly=true:

--- a/tests/unit/qa_issue_count_test.go
+++ b/tests/unit/qa_issue_count_test.go
@@ -53,20 +53,20 @@ func buildIssueCountList(t *testing.T, resources []resource.Resource) views.Reso
 func TestResourceListIssueCountOnlyRedYellow(t *testing.T) {
 	resources := []resource.Resource{
 		// Green — running (not an issue)
-		{ID: "i-001", Name: "web-01", Status: "running"},
-		{ID: "i-002", Name: "web-02", Status: "running"},
-		{ID: "i-003", Name: "web-03", Status: "running"},
-		{ID: "i-004", Name: "web-04", Status: "running"},
-		{ID: "i-005", Name: "web-05", Status: "running"},
+		{ID: "i-001", Name: "web-01", Fields: map[string]string{"status": "running"}},
+		{ID: "i-002", Name: "web-02", Fields: map[string]string{"status": "running"}},
+		{ID: "i-003", Name: "web-03", Fields: map[string]string{"status": "running"}},
+		{ID: "i-004", Name: "web-04", Fields: map[string]string{"status": "running"}},
+		{ID: "i-005", Name: "web-05", Fields: map[string]string{"status": "running"}},
 		// Red — stopped (issue)
-		{ID: "i-006", Name: "db-01", Status: "stopped"},
-		{ID: "i-007", Name: "db-02", Status: "stopped"},
-		{ID: "i-008", Name: "db-03", Status: "stopped"},
+		{ID: "i-006", Name: "db-01", Fields: map[string]string{"status": "stopped"}},
+		{ID: "i-007", Name: "db-02", Fields: map[string]string{"status": "stopped"}},
+		{ID: "i-008", Name: "db-03", Fields: map[string]string{"status": "stopped"}},
 		// Yellow — pending (issue)
-		{ID: "i-009", Name: "cache-01", Status: "pending"},
-		{ID: "i-010", Name: "cache-02", Status: "pending"},
+		{ID: "i-009", Name: "cache-01", Fields: map[string]string{"status": "pending"}},
+		{ID: "i-010", Name: "cache-02", Fields: map[string]string{"status": "pending"}},
 		// Dim — terminated (not an issue)
-		{ID: "i-011", Name: "old-01", Status: "terminated"},
+		{ID: "i-011", Name: "old-01", Fields: map[string]string{"status": "terminated"}},
 	}
 
 	m := buildIssueCountList(t, resources)
@@ -85,9 +85,9 @@ func TestResourceListIssueCountOnlyRedYellow(t *testing.T) {
 // returns 0 when all resources have a healthy (green) status.
 func TestResourceListIssueCountZeroWhenAllHealthy(t *testing.T) {
 	resources := []resource.Resource{
-		{ID: "i-001", Name: "web-01", Status: "running"},
-		{ID: "i-002", Name: "web-02", Status: "running"},
-		{ID: "i-003", Name: "web-03", Status: "running"},
+		{ID: "i-001", Name: "web-01", Fields: map[string]string{"status": "running"}},
+		{ID: "i-002", Name: "web-02", Fields: map[string]string{"status": "running"}},
+		{ID: "i-003", Name: "web-03", Fields: map[string]string{"status": "running"}},
 	}
 
 	m := buildIssueCountList(t, resources)
@@ -105,11 +105,11 @@ func TestResourceListIssueCountZeroWhenAllHealthy(t *testing.T) {
 // total resource count when all resources have red or yellow statuses.
 func TestResourceListIssueCountAllIssues(t *testing.T) {
 	resources := []resource.Resource{
-		{ID: "i-001", Name: "db-01", Status: "stopped"},
-		{ID: "i-002", Name: "db-02", Status: "failed"},
-		{ID: "i-003", Name: "db-03", Status: "error"},
-		{ID: "i-004", Name: "cache-01", Status: "pending"},
-		{ID: "i-005", Name: "cache-02", Status: "creating"},
+		{ID: "i-001", Name: "db-01", Fields: map[string]string{"status": "stopped"}},
+		{ID: "i-002", Name: "db-02", Fields: map[string]string{"status": "failed"}},
+		{ID: "i-003", Name: "db-03", Fields: map[string]string{"status": "error"}},
+		{ID: "i-004", Name: "cache-01", Fields: map[string]string{"status": "pending"}},
+		{ID: "i-005", Name: "cache-02", Fields: map[string]string{"status": "creating"}},
 	}
 
 	m := buildIssueCountList(t, resources)


### PR DESCRIPTION
## Summary

W1.4b.2 of AS-1428 — flips the last 11 real-value `Status:` fetcher writes to `Resource.Fields[\"status\"]` and updates the 5 production reader sites atomically, eliminating the dual-source-of-truth window on `main`.

Stacks logically on W1.4b.1 (#422), but file scope is disjoint, so this PR branches from `origin/main` per dispatch and merges independently.

## Writers (11 fetchers + 1 AMI stub delete)

- `acm`, `asg_activities`, `cb_build_logs`, `ecr_images`, `lambda_invocations`, `pipeline_stages`, `sfn_executions`, `sfn_execution_history`, `tg_health`: `Status: <expr>` → `Fields[\"status\"]: <expr>`
- `s3.go`: pure delete of `Status: \"folder\"` and `Status: \"file\"` (production `DrillCondition` reads `Fields[\"kind\"]`); godoc updated
- `catalog_compute.go` AMI `StubCreator`: pure delete of `Status: \"-\"` (Color: colorAMI never falls through to colorFallback)

## Readers (atomic with the writes)

- `internal/catalog/types.go` `ResolveColor`: fallback reads `Fields[\"status\"]`
- `internal/aws/catalog_compute.go` `colorEC2` / `colorLambda`: drop the `state = r.Status` fallback blocks; both fetchers already write `Fields[\"state\"]`
- `internal/semantics/ctevent/projector.go` `ctEventStatus`: return `Fields[\"status\"]` only
- `internal/semantics/projection/generic.go` bare-stub Fields synthesis: ID/Name only, drop Status synth
- `internal/tui/views/detail_fields.go` `phraseTier`: drop the Status probe (Fields probe stays)

## Tests

13 unit test files updated. IssueCount helpers flipped from `Status:` to `Fields[\"status\"]` (helper-type `{ShortName: \"ec2\"}` has no per-type Color so `colorFallback(Fields[\"status\"])` is the read path). Fetcher tests' `r.Status == \"X\"` assertions flipped to `r.Fields[\"status\"] == \"X\"`.

The `derive.go` Wave-1 legacy reads of `r.Status` survive to b.3 per dispatch read-only context note; b.3 drops the field and these reads together.

## Verification

```
go build ./...            # clean
go test ./tests/unit/ -count=1     # PASS
go test -tags integration ./tests/integration/ -count=1   # PASS
golangci-lint run ./...   # 0 issues
govulncheck ./...         # 0 vulnerabilities
go fix -inline -diff ./...   # no diff
verify-readonly heuristic # PASS (only CreateServiceClients hits, which the Makefile filter excludes)
verify-zero-init          # PASS
check-readme              # no diff
snapshot/golden tests     # PASS
demo binary               # boots cleanly
```

`test-race` and `make mdlint` skipped in sandbox (no gcc, no markdownlint-cli2); CI will run both.

Acceptance grep results:
- `rg 'Status:\\s*[a-zA-Z]' internal/aws/ | rg -v _test.go` → zero real writes (only doc comments + unrelated struct field names: `DesiredStatus`, `StageStatus`, `ActionStatus`, `DomainProcessingStatus`)
- Each migrated fetcher emits `Fields[\"status\"]` (verified per-file)

## Test plan

- [x] Build + unit + integration green locally
- [x] Lint + security + gofix + verify-readonly + verify-zero-init green
- [x] check-readme + snapshot tests green
- [x] Demo binary boots without panic
- [ ] CI: test-race (Linux/macOS/Windows), mdlint
- [ ] CodeReviewer Stage 5 sign-off
- [ ] CodexReviewer Stage 5 sign-off
- [ ] CTO final sign-off

Parent: AS-1428
Issue: AS-1433
Sibling: W1.4b.1 (#422)