### PR TITLE
docs(refactor): AS-1453 mark Phase 03-finding-model LANDED in 00-overview

### DIFF
--- a/docs/refactor/00-overview.md
+++ b/docs/refactor/00-overview.md
@@ -170,7 +170,7 @@ If at the end of the program this test fails — if adding a resource still requ
 |---|---|---|
 | 01-projection-hook | LANDED | `internal/domain` bootstrap + Section/Item/DetailProjector type decls landed |
 | 02-session-owner | LANDED | session-owned caches; `internal/aws/` package-globals removed |
-| 03-finding-model | in progress (PR-03n cleanup pending) | 17 PRs landed; PR-03n cleanup tracked under [AS-1390](../../specs/) umbrella + W1.* sibling issues |
+| 03-finding-model | LANDED | 17 PRs landed in 03a..03n; PR-03n cleanup completed via AS-1390 umbrella (W1+W5 children AS-1392..AS-1397) |
 | 04-catalog | LANDED | `aws.Install()` + `catalog.SetTypes(...)` two-step model in production; see `04-catalog.md` |
 | 05a-extract | LANDED | `runtime.Core` extracted from `internal/tui/app.go` (PR-05a-h4 series) |
 | 05a-gens | LANDED | gen-counter unification merged into 05a sequence |


### PR DESCRIPTION
## Summary

- Closes **AS-1453** — trivial-docs follow-up to **AS-1390** closure
- Updates `docs/refactor/00-overview.md:173` to reflect that Phase 03 (`03-finding-model`) is now **LANDED**
- AS-1390 closed `done`; all W1+W5 children (AS-1392..AS-1397) merged. The status table was the last consequential drift from program reality.

## Diff (single line)

```
- | 03-finding-model | in progress (PR-03n cleanup pending) | 17 PRs landed; PR-03n cleanup tracked under [AS-1390](../../specs/) umbrella + W1.* sibling issues |
+ | 03-finding-model | LANDED | 17 PRs landed in 03a..03n; PR-03n cleanup completed via AS-1390 umbrella (W1+W5 children AS-1392..AS-1397) |
```

## Stage 5 / Gate

- AS-595 **trivial-docs fast-path** — single-line `.md` edit
- `make mdlint` not run locally: the target excludes `docs/refactor/**` (see `Makefile:mdlint`), so this file is outside the lint surface entirely
- `make ready-to-push` waived per fast-path
- Required reviewers: **CR + CXR only** (XS docs, AS-805)

## Acceptance (from AS-1453)

- [x] `docs/refactor/00-overview.md:173` status = `LANDED`
- [x] `make mdlint` — out-of-glob (no failure possible)
- [x] PR description references AS-1390 closure

🤖 Generated with [Claude Code](https://claude.com/claude-code)