### PR TITLE
docs(comments): AS-1452 update stale godoc/comments referring to deleted Resource.Status/Issues

### DIFF
--- a/internal/aws/catalog_color_helpers.go
+++ b/internal/aws/catalog_color_helpers.go
@@ -74,8 +74,8 @@ func colorFromWave1(r domain.Resource) (domain.Color, bool) {
 
 // colorWave1OrHealthy classifies r from its first wave1 Finding, defaulting to
 // healthy when none is present. Used by child-type catalog entries whose only
-// severity signal comes from fetcher-emitted wave1 Findings (AS-1393: replaces
-// the Resource.Status string fallback for cb_builds, cfn_resources, glue_runs,
+// severity signal comes from fetcher-emitted wave1 Findings (AS-1393: replaced
+// the prior status-string fallback for cb_builds, cfn_resources, glue_runs,
 // log_events, lambda_invocation_logs, role_policies).
 func colorWave1OrHealthy(r domain.Resource) domain.Color {
 	if c, ok := colorFromWave1(r); ok {

--- a/internal/aws/cb_builds_codes.go
+++ b/internal/aws/cb_builds_codes.go
@@ -3,9 +3,10 @@ package aws
 import "github.com/k2m30/a9s/v3/internal/domain"
 
 // CodeBuild build-state findings emitted by FetchCBBuilds. Severity carries
-// the color signal so the list view can render the row red/yellow/dim without
-// a per-status Color fallback against Resource.Status (which is no longer
-// written under AS-1393).
+// the color signal so the list view can render the row red/yellow/dim from
+// the wave1 Finding alone — no per-status Color fallback against a status
+// string (AS-1393 made wave1 Findings the sole severity signal for this
+// fetcher).
 const (
 	CodeCBBuildFailed     domain.FindingCode = "cb-build.broken.failed"
 	CodeCBBuildFault      domain.FindingCode = "cb-build.broken.fault"

--- a/internal/aws/ct_events.go
+++ b/internal/aws/ct_events.go
@@ -229,7 +229,8 @@ func buildCTResource(event cloudtrailtypes.Event) resource.Resource {
 	sourceIP := strFromMap(parsed, "sourceIPAddress")
 	region := strFromMap(parsed, "awsRegion")
 
-	// Set Resource.Status using §1.2 severity ladder.
+	// Compute the §1.2 severity tier ("ct-info" | "ct-attention" | "ct-danger").
+	// Written below to Fields["status"] and used to build wave1 Findings.
 	status := computeCTStatus(verb, eventName, source, errorCode, uiType, accountID, recipientAccount)
 
 	r := resource.Resource{

--- a/internal/aws/dbc_snap.go
+++ b/internal/aws/dbc_snap.go
@@ -31,7 +31,7 @@ import (
 //     N = int(time.Since(SnapshotCreateTime).Hours()/24).
 //     Gate: SnapshotType == "manual" AND SnapshotCreateTime != nil AND age > 365.
 //
-// Cross-ref signals (orphan, past-retention) are added by the Wave-2 issue
+// Cross-ref signals (orphan, past-retention) are added by the Wave-1 issue
 // enricher via FieldUpdates, never here.
 func ComputeDBCSnapStatusAndIssues(snap docdbtypes.DBClusterSnapshot) (string, []string) {
 	rawStatus := ""

--- a/internal/aws/dbc_snap.go
+++ b/internal/aws/dbc_snap.go
@@ -17,8 +17,10 @@ import (
 
 // ComputeDBCSnapStatusAndIssues computes the §4 status phrase and ordered
 // issues slice for a DocDB / Aurora cluster snapshot. Returns ("", nil) for a
-// healthy (available) snapshot. The top phrase becomes Resource.Status; the
-// full slice becomes Resource.Issues.
+// healthy (available) snapshot. The returned values mirror the wave1 Findings
+// emitted by computeDBCSnapFindings: the top phrase is what
+// phraseFromFindings produces for Fields["status"], and the slice is the
+// ordered list of finding phrases.
 //
 // §0.1 / §3.1 precedence ladder (Broken > Warning, table order within severity):
 //  1. Broken: Status == "failed" → phrase "failed"
@@ -29,8 +31,8 @@ import (
 //     N = int(time.Since(SnapshotCreateTime).Hours()/24).
 //     Gate: SnapshotType == "manual" AND SnapshotCreateTime != nil AND age > 365.
 //
-// Cross-ref signals (orphan, past-retention) are added by the Wave-1 issue
-// enricher (ComputeDBCSnapStatusAndIssues) via FieldUpdates, never here.
+// Cross-ref signals (orphan, past-retention) are added by the Wave-2 issue
+// enricher via FieldUpdates, never here.
 func ComputeDBCSnapStatusAndIssues(snap docdbtypes.DBClusterSnapshot) (string, []string) {
 	rawStatus := ""
 	if snap.Status != nil {

--- a/internal/demo/fixtures/redis.go
+++ b/internal/demo/fixtures/redis.go
@@ -324,7 +324,7 @@ func buildRedisReplicationGroups() []elasticachetypes.ReplicationGroup {
 		// Multi-W1 fixture (U7a): Status=modifying + multi-AZ without auto-failover.
 		// Two coexisting §3.1 Warnings in the same row.
 		// Expected Fields["status"] == "modifying — config change (+1)".
-		// Expected Resource.Issues == ["modifying — config change", "multi-AZ without auto-failover"].
+		// Expected Findings (wave1) phrases == ["modifying — config change", "multi-AZ without auto-failover"].
 		{
 			ReplicationGroupId:   aws.String(WarnRedisMultiID),
 			Description:          aws.String("Legacy billing Redis (modifying + no failover)"),
@@ -454,7 +454,7 @@ func buildRedisReplicationGroups() []elasticachetypes.ReplicationGroup {
 
 		// Multi-shard one-modifying — shard 0001 modifying, 0002 + 0003 available.
 		// Expected Fields["status"] == "shard 0001: modifying".
-		// Expected Resource.Issues == ["shard 0001: modifying"].
+		// Expected Findings (wave1) phrases == ["shard 0001: modifying"].
 		{
 			ReplicationGroupId: aws.String(MultiShardOneModifyingID),
 			Description:        aws.String("Multi-shard cluster (shard 0001 modifying)"),
@@ -527,7 +527,7 @@ func buildRedisReplicationGroups() []elasticachetypes.ReplicationGroup {
 
 		// Multi-shard two-transitioning — shard 0001 modifying + 0002 snapshotting + 0003 available.
 		// Expected Fields["status"] == "shard 0001: modifying (+1)".
-		// Expected Resource.Issues == ["shard 0001: modifying", "shard 0002: snapshotting"] (alphabetical).
+		// Expected Findings (wave1) phrases == ["shard 0001: modifying", "shard 0002: snapshotting"] (alphabetical).
 		{
 			ReplicationGroupId: aws.String(MultiShardTwoTransitioningID),
 			Description:        aws.String("Multi-shard cluster (two shards transitioning)"),

--- a/internal/demo/fixtures/redshift.go
+++ b/internal/demo/fixtures/redshift.go
@@ -386,7 +386,7 @@ func buildRedshiftClusters() []redshifttypes.Cluster {
 	// -----------------------------------------------------------------------
 	// 20. redshift-broken-with-warning-hidden — Broken suppresses Warnings (U8)
 	// ClusterStatus=storage-full (Broken) + ClusterAvailabilityStatus=Modifying + PubliclyAccessible=true + Encrypted=false
-	// Expected: Resource.Status = "broken: storage-full", Issues = ["broken: storage-full"]
+	// Expected: Fields["status"] = "broken: storage-full", Findings (wave1) phrases = ["broken: storage-full"]
 	// -----------------------------------------------------------------------
 	brokenWithWarning := redshiftBaselineHealthy(RedshiftBrokenWithWarningHiddenID)
 	brokenWithWarning.ClusterStatus = aws.String("storage-full")
@@ -399,7 +399,7 @@ func buildRedshiftClusters() []redshifttypes.Cluster {
 	// -----------------------------------------------------------------------
 	// 21. redshift-avail-unavailable-with-warning-hidden — availability-driven Broken suppresses Warning (U8)
 	// ClusterStatus=available, ClusterAvailabilityStatus=Unavailable + PubliclyAccessible=true
-	// Expected: Resource.Status = "unavailable", Issues = ["unavailable"]
+	// Expected: Fields["status"] = "unavailable", Findings (wave1) phrases = ["unavailable"]
 	// -----------------------------------------------------------------------
 	availUnavailableWithWarning := redshiftBaselineHealthy(RedshiftAvailUnavailableWithWarningHiddenID)
 	availUnavailableWithWarning.ClusterAvailabilityStatus = aws.String("Unavailable")

--- a/internal/semantics/ctevent/types.go
+++ b/internal/semantics/ctevent/types.go
@@ -56,7 +56,9 @@ type Event struct {
 	// internal/aws/ct_events_severity.go ClassifyCTVerb)
 	Verb string // "R" | "W" | "D" | "S" | "I" | "N" | "?"
 
-	// Status is the severity tier computed from the event (from resource.Resource.Status).
+	// Status is the severity tier computed from the event by
+	// internal/aws/ct_events.go#computeCTStatus and written to
+	// resource.Resource.Fields["status"].
 	// One of "ct-info" | "ct-attention" | "ct-danger".
 	Status string
 }


### PR DESCRIPTION
## Summary

AS-1390 W1.4b.3 (commit `ae2cfad`) physically removed `domain.Resource.Status` / `Resource.Issues`, but left 11 stale godoc/comment hits across `internal/` referring to those fields by name. Build was clean / tests passing / CI green — these were just misleading comments. This PR rewrites them to describe the canonical post-AS-1390 model.

**Comment-only edits — no behavior change.**

## Sites updated (verified against issue list on `origin/main` HEAD `ae2cfad`)

- `internal/aws/dbc_snap.go:18-21,32-33` — `ComputeDBCSnapStatusAndIssues` godoc rewritten to describe wave1 Findings / `phraseFromFindings` and Wave-2 enricher cross-ref.
- `internal/aws/ct_events.go:232` — "Set Resource.Status using §1.2 …" → describes the §1.2 severity tier written to `Fields["status"]`.
- `internal/aws/cb_builds_codes.go:7` — past-tense the AS-1393 outcome.
- `internal/aws/catalog_color_helpers.go:78` — past-tense the AS-1393 status-string fallback.
- `internal/semantics/ctevent/types.go:59` — `Status` field godoc points to `computeCTStatus` + `Fields["status"]`.
- `internal/demo/fixtures/redis.go:327,457,530` — "Expected `Resource.Issues` ==" → "Expected `Findings` (wave1) phrases ==".
- `internal/demo/fixtures/redshift.go:389,402` — "Expected: `Resource.Status` … `Issues` =" → "Expected: `Fields["status"]` … `Findings` (wave1) phrases =".

## Acceptance (per AS-1452)

- ✅ `grep -rn 'Resource\.Status\b\|Resource\.Issues\b' internal/` → 0 hits
- ✅ `go build ./...` clean
- ✅ `go vet ./...` clean
- ✅ `go test ./tests/unit/ -count=1` → ok
- ✅ `golangci-lint run ./...` → 0 issues
- ✅ `go fix -inline -diff ./...` → no diff

`make ready-to-push` could not be run locally (no `make` in this environment), so CI is the gate for `test-race` / `snapshot` / `mdlint`. All other sub-targets verified individually above.

## Test plan

- [x] Code search confirms 0 remaining `Resource.Status` / `Resource.Issues` hits in `internal/`
- [x] Build + vet + unit tests + lint + gofix green locally
- [ ] CI green
- [ ] CodeReviewer + CodexReviewer (XS, no Architect needed per dispatch)

Closes AS-1452.

Co-Authored-By: Paperclip <noreply@paperclip.ing>