### PR TITLE
fix(eks-related): soft-skip deleted launch template does not surface Err

### DIFF
--- a/internal/aws/eks_related_extra.go
+++ b/internal/aws/eks_related_extra.go
@@ -179,7 +179,6 @@ func checkEKSAMI(ctx context.Context, clients any, res resource.Resource, _ reso
 			// "no AMI to relate to" rather than a fetch failure.
 			var apiErr smithy.APIError
 			if errors.As(ltErr, &apiErr) && apiErr.ErrorCode() == "InvalidLaunchTemplateId.NotFound" {
-				failures = append(failures, fmt.Sprintf("%s: launch template deleted", ngName))
 				continue
 			}
 			failures = append(failures, fmt.Sprintf("%s/lt: %v", ngName, ltErr))

--- a/tests/unit/aws_eks_related_test.go
+++ b/tests/unit/aws_eks_related_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	smithy "github.com/aws/smithy-go"
 
 	_ "github.com/k2m30/a9s/v3/internal/aws"
 	awsclient "github.com/k2m30/a9s/v3/internal/aws"
@@ -459,6 +460,78 @@ func TestRelated_EKS_AMI_WrongRawStruct(t *testing.T) {
 
 	if result.Count != -1 {
 		t.Errorf("Count = %d, want -1 (wrong RawStruct type)", result.Count)
+	}
+}
+
+// TestRelated_EKS_AMI_SoftSkipsDeletedLaunchTemplate verifies that when one node
+// group's launch template has been deleted (AWS returns
+// InvalidLaunchTemplateId.NotFound), the checker soft-skips that NG — collecting
+// the valid AMI from the remaining NG — and does NOT surface an Err.
+func TestRelated_EKS_AMI_SoftSkipsDeletedLaunchTemplate(t *testing.T) {
+	const ltValid = "lt-valid"
+	const ltDeleted = "lt-deleted"
+	const ami1 = "ami-0a1b2c3d4e5f60001"
+
+	eksNodegroups := map[string]*ekstypes.Nodegroup{
+		"ng-valid": {
+			NodegroupName: aws.String("ng-valid"),
+			ClusterName:   aws.String("acme-services"),
+			LaunchTemplate: &ekstypes.LaunchTemplateSpecification{
+				Id:      aws.String(ltValid),
+				Version: aws.String("1"),
+			},
+		},
+		"ng-deleted": {
+			NodegroupName: aws.String("ng-deleted"),
+			ClusterName:   aws.String("acme-services"),
+			LaunchTemplate: &ekstypes.LaunchTemplateSpecification{
+				Id:      aws.String(ltDeleted),
+				Version: aws.String("1"),
+			},
+		},
+	}
+	fakeEKS := newFakeEKSWithNodegroups([]string{"ng-valid", "ng-deleted"}, eksNodegroups)
+
+	fakeEC2 := &fakeEC2Batch2{
+		describeLaunchTemplateVersionsFn: func(input *ec2.DescribeLaunchTemplateVersionsInput) (*ec2.DescribeLaunchTemplateVersionsOutput, error) {
+			if input.LaunchTemplateId != nil && *input.LaunchTemplateId == ltDeleted {
+				return nil, &smithy.GenericAPIError{
+					Code:    "InvalidLaunchTemplateId.NotFound",
+					Message: "The launch template ID '" + ltDeleted + "' does not exist",
+				}
+			}
+			return &ec2.DescribeLaunchTemplateVersionsOutput{
+				LaunchTemplateVersions: []ec2types.LaunchTemplateVersion{
+					{
+						LaunchTemplateData: &ec2types.ResponseLaunchTemplateData{
+							ImageId: aws.String(ami1),
+						},
+					},
+				},
+			}, nil
+		},
+	}
+	clients := &awsclient.ServiceClients{EKS: fakeEKS, EC2: fakeEC2}
+	res := eksClusterSrcResource()
+
+	checker := eksCheckerByTarget(t, "ami")
+	result := checker(context.Background(), clients, res, nil)
+
+	if result.Err != nil {
+		t.Errorf("Err = %v, want nil (deleted LT must be soft-skipped, not surfaced as error)", result.Err)
+	}
+	if result.Count != 1 {
+		t.Errorf("Count = %d, want 1 (only valid-LT nodegroup's AMI collected)", result.Count)
+	}
+	found := false
+	for _, id := range result.ResourceIDs {
+		if id == ami1 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("ResourceIDs %v missing %q (valid nodegroup AMI must appear)", result.ResourceIDs, ami1)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes AS-1688: `checkEKSAMI` was appending the deleted-launch-template soft-skip case to `failures`, which then surfaced through `AggregateFailures` as a non-nil `result.Err`. That contradicted the function's own comment ("a true 'no AMI to relate to' rather than a fetch failure") and caused `TestLiveFullIntegration_AllResourcesBaseline/eks` to mark eks/ami as a related-def failure on accounts with stale node groups (AS-1685 acceptance gate #4).

- `internal/aws/eks_related_extra.go`: delete the single `failures = append(...)` line inside the `InvalidLaunchTemplateId.NotFound` branch. The genuine-failure path (`%s/lt: %v`) below still appends, and `AggregateFailures` is unchanged.
- `tests/unit/aws_eks_related_test.go`: adds `TestRelated_EKS_AMI_SoftSkipsDeletedLaunchTemplate` — two node groups, one with a valid LT → AMI, one whose `DescribeLaunchTemplateVersions` returns `&smithy.GenericAPIError{Code: "InvalidLaunchTemplateId.NotFound"}`. Asserts `result.Err == nil`, `result.Count == 1`, valid AMI in `result.ResourceIDs`.

## Design choice (CTO call, per issue body §"Why this design")

Option 1 (pure no-op, no append to `failures`) over Option 2 (separate softSkipped counter). `failures` exists solely to produce `result.Err`; a non-failure must not be in it. Observability is preserved via the existing comment + the `total` vs `len(amiSet)` count delta.

## Test plan

- [x] `go test ./tests/unit/ -run TestRelated_EKS_AMI -count=1 -v` — all 4 AMI tests pass (Match, Empty, WrongRawStruct, SoftSkipsDeletedLaunchTemplate)
- [x] `go test ./tests/unit/ -count=1` — full unit suite green (16.8s)
- [x] `golangci-lint run ./...` — clean
- [x] `govulncheck ./...` — 0 vulnerabilities
- [x] `go fix -inline -diff ./...` — no unfixed directives
- [x] verify-readonly — no write API calls introduced
- [x] verify-zero-init — no init() bodies introduced
- [ ] `go test -race` — not runnable locally (no gcc/cgo in sandbox); CI gate covers it. Change is pure deletion in sequential code; new test has no concurrency.

## Issue refs

- Closes AS-1689
- Parent AS-1688
- Acceptance gate AS-1685 #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)