### PR TITLE
fix(runtime): route every cross-package pair read through CurrentPair

### DIFF
--- a/core/runtime/accessors.go
+++ b/core/runtime/accessors.go
@@ -46,21 +46,33 @@ func (c *Core) CurrentGenFor(a messages.Aspect) domain.Gen {
 }
 
 // Profile returns the active session profile.
-func (c *Core) Profile() string { return c.session.Profile }
+func (c *Core) Profile() string {
+	p, _ := c.session.CurrentPair()
+	return p
+}
 
 // SetProfile sets the active session profile. Used by the WithProfile
 // constructor option only, before any goroutine other than the caller's own
 // can observe the session — goes through SetProfileRegion regardless, so a
 // later WithProfile/WithRegion combination (both constructor options run
 // during the same single-threaded construction) never risks a torn pair.
-func (c *Core) SetProfile(p string) { c.session.SetProfileRegion(p, c.session.Region) }
+func (c *Core) SetProfile(p string) {
+	_, r := c.session.CurrentPair()
+	c.session.SetProfileRegion(p, r)
+}
 
 // Region returns the active session region.
-func (c *Core) Region() string { return c.session.Region }
+func (c *Core) Region() string {
+	_, r := c.session.CurrentPair()
+	return r
+}
 
 // SetRegion sets the active session region. Used by the WithRegion
 // constructor option only. See SetProfile's doc comment.
-func (c *Core) SetRegion(r string) { c.session.SetProfileRegion(c.session.Profile, r) }
+func (c *Core) SetRegion(r string) {
+	p, _ := c.session.CurrentPair()
+	c.session.SetProfileRegion(p, r)
+}
 
 // NoCache reports whether the --no-cache / --demo CLI flags disabled
 // on-disk availability caching and background probes.

--- a/core/runtime/executor.go
+++ b/core/runtime/executor.go
@@ -59,14 +59,15 @@ type DispatchSnapshot struct {
 // CaptureDispatch snapshots the session generations and clients. Call it
 // synchronously at task-dispatch time (NOT inside a goroutine).
 func (c *Core) CaptureDispatch() DispatchSnapshot {
+	profile, region := c.session.CurrentPair()
 	return DispatchSnapshot{
 		Clients:           c.session.Clients,
 		AvailabilityGen:   c.session.AvailabilityGen,
 		EnrichmentGen:     c.session.EnrichmentGen,
 		ConnectGen:        c.session.ConnectGen,
 		EnrichmentTypeGen: c.session.EnrichmentTypeGenSnapshot(),
-		Profile:           c.session.Profile,
-		Region:            c.session.Region,
+		Profile:           profile,
+		Region:            region,
 		NoCache:           c.session.NoCache,
 	}
 }

--- a/core/runtime/handlers.go
+++ b/core/runtime/handlers.go
@@ -529,11 +529,12 @@ type ThemeFileReadEvent struct {
 // the selector can render the "(current)" indicator. No tasks fire — the
 // adapter's builder closure constructs the SelectorModel synchronously.
 func (c *Core) HandleProfilesLoaded(ev ProfilesLoadedEvent) ([]UIIntent, []TaskRequest) {
+	current, _ := c.session.CurrentPair()
 	intents := []UIIntent{PushScreen{
 		ID: ScreenProfileSelector,
 		Payload: ProfileSelectorPayload{
 			Profiles: ev.Profiles,
-			Current:  c.session.Profile,
+			Current:  current,
 		},
 	}}
 	return intents, nil

--- a/tests/unit/runtime_pair_accessor_race_test.go
+++ b/tests/unit/runtime_pair_accessor_race_test.go
@@ -1,0 +1,64 @@
+// runtime_pair_accessor_race_test.go — race-regression pin for GitHub issue
+// #471: Core.Profile()/Core.Region() must never race a concurrent
+// SetProfile()/SetRegion() (both routed through session.SetProfileRegion,
+// guarded by session.pairMu). Meaningful only under -race; passes vacuously
+// without it.
+package unit
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/k2m30/a9s/v3/core/runtime"
+	"github.com/k2m30/a9s/v3/core/session"
+)
+
+// TestPairAccessors_ConcurrentSwitchAndRead_RaceClean drives concurrent
+// profile/region switches against concurrent Profile()/Region() reads and
+// must complete clean under `go test -race`.
+func TestPairAccessors_ConcurrentSwitchAndRead_RaceClean(t *testing.T) {
+	const iterations = 1000
+
+	core := runtime.New(session.New(), nil)
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			core.SetProfile("p-a")
+			core.SetRegion("r-b")
+		}
+	}()
+
+	var profileLen, regionLen int
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			profileLen += len(core.Profile())
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			regionLen += len(core.Region())
+		}
+	}()
+
+	wg.Wait()
+
+	if profileLen < 0 || regionLen < 0 {
+		t.Fatalf("unreachable: len() never negative (profileLen=%d regionLen=%d)", profileLen, regionLen)
+	}
+
+	gotProfile := core.Profile()
+	if gotProfile != "p-a" {
+		t.Errorf("final Profile() = %q, want %q (the only value ever written)", gotProfile, "p-a")
+	}
+	gotRegion := core.Region()
+	if gotRegion != "r-b" {
+		t.Errorf("final Region() = %q, want %q (the only value ever written)", gotRegion, "r-b")
+	}
+}


### PR DESCRIPTION
Fixes #471 — `Core.Profile()`/`Core.Region()` read `session.Profile`/`session.Region` raw while every write goes through the `pairMu`-guarded `SetProfileRegion`, a race-detector-proven data race on concurrent hosts (web lane, desktop shell).

## Fix

Every cross-package read of the pair now routes through the guarded `Session.CurrentPair()` — the issue's desired contract — covering the whole defect class, not just the two reported accessors:

- `Profile()` / `Region()` (the reported sites)
- `SetProfile()` / `SetRegion()` — both composed the pair from an unguarded read of the opposite half
- `HandleProfilesLoaded` (`ProfileSelectorPayload.Current`) and `CaptureDispatch` (`DispatchSnapshot.Profile/Region`) — raw reads racing the same host-goroutine writes

## Proof

New `TestPairAccessors_ConcurrentSwitchAndRead_RaceClean` drives concurrent profile/region switches against concurrent reads:

- pre-fix (fix stashed): `WARNING: DATA RACE` → FAIL
- post-fix: clean under `-race`

Full `make test-race` green (all packages), `make lint` 0 issues, demo smoke green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
