### PR TITLE
fix(smoke): guard helper grep patterns with -- so dash-leading patterns scan

### DIFF
--- a/scripts/smoke-costs-demo.sh
+++ b/scripts/smoke-costs-demo.sh
@@ -38,7 +38,7 @@ GROWTH_LABEL="$(date -v-6m "+%b" 2>/dev/null || date -d '-6 months' "+%b")"
 
 expect() {
 	# $1 = capture file, $2 = required substring, $3 = human label
-	if grep -qF "$2" "$CAPDIR/$1"; then
+	if grep -qF -- "$2" "$CAPDIR/$1"; then
 		echo "PASS  $3"
 	else
 		echo "FAIL  $3 — missing \"$2\" in $CAPDIR/$1"
@@ -48,7 +48,7 @@ expect() {
 
 expect_re() {
 	# $1 = capture file, $2 = required ERE, $3 = human label
-	if grep -qE "$2" "$CAPDIR/$1"; then
+	if grep -qE -- "$2" "$CAPDIR/$1"; then
 		echo "PASS  $3"
 	else
 		echo "FAIL  $3 — no match for /$2/ in $CAPDIR/$1"
@@ -58,7 +58,7 @@ expect_re() {
 
 expect_absent() {
 	# $1 = capture file, $2 = forbidden substring, $3 = human label
-	if grep -qF "$2" "$CAPDIR/$1"; then
+	if grep -qF -- "$2" "$CAPDIR/$1"; then
 		echo "FAIL  $3 — forbidden \"$2\" present in $CAPDIR/$1"
 		FAILURES=$((FAILURES + 1))
 	else

--- a/scripts/smoke-demo.sh
+++ b/scripts/smoke-demo.sh
@@ -86,7 +86,7 @@ tmux capture-pane -t "$SESSION" -p > "$CAPDIR/s3_attention.txt"
 
 expect() {
 	# $1 = capture file, $2 = required substring, $3 = human label
-	if grep -qF "$2" "$CAPDIR/$1"; then
+	if grep -qF -- "$2" "$CAPDIR/$1"; then
 		echo "PASS  $3"
 	else
 		echo "FAIL  $3 — missing \"$2\" in $CAPDIR/$1"
@@ -96,7 +96,7 @@ expect() {
 
 expect_re() {
 	# $1 = capture file, $2 = required ERE, $3 = human label
-	if grep -qE "$2" "$CAPDIR/$1"; then
+	if grep -qE -- "$2" "$CAPDIR/$1"; then
 		echo "PASS  $3"
 	else
 		echo "FAIL  $3 — no match for /$2/ in $CAPDIR/$1"
@@ -106,7 +106,7 @@ expect_re() {
 
 forbid() {
 	# $1 = capture file, $2 = forbidden substring, $3 = human label
-	if grep -qF "$2" "$CAPDIR/$1"; then
+	if grep -qF -- "$2" "$CAPDIR/$1"; then
 		echo "FAIL  $3 — forbidden \"$2\" present in $CAPDIR/$1"
 		FAILURES=$((FAILURES + 1))
 	else

--- a/scripts/smoke-readonly.sh
+++ b/scripts/smoke-readonly.sh
@@ -76,7 +76,7 @@ sleep 8
 tmux capture-pane -t "$SESSION" -p > "$CAPDIR/ec2_detail.txt"
 
 expect() {
-	if grep -qE "$2" "$CAPDIR/$1"; then
+	if grep -qE -- "$2" "$CAPDIR/$1"; then
 		echo "PASS  $3"
 	else
 		echo "FAIL  $3 — no match for /$2/ in $CAPDIR/$1"
@@ -85,7 +85,7 @@ expect() {
 }
 
 forbid() {
-	if grep -qE "$2" "$CAPDIR/$1"; then
+	if grep -qE -- "$2" "$CAPDIR/$1"; then
 		echo "FAIL  $3 — forbidden /$2/ present in $CAPDIR/$1"
 		FAILURES=$((FAILURES + 1))
 	else

--- a/scripts/smoke-related-demo.sh
+++ b/scripts/smoke-related-demo.sh
@@ -138,7 +138,7 @@ tmux capture-pane -t "$SESSION" -p > "$CAPDIR/ec2_detail.txt"
 
 expect() {
 	# $1 = capture file, $2 = required substring, $3 = human label
-	if grep -qF "$2" "$CAPDIR/$1"; then
+	if grep -qF -- "$2" "$CAPDIR/$1"; then
 		echo "PASS  $3"
 	else
 		echo "FAIL  $3 — missing \"$2\" in $CAPDIR/$1"
@@ -148,7 +148,7 @@ expect() {
 
 expect_re() {
 	# $1 = capture file, $2 = required ERE, $3 = human label
-	if grep -qE "$2" "$CAPDIR/$1"; then
+	if grep -qE -- "$2" "$CAPDIR/$1"; then
 		echo "PASS  $3"
 	else
 		echo "FAIL  $3 — no match for /$2/ in $CAPDIR/$1"
@@ -158,7 +158,7 @@ expect_re() {
 
 forbid() {
 	# $1 = capture file, $2 = forbidden substring, $3 = human label
-	if grep -qF "$2" "$CAPDIR/$1"; then
+	if grep -qF -- "$2" "$CAPDIR/$1"; then
 		echo "FAIL  $3 — forbidden \"$2\" present in $CAPDIR/$1"
 		FAILURES=$((FAILURES + 1))
 	else
@@ -168,7 +168,7 @@ forbid() {
 
 forbid_re() {
 	# $1 = capture file, $2 = forbidden ERE, $3 = human label
-	if grep -qE "$2" "$CAPDIR/$1"; then
+	if grep -qE -- "$2" "$CAPDIR/$1"; then
 		echo "FAIL  $3 — forbidden /$2/ present in $CAPDIR/$1"
 		FAILURES=$((FAILURES + 1))
 	else

--- a/scripts/smoke-related-readonly.sh
+++ b/scripts/smoke-related-readonly.sh
@@ -53,7 +53,7 @@ open_and_capture() {
 }
 
 expect() {
-	if grep -qE "$2" "$CAPDIR/$1"; then
+	if grep -qE -- "$2" "$CAPDIR/$1"; then
 		echo "PASS  $3"
 	else
 		echo "FAIL  $3 — no match for /$2/ in $CAPDIR/$1"
@@ -62,7 +62,7 @@ expect() {
 }
 
 forbid() {
-	if grep -qE "$2" "$CAPDIR/$1"; then
+	if grep -qE -- "$2" "$CAPDIR/$1"; then
 		echo "FAIL  $3 — forbidden /$2/ present in $CAPDIR/$1"
 		FAILURES=$((FAILURES + 1))
 	else
@@ -76,7 +76,7 @@ forbid() {
 # resource carries findings. Only that exact header token is masked, so a
 # vacuous word anywhere else on the same line still fails.
 forbid_status() {
-	if sed -E 's/Attention \([0-9]+\)/attention-block-header/' "$CAPDIR/$1" | grep -qE "$2"; then
+	if sed -E 's/Attention \([0-9]+\)/attention-block-header/' "$CAPDIR/$1" | grep -qE -- "$2"; then
 		echo "FAIL  $3 — forbidden /$2/ present in $CAPDIR/$1"
 		FAILURES=$((FAILURES + 1))
 	else


### PR DESCRIPTION
The costs demo smoke's `expect_absent grid.txt "-0.0"` check passed its pattern to grep unguarded: grep parsed `-0.0` as options, errored with a usage message, and the non-zero exit read as "pattern absent" — a vacuous PASS (visible as `grep: invalid option -- .` mid-run while the check still reported green).

Root fix in the shared helpers, not the call site: every pattern-taking helper (`expect`, `expect_re`, `expect_absent`, `forbid`, `forbid_re`, `forbid_status`) across the five smoke scripts now passes `--` before the pattern, so any dash-leading pattern scans instead of being parsed as options.

Verified: all three demo smokes green post-fix, with the previously-vacuous "no negative-zero amounts" check now genuinely scanning (no grep error in the output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
