### PR TITLE
fix(web): wire the copy key to the clipboard via controller-owned CopyContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.55.2] - 2026-07-20
+
+### Fixed
+
+- Web mode's `c` copy key works (#478): it was a silent no-op — the
+  client POSTed the action to a server that treats copy as
+  renderer-only, and the browser half was never implemented. Copy
+  resolution now lives once in the controller
+  (`Controller.CopyContent`), exposed through
+  `ViewState.CopyText/CopyLabel` and rendered as `data-copy-*`
+  attributes; the web client writes the clipboard in the keydown
+  handler and shows a client-side flash. The TUI's `handleCopy`
+  delegates to the same resolution, deleting its duplicated logic.
+- `CopyField` actually resolves (#478): every `CopyField` in the
+  catalog is registered on a child type, but the copy path consulted
+  only the top-level registry — so copy always fell back to the row ID.
+  The shared lookup consults both registries; on an
+  `sns_subscriptions` child list, `c` now copies the endpoint.
+- `Controller.CopyContent` takes the write lock: the detail branch
+  reaches the mutating detail-body builder, and the read lock allowed
+  concurrent map writes (crash) under concurrent web requests.
+- Identity no longer survives a profile/region rotation stale: a new
+  `ClearIdentityIntent` (emitted by `HandleProfileSelected` /
+  `HandleRegionSelected`) clears the controller's cached identity and
+  the TUI identity screen's renderer state, so neither renderer shows
+  or copies the previous pair's ARN. Repopulation is owned exclusively
+  by the post-connect identity fetch — rotation itself never fetches
+  (the retained pre-rotation clients would re-land the old identity
+  stamped with the new generation). On `--no-cache` rotations (demo
+  included), where no post-connect refetch exists, the identity screen
+  resets to blank instead of a never-resolving loading state.
+
+### Added
+
+- `core/` exports: `app.Controller.CopyContent`,
+  `app.ViewState.CopyText/CopyLabel`, `runtime.ClearIdentityIntent`.
+
 ## [3.55.1] - 2026-07-20
 
 ### Fixed

--- a/core/app/copy.go
+++ b/core/app/copy.go
@@ -21,14 +21,17 @@ import (
 // once instead of drifting between a TUI-local implementation and a web
 // no-op.
 func (c *Controller) CopyContent() (content, label string) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.copyContent()
 }
 
 // copyContent is the lock-free core of CopyContent, also called by
 // snapshot() to populate ViewState.CopyText/CopyLabel from the identical
-// resolution. Callers must already hold c.mu (read or write).
+// resolution. Callers must already hold c.mu for WRITE — copyContentDetail
+// reaches buildDetailBody, which may maps.Copy into the shared resource's
+// AttentionDetails map (detail_body.go), the same mutation-on-read hazard
+// Snapshot() documents on its own write-lock choice.
 func (c *Controller) copyContent() (content, label string) {
 	if len(c.stack) == 0 {
 		return "", ""

--- a/core/app/copy.go
+++ b/core/app/copy.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/k2m30/a9s/v3/core/fieldpath"
 	"github.com/k2m30/a9s/v3/core/resource"
+	"github.com/k2m30/a9s/v3/core/runtime"
 )
 
 // CopyContent resolves the (content, label) pair for the copy action ('c' in
@@ -38,7 +39,7 @@ func (c *Controller) copyContent() (content, label string) {
 	case BodyKindDetail:
 		return c.copyContentDetail()
 	case BodyKindText:
-		return copyContentText(c.topTextState())
+		return copyContentText(c.stack[len(c.stack)-1].ID, c.topTextState())
 	case BodyKindIdentity:
 		return copyContentIdentity(c.buildIdentityBody())
 	default:
@@ -124,9 +125,11 @@ func detailResourceRawYAML(res resource.Resource) string {
 	return string(data)
 }
 
-// copyContentText resolves copy content for a YAML/JSON text screen: every
-// line joined with newlines, ANSI escape codes stripped.
-func copyContentText(ts *TextState) (string, string) {
+// copyContentText resolves copy content for a text screen (YAML, JSON, or
+// error log): every line joined with newlines, ANSI escape codes stripped.
+// The label is screen-exact — BodyKindText covers all three screen IDs
+// (bodyKindForScreen), so a bare "YAML" label was wrong for JSON/error-log.
+func copyContentText(id runtime.ScreenID, ts *TextState) (string, string) {
 	if ts == nil || len(ts.Lines) == 0 {
 		return "", ""
 	}
@@ -137,7 +140,14 @@ func copyContentText(ts *TextState) (string, string) {
 		}
 		sb.WriteString(ansi.Strip(line))
 	}
-	return sb.String(), "Copied YAML to clipboard"
+	label := "Copied text to clipboard"
+	switch id {
+	case runtime.ScreenYAML:
+		label = "Copied YAML to clipboard"
+	case runtime.ScreenJSON:
+		label = "Copied JSON to clipboard"
+	}
+	return sb.String(), label
 }
 
 // copyContentIdentity resolves copy content for the identity screen: the

--- a/core/app/copy.go
+++ b/core/app/copy.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
+
+package app
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+	"gopkg.in/yaml.v3"
+
+	"github.com/k2m30/a9s/v3/core/fieldpath"
+	"github.com/k2m30/a9s/v3/core/resource"
+)
+
+// CopyContent resolves the (content, label) pair for the copy action ('c' in
+// the TUI, the web copy button) from the controller's current screen — the
+// single source of truth both renderers delegate to, so a resolution fix
+// (e.g. consulting the child-type registry for CopyField) lands for both at
+// once instead of drifting between a TUI-local implementation and a web
+// no-op.
+func (c *Controller) CopyContent() (content, label string) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.copyContent()
+}
+
+// copyContent is the lock-free core of CopyContent, also called by
+// snapshot() to populate ViewState.CopyText/CopyLabel from the identical
+// resolution. Callers must already hold c.mu (read or write).
+func (c *Controller) copyContent() (content, label string) {
+	if len(c.stack) == 0 {
+		return "", ""
+	}
+	switch bodyKindForScreen(c.stack[len(c.stack)-1]) {
+	case BodyKindList:
+		return c.copyContentList()
+	case BodyKindDetail:
+		return c.copyContentDetail()
+	case BodyKindText:
+		return copyContentText(c.topTextState())
+	case BodyKindIdentity:
+		return copyContentIdentity(c.buildIdentityBody())
+	default:
+		return "", ""
+	}
+}
+
+// copyContentList resolves copy content for the active resource/child list:
+// the type's CopyField value when the catalog registers one and the selected
+// row has it set, else the row's ID. The type lookup consults both the
+// top-level and child catalog registries — every CopyField entry in the
+// installed catalog is on a child type (core/aws/catalog_*.go) — so a
+// top-level-only lookup would never resolve one. Callers must hold c.mu.
+func (c *Controller) copyContentList() (string, string) {
+	r, ok := c.listSelected()
+	if !ok {
+		return "", ""
+	}
+	typeName := c.stack[len(c.stack)-1].Ctx.ResourceType
+	td := resource.FindResourceType(typeName)
+	if td == nil {
+		td = resource.GetChildType(typeName)
+	}
+	if td != nil && td.CopyField != "" {
+		if val := r.Fields[td.CopyField]; val != "" {
+			return val, "Copied: " + val
+		}
+	}
+	return r.ID, "Copied: " + r.ID
+}
+
+// copyContentDetail resolves copy content for the active detail screen: the
+// focused related row's DisplayName when the related panel has focus,
+// otherwise the FieldCursor row's Value (falling back to its Key when Value
+// is empty), otherwise the raw YAML of the detail resource. Callers must
+// hold c.mu.
+func (c *Controller) copyContentDetail() (string, string) {
+	ds := c.topDetailState()
+	if ds == nil {
+		return "", ""
+	}
+	if ds.RelatedFocus {
+		row := ds.focusedRelatedRow()
+		if row == nil || row.DisplayName == "" {
+			return "", ""
+		}
+		return row.DisplayName, "Copied: " + row.DisplayName
+	}
+	body := buildDetailBody(ds, c.viewConfig)
+	if fc := body.FieldCursor; fc >= 0 && fc < len(body.Fields) {
+		item := body.Fields[fc]
+		val := item.Value
+		if val == "" {
+			val = item.Key
+		}
+		if val != "" {
+			return val, "Copied: " + val
+		}
+	}
+	content := detailResourceRawYAML(ds.Resource)
+	if content == "" {
+		return "", ""
+	}
+	return content, "Copied detail to clipboard"
+}
+
+// detailResourceRawYAML marshals res to YAML text for the detail-screen copy
+// fallback, mirroring views.DetailModel.RawYAML's RawStruct-then-Fields
+// precedence. Kept in core (duplicated rather than shared) so CopyContent
+// never imports internal/tui.
+func detailResourceRawYAML(res resource.Resource) string {
+	var data []byte
+	var err error
+	if res.RawStruct != nil {
+		safe := fieldpath.ToSafeValue(reflect.ValueOf(res.RawStruct))
+		data, err = yaml.Marshal(safe)
+	} else if len(res.Fields) > 0 {
+		data, err = yaml.Marshal(res.Fields)
+	}
+	if err != nil || len(data) == 0 {
+		return ""
+	}
+	return string(data)
+}
+
+// copyContentText resolves copy content for a YAML/JSON text screen: every
+// line joined with newlines, ANSI escape codes stripped.
+func copyContentText(ts *TextState) (string, string) {
+	if ts == nil || len(ts.Lines) == 0 {
+		return "", ""
+	}
+	var sb strings.Builder
+	for i, line := range ts.Lines {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(ansi.Strip(line))
+	}
+	return sb.String(), "Copied YAML to clipboard"
+}
+
+// copyContentIdentity resolves copy content for the identity screen: the
+// resolved caller ARN once loaded, or ("", "") while loading or on an empty ARN.
+func copyContentIdentity(body *IdentityBody) (string, string) {
+	if body == nil || body.Loading || body.ARN == "" {
+		return "", ""
+	}
+	return body.ARN, "Copied!"
+}

--- a/core/app/intents.go
+++ b/core/app/intents.go
@@ -239,6 +239,16 @@ func (c *Controller) applyIntents(intents []runtime.UIIntent) ViewState {
 				c.identityErrMsg = ""
 			}
 
+		case runtime.ClearIdentityIntent:
+			// Emitted unconditionally by HandleProfileSelected/HandleRegionSelected
+			// (never by a same-pair refresh) so the previous pair's ARN is never
+			// served — via CopyContent or the identity screen — after a rotation,
+			// before the new pair's identity fetch (if any) lands. identityLoading
+			// is deliberately left alone: it is owned by handleActionOpenIdentity's
+			// fetch-start/fetch-end lifecycle, not this rotation chokepoint.
+			c.identityResult = nil
+			c.identityErrMsg = ""
+
 		case runtime.FlashIntent:
 			// Surface the transient notification (e.g. the API-error flash from
 			// HandleAPIError) as Header.Flash; cleared at the start of the next Apply.

--- a/core/app/snapshot.go
+++ b/core/app/snapshot.go
@@ -80,6 +80,7 @@ func (c *Controller) snapshot() ViewState {
 		vs.FrameTitle = costsFrameTitle(vs.Body.Costs)
 		vs.Footer = CostsFooterHintsFor(c.uiMode)
 	}
+	vs.CopyText, vs.CopyLabel = c.copyContent()
 	return vs
 }
 

--- a/core/app/viewstate.go
+++ b/core/app/viewstate.go
@@ -17,6 +17,12 @@ type ViewState struct {
 	Footer      []KeyHint `json:"footer,omitempty"`
 	HelpContext string    `json:"help_context,omitempty"`
 	Body        Body      `json:"body"`
+	// CopyText/CopyLabel are the (content, label) pair CopyContent() resolves
+	// for the current screen, so a renderer (the web copy key handler) can
+	// read the resolution straight off the snapshot instead of calling
+	// CopyContent() a second time.
+	CopyText  string `json:"copy_text,omitempty"`
+	CopyLabel string `json:"copy_label,omitempty"`
 }
 
 // Header mirrors the top bar rendered by internal/tui/layout.

--- a/core/runtime/handlers.go
+++ b/core/runtime/handlers.go
@@ -451,6 +451,7 @@ func (c *Core) HandleProfileSelected(ev ProfileSelectedEvent) ([]UIIntent, []Tas
 
 	intents := []UIIntent{
 		MenuClearAvailabilityIntent{},
+		ClearIdentityIntent{},
 		PopSelectorIntent{},
 		FlashIntent{Text: "Switching to " + ev.Profile + "..."},
 	}
@@ -674,6 +675,7 @@ func (c *Core) HandleRegionSelected(ev RegionSelectedEvent) ([]UIIntent, []TaskR
 
 	intents := []UIIntent{
 		MenuClearAvailabilityIntent{},
+		ClearIdentityIntent{},
 		PopSelectorIntent{},
 		FlashIntent{Text: "Switching to " + ev.Region + "..."},
 	}

--- a/core/runtime/intent.go
+++ b/core/runtime/intent.go
@@ -332,6 +332,16 @@ type SetIdentityIntent struct {
 
 func (SetIdentityIntent) isIntent() {}
 
+// ClearIdentityIntent tells the adapter to discard any resolved identity for
+// the outgoing profile/region pair. Emitted unconditionally by
+// HandleProfileSelected / HandleRegionSelected (never by a same-pair refresh,
+// e.g. menu Ctrl+R's MenuClearAvailabilityIntent) so a stale ARN from the
+// previous pair can never be copied or displayed before the new pair's
+// identity fetch (if any) lands.
+type ClearIdentityIntent struct{}
+
+func (ClearIdentityIntent) isIntent() {}
+
 // HeaderInvalidateIntent asks the adapter to bust the cached header so
 // the next View() pass recomputes the badge / role / right-side string.
 // Emitted alongside SetIdentityIntent on successful identity resolution

--- a/core/web/static/app.js
+++ b/core/web/static/app.js
@@ -133,7 +133,6 @@
     { key: "r",          action: { kind: "toggle-related" } },
     { key: "R",          action: { kind: "refresh" } },
     { key: "m",          action: { kind: "load-more" } },
-    { key: "c",          action: { kind: "copy" } },
     { key: "w",          action: { kind: "toggle-wrap" } },
     { key: "!",          action: { kind: "open-error-log" } },
     { key: "Tab",        action: { kind: "toggle-focus" } },
@@ -226,6 +225,24 @@
   function hideInputBar() {
     var bar = document.getElementById("input-bar");
     if (bar) bar.style.display = "none";
+  }
+
+  // showClientFlash displays a short-lived message in #client-flash, which
+  // lives outside #main (page.html) so it survives the next body swap
+  // instead of being wiped along with the server-rendered #flash. Used for
+  // the copy action's result, since a Clipboard API write only resolves
+  // client-side and has no /action round-trip to carry a server flash.
+  var clientFlashTimer = null;
+  function showClientFlash(text, isError) {
+    var el = document.getElementById("client-flash");
+    if (!el) return;
+    el.textContent = text;
+    el.className = isError ? "hdr-flash-err" : "hdr-flash-ok";
+    el.style.display = "block";
+    if (clientFlashTimer) clearTimeout(clientFlashTimer);
+    clientFlashTimer = setTimeout(function () {
+      el.style.display = "none";
+    }, 2000);
   }
 
   document.addEventListener("keydown", function (e) {
@@ -424,6 +441,28 @@
         e.preventDefault();
         return;
       }
+    }
+
+    // Copy: reads the copy text/label the controller resolved for the
+    // current screen (Controller.CopyContent, mirrored onto #body's
+    // data-copy-text/data-copy-label by ViewState.CopyText/CopyLabel) and
+    // writes it to the clipboard directly in this handler — the Clipboard
+    // API's writeText requires a user-activation call stack, so it cannot be
+    // deferred into the async /action round-trip like every other key.
+    if (e.key === "c" && !e.ctrlKey && !e.metaKey) {
+      e.preventDefault();
+      var bodyEl = document.getElementById("body");
+      var copyText = bodyEl ? (bodyEl.getAttribute("data-copy-text") || "") : "";
+      if (!copyText) return;
+      var copyLabel = bodyEl.getAttribute("data-copy-label") || "Copied!";
+      if (!navigator.clipboard || !navigator.clipboard.writeText) {
+        showClientFlash("Clipboard unavailable", true);
+        return;
+      }
+      navigator.clipboard.writeText(copyText)
+        .then(function () { showClientFlash(copyLabel, false); })
+        .catch(function () { showClientFlash("Copy failed", true); });
+      return;
     }
 
     // Look up in key map.

--- a/core/web/templates/main.html
+++ b/core/web/templates/main.html
@@ -1,7 +1,7 @@
 {{define "main.html"}}
 {{if .Header.Flash.Text}}<div id="flash" class="{{if .Header.Flash.IsError}}hdr-flash-err{{else}}hdr-flash-ok{{end}}">{{.Header.Flash.Text}}</div>{{else if .Header.ErrorHintVisible}}<div id="flash" class="hdr-flash-err">! for errors</div>{{end}}
 {{if .FrameTitle}}<div id="frame-title">{{.FrameTitle}}</div>{{end}}
-<div id="body">
+<div id="body" data-copy-text="{{.CopyText}}" data-copy-label="{{.CopyLabel}}">
   {{template "body.html" .Body}}
 </div>
 <div id="footer">

--- a/core/web/templates/page.html
+++ b/core/web/templates/page.html
@@ -52,6 +52,20 @@ body { background: var(--bg); color: var(--fg); height: 100vh; overflow: hidden;
 }
 #flash { padding: 2px 12px; background: var(--header); border-bottom: 1px solid var(--border); flex-shrink: 0; font-size: 13px; }
 
+/* client-flash mirrors #flash's look but lives outside #main (below) so a
+   client-only result (the copy action's clipboard write) survives the next
+   body swap instead of being wiped along with the server-rendered #flash. */
+#client-flash {
+  display: none;
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  padding: 2px 12px;
+  background: var(--header);
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+  z-index: 20;
+}
+
 /* main content (frame-title + body + footer) — swapped as one fragment on
    navigation so the title/footer update, not just the body. */
 #main { flex: 1; display: flex; flex-direction: column; min-height: 0; }
@@ -243,6 +257,8 @@ body { background: var(--bg); color: var(--fg); height: 100vh; overflow: hidden;
 <div id="main">
 {{template "main.html" .VS}}
 </div>
+
+<div id="client-flash"></div>
 
 <div id="input-bar"></div>
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -474,27 +474,15 @@ All in `internal/tui/views/`:
 | **SelectorModel** | `selector.go` | Generic list picker (profile, region, theme selection) |
 | **IdentityModel** | `identity.go` | Shows `sts:GetCallerIdentity` result |
 
-Views implement the `View` interface (`views/view.go`):
+Views are concrete models with no shared interface: each returns its own concrete type from its update method, and the root model's dispatch (`updateActiveRS`) type-switches on the active renderer state to route and write back.
 
-```go
-type View interface {
-    View() string
-    SetSize(w, h int)
-    FrameTitle() string
-    CopyContent() (string, string)
-    GetHelpContext() HelpContext
-}
-```
+Cross-view behaviors that older revisions expressed as per-view capability interfaces now live in the renderer-agnostic snapshot, so the TUI and web renderers consume one truth:
 
-`Update` is deliberately excluded from the interface because each view returns its own concrete type. The root model's `updateActiveView()` type-switches on each concrete type to dispatch and write back.
-
-**Optional capability interfaces** (`views/view.go`): views implement these only when the capability applies. The root model type-asserts against each interface and calls only the implementations present, so older views without the capability keep working.
-
-| Interface | Methods | Implemented by |
-|-----------|---------|----------------|
-| `Filterable` | `SetFilter(text string)`, `GetFilter() string` | Navigable list views (main menu, resource list, selector). Static views (detail, YAML, JSON, help, reveal) do NOT implement it. |
-| `Searchable` | `IsSearchActive() bool`, `IsSearchInputMode() bool`, `SearchInfo() string` | Text-content views (detail, YAML, JSON). Drives the search status line in the frame footer. |
-| `Hintable` | `BottomHints() []layout.KeyHint` | Views that render context-specific key hints along the bottom border. Views that omit it get a plain bottom border — the absence is backward-compatible. |
+| Behavior | Source of truth |
+|----------|-----------------|
+| Filter / search state | `ViewState` body fields (`ListBody.Filter`, `DetailBody.Search`, `TextBody.Search`, …) populated by the controller |
+| Footer key hints | `core/app` footer builders (`buildListFooterHints`, `MenuFooterHintsFor`, `CostsFooterHintsFor`) via `ViewState.Footer` |
+| Copy content (`c`) | `Controller.CopyContent()` (`core/app/copy.go`) — one resolution for list/detail/text/identity, exposed as `ViewState.CopyText`/`CopyLabel`; the TUI's `handleCopy` delegates to it, the web client reads the rendered `data-copy-*` attributes. Only the reveal screen's copy stays adapter-local (the controller has no reveal screen). |
 
 ### Issue Counting & Attention Filter
 

--- a/internal/tui/runtime_adapter.go
+++ b/internal/tui/runtime_adapter.go
@@ -133,17 +133,19 @@ func (m *Model) applyIntent(intent runtime.UIIntent) tea.Cmd {
 		// by SetIdentityIntent's loop over m.stack (app_dispatch.go). Without
 		// this, a rotation that reveals an already-pushed identity rs (e.g.
 		// selector-on-top popped by PopSelectorIntent) would keep showing the
-		// previous pair's ARN. Reset every identity rs to a truthful
-		// "re-fetching" state; loading=true is truthful without dispatching a
-		// fetch here because the reconnect task already in this batch
-		// (HandleClientsReady success, core/runtime/handlers.go) dispatches
-		// TaskKindFetchIdentity itself against the NEW clients — dispatching
-		// our own fetch here would race it using the still-old clients.
+		// previous pair's ARN. Reset every identity rs to a truthful state;
+		// loading=true is only truthful when a post-connect refetch will
+		// actually follow — HandleClientsReady's no-cache branch skips
+		// TaskKindFetchIdentity entirely (core/runtime/handlers.go, "Identity
+		// fetch is skipped in this mode (synthetic creds)"), so no-cache
+		// rotation zeroes the data and leaves loading=false (a blank identity
+		// screen; pressing i again re-fetches) instead of spinning forever.
+		willRefetch := !m.core.NoCache()
 		for _, s := range m.stack {
 			if s.kind == rsKindIdentity {
 				s.identityData = views.IdentityData{}
 				s.identityErr = ""
-				s.identityLoading = true
+				s.identityLoading = willRefetch
 			}
 		}
 	case runtime.PopSelectorIntent:

--- a/internal/tui/runtime_adapter.go
+++ b/internal/tui/runtime_adapter.go
@@ -36,6 +36,7 @@ import (
 	"github.com/k2m30/a9s/v3/core/resource"
 	"github.com/k2m30/a9s/v3/core/runtime"
 	"github.com/k2m30/a9s/v3/core/runtime/messages"
+	"github.com/k2m30/a9s/v3/internal/tui/views"
 )
 
 // handleEnrichDetail invokes m.core.HandleEnrichDetail (Core builds the payload's
@@ -125,6 +126,29 @@ func (m *Model) applyIntent(intent runtime.UIIntent) tea.Cmd {
 		m.ctrl.ApplyIntents([]runtime.UIIntent{runtime.MenuClearAvailabilityIntent{}})
 	case runtime.ClearIdentityIntent:
 		m.ctrl.ApplyIntents([]runtime.UIIntent{runtime.ClearIdentityIntent{}})
+		// The controller forward above clears ctrl.identityResult, but the
+		// identity overlay's DISPLAYED state lives on the renderer's own
+		// rendererState (identityData/identityLoading/identityErr — see
+		// newIdentityRS's doc comment), populated by the 'i' key handler and
+		// by SetIdentityIntent's loop over m.stack (app_dispatch.go). Without
+		// this, a rotation that reveals an already-pushed identity rs (e.g.
+		// selector-on-top popped by PopSelectorIntent) would keep showing the
+		// previous pair's ARN. Reset every identity rs to a truthful
+		// "re-fetching" state and re-dispatch the same fetch the 'i' key
+		// uses, so the screen actually clears instead of going stale.
+		identityReset := false
+		for _, s := range m.stack {
+			if s.kind == rsKindIdentity {
+				s.identityData = views.IdentityData{}
+				s.identityErr = ""
+				s.identityLoading = true
+				identityReset = true
+			}
+		}
+		if identityReset {
+			m.core.SetIdentityFetching(true)
+			return m.fetchIdentity(m.core.ConnectGen())
+		}
 	case runtime.PopSelectorIntent:
 		// Controller-first (goal 4): forward so the controller applies its own
 		// type-checked gate (pop only when top.ID is a selector screen —

--- a/internal/tui/runtime_adapter.go
+++ b/internal/tui/runtime_adapter.go
@@ -134,20 +134,17 @@ func (m *Model) applyIntent(intent runtime.UIIntent) tea.Cmd {
 		// this, a rotation that reveals an already-pushed identity rs (e.g.
 		// selector-on-top popped by PopSelectorIntent) would keep showing the
 		// previous pair's ARN. Reset every identity rs to a truthful
-		// "re-fetching" state and re-dispatch the same fetch the 'i' key
-		// uses, so the screen actually clears instead of going stale.
-		identityReset := false
+		// "re-fetching" state; loading=true is truthful without dispatching a
+		// fetch here because the reconnect task already in this batch
+		// (HandleClientsReady success, core/runtime/handlers.go) dispatches
+		// TaskKindFetchIdentity itself against the NEW clients — dispatching
+		// our own fetch here would race it using the still-old clients.
 		for _, s := range m.stack {
 			if s.kind == rsKindIdentity {
 				s.identityData = views.IdentityData{}
 				s.identityErr = ""
 				s.identityLoading = true
-				identityReset = true
 			}
-		}
-		if identityReset {
-			m.core.SetIdentityFetching(true)
-			return m.fetchIdentity(m.core.ConnectGen())
 		}
 	case runtime.PopSelectorIntent:
 		// Controller-first (goal 4): forward so the controller applies its own

--- a/internal/tui/runtime_adapter.go
+++ b/internal/tui/runtime_adapter.go
@@ -123,6 +123,8 @@ func (m *Model) applyIntent(intent runtime.UIIntent) tea.Cmd {
 		}
 	case runtime.MenuClearAvailabilityIntent:
 		m.ctrl.ApplyIntents([]runtime.UIIntent{runtime.MenuClearAvailabilityIntent{}})
+	case runtime.ClearIdentityIntent:
+		m.ctrl.ApplyIntents([]runtime.UIIntent{runtime.ClearIdentityIntent{}})
 	case runtime.PopSelectorIntent:
 		// Controller-first (goal 4): forward so the controller applies its own
 		// type-checked gate (pop only when top.ID is a selector screen —

--- a/internal/tui/runtime_adapter_navigate.go
+++ b/internal/tui/runtime_adapter_navigate.go
@@ -21,7 +21,6 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/atotto/clipboard"
-	"github.com/charmbracelet/x/ansi"
 
 	"github.com/k2m30/a9s/v3/core/app"
 	"github.com/k2m30/a9s/v3/core/config"
@@ -503,76 +502,20 @@ func navigateTasksToCmd(m Model, tasks []runtime.TaskRequest) tea.Cmd {
 	}
 }
 
-// handleCopy performs context-dependent clipboard copy as a tea.Cmd.
-// Dispatches by active rs.kind to produce (content, label) pairs.
+// handleCopy performs context-dependent clipboard copy as a tea.Cmd. The
+// reveal screen stays TUI-local — the controller has no reveal screen — so
+// it is handled directly from the renderer's own rs.revealValue; every other
+// kind delegates to the controller's CopyContent, the single source of truth
+// shared with the web renderer.
 func (m Model) handleCopy() (tea.Model, tea.Cmd) {
 	rs := m.activeRS()
-	snap := m.ctrl.Snapshot()
-	var content, label string
-	switch rs.kind {
-	case rsKindList:
-		r, ok := m.ctrl.ListSelected()
-		if !ok {
+	if rs.kind == rsKindReveal {
+		if rs.revealValue == "" {
 			return m, nil
 		}
-		rt := resource.FindResourceType(rs.resourceType)
-		if rt != nil && rt.CopyField != "" {
-			if val, ok2 := r.Fields[rt.CopyField]; ok2 && val != "" {
-				content, label = val, "Copied: "+val
-				break
-			}
-		}
-		content, label = r.ID, "Copied: "+r.ID
-	case rsKindDetail:
-		if rs.rightCol.IsFocused() {
-			// Copy the focused related row's name from controller state (the
-			// same row the renderer highlights), not the right-column widget.
-			if row, ok := m.ctrl.SelectedRelatedRow(); ok && row.DisplayName != "" {
-				content, label = row.DisplayName, "Copied: "+row.DisplayName
-			}
-			break
-		}
-		if snap.Body.Detail != nil {
-			fc := snap.Body.Detail.FieldCursor
-			if fc >= 0 && fc < len(snap.Body.Detail.Fields) {
-				item := snap.Body.Detail.Fields[fc]
-				val := item.Value
-				if val == "" {
-					val = item.Key
-				}
-				if val != "" {
-					content, label = val, "Copied: "+val
-					break
-				}
-			}
-		}
-		// Fallback: copy raw YAML of the detail resource.
-		if snap.Body.Detail != nil {
-			rawLines := snap.Body.Detail.Fields
-			_ = rawLines
-			// Build raw YAML using the controller resource.
-			res := m.ctrl.GetDetailResource()
-			if res.ID != "" {
-				content = views.RawYAMLFromResource(res)
-				if content != "" {
-					label = "Copied detail to clipboard"
-				}
-			}
-		}
-	case rsKindReveal:
-		content, label = rs.revealValue, "Secret copied to clipboard"
-	case rsKindText:
-		if snap.Body.Text != nil {
-			content = rawContentFromTextBody(snap.Body.Text)
-			if content != "" {
-				label = "Copied YAML to clipboard"
-			}
-		}
-	case rsKindIdentity:
-		if !rs.identityLoading && rs.identityData.ARN != "" {
-			content, label = rs.identityData.ARN, "Copied!"
-		}
+		return m, copyToClipboard(rs.revealValue, "Secret copied to clipboard")
 	}
+	content, label := m.ctrl.CopyContent()
 	if content == "" {
 		return m, nil
 	}
@@ -782,23 +725,6 @@ func (m Model) refreshActiveListWithEnrichmentRerun(tok domain.Gen) tea.Cmd {
 		}
 		return msg
 	}
-}
-
-// rawContentFromTextBody returns the plain-text content from a TextBody for
-// clipboard copy. Joins lines with newlines, stripping any ANSI color codes
-// that the syntax-colorizer may have embedded.
-func rawContentFromTextBody(body *app.TextBody) string {
-	if body == nil {
-		return ""
-	}
-	var sb strings.Builder
-	for i, line := range body.Lines {
-		if i > 0 {
-			sb.WriteByte('\n')
-		}
-		sb.WriteString(ansi.Strip(line))
-	}
-	return sb.String()
 }
 
 // handleReveal fetches a revealed value using the resource type's registered

--- a/releases/v3.55.2.md
+++ b/releases/v3.55.2.md
@@ -1,0 +1,71 @@
+# v3.55.2 — Web copy works, identity stops time-traveling
+
+A patch release fixing the web-mode copy key — a silent no-op since web
+mode shipped — by moving copy resolution into the headless controller as
+the single source both renderers consume. The review cycle on that
+change (CodeRabbit + five adversarial Codex rounds, every finding pinned
+by a red test first) surfaced and closed a concurrency crash and a
+family of stale-identity defects around profile/region rotation.
+
+## Web copy (#478)
+
+Pressing `c` in `--web` mode did nothing: the client POSTed
+`{kind:"copy"}` to a server whose `ActionCopy` is a deliberate
+renderer-only no-op, and the web renderer never implemented its half.
+
+Copy content is now resolved once, in the controller
+(`Controller.CopyContent`) — list rows (per-type `CopyField`, else row
+ID), detail (focused related row → field cursor → raw-YAML fallback),
+YAML/JSON text (ANSI-stripped, screen-exact label), identity (ARN) —
+and exposed through `ViewState.CopyText/CopyLabel`, rendered as
+`data-copy-*` attributes on the body fragment. The web client writes
+the clipboard inside the keydown handler (user-activation rules,
+Safari included) and shows a client-side flash that survives fragment
+swaps; clipboard-unavailable and write failures flash as errors. The
+TUI's `handleCopy` now delegates to the same resolution — its
+duplicated logic is deleted, so the two renderers can no longer drift.
+
+Along the way the shared lookup fixed a latent app-wide bug: every
+`CopyField` in the catalog lives on a child type, but the old path
+consulted only the top-level registry — `CopyField` never resolved
+anywhere and copy always fell back to the row ID. On an
+`sns_subscriptions` child list, `c` now copies the subscription
+endpoint, as the catalog always intended.
+
+## Concurrency
+
+`CopyContent`'s detail branch reaches the mutating detail-body builder
+(attention-detail merge into a shared map). Under the read lock it
+crashed outright — `fatal error: concurrent map writes` — with two
+concurrent callers; the race test that pins this reproduced the crash
+within a handful of iterations. It now takes the write lock, the same
+contract `Snapshot()` documents for this builder class.
+
+## Identity vs. rotation
+
+Rotating profile or region cleared the session identity but not the
+controller's cached copy, nor the TUI identity screen's renderer state
+— the previous pair's account/ARN kept rendering (and, post-delegation,
+copying) until a refetch happened to land. Three coupled fixes, each
+pinned by its own red test:
+
+- A new `ClearIdentityIntent`, emitted by both rotation handlers,
+  clears the controller cache and the TUI identity renderer state at
+  one shared chokepoint — a dedicated intent rather than piggybacking
+  on `MenuClearAvailabilityIntent`, so a same-pair menu refresh never
+  blanks a valid identity.
+- Rotation itself never fetches identity. The session deliberately
+  retains the old clients until `ClientsReady`; an eager fetch re-lands
+  the outgoing profile's ARN stamped with the new generation (both
+  reviewers converged on this after one proposed each direction).
+  Repopulation is owned by the post-connect fetch chain, which the web
+  drain and the TUI both already run.
+- On `--no-cache` rotations (demo mode included) that chain skips the
+  identity fetch by design, so the reset screen shows blank instead of
+  an unresolvable "Fetching identity...".
+
+## For `core/` importers
+
+New exports: `app.Controller.CopyContent` (write-locking),
+`app.ViewState.CopyText`/`CopyLabel` (JSON: `copy_text`/`copy_label`),
+`runtime.ClearIdentityIntent`. No breaking changes.

--- a/tests/unit/tui_identity_rotation_test.go
+++ b/tests/unit/tui_identity_rotation_test.go
@@ -156,3 +156,99 @@ func TestRoot_ProfileRotation_DispatchesNoIdentityFetchBeforeReconnect(t *testin
 		}
 	}
 }
+
+// identityFetchingPlaceholder is the exact loading string renderIdentity's
+// live path shows (views/identity.go's renderLoading, reached whenever
+// rs.identityLoading is true — internal/tui/renderer.go's renderIdentity).
+const identityFetchingPlaceholder = "Fetching identity..."
+
+// TestRoot_NoCacheRotation_IdentityScreenNotStuckLoading is a Codex round-5
+// P2 finding, the last in this identity-rotation chain: core/runtime/
+// handlers.go's no-cache success branch (handleClientsReadySuccess, "Demo /
+// no-cache: synchronous prefetch instead of the async probe pipeline.
+// Identity fetch is skipped in this mode (synthetic creds).") never
+// dispatches TaskKindFetchIdentity. The ClearIdentityIntent case (internal/
+// tui/runtime_adapter.go) sets rs.identityLoading=true on rotation
+// expecting the reconnect's OWN identity fetch to resolve it — true on the
+// live path (handlers.go dispatches TaskKindFetchIdentity itself there) but
+// never true in --no-cache/demo mode, so a rotation while the identity
+// screen is open leaves it showing "Fetching identity..." forever.
+//
+// Cheapest no-cache arrangement: tui.WithNoCache(true) (internal/tui/
+// app_options.go's WithNoCache calls m.core.SetNoCache, the same session.
+// NoCache flag handlers.go's "if s.NoCache" branches on) — the same option
+// already used by the sibling tests above and by text_ports_test.go's reveal
+// tests, paired with tui.WithClients so Init() doesn't need a live connect.
+//
+// The rotation's OWN Connect task cmd fails locally for the bogus
+// "other-profile" (SharedConfigProfileNotExistError — no such profile in
+// ~/.aws/config), so its raw messages.ClientsReady carries a real Err and
+// would take the error branch, never reaching the no-cache success path
+// this test targets. A successful reconnect is modeled instead by reusing
+// that message's own Region/Gen (so the ConnectGen staleness check still
+// matches) with Err cleared and the same demo Clients reinstalled — this is
+// the "no-cache ClientsReady" a genuinely successful rotation would deliver.
+func TestRoot_NoCacheRotation_IdentityScreenNotStuckLoading(t *testing.T) {
+	clients := demo.NewServiceClients()
+	tui.Version = "test"
+	m := tui.New("test-profile", "us-east-1", tui.WithClients(clients), tui.WithNoCache(true))
+	m, _ = rootApplyMsg(m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m, _ = rootApplyMsg(m, messages.ClientsReady{Clients: clients, Region: "us-east-1", Gen: 0})
+
+	m, cmd := rootApplyMsg(m, rootKeyPress("i"))
+	if cmd == nil {
+		t.Fatal("pressing 'i' with clients ready must return a non-nil fetchIdentity cmd")
+	}
+	loadedMsg := cmd()
+	loaded, ok := loadedMsg.(messages.IdentityLoaded)
+	if !ok || loaded.Identity == nil {
+		t.Fatalf("initial fetchIdentity did not produce messages.IdentityLoaded with a non-nil Identity (cannot reproduce via this harness): got %T: %+v", loadedMsg, loadedMsg)
+	}
+	loadedIdentity, ok := loaded.Identity.(*awsclient.CallerIdentity)
+	if !ok {
+		t.Fatalf("messages.IdentityLoaded.Identity is not a *awsclient.CallerIdentity: got %T", loaded.Identity)
+	}
+	staleARN := loadedIdentity.Arn
+	if staleARN == "" {
+		t.Fatal("precondition: demo STS transport returned an empty ARN — cannot pin staleness against an empty string")
+	}
+	m, _ = rootApplyMsg(m, loaded)
+
+	plain := stripANSI(rootViewContent(m))
+	if !strings.Contains(plain, staleARN) {
+		t.Fatalf("precondition: identity screen must show the fetched ARN %q before rotation, got:\n%s", staleARN, plain)
+	}
+
+	m, _ = rootApplyMsg(m, messages.Navigate{Target: messages.TargetProfile})
+	m, cmd = rootApplyMsg(m, messages.ProfileSelected{Profile: "other-profile"})
+	if cmd == nil {
+		t.Fatal("ProfileSelected must return a non-nil cmd")
+	}
+
+	var rawReady *messages.ClientsReady
+	for _, got := range wave5CollectCmdMsgs(cmd) {
+		if cr, ok := got.(messages.ClientsReady); ok {
+			rawReady = &cr
+			break
+		}
+	}
+	if rawReady == nil {
+		t.Fatal("ProfileSelected's cmd tree produced no messages.ClientsReady to derive a successful reconnect from")
+	}
+	// Reinstall the same demo clients and clear Err — the local connect
+	// attempt fails (no such profile), but the Region/Gen the framework
+	// itself computed are reused so the no-cache success path is entered
+	// under the exact ConnectGen the rotation armed.
+	noCacheReady := messages.ClientsReady{Clients: clients, Region: rawReady.Region, Gen: rawReady.Gen}
+	m, _ = rootApplyMsg(m, noCacheReady)
+
+	final := stripANSI(rootViewContent(m))
+	if strings.Contains(final, staleARN) {
+		t.Errorf("identity screen still shows the stale pre-switch ARN %q after the no-cache reconnect settled; got:\n%s", staleARN, final)
+	}
+	if strings.Contains(final, identityFetchingPlaceholder) {
+		t.Errorf("identity screen is stuck on the %q placeholder after the no-cache reconnect settled — "+
+			"no-cache/demo mode never dispatches TaskKindFetchIdentity (core/runtime/handlers.go), so nothing "+
+			"ever resolves the loading state ClearIdentityIntent set; got:\n%s", identityFetchingPlaceholder, final)
+	}
+}

--- a/tests/unit/tui_identity_rotation_test.go
+++ b/tests/unit/tui_identity_rotation_test.go
@@ -1,0 +1,81 @@
+package unit
+
+import (
+	"strings"
+	"testing"
+
+	awsclient "github.com/k2m30/a9s/v3/core/aws"
+	"github.com/k2m30/a9s/v3/core/runtime/messages"
+)
+
+// TestRoot_IdentityScreen_StaleARN_ClearedAfterProfileRotation is a Codex
+// round-3 P2 finding: ClearIdentityIntent (emitted by
+// HandleProfileSelected/HandleRegionSelected on rotation) is forwarded by the
+// TUI's applyIntent (internal/tui/runtime_adapter.go, ClearIdentityIntent
+// case) to the CONTROLLER only. The identity SCREEN's own renderer state
+// (rs.identityData/rs.identityLoading on the rendererState stack, populated
+// via runtime.SetIdentityIntent's loop over m.stack in app_dispatch.go's
+// applyIntents) is never reset — nothing clears it on a profile/region
+// switch.
+//
+// Real flow driven here (confirmed empirically — see the stack-shape
+// t.Logf below): press 'i' (pushes rsKindIdentity, loading=true, schedules a
+// fetch) -> messages.IdentityLoaded lands while that rs is still on the
+// stack (populates rs.identityData via the live SetIdentityIntent path,
+// exactly as TestRoot_IdentityLoaded_UpdatesHeader/text_ports_test.go's
+// TestPort_IdentityCopy_CopiesExactARN do) -> the ':' key is a GLOBAL key in
+// app_input.go's key router (no rs.kind guard, unlike Identity/Help/ErrorLog
+// which only special-case their OWN key), so colon-command mode works from
+// the identity screen -> "profile"/"ctx" resolves to
+// messages.Navigate{Target: messages.TargetProfile} (app_input.go's
+// executeCommand), pushing the profile selector ON TOP of the still-present
+// identity rs -> messages.ProfileSelected{Profile: ...} is exactly what the
+// selector's Enter-confirm emits (core/runtime/messages/cmd.go), routed to
+// Model.handleProfileSelected -> Core.HandleProfileSelected ->
+// dispatchHandlerResult -> applyIntent per intent, including the buggy
+// ClearIdentityIntent forward -> PopSelectorIntent (also emitted) pops the
+// selector screen (it only pops a profile/region/theme selector — core/app/
+// intents.go), REVEALING the identity screen again, still carrying the
+// stale, pre-switch ARN.
+func TestRoot_IdentityScreen_StaleARN_ClearedAfterProfileRotation(t *testing.T) {
+	m := newRootSizedModel()
+
+	m, _ = rootApplyMsg(m, rootKeyPress("i"))
+
+	staleARN := "arn:aws:iam::123456789012:user/stale-preswitch-operator"
+	m, _ = rootApplyMsg(m, messages.IdentityLoaded{
+		Identity: &awsclient.CallerIdentity{
+			AccountID: "123456789012",
+			Arn:       staleARN,
+			UserName:  "stale-preswitch-operator",
+		},
+		Gen: 0,
+	})
+
+	plain := stripANSI(rootViewContent(m))
+	if !strings.Contains(plain, staleARN) {
+		t.Fatalf("precondition: identity screen must show the loaded ARN before rotation, got:\n%s", plain)
+	}
+
+	// Open the profile selector on top of the identity screen via the same
+	// colon-command flow a real user takes (':' is a global key even while
+	// on the identity screen — app_input.go).
+	m, _ = rootApplyMsg(m, messages.Navigate{Target: messages.TargetProfile})
+	t.Logf("after Navigate(TargetProfile) while on identity screen, view contains 'identity'=%v 'profile'=%v",
+		strings.Contains(strings.ToLower(stripANSI(rootViewContent(m))), "identity"),
+		strings.Contains(strings.ToLower(stripANSI(rootViewContent(m))), "profile"))
+
+	// Confirm a different profile — the exact message the selector's Enter
+	// key emits (core/runtime/messages/cmd.go's ProfileSelected).
+	m, _ = rootApplyMsg(m, messages.ProfileSelected{Profile: "other-profile"})
+
+	afterPlain := strings.ToLower(stripANSI(rootViewContent(m)))
+	t.Logf("after ProfileSelected, view contains 'identity'=%v (stack should have popped the selector, revealing identity)",
+		strings.Contains(afterPlain, "identity"))
+
+	if strings.Contains(rootViewContent(m), staleARN) {
+		t.Errorf("identity screen must NOT show the stale pre-switch ARN %q after a profile rotation "+
+			"(a loading placeholder or blank is fine — the old ARN must be cleared); got:\n%s",
+			staleARN, stripANSI(rootViewContent(m)))
+	}
+}

--- a/tests/unit/tui_identity_rotation_test.go
+++ b/tests/unit/tui_identity_rotation_test.go
@@ -4,8 +4,12 @@ import (
 	"strings"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
+
 	awsclient "github.com/k2m30/a9s/v3/core/aws"
+	"github.com/k2m30/a9s/v3/core/demo"
 	"github.com/k2m30/a9s/v3/core/runtime/messages"
+	"github.com/k2m30/a9s/v3/internal/tui"
 )
 
 // TestRoot_IdentityScreen_StaleARN_ClearedAfterProfileRotation is a Codex
@@ -77,5 +81,78 @@ func TestRoot_IdentityScreen_StaleARN_ClearedAfterProfileRotation(t *testing.T) 
 		t.Errorf("identity screen must NOT show the stale pre-switch ARN %q after a profile rotation "+
 			"(a loading placeholder or blank is fine — the old ARN must be cleared); got:\n%s",
 			staleARN, stripANSI(rootViewContent(m)))
+	}
+}
+
+// wave5CollectCmdMsgs recursively executes cmd, flattening any nested
+// tea.BatchMsg into the flat list of leaf tea.Msg values every terminal cmd
+// in the tree produced. Nothing is fed back into any model — this is a pure
+// structural inspection of what a dispatch WOULD deliver, used to assert on
+// the shape of a cmd tree without executing side-effecting cmds (like a real
+// AWS connect) any further than calling them once each.
+func wave5CollectCmdMsgs(cmd tea.Cmd) []tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if msg == nil {
+		return nil
+	}
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var all []tea.Msg
+		for _, c := range batch {
+			all = append(all, wave5CollectCmdMsgs(c)...)
+		}
+		return all
+	}
+	return []tea.Msg{msg}
+}
+
+// TestRoot_ProfileRotation_DispatchesNoIdentityFetchBeforeReconnect is a
+// Codex round-4 P2 finding, reworked into a structural contract test after
+// the coder's fix landed: internal/tui/runtime_adapter.go's
+// ClearIdentityIntent case used to return m.fetchIdentity(m.core.ConnectGen())
+// IMMEDIATELY on rotation. But Session.Rotate() (core/session/session.go)
+// deliberately keeps the OLD clients until a ClientsReady for the new
+// profile lands (core/runtime/handlers.go's ClientsReady/"Live AWS path"
+// always dispatches its OWN TaskKindFetchIdentity afterward with the NEW
+// clients) — so that premature fetch resolved the OUTGOING profile's
+// identity via the OLD clients, yet stamped it with the NEW ConnectGen,
+// getting accepted as fresh once IdentityLoaded landed.
+//
+// A content-based "stale ARN absent" assertion cannot distinguish stale from
+// fresh here: the demo STS fake returns the SAME identity for every profile,
+// so the legitimate POST-connect refetch shows an identical ARN too. The
+// only thing that actually distinguishes correct from broken is WHICH cmds
+// a profile rotation dispatches — so this asserts the structural contract
+// directly: messages.ProfileSelected's cmd tree must never contain an
+// IdentityLoaded message. messages.ClientsReady (from the Connect task) and
+// the flash tick are expected and are only inspected, never delivered back
+// into the model (delivering ClientsReady would itself trigger the
+// legitimate follow-up identity fetch, muddying what this test isolates).
+func TestRoot_ProfileRotation_DispatchesNoIdentityFetchBeforeReconnect(t *testing.T) {
+	clients := demo.NewServiceClients()
+	tui.Version = "test"
+	m := tui.New("test-profile", "us-east-1", tui.WithClients(clients), tui.WithNoCache(true))
+	m, _ = rootApplyMsg(m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m, _ = rootApplyMsg(m, messages.ClientsReady{Clients: clients, Region: "us-east-1", Gen: 0})
+
+	_, cmd := rootApplyMsg(m, messages.ProfileSelected{Profile: "other-profile"})
+	if cmd == nil {
+		t.Fatal("ProfileSelected must return a non-nil cmd")
+	}
+
+	msgs := wave5CollectCmdMsgs(cmd)
+	if len(msgs) == 0 {
+		t.Fatal("ProfileSelected's cmd tree produced no messages at all — harness did not actually exercise the dispatch")
+	}
+	t.Logf("ProfileSelected dispatched %d message(s): %#v", len(msgs), msgs)
+
+	for _, got := range msgs {
+		if _, ok := got.(messages.IdentityLoaded); ok {
+			t.Errorf("ProfileSelected's dispatched cmds must NOT fetch identity before the reconnect lands "+
+				"(identity may only arrive as a follow-up of ClientsReady with the NEW clients); "+
+				"got messages.IdentityLoaded among the dispatched messages: %#v", msgs)
+		}
 	}
 }

--- a/tests/unit/web_copy_content_test.go
+++ b/tests/unit/web_copy_content_test.go
@@ -10,6 +10,7 @@ package unit_test
 
 import (
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/k2m30/a9s/v3/core/app"
@@ -469,4 +470,77 @@ func TestCopyContent_NoOpScreens_ReturnEmpty(t *testing.T) {
 			t.Errorf("CopyContent() on the costs screen = (%q, %q), want (\"\", \"\")", content, label)
 		}
 	})
+}
+
+// ===========================================================================
+// 8. Concurrency — CopyContent() must be safe to call from multiple
+// goroutines. Codex P2 finding (core/app/copy.go): CopyContent() takes only
+// c.mu.RLock(), but its detail branch calls buildDetailBody ->
+// buildDetailFieldItems, which — whenever ds.Resource.AttentionDetails is
+// already a non-nil map — merges ds.AttentionDetails into it in place via
+// maps.Copy (detail_body.go). That merge MUTATES a map shared across every
+// call, the same class of builder-mutation snapshot.go's own doc comment
+// says requires the WRITE lock ("buildListBody ... may populate
+// ListState.bodyMemo on a cache miss"). Concurrent CopyContent() calls on a
+// detail screen with pre-populated AttentionDetails therefore race on that
+// shared map.
+// ===========================================================================
+
+// wave4ConcurrentCopyResource carries a non-nil, non-empty AttentionDetails
+// map (set on the resource itself, not just delivered later via
+// ApplyDetailFinding) so ensureDetailState seeds ds.Resource.AttentionDetails
+// as a non-nil map AND ds.AttentionDetails (a clone) as non-empty — the exact
+// precondition that makes buildDetailFieldItems's "if r.AttentionDetails ==
+// nil { r.AttentionDetails = make(...) }" guard skip allocating a fresh map,
+// so every call's maps.Copy writes into the SAME shared map instead.
+func wave4ConcurrentCopyResource() resource.Resource {
+	code := domain.FindingCode("concurrent.test.finding")
+	return resource.Resource{
+		ID:   "res-detail-004",
+		Name: "detail-concurrent-test",
+		AttentionDetails: map[domain.FindingCode]domain.AttentionDetail{
+			code: {Rows: []domain.DetailRow{{Label: "Action", Value: "reboot"}}},
+		},
+	}
+}
+
+// TestCopyContent_ConcurrentCallsAreSerialized hammers CopyContent() from
+// several goroutines on the same detail screen. Each goroutine writes only
+// to its own disjoint slice range (no race in the harness itself) so any
+// race reported by `go test -race` is exclusively inside CopyContent()'s own
+// locking. Asserts nothing beyond "no panic and every call agrees" — the
+// race detector, not this assertion, is the oracle for the locking bug.
+func TestCopyContent_ConcurrentCallsAreSerialized(t *testing.T) {
+	c := newDetailController(t, wave4ConcurrentCopyResource(), "copytest-detail-concurrent")
+
+	const goroutines = 8
+	const iterations = 50
+
+	type copyResult struct{ content, label string }
+	results := make([][]copyResult, goroutines)
+	for g := range results {
+		results[g] = make([]copyResult, iterations)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := range goroutines {
+		go func(g int) {
+			defer wg.Done()
+			for i := range iterations {
+				content, label := c.CopyContent()
+				results[g][i] = copyResult{content, label}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	want := results[0][0]
+	for g := range results {
+		for i, got := range results[g] {
+			if got != want {
+				t.Errorf("CopyContent() result diverged across concurrent calls: goroutine %d iter %d = %+v, want %+v", g, i, got, want)
+			}
+		}
+	}
 }

--- a/tests/unit/web_copy_content_test.go
+++ b/tests/unit/web_copy_content_test.go
@@ -291,19 +291,16 @@ func TestCopyContent_Detail_FallbackToRawYAML_WhenNoUsableField(t *testing.T) {
 // 5. Text screen (YAML/JSON) — ANSI-stripped, newline-joined content.
 // ===========================================================================
 
-func TestCopyContent_Text_StripsANSI_JoinsLines(t *testing.T) {
-	res := resource.Resource{
-		ID:   "i-0copytext001",
-		Name: "copy-text-server",
-		Fields: map[string]string{
-			"state":         "running",
-			"instance_type": "t3.medium",
-		},
-	}
-	m := views.NewYAMLWithCtrl(res, "ec2", keys.Default(), nil)
-	m.SetSize(120, 40)
-	lines := m.ContentLines()
-
+// wave4AssertTextScreenCopy pushes screenID with lines via the blessed
+// newTestController helper (see qa_controller_construction_discipline_test.go
+// — a direct app.New here isn't callable from this package's
+// newTextScreenController equivalent, which lives in package unit) and
+// asserts CopyContent()'s content is the ANSI-stripped, newline-joined body
+// with the screen-exact label (BodyKindText covers ScreenYAML, ScreenJSON,
+// and ScreenErrorLog — copyContentText, core/app/copy.go — so the label must
+// vary by id, not stay hardcoded to "YAML").
+func wave4AssertTextScreenCopy(t *testing.T, screenID runtime.ScreenID, lines []string, wantLabel string) {
+	t.Helper()
 	hasANSI := false
 	for _, l := range lines {
 		if strings.Contains(l, "\x1b[") {
@@ -312,17 +309,11 @@ func TestCopyContent_Text_StripsANSI_JoinsLines(t *testing.T) {
 		}
 	}
 	if !hasANSI {
-		t.Fatal("precondition: YAML ContentLines() must contain ANSI color codes for this test to be meaningful")
+		t.Fatal("precondition: ContentLines() must contain ANSI color codes for this test to be meaningful")
 	}
 
-	// Route construction through the blessed newTestController helper (see
-	// qa_controller_construction_discipline_test.go) instead of a direct
-	// app.New — it already pairs t.TempDir()/t.Cleanup(c.Close) correctly;
-	// text_ports_test.go's newTextScreenController does the same
-	// PushScreen+EnsureTextState arrangement but lives in package unit, not
-	// unit_test, so it isn't callable from here.
 	c := newTestController(t)
-	c.ApplyIntents([]runtime.UIIntent{runtime.PushScreen{ID: runtime.ScreenYAML}})
+	c.ApplyIntents([]runtime.UIIntent{runtime.PushScreen{ID: screenID}})
 	c.EnsureTextState(lines)
 
 	content, label := wave4AssertCopyContent(t, c)
@@ -333,9 +324,32 @@ func TestCopyContent_Text_StripsANSI_JoinsLines(t *testing.T) {
 	if content != wantPlain {
 		t.Errorf("CopyContent() content mismatch:\ngot:\n%q\nwant:\n%q", content, wantPlain)
 	}
-	if label != "Copied YAML to clipboard" {
-		t.Errorf("CopyContent() label = %q, want %q", label, "Copied YAML to clipboard")
+	if label != wantLabel {
+		t.Errorf("CopyContent() label = %q, want %q", label, wantLabel)
 	}
+}
+
+func wave4CopyTextResource() resource.Resource {
+	return resource.Resource{
+		ID:   "i-0copytext001",
+		Name: "copy-text-server",
+		Fields: map[string]string{
+			"state":         "running",
+			"instance_type": "t3.medium",
+		},
+	}
+}
+
+func TestCopyContent_Text_StripsANSI_JoinsLines(t *testing.T) {
+	m := views.NewYAMLWithCtrl(wave4CopyTextResource(), "ec2", keys.Default(), nil)
+	m.SetSize(120, 40)
+	wave4AssertTextScreenCopy(t, runtime.ScreenYAML, m.ContentLines(), "Copied YAML to clipboard")
+}
+
+func TestCopyContent_JSON_StripsANSI_JoinsLines(t *testing.T) {
+	m := views.NewJSONWithCtrl(wave4CopyTextResource(), "ec2", keys.Default(), nil)
+	m.SetSize(120, 40)
+	wave4AssertTextScreenCopy(t, runtime.ScreenJSON, m.ContentLines(), "Copied JSON to clipboard")
 }
 
 // ===========================================================================

--- a/tests/unit/web_copy_content_test.go
+++ b/tests/unit/web_copy_content_test.go
@@ -1,0 +1,458 @@
+// web_copy_content_test.go — pins for Controller.CopyContent(), the new
+// single source of truth for copy-content resolution shared by the TUI and
+// web renderers (fixes web mode's silent-no-op copy key). Mirrors the
+// reference semantics of internal/tui/runtime_adapter_navigate.go's
+// handleCopy (rsKindList/Detail/Text/Identity/Menu/Selector/Help/Costs), but
+// asserts directly against the CONTROLLER method and the new
+// ViewState.CopyText/CopyLabel snapshot fields — neither exists yet, so this
+// file is expected to fail to compile until both land.
+package unit_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/k2m30/a9s/v3/core/app"
+	awsclient "github.com/k2m30/a9s/v3/core/aws"
+	"github.com/k2m30/a9s/v3/core/demo/fixtures"
+	"github.com/k2m30/a9s/v3/core/domain"
+	"github.com/k2m30/a9s/v3/core/resource"
+	"github.com/k2m30/a9s/v3/core/runtime"
+	"github.com/k2m30/a9s/v3/core/runtime/messages"
+	"github.com/k2m30/a9s/v3/internal/tui/keys"
+	"github.com/k2m30/a9s/v3/internal/tui/views"
+)
+
+// wave4AssertCopyContent calls c.CopyContent() and cross-checks that
+// Snapshot().CopyText/CopyLabel expose the exact same pair at that moment —
+// the dispatch's "single source of truth for both renderers" contract.
+// Every test in this file routes through this helper so the snapshot
+// exposure is pinned across all 9 behaviors, not just once.
+func wave4AssertCopyContent(t *testing.T, c *app.Controller) (content, label string) {
+	t.Helper()
+	content, label = c.CopyContent()
+	snap := c.Snapshot()
+	if snap.CopyText != content {
+		t.Errorf("Snapshot().CopyText = %q, want %q (must match CopyContent())", snap.CopyText, content)
+	}
+	if snap.CopyLabel != label {
+		t.Errorf("Snapshot().CopyLabel = %q, want %q (must match CopyContent())", snap.CopyLabel, label)
+	}
+	return content, label
+}
+
+// ===========================================================================
+// 1. List screen — CopyField precedence.
+//
+// Every CopyField entry in the entire catalog is on a CHILD type (grepped
+// core/aws/catalog_*.go: cb_builds, cb_build_logs, pipeline_stages,
+// eb_rule_targets, sfn_executions, sfn_execution_history, sns_subscriptions,
+// image_uri child, error_message child, message child, conditions_summary
+// child, user_name child — zero top-level types set it). "sns_subscriptions"
+// (CopyField: "endpoint") is used as the real CopyField-bearing type;
+// resource.FindResourceType only searches the TOP-LEVEL catalog (confirmed
+// by reading core/catalog/catalog.go's Find vs FindChild), so CopyContent
+// must resolve CopyField via the child registry too for this to pass — a
+// real bug this test is positioned to catch.
+// ===========================================================================
+
+func wave4SNSSubscriptionResource(id, endpoint string) resource.Resource {
+	return resource.Resource{
+		ID:   id,
+		Name: "orders-topic-subscription",
+		Fields: map[string]string{
+			"protocol":            "https",
+			"endpoint":            endpoint,
+			"confirmation_status": "Confirmed",
+			"owner":               "123456789012",
+			"subscription_arn":    id,
+			"topic_arn":           "arn:aws:sns:us-east-1:123456789012:orders-topic",
+		},
+	}
+}
+
+func TestCopyContent_List_UsesCopyField_WhenFieldNonEmpty(t *testing.T) {
+	td := resource.GetChildType("sns_subscriptions")
+	if td == nil {
+		t.Fatal("sns_subscriptions child type not registered")
+	}
+	if td.CopyField != "endpoint" {
+		t.Fatalf("precondition: sns_subscriptions.CopyField = %q, want %q — update this test if the catalog changed", td.CopyField, "endpoint")
+	}
+
+	id := "arn:aws:sns:us-east-1:123456789012:orders-topic:8f14e45f-ceea-467e-adc8-b71d1d09b1a1"
+	endpoint := "https://hooks.example.com/notify/orders"
+	c := wave3ChildListController(t, "sns_subscriptions")
+	c.ApplyResourcesLoaded("sns_subscriptions", []resource.Resource{wave4SNSSubscriptionResource(id, endpoint)}, nil, false)
+
+	content, label := wave4AssertCopyContent(t, c)
+	if content != endpoint {
+		t.Errorf("CopyContent() content = %q, want CopyField value %q", content, endpoint)
+	}
+	if label != "Copied: "+endpoint {
+		t.Errorf("CopyContent() label = %q, want %q", label, "Copied: "+endpoint)
+	}
+}
+
+func TestCopyContent_List_FallsBackToResourceID_WhenCopyFieldEmptyOnRow(t *testing.T) {
+	td := resource.GetChildType("sns_subscriptions")
+	if td == nil {
+		t.Fatal("sns_subscriptions child type not registered")
+	}
+
+	id := "arn:aws:sns:us-east-1:123456789012:orders-topic:11111111-2222-3333-4444-555555555555"
+	c := wave3ChildListController(t, "sns_subscriptions")
+	c.ApplyResourcesLoaded("sns_subscriptions", []resource.Resource{wave4SNSSubscriptionResource(id, "")}, nil, false)
+
+	content, label := wave4AssertCopyContent(t, c)
+	if content != id {
+		t.Errorf("CopyContent() content = %q, want resource ID %q (CopyField %q empty on this row)", content, id, td.CopyField)
+	}
+	if label != "Copied: "+id {
+		t.Errorf("CopyContent() label = %q, want %q", label, "Copied: "+id)
+	}
+}
+
+func TestCopyContent_List_FallsBackToResourceID_WhenTypeHasNoCopyField(t *testing.T) {
+	if td := resource.FindResourceType("ec2"); td != nil && td.CopyField != "" {
+		t.Fatalf("precondition: ec2.CopyField = %q, want empty — update this test if the catalog changed", td.CopyField)
+	}
+
+	id := "i-0a1b2c3d4e5f67890"
+	c := openListController(t, "ec2")
+	c.ApplyResourcesLoaded("ec2", []resource.Resource{
+		{
+			ID:   id,
+			Name: "prod-web-01",
+			Fields: map[string]string{
+				"instance_id":   id,
+				"state":         "running",
+				"instance_type": "m5.large",
+				"private_ip":    "10.0.4.15",
+			},
+		},
+	}, nil, false)
+
+	content, label := wave4AssertCopyContent(t, c)
+	if content != id {
+		t.Errorf("CopyContent() content = %q, want resource ID %q (ec2 has no CopyField)", content, id)
+	}
+	if label != "Copied: "+id {
+		t.Errorf("CopyContent() label = %q, want %q", label, "Copied: "+id)
+	}
+}
+
+func TestCopyContent_List_EmptySelection_ReturnsEmpty(t *testing.T) {
+	c := openListController(t, "ec2")
+	// No ApplyResourcesLoaded call — list is empty, ListSelected() has nothing.
+
+	content, label := wave4AssertCopyContent(t, c)
+	if content != "" || label != "" {
+		t.Errorf("CopyContent() on an empty list = (%q, %q), want (\"\", \"\")", content, label)
+	}
+}
+
+// ===========================================================================
+// 2. Detail screen — related panel focused.
+// ===========================================================================
+
+func TestCopyContent_Detail_RelatedFocused_UsesSelectedRowDisplayName(t *testing.T) {
+	res := resource.Resource{
+		ID:   "i-0abc123def456789a",
+		Name: "prod-backend-01",
+		Fields: map[string]string{
+			"instance_id": "i-0abc123def456789a",
+			"state":       "running",
+		},
+	}
+	c := newDetailController(t, res, "ec2")
+	wantName := "sg-0a1b2c3d4e5f67890"
+	c.ApplyDetailRelated([]app.DetailRelatedRow{
+		{TargetType: "sg", DisplayName: wantName, State: domain.RelatedResolved, Count: 2},
+	})
+	// ApplyDetailRelated only replaces RelatedRows; RelatedVisible is a
+	// separate flag (mirrors DetailState.RelatedVisible) that ActionToggleFocus
+	// gates on (core/app/detail_cursor.go) — set it via the same seam
+	// detail_ports_test.go uses before exercising Tab focus.
+	c.SetDetailRelatedVisible(true, true)
+	c.Apply(app.Action{Kind: app.ActionToggleFocus})
+
+	row, ok := c.SelectedRelatedRow()
+	if !ok || row.DisplayName != wantName {
+		t.Fatalf("precondition: SelectedRelatedRow() = (%+v, %v), want DisplayName %q selected", row, ok, wantName)
+	}
+
+	content, label := wave4AssertCopyContent(t, c)
+	if content != wantName {
+		t.Errorf("CopyContent() content = %q, want selected related row's DisplayName %q", content, wantName)
+	}
+	if label != "Copied: "+wantName {
+		t.Errorf("CopyContent() label = %q, want %q", label, "Copied: "+wantName)
+	}
+}
+
+// ===========================================================================
+// 3. Detail screen — related NOT focused, FieldCursor on a field row.
+// ===========================================================================
+
+// TestCopyContent_Detail_FieldCursor_UsesFieldValue uses an unregistered
+// synthetic resource type (no td.Project override) with EXACTLY ONE Fields
+// entry so the generic flat-alphabetical projector produces a single,
+// unambiguous field row at FieldCursor's default index 0.
+func TestCopyContent_Detail_FieldCursor_UsesFieldValue(t *testing.T) {
+	wantValue := "arn:aws:iam::123456789012:role/deploy-role"
+	res := resource.Resource{
+		ID:     "res-detail-001",
+		Name:   "detail-field-cursor-test",
+		Fields: map[string]string{"account_arn": wantValue},
+	}
+	c := newDetailController(t, res, "copytest-detail-fieldcursor")
+
+	body := c.Snapshot().Body.Detail
+	if body == nil || len(body.Fields) != 1 || body.Fields[0].Value != wantValue {
+		t.Fatalf("precondition: expected exactly 1 detail field row with Value %q, got: %+v", wantValue, body)
+	}
+
+	content, label := wave4AssertCopyContent(t, c)
+	if content != wantValue {
+		t.Errorf("CopyContent() content = %q, want focused field's Value %q", content, wantValue)
+	}
+	if label != "Copied: "+wantValue {
+		t.Errorf("CopyContent() label = %q, want %q", label, "Copied: "+wantValue)
+	}
+}
+
+// TestCopyContent_Detail_FieldCursor_DashValue_CopiesDash pins the reachable
+// reality of a Fields entry whose map value is empty: core/fieldpath (frozen)
+// substitutes the display placeholder "-" for an empty value before the item
+// ever reaches domainItemToFieldItemDetail, so no projected row's Value is
+// ever the literal empty string — the projected row instead carries
+// Value:"-", and the live handleCopy/CopyContent path copies that dash
+// verbatim (TUI parity), not the Key.
+func TestCopyContent_Detail_FieldCursor_DashValue_CopiesDash(t *testing.T) {
+	res := resource.Resource{
+		ID:     "res-detail-002",
+		Name:   "detail-dash-value-test",
+		Fields: map[string]string{"launch_time": ""},
+	}
+	c := newDetailController(t, res, "copytest-detail-dashvalue")
+
+	body := c.Snapshot().Body.Detail
+	if body == nil || len(body.Fields) != 1 || body.Fields[0].Value != "-" {
+		t.Fatalf("precondition: expected exactly 1 detail field row with the fieldpath dash placeholder Value \"-\", got: %+v", body)
+	}
+
+	content, label := wave4AssertCopyContent(t, c)
+	if content != "-" {
+		t.Errorf("CopyContent() content = %q, want the projected dash placeholder %q", content, "-")
+	}
+	if label != "Copied: -" {
+		t.Errorf("CopyContent() label = %q, want %q", label, "Copied: -")
+	}
+}
+
+// ===========================================================================
+// 4. Detail screen — fallback to raw YAML when no usable field is focused.
+//
+// An unregistered synthetic type with NO Fields map produces a genuinely
+// EMPTY detail Fields slice regardless of RawStruct (confirmed by reading
+// core/semantics/projection/generic.go's buildItems: with no view config the
+// flat-rendering branch reads only r.Fields, never r.RawStruct, and the
+// ID/Name-synthesis branch is skipped whenever RawStruct is non-nil) — the
+// FieldCursor-in-range branch of the reference handleCopy logic can never
+// fire, forcing the YAML fallback. RawStruct is a real SDK-typed fixture
+// (core/demo/fixtures) so RawYAMLFromResource has real data to marshal.
+// ===========================================================================
+
+func TestCopyContent_Detail_FallbackToRawYAML_WhenNoUsableField(t *testing.T) {
+	inst := fixtures.NewEC2Fixtures().Reservations[0].Instances[0]
+	res := resource.Resource{ID: "res-detail-003", Name: "detail-yaml-fallback-test", RawStruct: inst}
+	c := newDetailController(t, res, "copytest-detail-yamlfallback")
+
+	body := c.Snapshot().Body.Detail
+	if body == nil || len(body.Fields) != 0 {
+		t.Fatalf("precondition: expected zero detail Fields rows for an unregistered type with no Fields/Findings, got %d: %+v", len(body.Fields), body)
+	}
+	wantYAML := views.RawYAMLFromResource(c.GetDetailResource())
+	if wantYAML == "" {
+		t.Fatal("precondition: views.RawYAMLFromResource produced empty output for a non-empty resource")
+	}
+
+	content, label := wave4AssertCopyContent(t, c)
+	if content != wantYAML {
+		t.Errorf("CopyContent() content does not match RawYAMLFromResource(GetDetailResource()):\ngot:\n%s\nwant:\n%s", content, wantYAML)
+	}
+	if label != "Copied detail to clipboard" {
+		t.Errorf("CopyContent() label = %q, want %q", label, "Copied detail to clipboard")
+	}
+}
+
+// ===========================================================================
+// 5. Text screen (YAML/JSON) — ANSI-stripped, newline-joined content.
+// ===========================================================================
+
+func TestCopyContent_Text_StripsANSI_JoinsLines(t *testing.T) {
+	res := resource.Resource{
+		ID:   "i-0copytext001",
+		Name: "copy-text-server",
+		Fields: map[string]string{
+			"state":         "running",
+			"instance_type": "t3.medium",
+		},
+	}
+	m := views.NewYAMLWithCtrl(res, "ec2", keys.Default(), nil)
+	m.SetSize(120, 40)
+	lines := m.ContentLines()
+
+	hasANSI := false
+	for _, l := range lines {
+		if strings.Contains(l, "\x1b[") {
+			hasANSI = true
+			break
+		}
+	}
+	if !hasANSI {
+		t.Fatal("precondition: YAML ContentLines() must contain ANSI color codes for this test to be meaningful")
+	}
+
+	// Route construction through the blessed newTestController helper (see
+	// qa_controller_construction_discipline_test.go) instead of a direct
+	// app.New — it already pairs t.TempDir()/t.Cleanup(c.Close) correctly;
+	// text_ports_test.go's newTextScreenController does the same
+	// PushScreen+EnsureTextState arrangement but lives in package unit, not
+	// unit_test, so it isn't callable from here.
+	c := newTestController(t)
+	c.ApplyIntents([]runtime.UIIntent{runtime.PushScreen{ID: runtime.ScreenYAML}})
+	c.EnsureTextState(lines)
+
+	content, label := wave4AssertCopyContent(t, c)
+	if strings.Contains(content, "\x1b[") {
+		t.Errorf("CopyContent() content must have ANSI codes stripped, got: %q", content)
+	}
+	wantPlain := stripAnsi(strings.Join(lines, "\n"))
+	if content != wantPlain {
+		t.Errorf("CopyContent() content mismatch:\ngot:\n%q\nwant:\n%q", content, wantPlain)
+	}
+	if label != "Copied YAML to clipboard" {
+		t.Errorf("CopyContent() label = %q, want %q", label, "Copied YAML to clipboard")
+	}
+}
+
+// ===========================================================================
+// 6. Identity screen.
+// ===========================================================================
+
+func TestCopyContent_Identity_LoadedWithARN_ReturnsARNAndBangLabel(t *testing.T) {
+	c := newTestController(t)
+	c.Apply(app.Action{Kind: app.ActionOpenIdentity})
+
+	wantARN := "arn:aws:iam::123456789012:user/copy-test-operator"
+	c.Handle(messages.IdentityLoaded{
+		Identity: &awsclient.CallerIdentity{
+			AccountID: "123456789012",
+			Arn:       wantARN,
+			UserName:  "copy-test-operator",
+		},
+		Gen: 0,
+	})
+
+	content, label := wave4AssertCopyContent(t, c)
+	if content != wantARN {
+		t.Errorf("CopyContent() content = %q, want identity ARN %q", content, wantARN)
+	}
+	if label != "Copied!" {
+		t.Errorf("CopyContent() label = %q, want %q", label, "Copied!")
+	}
+}
+
+func TestCopyContent_Identity_NoOp(t *testing.T) {
+	t.Run("still loading (no IdentityLoaded delivered)", func(t *testing.T) {
+		c := newTestController(t)
+		c.Apply(app.Action{Kind: app.ActionOpenIdentity})
+
+		if !c.Snapshot().Body.Identity.Loading {
+			t.Fatal("precondition: identity screen must still be in the Loading state before any IdentityLoaded event")
+		}
+
+		content, label := wave4AssertCopyContent(t, c)
+		if content != "" || label != "" {
+			t.Errorf("CopyContent() while identity is loading = (%q, %q), want (\"\", \"\")", content, label)
+		}
+	})
+
+	t.Run("loaded with empty ARN", func(t *testing.T) {
+		c := newTestController(t)
+		c.Apply(app.Action{Kind: app.ActionOpenIdentity})
+		c.Handle(messages.IdentityLoaded{
+			Identity: &awsclient.CallerIdentity{
+				AccountID: "123456789012",
+				Arn:       "",
+				UserName:  "copy-test-operator-blank-arn",
+			},
+			Gen: 0,
+		})
+
+		body := c.Snapshot().Body.Identity
+		if body == nil || body.Loading || body.ARN != "" {
+			t.Fatalf("precondition: identity must be loaded with an empty ARN, got: %+v", body)
+		}
+
+		content, label := wave4AssertCopyContent(t, c)
+		if content != "" || label != "" {
+			t.Errorf("CopyContent() with an empty ARN = (%q, %q), want (\"\", \"\")", content, label)
+		}
+	})
+}
+
+// ===========================================================================
+// 7. Menu / selector / help / costs screens — always a no-op.
+// ===========================================================================
+
+func TestCopyContent_NoOpScreens_ReturnEmpty(t *testing.T) {
+	t.Run("menu", func(t *testing.T) {
+		c := newTestController(t)
+		if c.Snapshot().Body.Kind != app.BodyKindMenu {
+			t.Fatalf("precondition: fresh controller must start on the menu screen, got Body.Kind = %q", c.Snapshot().Body.Kind)
+		}
+		content, label := wave4AssertCopyContent(t, c)
+		if content != "" || label != "" {
+			t.Errorf("CopyContent() on the menu screen = (%q, %q), want (\"\", \"\")", content, label)
+		}
+	})
+
+	t.Run("selector", func(t *testing.T) {
+		c := newTestController(t)
+		c.Apply(app.Action{Kind: app.ActionCommand, Arg: "region"})
+		if c.Snapshot().Body.Kind != app.BodyKindSelector {
+			t.Fatalf("precondition: Command(region) must push a selector screen, got Body.Kind = %q", c.Snapshot().Body.Kind)
+		}
+		content, label := wave4AssertCopyContent(t, c)
+		if content != "" || label != "" {
+			t.Errorf("CopyContent() on the region selector screen = (%q, %q), want (\"\", \"\")", content, label)
+		}
+	})
+
+	t.Run("help", func(t *testing.T) {
+		c := newTestController(t)
+		c.Apply(app.Action{Kind: app.ActionOpenHelp})
+		if c.Snapshot().Body.Kind != app.BodyKindHelp {
+			t.Fatalf("precondition: OpenHelp must push the help screen, got Body.Kind = %q", c.Snapshot().Body.Kind)
+		}
+		content, label := wave4AssertCopyContent(t, c)
+		if content != "" || label != "" {
+			t.Errorf("CopyContent() on the help screen = (%q, %q), want (\"\", \"\")", content, label)
+		}
+	})
+
+	t.Run("costs", func(t *testing.T) {
+		c := newTestController(t)
+		c.ApplyIntents([]runtime.UIIntent{runtime.PushScreen{ID: runtime.ScreenCosts}})
+		if c.Snapshot().Body.Kind != app.BodyKindCosts {
+			t.Fatalf("precondition: PushScreen(ScreenCosts) must report Body.Kind = %q, got %q", app.BodyKindCosts, c.Snapshot().Body.Kind)
+		}
+		content, label := wave4AssertCopyContent(t, c)
+		if content != "" || label != "" {
+			t.Errorf("CopyContent() on the costs screen = (%q, %q), want (\"\", \"\")", content, label)
+		}
+	})
+}

--- a/tests/unit/web_copy_content_test.go
+++ b/tests/unit/web_copy_content_test.go
@@ -419,6 +419,53 @@ func TestCopyContent_Identity_NoOp(t *testing.T) {
 	})
 }
 
+// TestCopyContent_Identity_ClearedAfterRotation is a Codex P2 finding: the
+// controller caches the resolved identity in c.identityResult (set via
+// SetIdentityIntent, core/app/intents.go, from a messages.IdentityLoaded
+// delivery) and clears it ONLY in handleActionOpenIdentity
+// (core/app/actions_view.go). handleActionSelectProfile/
+// handleActionSelectRegion rotate the session (which clears
+// Session.Identity) but never touch identityLoading/identityResult/
+// identityErrMsg — so CopyContent() on an already-open identity screen keeps
+// serving the PREVIOUS profile's ARN across a profile/region switch, until
+// the refetch eventually lands.
+//
+// HandleProfileSelected's own intents are MenuClearAvailabilityIntent,
+// PopSelectorIntent, and a FlashIntent — PopSelectorIntent (core/app/
+// intents.go) only pops the top screen when it is a profile/region/theme
+// SELECTOR, never ScreenIdentity, so the identity screen legitimately stays
+// on top of the stack across ActionSelectProfile (confirmed by the
+// Body.Kind precondition below) — no re-open/re-navigate is needed to
+// reproduce this on the real seam.
+func TestCopyContent_Identity_ClearedAfterRotation(t *testing.T) {
+	c := newTestController(t)
+	c.Apply(app.Action{Kind: app.ActionOpenIdentity})
+
+	wantARN := "arn:aws:iam::123456789012:user/copy-test-preswitch-operator"
+	c.Handle(messages.IdentityLoaded{
+		Identity: &awsclient.CallerIdentity{
+			AccountID: "123456789012",
+			Arn:       wantARN,
+			UserName:  "copy-test-preswitch-operator",
+		},
+		Gen: 0,
+	})
+	if content, _ := c.CopyContent(); content != wantARN {
+		t.Fatalf("precondition: CopyContent() before rotation = %q, want the loaded ARN %q", content, wantARN)
+	}
+
+	c.Apply(app.Action{Kind: app.ActionSelectProfile, Arg: "other-profile"})
+
+	if kind := c.Snapshot().Body.Kind; kind != app.BodyKindIdentity {
+		t.Fatalf("precondition: identity screen must still be on top after ActionSelectProfile (PopSelectorIntent only pops a selector screen), got Body.Kind = %q", kind)
+	}
+
+	content, label := wave4AssertCopyContent(t, c)
+	if content != "" || label != "" {
+		t.Errorf("CopyContent() after a profile rotation must not serve the stale pre-switch ARN: got (%q, %q), want (\"\", \"\") until the refetch lands", content, label)
+	}
+}
+
 // ===========================================================================
 // 7. Menu / selector / help / costs screens — always a no-op.
 // ===========================================================================


### PR DESCRIPTION
## Problem

In `--web` mode, pressing `c` did nothing: the client POSTed `{kind:"copy"}` to the server, `ActionCopy` is a deliberate renderer-only no-op (`core/app/controller.go`), and the web renderer never implemented its half — no clipboard write, no feedback.

## Fix

Copy-content resolution now lives once in the controller and both renderers consume it:

- **`Controller.CopyContent()`** (`core/app/copy.go`, new) resolves what `c` copies for the current screen — list (per-type `CopyField`, else row ID), detail (focused related row → field cursor → raw-YAML fallback), text (ANSI-stripped lines), identity (ARN); menu/selector/help/costs return empty.
- **`ViewState.CopyText/CopyLabel`** are populated in every snapshot and rendered as `data-copy-*` attributes on `#body`, so the payload is always current in the DOM across `/action`, `/body`, and initial page render.
- **Web client** handles `c` in the keydown handler: `navigator.clipboard.writeText` (user-activation requirement) + a client-side flash toast outside `#main` (survives fragment swaps); error flash when the clipboard API is unavailable. The dead `{kind:"copy"}` keyMap POST is removed.
- **TUI `handleCopy`** now delegates to the same `CopyContent()` (reveal stays adapter-local — the controller has no reveal screen); its duplicated resolution logic and `rawContentFromTextBody` are deleted.

### Latent bug fixed by the shared lookup

Every `CopyField` in the catalog is registered on **child types**, but the TUI's lookup only consulted the top-level registry — so `CopyField` never resolved anywhere and copy always fell back to the row ID. `CopyContent` consults both registries; on an `sns_subscriptions` child list, `c` now copies the endpoint (e.g. `oncall@acme-corp.com`) instead of the subscription ARN.

## Testing

- TDD: `tests/unit/web_copy_content_test.go` written red-first — 12 tests covering the full behavior table (CopyField precedence via a child type, ID fallback, related-focused vs field-cursor detail branches, dash-value reality of the frozen fieldpath projector, raw-YAML fallback with a real SDK `RawStruct`, ANSI-strip on text, identity ARN gating, no-op screens) plus `Snapshot()` exposure.
- `make ready-to-push` green (full race suite, lint, security, demo smoke, no-real-data scan).
- Real-browser verification against `./a9s --demo --web`: copy payload + flash verified live on menu (empty), EC2/S3 lists, S3 detail (payload tracks the field cursor), YAML view, identity, and the `sns_subscriptions` child list (CopyField endpoint). Flash renders only on a resolved `clipboard.writeText`, so a visible toast is proof of the write.
